### PR TITLE
[cmake] OpenEXR is a direct dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -446,6 +446,16 @@ if(ALICEVISION_HAVE_OPENGV)
 endif()
 
 # ==============================================================================
+# OpenEXR
+# ==============================================================================
+find_package(OpenEXR)
+if(OPENEXR_FOUND)
+  message(STATUS "OpenEXR found. (Version ${OPENEXR_VERSION})")
+else()
+  message(SEND_ERROR "Failed to find OpenEXR.")
+endif()
+
+# ==============================================================================
 # OpenImageIO
 # ==============================================================================
 find_package(OpenImageIO)

--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -32,12 +32,16 @@ add_library(aliceVision_image
 
 target_include_directories(aliceVision_image
   PUBLIC ${OPENIMAGEIO_INCLUDE_DIRS}
+  PRIVATE ${OPENEXR_INCLUDE_DIR}
 )
 
 target_link_libraries(aliceVision_image
+  PUBLIC
   aliceVision_numeric
+  PRIVATE
   ${OPENIMAGEIO_LIBRARIES}
   ${LOG_LIB}
+  ${OPENEXR_LIBRARIES}
 )
 
 set_target_properties(aliceVision_image


### PR DESCRIPTION
## Description

OpenEXR must be treated as a direct dependency and not just rely on OIIO
(because of this https://github.com/alicevision/AliceVision/blob/develop/src/aliceVision/image/io.cpp#L13)

