### PR TITLE
[matching] fix comparing int* to int (clang 4 crash)

### DIFF
--- a/src/aliceVision/matching/ArrayMatcher_kdtreeFlann.hpp
+++ b/src/aliceVision/matching/ArrayMatcher_kdtreeFlann.hpp
@@ -137,11 +137,8 @@ class ArrayMatcher_kdtreeFlann : public ArrayMatcher<Scalar, Metric>
     {
       for (size_t j = 0; j < NN; ++j)
       {
-        if (indices[i] > 0)
-        {
           pvec_indices->emplace_back(IndMatch(i, vec_indices[i*NN+j]));
           pvec_distances->emplace_back(vec_distances[i*NN+j]);
-        }
       }
     }
     return true;


### PR DESCRIPTION
It fixes a clang 4 compiling error.
Also the if was useless in the first place.