### PR TITLE
Fix mesh filtering

### DIFF
--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -2502,9 +2502,12 @@ bool Mesh::loadFromObjAscii(int& nmtls, StaticVector<int>** trisMtlIds, StaticVe
             {
                 int n1 = mvsUtils::findNSubstrsInString(line, "/");
                 int n2 = mvsUtils::findNSubstrsInString(line, "//");
-                if((n2 == 0 && n1 == 3) || n2 == 3)
+                if((n1 == 3 && n2 == 0) ||
+                   (n1 == 0 && n2 == 3) ||
+                   (n1 == 0 && n2 == 0))
                     ntris += 1;
-                else if((n2 == 0 && n1 == 4) || n2 == 4)
+                else if((n1 == 4 && n2 == 0) ||
+                        (n1 == 0 && n2 == 4))
                     ntris += 2;
             }
             nlines++;

--- a/src/aliceVision/mesh/MeshAnalyze.cpp
+++ b/src/aliceVision/mesh/MeshAnalyze.cpp
@@ -165,7 +165,7 @@ bool MeshAnalyze::applyLaplacianOperator(int ptId, StaticVector<Point3d>* ptsToA
 
         if((npt.x == 0.0f) && (npt.y == 0.0f) && (npt.z == 0.0f))
         {
-            // printf("zero neighb pt\n");
+            ALICEVISION_LOG_WARNING("MeshAnalyze::applyLaplacianOperator: zero neighb pt");
             return false;
         }
         ln = ln + npt;
@@ -178,14 +178,14 @@ bool MeshAnalyze::applyLaplacianOperator(int ptId, StaticVector<Point3d>* ptsToA
     if(std::isnan(d) || std::isnan(n.x) || std::isnan(n.y) || std::isnan(n.z) || (d != d) || (n.x != n.x) ||
        (n.y != n.y) || (n.z != n.z)) // check if is not NaN
     {
-        // printf("nan\n");
+        ALICEVISION_LOG_WARNING("MeshAnalyze::applyLaplacianOperator: nan");
         return false;
     }
 
     if(std::isnan(d) || std::isnan(n.x) || std::isnan(n.y) || std::isnan(n.z) || (d != d) || (n.x != n.x) ||
        (n.y != n.y) || (n.z != n.z)) // check if is not NaN
     {
-        // printf("nan\n");
+        ALICEVISION_LOG_WARNING("MeshAnalyze::applyLaplacianOperator: nan");
         return false;
     }
 
@@ -200,7 +200,7 @@ bool MeshAnalyze::getLaplacianSmoothingVector(int ptId, Point3d& ln)
 }
 
 // kobbelt kampagna 98 Interactive Multi-Resolution Modeling on Arbitrary Meshes
-// page 5 - U1 - laplacian is obtained wnen apply to origina pts , U2 - bi-laplacian is obtained when apply to laplacian
+// page 5 - U1 - laplacian is obtained when apply to origina pts , U2 - bi-laplacian is obtained when apply to laplacian
 // pts
 bool MeshAnalyze::getBiLaplacianSmoothingVector(int ptId, StaticVector<Point3d>* ptsLaplacian, Point3d& tp)
 {

--- a/src/aliceVision/mesh/MeshClean.cpp
+++ b/src/aliceVision/mesh/MeshClean.cpp
@@ -384,7 +384,7 @@ void MeshClean::path::deployPath(StaticVector<MeshClean::path::pathPart>* _pth)
 
 void MeshClean::path::updatePtNeighPtsOrderedByPath(int _ptId, StaticVector<MeshClean::path::pathPart>* _pth)
 {
-    auto* ptNeighPtsOrderedByPath = (*me->ptsNeighPtsOrdered)[_ptId];
+    StaticVector<int>*& ptNeighPtsOrderedByPath = (*me->ptsNeighPtsOrdered)[_ptId];
 
     if(ptNeighPtsOrderedByPath != nullptr)
     {
@@ -453,7 +453,7 @@ MeshClean::path::createPath(StaticVector<int>* ptNeighTrisSortedAscToProcess)
 
 int MeshClean::path::deployAll()
 {
-    auto* ptsNeighTrisSortedAsc = (*me->ptsNeighTrisSortedAsc)[ptId];
+    StaticVector<int>*& ptsNeighTrisSortedAsc = (*me->ptsNeighTrisSortedAsc)[ptId];
     if(sizeOfStaticVector<int>(ptsNeighTrisSortedAsc) == 0)
     {
         return 0;
@@ -489,14 +489,12 @@ int MeshClean::path::deployAll()
         }
         else
         {
-
             if(ptsNeighTrisSortedAsc == nullptr)
             {
                 ptsNeighTrisSortedAsc = new StaticVector<int>();
                 ptsNeighTrisSortedAsc->reserve(pthNew->size());
                 printfState(pth);
                 printfState(pthNew);
-                delete ptsNeighTrisSortedAsc;
                 throw std::runtime_error("deployAll: bad condition, pthNew size: " + std::to_string(pthNew->size()));
             }
 

--- a/src/aliceVision/mesh/MeshEnergyOpt.cpp
+++ b/src/aliceVision/mesh/MeshEnergyOpt.cpp
@@ -43,7 +43,7 @@ StaticVector<Point3d>* MeshEnergyOpt::computeLaplacianPtsParallel()
     return lapPts;
 }
 
-void MeshEnergyOpt::updateGradientParallel(float lambda, float epsilon, int type, const Point3d& LU,
+void MeshEnergyOpt::updateGradientParallel(float lambda, const Point3d& LU,
                                                 const Point3d& RD, StaticVectorBool* ptsCanMove)
 {
     // printf("nlabpts %i of %i\n",nlabpts,pts->size());
@@ -54,73 +54,19 @@ void MeshEnergyOpt::updateGradientParallel(float lambda, float epsilon, int type
     newPts->push_back_arr(pts);
 
 #pragma omp parallel for
-    for(int i = 0; i < pts->size(); i++)
+    for(int i = 0; i < pts->size(); ++i)
     {
         if((ptsCanMove == nullptr) || ((*ptsCanMove)[i]))
         {
-
             Point3d n;
 
-            switch(type)
+            if(getBiLaplacianSmoothingVector(i, lapPts, n))
             {
-                case 0:
-                // doesn't work
-                    if(getVertexMeanCurvatureNormal(i, n))
-                    {
-                        (*newPts)[i] = (*newPts)[i] + n * lambda;
-                    }
-                    break;
-                case 1:
-                // smooth only
-                    if(applyLaplacianOperator(i, pts, n))
-                    {
-                        (*newPts)[i] = (*newPts)[i] + n * lambda;
-                    }
-                    break;
-                case 2:
-                // doesn't work
-                    if(getMeanCurvAndLaplacianSmoothing(i, n, epsilon))
-                    {
-                        (*newPts)[i] = (*newPts)[i] + n * lambda;
-                    }
-                    break;
-                case 3:
-                // default mode
-
-                    // if (isIsBoundaryPt(i)==false)
-                    //{
-                    if(getBiLaplacianSmoothingVector(i, lapPts, n))
-                    {
-                        Point3d p = (*newPts)[i] + n * lambda;
-                        if((p.x > LU.x) && (p.y > LU.y) && (p.z > LU.z) && (p.x < RD.x) && (p.y < RD.y) && (p.z < RD.z))
-                        {
-                            (*newPts)[i] = p;
-                        }
-                    }
-                    /*
-            }else{
-                    if (applyLaplacianOperator(i, pts, n)==true)
-                    {
-                            Point3d p = (*newPts)[i] + n * lamda;
-                            if ((p.x>LU.x)&&(p.y>LU.y)&&(p.z>LU.z)&&
-                                    (p.x<RD.x)&&(p.y<RD.y)&&(p.z<RD.z))
-                            {
-                                    (*newPts)[i] = p;
-                            };
-                    };
-            };
-            */
-                    break;
-                case 4:
-                // doesn't work
-                    Point3d lap;
-                    Point3d bilap;
-                    if((applyLaplacianOperator(i, pts, lap)) && (applyLaplacianOperator(i, lapPts, bilap)) &&
-                       (!isIsBoundaryPt(i)))
-                    {
-                        (*newPts)[i] = (*newPts)[i] + bilap * lambda;
-                    }
-                    break;
+                Point3d p = (*newPts)[i] + n * lambda;
+                if((p.x > LU.x) && (p.y > LU.y) && (p.z > LU.z) && (p.x < RD.x) && (p.y < RD.y) && (p.z < RD.z))
+                {
+                    (*newPts)[i] = p;
+                }
             }
         }
     }
@@ -130,7 +76,7 @@ void MeshEnergyOpt::updateGradientParallel(float lambda, float epsilon, int type
     delete lapPts;
 }
 
-bool MeshEnergyOpt::optimizeSmooth(float lambda, float epsilon, int type, int niter, StaticVectorBool* ptsCanMove)
+bool MeshEnergyOpt::optimizeSmooth(float lambda, int niter, StaticVectorBool* ptsCanMove)
 {
     if(pts->size() <= 4)
     {
@@ -154,14 +100,12 @@ bool MeshEnergyOpt::optimizeSmooth(float lambda, float epsilon, int type, int ni
 
     ALICEVISION_LOG_INFO("Optimizing mesh smooth: " << std::endl
                          << "\t- lamda: " << lambda << std::endl
-                         << "\t- epsilon: " << epsilon << std::endl
-                         << "\t- type: " << type << std::endl
                          << "\t- niters: " << niter << std::endl);
 
     for(int i = 0; i < niter; i++)
     {
         ALICEVISION_LOG_INFO("Optimizing mesh smooth: iteration " << i);
-        updateGradientParallel(lambda, epsilon, type, LU, RD, ptsCanMove);
+        updateGradientParallel(lambda, LU, RD, ptsCanMove);
         if(saveDebug)
             saveToObj(mp->mip->mvDir + "mesh_smoothed_" + std::to_string(i) + ".obj");
     }

--- a/src/aliceVision/mesh/MeshEnergyOpt.hpp
+++ b/src/aliceVision/mesh/MeshEnergyOpt.hpp
@@ -18,12 +18,11 @@ public:
     explicit MeshEnergyOpt(mvsUtils::MultiViewParams* _mp);
     ~MeshEnergyOpt();
 
-    bool optimizeSmooth(float lambda, float epsilon, int type, int niter, StaticVectorBool* ptsCanMove);
+    bool optimizeSmooth(float lambda, int niter, StaticVectorBool* ptsCanMove);
 
 private:
     StaticVector<Point3d>* computeLaplacianPtsParallel();
-    void updateGradientParallel(float lambda, float epsilon, int type, const Point3d& LU, const Point3d& RD,
-                                StaticVectorBool* ptsCanMove);
+    void updateGradientParallel(float lambda, const Point3d& LU, const Point3d& RD, StaticVectorBool* ptsCanMove);
 };
 
 } // namespace mesh

--- a/src/aliceVision/mesh/meshPostProcessing.cpp
+++ b/src/aliceVision/mesh/meshPostProcessing.cpp
@@ -197,9 +197,7 @@ void meshPostProcessing(Mesh*& inout_mesh, StaticVector<StaticVector<int>*>*& in
         {
             ALICEVISION_LOG_INFO("Mesh smoothing.");
             float lambda = (float)mp.mip->_ini.get<double>("meshEnergyOpt.lambda", 1.0f);
-            float epsilon = (float)mp.mip->_ini.get<double>("meshEnergyOpt.epsilon", 0.1f); // unused in type 3
-            int type = mp.mip->_ini.get<int>("meshEnergyOpt.smoothType", 3); // 0, 1, 2, 3, 4 => only 1 and 3 works
-            meOpt->optimizeSmooth(lambda, epsilon, type, smoothNIter, ptsCanMove);
+            meOpt->optimizeSmooth(lambda, smoothNIter, ptsCanMove);
 
             if(exportDebug)
                 meOpt->saveToObj(resultFolderName + "mesh_smoothed.obj");

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -118,9 +118,7 @@ int main(int argc, char* argv[])
         meOpt.cleanMesh(10);
 
         StaticVectorBool* ptsCanMove = nullptr;
-        float epsilon = 0.0f; // unused
-        int type = 3; // 0, 1, 2, 3, 4 => only 1 and 3 works
-        meOpt.optimizeSmooth(lambda, epsilon, type, smoothNIter, ptsCanMove);
+        meOpt.optimizeSmooth(lambda, smoothNIter, ptsCanMove);
 
         ALICEVISION_LOG_INFO("Mesh filtering done.");
     }


### PR DESCRIPTION
## Features list

- [x] Bug fix in OBJ loader: the initial computation of the number of facets was not correct in some cases
- [x] Bug fix in MeshFiltering: the variable introduced as an alias was not a reference, so the modifications were not applied anymore

## Implementation remarks

- [x] add more log in filtering
- [x] remove unused modes in mesh filtering
