### PR TITLE
Move image downscale from prepareDenseScene to depthMapEstimation

### DIFF
--- a/src/aliceVision/depthMap/RcTc.cpp
+++ b/src/aliceVision/depthMap/RcTc.cpp
@@ -22,8 +22,8 @@ void RcTc::refineRcTcDepthSimMap(bool useTcOrRcPixSize, DepthSimMap* depthSimMap
                                     int ndepthsToRefine, int wsh, float gammaC, float gammaP, float epipShift)
 {
     int scale = depthSimMap->scale;
-    int w = mp->mip->getWidth(rc) / scale;
-    int h = mp->mip->getHeight(rc) / scale;
+    int w = mp->getWidth(rc) / scale;
+    int h = mp->getHeight(rc) / scale;
 
     if(verbose)
         ALICEVISION_LOG_DEBUG("refineRcTcDepthSimMap: width: " << w << ", height: " << h);

--- a/src/aliceVision/depthMap/SemiGlobalMatchingParams.cpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingParams.cpp
@@ -24,53 +24,53 @@ SemiGlobalMatchingParams::SemiGlobalMatchingParams(mvsUtils::MultiViewParams* _m
     cps = _cps;
     prt = new RcTc(mp, cps);
 
-    visualizeDepthMaps = mp->mip->_ini.get<bool>("semiGlobalMatching.visualizeDepthMaps", false);
+    visualizeDepthMaps = mp->_ini.get<bool>("semiGlobalMatching.visualizeDepthMaps", false);
     visualizePartialDepthMaps =
-        mp->mip->_ini.get<bool>("semiGlobalMatching.visualizePartialDepthMaps", false);
+        mp->_ini.get<bool>("semiGlobalMatching.visualizePartialDepthMaps", false);
 
-    doSmooth = mp->mip->_ini.get<bool>("semiGlobalMatching.smooth", true);
+    doSmooth = mp->_ini.get<bool>("semiGlobalMatching.smooth", true);
 
 
-    doRefine = mp->mip->_ini.get<bool>("semiGlobalMatching.doRefine", true);
-    refineUseTcOrPixSize = mp->mip->_ini.get<bool>("semiGlobalMatching.refineUseTcOrPixSize", true);
+    doRefine = mp->_ini.get<bool>("semiGlobalMatching.doRefine", true);
+    refineUseTcOrPixSize = mp->_ini.get<bool>("semiGlobalMatching.refineUseTcOrPixSize", true);
 
-    ndepthsToRefine = mp->mip->_ini.get<int>("semiGlobalMatching.ndepthsToRefine", 15);
+    ndepthsToRefine = mp->_ini.get<int>("semiGlobalMatching.ndepthsToRefine", 15);
 
-    P1 = (unsigned char)mp->mip->_ini.get<int>("semiGlobalMatching.P1", 10);
-    P2 = (unsigned char)mp->mip->_ini.get<int>("semiGlobalMatching.P2", 125);
-    P3 = (unsigned char)mp->mip->_ini.get<int>("semiGlobalMatching.P3", 0);
+    P1 = (unsigned char)mp->_ini.get<int>("semiGlobalMatching.P1", 10);
+    P2 = (unsigned char)mp->_ini.get<int>("semiGlobalMatching.P2", 125);
+    P3 = (unsigned char)mp->_ini.get<int>("semiGlobalMatching.P3", 0);
 
-    maxDepthsToStore = mp->mip->_ini.get<int>("semiGlobalMatching.maxDepthsToStore", 3000);
-    maxDepthsToSweep = mp->mip->_ini.get<int>("semiGlobalMatching.maxDepthsToSweep", 1500);
-    rcTcDepthsHalfLimit = mp->mip->_ini.get<int>("semiGlobalMatching.rcTcDepthsHalfLimit", 2048);
+    maxDepthsToStore = mp->_ini.get<int>("semiGlobalMatching.maxDepthsToStore", 3000);
+    maxDepthsToSweep = mp->_ini.get<int>("semiGlobalMatching.maxDepthsToSweep", 1500);
+    rcTcDepthsHalfLimit = mp->_ini.get<int>("semiGlobalMatching.rcTcDepthsHalfLimit", 2048);
 
-    rcDepthsCompStep = mp->mip->_ini.get<int>("semiGlobalMatching.rcDepthsCompStep", 6);
+    rcDepthsCompStep = mp->_ini.get<int>("semiGlobalMatching.rcDepthsCompStep", 6);
 
     useSeedsToCompDepthsToSweep =
-        mp->mip->_ini.get<bool>("semiGlobalMatching.useSeedsToCompDepthsToSweep", true);
-    seedsRangePercentile = (float)mp->mip->_ini.get<double>("semiGlobalMatching.seedsRangePercentile", 0.001);
-    seedsRangeInflate = (float)mp->mip->_ini.get<double>("semiGlobalMatching.seedsRangeInflate", 0.2);
+        mp->_ini.get<bool>("semiGlobalMatching.useSeedsToCompDepthsToSweep", true);
+    seedsRangePercentile = (float)mp->_ini.get<double>("semiGlobalMatching.seedsRangePercentile", 0.001);
+    seedsRangeInflate = (float)mp->_ini.get<double>("semiGlobalMatching.seedsRangeInflate", 0.2);
 
     saveDepthsToSweepToTxtForVis =
-        mp->mip->_ini.get<bool>("semiGlobalMatching.saveDepthsToSweepToTxtForVis", false);
+        mp->_ini.get<bool>("semiGlobalMatching.saveDepthsToSweepToTxtForVis", false);
 
-    doSGMoptimizeVolume = mp->mip->_ini.get<bool>("semiGlobalMatching.doSGMoptimizeVolume", true);
-    doRefineRc = mp->mip->_ini.get<bool>("semiGlobalMatching.doRefineRc", true);
+    doSGMoptimizeVolume = mp->_ini.get<bool>("semiGlobalMatching.doSGMoptimizeVolume", true);
+    doRefineRc = mp->_ini.get<bool>("semiGlobalMatching.doRefineRc", true);
 
-    modalsMapDistLimit = mp->mip->_ini.get<int>("semiGlobalMatching.modalsMapDistLimit", 2);
-    minNumOfConsistentCams = mp->mip->_ini.get<int>("semiGlobalMatching.minNumOfConsistentCams", 2);
-    minObjectThickness = mp->mip->_ini.get<int>("semiGlobalMatching.minObjectThickness", 8);
+    modalsMapDistLimit = mp->_ini.get<int>("semiGlobalMatching.modalsMapDistLimit", 2);
+    minNumOfConsistentCams = mp->_ini.get<int>("semiGlobalMatching.minNumOfConsistentCams", 2);
+    minObjectThickness = mp->_ini.get<int>("semiGlobalMatching.minObjectThickness", 8);
     maxTcRcPixSizeInVoxRatio =
-        (float)mp->mip->_ini.get<double>("semiGlobalMatching.maxTcRcPixSizeInVoxRatio", 2.0f);
-    nSGGCIters = mp->mip->_ini.get<int>("semiGlobalMatching.nSGGCIters", 0);
+        (float)mp->_ini.get<double>("semiGlobalMatching.maxTcRcPixSizeInVoxRatio", 2.0f);
+    nSGGCIters = mp->_ini.get<int>("semiGlobalMatching.nSGGCIters", 0);
 
-    SGMoutDirName = mp->mip->_ini.get<std::string>("semiGlobalMatching.outDirName", "SGM");
-    SGMtmpDirName = mp->mip->_ini.get<std::string>("semiGlobalMatching.tmpDirName", "_tmp");
+    SGMoutDirName = mp->_ini.get<std::string>("semiGlobalMatching.outDirName", "SGM");
+    SGMtmpDirName = mp->_ini.get<std::string>("semiGlobalMatching.tmpDirName", "_tmp");
 
-    useSilhouetteMaskCodedByColor = mp->mip->_ini.get<bool>("global.useSilhouetteMaskCodedByColor", false);
-    silhouetteMaskColor.r = mp->mip->_ini.get<int>("global.silhouetteMaskColorR", 0);
-    silhouetteMaskColor.g = mp->mip->_ini.get<int>("global.silhouetteMaskColorG", 0);
-    silhouetteMaskColor.b = mp->mip->_ini.get<int>("global.silhouetteMaskColorB", 0);
+    useSilhouetteMaskCodedByColor = mp->_ini.get<bool>("global.useSilhouetteMaskCodedByColor", false);
+    silhouetteMaskColor.r = mp->_ini.get<int>("global.silhouetteMaskColorR", 0);
+    silhouetteMaskColor.g = mp->_ini.get<int>("global.silhouetteMaskColorG", 0);
+    silhouetteMaskColor.b = mp->_ini.get<int>("global.silhouetteMaskColorB", 0);
 }
 
 SemiGlobalMatchingParams::~SemiGlobalMatchingParams()
@@ -80,52 +80,52 @@ SemiGlobalMatchingParams::~SemiGlobalMatchingParams()
 
 std::string SemiGlobalMatchingParams::getREFINE_photo_depthMapFileName(IndexT viewId, int scale, int step)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_depthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refinePhoto.exr";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_depthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refinePhoto.exr";
 }
 
 std::string SemiGlobalMatchingParams::getREFINE_photo_simMapFileName(IndexT viewId, int scale, int step)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_simMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refinePhoto.exr";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_simMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refinePhoto.exr";
 }
 
 std::string SemiGlobalMatchingParams::getREFINE_opt_depthMapFileName(IndexT viewId, int scale, int step)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_depthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refineOpt.exr";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_depthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refineOpt.exr";
 }
 
 std::string SemiGlobalMatchingParams::getREFINE_opt_simMapFileName(IndexT viewId, int scale, int step)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_simMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refineOpt.exr";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_simMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_refineOpt.exr";
 }
 
 std::string SemiGlobalMatchingParams::getSGMTmpDir()
 {
-    return mp->mip->_depthMapFolder + SGMoutDirName + "/" + SGMtmpDirName + "/";
+    return mp->getDepthMapFolder() + SGMoutDirName + "/" + SGMtmpDirName + "/";
 }
 
 std::string SemiGlobalMatchingParams::getSGM_depthMapFileName(IndexT viewId, int scale, int step)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_depthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_SGM.bin";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_depthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_SGM.bin";
 }
 
 std::string SemiGlobalMatchingParams::getSGM_simMapFileName(IndexT viewId, int scale, int step)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_simMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_SGM.bin";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_simMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_SGM.bin";
 }
 
 std::string SemiGlobalMatchingParams::getSGM_idDepthMapFileName(IndexT viewId, int scale, int step)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_idDepthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_SGM.png";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_idDepthMap_scale" + mvsUtils::num2str(scale) + "_step" + mvsUtils::num2str(step) + "_SGM.png";
 }
 
 std::string SemiGlobalMatchingParams::getSGM_tcamsFileName(IndexT viewId)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_tcams.bin";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_tcams.bin";
 }
 
 std::string SemiGlobalMatchingParams::getSGM_depthsFileName(IndexT viewId)
 {
-    return mp->mip->_depthMapFolder + std::to_string(viewId) + "_depths.bin";
+    return mp->getDepthMapFolder() + std::to_string(viewId) + "_depths.bin";
 }
 
 DepthSimMap* SemiGlobalMatchingParams::getDepthSimMapFromBestIdVal(int w, int h, StaticVector<IdValue>* volumeBestIdVal,

--- a/src/aliceVision/depthMap/SemiGlobalMatchingRc.cpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingRc.cpp
@@ -33,24 +33,24 @@ SemiGlobalMatchingRc::SemiGlobalMatchingRc(bool doComputeDepthsAndResetTCams, in
     scale = _scale;
     step = _step;
 
-    w = sp->mp->mip->getWidth(rc) / (scale * step);
-    h = sp->mp->mip->getHeight(rc) / (scale * step);
+    w = sp->mp->getWidth(rc) / (scale * step);
+    h = sp->mp->getHeight(rc) / (scale * step);
 
-    int nnearestcams = sp->mp->mip->_ini.get<int>("semiGlobalMatching.maxTCams", 10);
+    int nnearestcams = sp->mp->_ini.get<int>("semiGlobalMatching.maxTCams", 10);
     tcams = new StaticVector<int>();
     *tcams = sp->pc->findNearestCamsFromSeeds(rc, nnearestcams);
 
-    wsh = sp->mp->mip->_ini.get<int>("semiGlobalMatching.wsh", 4);
-    gammaC = (float)sp->mp->mip->_ini.get<double>("semiGlobalMatching.gammaC", 5.5);
-    gammaP = (float)sp->mp->mip->_ini.get<double>("semiGlobalMatching.gammaP", 8.0);
+    wsh = sp->mp->_ini.get<int>("semiGlobalMatching.wsh", 4);
+    gammaC = (float)sp->mp->_ini.get<double>("semiGlobalMatching.gammaC", 5.5);
+    gammaP = (float)sp->mp->_ini.get<double>("semiGlobalMatching.gammaP", 8.0);
 
     sp->cps->verbose = sp->mp->verbose;
 
-    const IndexT viewId = sp->mp->mip->getViewId(rc);
+    const IndexT viewId = sp->mp->getViewId(rc);
 
     tcamsFileName = sp->getSGM_tcamsFileName(viewId);
     depthsFileName = sp->getSGM_depthsFileName(viewId);
-    depthsTcamsLimitsFileName =  sp->mp->mip->_depthMapFolder + std::to_string(viewId) + "_depthsTcamsLimits.bin";
+    depthsTcamsLimitsFileName =  sp->mp->getDepthMapFolder() + std::to_string(viewId) + "_depthsTcamsLimits.bin";
     SGM_depthMapFileName = sp->getSGM_depthMapFileName(viewId, scale, step);
     SGM_simMapFileName = sp->getSGM_simMapFileName(viewId, scale, step);
     SGM_idDepthMapFileName = sp->getSGM_idDepthMapFileName(viewId, scale, step);
@@ -98,7 +98,7 @@ StaticVector<float>* SemiGlobalMatchingRc::getTcSeedsRcPlaneDists(int rc, Static
     for(int c = 0; c < tcams->size(); c++)
     {
         StaticVector<SeedPoint>* seeds;
-        mvsUtils::loadSeedsFromFile(&seeds, (*tcams)[c], sp->mp->mip, mvsUtils::EFileType::seeds);
+        mvsUtils::loadSeedsFromFile(&seeds, (*tcams)[c], sp->mp, mvsUtils::EFileType::seeds);
         nTcSeeds += seeds->size();
         delete seeds;
     } // for c
@@ -109,7 +109,7 @@ StaticVector<float>* SemiGlobalMatchingRc::getTcSeedsRcPlaneDists(int rc, Static
     for(int c = 0; c < tcams->size(); c++)
     {
         StaticVector<SeedPoint>* seeds;
-        mvsUtils::loadSeedsFromFile(&seeds, (*tcams)[c], sp->mp->mip, mvsUtils::EFileType::seeds);
+        mvsUtils::loadSeedsFromFile(&seeds, (*tcams)[c], sp->mp, mvsUtils::EFileType::seeds);
         for(int i = 0; i < seeds->size(); i++)
         {
             rcDists->push_back(pointPlaneDistance((*seeds)[i].op.p, rcplane.p, rcplane.n));
@@ -396,7 +396,7 @@ void SemiGlobalMatchingRc::computeDepthsAndResetTCams()
         computeDepths(minDepthAll, maxDepthAll, alldepths);
         if(sp->saveDepthsToSweepToTxtForVis)
         {
-            std::string fn = tmpDir + std::to_string(sp->mp->mip->getViewId(rc)) + "depthsAll.txt";
+            std::string fn = tmpDir + std::to_string(sp->mp->getViewId(rc)) + "depthsAll.txt";
             FILE* f = fopen(fn.c_str(), "w");
             for(int j = 0; j < depths->size(); j++)
             {
@@ -442,7 +442,7 @@ void SemiGlobalMatchingRc::computeDepthsAndResetTCams()
 
         if(sp->saveDepthsToSweepToTxtForVis)
         {
-            std::string fn = tmpDir + std::to_string(sp->mp->mip->getViewId(rc)) + "depthsAll.txt";
+            std::string fn = tmpDir + std::to_string(sp->mp->getViewId(rc)) + "depthsAll.txt";
             FILE* f = fopen(fn.c_str(), "w");
             for(int j = 0; j < depths->size(); j++)
             {
@@ -457,7 +457,7 @@ void SemiGlobalMatchingRc::computeDepthsAndResetTCams()
 
         if(sp->saveDepthsToSweepToTxtForVis)
         {
-            std::string fn = tmpDir + std::to_string(sp->mp->mip->getViewId(rc)) + "rcSeedsDists.txt";
+            std::string fn = tmpDir + std::to_string(sp->mp->getViewId(rc)) + "rcSeedsDists.txt";
             FILE* f = fopen(fn.c_str(), "w");
             for(int j = 0; j < rcSeedsDistsAsc->size(); j++)
             {
@@ -475,7 +475,7 @@ void SemiGlobalMatchingRc::computeDepthsAndResetTCams()
 
     if(sp->saveDepthsToSweepToTxtForVis)
     {
-        std::string fn = tmpDir + std::to_string(sp->mp->mip->getViewId(rc)) + "depthsTcamsLimits.txt";
+        std::string fn = tmpDir + std::to_string(sp->mp->getViewId(rc)) + "depthsTcamsLimits.txt";
         FILE* f = fopen(fn.c_str(), "w");
         for(int j = 0; j < depthsTcamsLimits->size(); j++)
         {
@@ -488,7 +488,7 @@ void SemiGlobalMatchingRc::computeDepthsAndResetTCams()
 
     if(sp->saveDepthsToSweepToTxtForVis)
     {
-        std::string fn = tmpDir + std::to_string(sp->mp->mip->getViewId(rc)) + "depths.txt";
+        std::string fn = tmpDir + std::to_string(sp->mp->getViewId(rc)) + "depths.txt";
         FILE* f = fopen(fn.c_str(), "w");
         for(int j = 0; j < depths->size(); j++)
         {
@@ -502,7 +502,7 @@ void SemiGlobalMatchingRc::computeDepthsAndResetTCams()
     {
         for(int i = 0; i < alldepths->size(); i++)
         {
-            std::string fn = tmpDir + std::to_string(sp->mp->mip->getViewId(rc)) + "depths" + mvsUtils::num2str(i) + ".txt";
+            std::string fn = tmpDir + std::to_string(sp->mp->getViewId(rc)) + "depths" + mvsUtils::num2str(i) + ".txt";
             FILE* f = fopen(fn.c_str(), "w");
             for(int j = 0; j < (*alldepths)[i]->size(); j++)
             {
@@ -520,7 +520,7 @@ void SemiGlobalMatchingRc::computeDepthsAndResetTCams()
         rcplane.n = sp->mp->iRArr[rc] * Point3d(0.0, 0.0, 1.0);
         rcplane.n = rcplane.n.normalize();
 
-        std::string fn = tmpDir + std::to_string(sp->mp->mip->getViewId(rc)) + "rcDepths.txt";
+        std::string fn = tmpDir + std::to_string(sp->mp->getViewId(rc)) + "rcDepths.txt";
         FILE* f = fopen(fn.c_str(), "w");
         float depth = minDepthAll;
         while(depth < maxDepthAll)
@@ -677,7 +677,7 @@ bool SemiGlobalMatchingRc::sgmrc(bool checkIfExists)
     mvsUtils::printfElapsedTime(tall, "PSSGM rc " + mvsUtils::num2str(rc) + " of " + mvsUtils::num2str(sp->mp->ncams));
 
     if(sp->visualizeDepthMaps)
-        depthSimMapFinal->saveToImage(tmpDir + "SemiGlobalMatchingRc_SGM" + std::to_string(sp->mp->mip->getViewId(rc)) + "_" + "scale" +
+        depthSimMapFinal->saveToImage(tmpDir + "SemiGlobalMatchingRc_SGM" + std::to_string(sp->mp->getViewId(rc)) + "_" + "scale" +
                                         mvsUtils::num2str(depthSimMapFinal->scale) + "step" + mvsUtils::num2str(depthSimMapFinal->step) +
                                         ".depthSimMap.png", 1.0f);
 
@@ -690,26 +690,28 @@ bool SemiGlobalMatchingRc::sgmrc(bool checkIfExists)
 
 void computeDepthMapsPSSGM(int CUDADeviceNo, mvsUtils::MultiViewParams* mp, mvsUtils::PreMatchCams* pc, const StaticVector<int>& cams)
 {
-    int scale = mp->mip->_ini.get<int>("semiGlobalMatching.scale", -1);
-    int step = mp->mip->_ini.get<int>("semiGlobalMatching.step", -1);
-    if(scale == -1)
+    const int fileScale = 1; // input images scale (should be one)
+    int sgmScale = mp->_ini.get<int>("semiGlobalMatching.scale", -1);
+    int sgmStep = mp->_ini.get<int>("semiGlobalMatching.step", -1);
+
+    if(sgmScale == -1)
     {
         // Compute the number of scales that will be used in the plane sweeping.
         // The highest scale should have a minimum resolution of 700x550.
-        int width = mp->mip->getMaxImageWidth();
-        int height = mp->mip->getMaxImageHeight();
-        int scaleTmp = computeStep(mp->mip, 1, (width > height ? 700 : 550), (width > height ? 550 : 700));
-        scale = std::min(2, scaleTmp);
-        step = computeStep(mp->mip, scale, (width > height ? 700 : 550), (width > height ? 550 : 700));
-        ALICEVISION_LOG_INFO("PSSGM autoScaleStep: scale: " << scale << ", step: " << step);
+        int width = mp->getMaxImageWidth();
+        int height = mp->getMaxImageHeight();
+        int scaleTmp = computeStep(mp, fileScale, (width > height ? 700 : 550), (width > height ? 550 : 700));
+        sgmScale = std::min(2, scaleTmp);
+        sgmStep = computeStep(mp, fileScale * sgmScale, (width > height ? 700 : 550), (width > height ? 550 : 700));
+        ALICEVISION_LOG_INFO("PSSGM autoScaleStep: scale: " << sgmScale << ", step: " << sgmStep);
     }
 
-    int bandType = 0;
+    const int bandType = 0;
     
     // load images from files into RAM 
     mvsUtils::ImagesCache ic(mp, bandType, true);
     // load stuff on GPU memory and creates multi-level images and computes gradients
-    PlaneSweepingCuda cps(CUDADeviceNo,& ic, mp, pc, scale);
+    PlaneSweepingCuda cps(CUDADeviceNo, &ic, mp, pc, sgmScale);
     // init plane sweeping parameters
     SemiGlobalMatchingParams sp(mp, pc, &cps);
 
@@ -717,11 +719,11 @@ void computeDepthMapsPSSGM(int CUDADeviceNo, mvsUtils::MultiViewParams* mp, mvsU
 
     for(const int rc : cams)
     {
-        std::string depthMapFilepath = sp.getSGM_idDepthMapFileName(mp->mip->getViewId(rc), scale, step);
+        std::string depthMapFilepath = sp.getSGM_idDepthMapFileName(mp->getViewId(rc), sgmScale, sgmStep);
         if(!mvsUtils::FileExists(depthMapFilepath))
         {
             ALICEVISION_LOG_INFO("Compute depth map: " << depthMapFilepath);
-            SemiGlobalMatchingRc psgr(true, rc, scale, step, &sp);
+            SemiGlobalMatchingRc psgr(true, rc, sgmScale, sgmStep, &sp);
             psgr.sgmrc();
         }
         else
@@ -738,7 +740,7 @@ void computeDepthMapsPSSGM(mvsUtils::MultiViewParams* mp, mvsUtils::PreMatchCams
     ALICEVISION_LOG_INFO("Number of GPU devices: " << num_gpus << ", number of CPU threads: " << num_cpu_threads);
     int numthreads = std::min(num_gpus, num_cpu_threads);
 
-    int num_gpus_to_use = mp->mip->_ini.get<int>("semiGlobalMatching.num_gpus_to_use", 1);
+    int num_gpus_to_use = mp->_ini.get<int>("semiGlobalMatching.num_gpus_to_use", 1);
     if(num_gpus_to_use > 0)
     {
         numthreads = num_gpus_to_use;

--- a/src/aliceVision/depthMap/SemiGlobalMatchingRcTc.cpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingRcTc.cpp
@@ -22,8 +22,8 @@ SemiGlobalMatchingRcTc::SemiGlobalMatchingRcTc(StaticVector<float>* _rcTcDepths,
 
     rcTcDepths = _rcTcDepths;
 
-    w = sp->mp->mip->getWidth(rc) / (scale * step);
-    h = sp->mp->mip->getHeight(rc) / (scale * step);
+    w = sp->mp->getWidth(rc) / (scale * step);
+    h = sp->mp->getHeight(rc) / (scale * step);
 
     rcSilhoueteMap = _rcSilhoueteMap;
 }

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -38,7 +38,7 @@ DelaunayGraphCut::DelaunayGraphCut(mvsUtils::MultiViewParams* _mp, mvsUtils::Pre
 
     _camsVertexes.resize(mp->ncams, -1);
 
-    saveTemporaryBinFiles = mp->mip->_ini.get<bool>("LargeScale.saveTemporaryBinFiles", false);
+    saveTemporaryBinFiles = mp->_ini.get<bool>("LargeScale.saveTemporaryBinFiles", false);
 
     GEO::initialize();
     _tetrahedralization = GEO::Delaunay::create(3, "BDEL");
@@ -249,7 +249,7 @@ StaticVector<int> DelaunayGraphCut::getIsUsedPerCamera() const
     long timer = std::clock();
 
     StaticVector<int> cams;
-    cams.resize_with(mp->mip->getNbCameras(), 0);
+    cams.resize_with(mp->getNbCameras(), 0);
 
 //#pragma omp parallel for
     for(int vi = 0; vi < _verticesAttr.size(); ++vi)
@@ -427,8 +427,8 @@ void DelaunayGraphCut::loadPrecomputedDensePoints(StaticVector<int>* voxelsIds, 
     Point3d cgpt;
     int ncgpt = 0;
 
-    bool doFilterOctreeTracks = mp->mip->_ini.get<bool>("LargeScale.doFilterOctreeTracks", true);
-    int minNumOfConsistentCams = mp->mip->_ini.get<int>("filter.minNumOfConsistentCams", 2);
+    bool doFilterOctreeTracks = mp->_ini.get<bool>("LargeScale.doFilterOctreeTracks", true);
+    int minNumOfConsistentCams = mp->_ini.get<int>("filter.minNumOfConsistentCams", 2);
 
     // add points from voxel
     for(int i = 0; i < voxelsIds->size(); i++)
@@ -514,7 +514,7 @@ void DelaunayGraphCut::createTetrahedralizationFromDepthMapsCamsVoxel(const Stat
     /* initialize random seed: */
     srand(time(nullptr));
 
-    int nGridHelperVolumePointsDim = mp->mip->_ini.get<int>("LargeScale.nGridHelperVolumePointsDim", 10);
+    int nGridHelperVolumePointsDim = mp->_ini.get<int>("LargeScale.nGridHelperVolumePointsDim", 10);
     // add volume points to prevent singularities
     addHelperPoints(nGridHelperVolumePointsDim, voxel, minDist);
 
@@ -531,9 +531,9 @@ void DelaunayGraphCut::computeVerticesSegSize(bool allPoints, float alpha) // al
 {
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("creating universe");
-    int scalePS = mp->mip->_ini.get<int>("global.scalePS", 1);
-    int step = mp->mip->_ini.get<int>("global.step", 1);
-    float pointToJoinPixSizeDist = (float)mp->mip->_ini.get<double>("delaunaycut.pointToJoinPixSizeDist", 2.0) *
+    int scalePS = mp->_ini.get<int>("global.scalePS", 1);
+    int step = mp->_ini.get<int>("global.step", 1);
+    float pointToJoinPixSizeDist = (float)mp->_ini.get<double>("delaunaycut.pointToJoinPixSizeDist", 2.0) *
                                    (float)scalePS * (float)step * 2.0f;
 
     std::vector<Pixel> edges;
@@ -1178,10 +1178,10 @@ void DelaunayGraphCut::forceTedgesByGradientCVPR11(bool fixesSigma, float nPixel
     ALICEVISION_LOG_INFO("Forcing t-edges.");
     long t2 = clock();
 
-    float delta = (float)mp->mip->_ini.get<double>("delaunaycut.delta", 0.1f);
+    float delta = (float)mp->_ini.get<double>("delaunaycut.delta", 0.1f);
     ALICEVISION_LOG_INFO("delta: " << delta);
 
-    float beta = (float)mp->mip->_ini.get<double>("delaunaycut.beta", 1000.0f);
+    float beta = (float)mp->_ini.get<double>("delaunaycut.beta", 1000.0f);
     ALICEVISION_LOG_INFO("beta: " << beta);
 
     for(GC_cellInfo& c: _cellsAttr)
@@ -1278,27 +1278,27 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
     ALICEVISION_LOG_INFO("Forcing t-edges");
     long t2 = clock();
 
-    float delta = (float)mp->mip->_ini.get<double>("delaunaycut.delta", 0.1f);
+    float delta = (float)mp->_ini.get<double>("delaunaycut.delta", 0.1f);
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("delta: " << delta);
 
-    float minJumpPartRange = (float)mp->mip->_ini.get<double>("delaunaycut.minJumpPartRange", 10000.0f);
+    float minJumpPartRange = (float)mp->_ini.get<double>("delaunaycut.minJumpPartRange", 10000.0f);
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("minJumpPartRange: " << minJumpPartRange);
 
-    float maxSilentPartRange = (float)mp->mip->_ini.get<double>("delaunaycut.maxSilentPartRange", 100.0f);
+    float maxSilentPartRange = (float)mp->_ini.get<double>("delaunaycut.maxSilentPartRange", 100.0f);
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("maxSilentPartRange: " << maxSilentPartRange);
 
-    float nsigmaJumpPart = (float)mp->mip->_ini.get<double>("delaunaycut.nsigmaJumpPart", 2.0f);
+    float nsigmaJumpPart = (float)mp->_ini.get<double>("delaunaycut.nsigmaJumpPart", 2.0f);
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("nsigmaJumpPart: " << nsigmaJumpPart);
 
-    float nsigmaFrontSilentPart = (float)mp->mip->_ini.get<double>("delaunaycut.nsigmaFrontSilentPart", 2.0f);
+    float nsigmaFrontSilentPart = (float)mp->_ini.get<double>("delaunaycut.nsigmaFrontSilentPart", 2.0f);
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("nsigmaFrontSilentPart: " << nsigmaFrontSilentPart);
 
-    float nsigmaBackSilentPart = (float)mp->mip->_ini.get<double>("delaunaycut.nsigmaBackSilentPart", 2.0f);
+    float nsigmaBackSilentPart = (float)mp->_ini.get<double>("delaunaycut.nsigmaBackSilentPart", 2.0f);
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("nsigmaBackSilentPart: " << nsigmaBackSilentPart);
 
@@ -1508,8 +1508,8 @@ void DelaunayGraphCut::updateGraphFromTmpPtsCamsHexahRC(int rc, Point3d hexah[8]
     std::string camPtsFileName;
     camPtsFileName = tmpCamsPtsFolderName + "camPtsGrid_" + mvsUtils::num2strFourDecimal(rc) + ".bin";
 
-    bool doFilterOctreeTracks = mp->mip->_ini.get<bool>("LargeScale.doFilterOctreeTracks", true);
-    int minNumOfConsistentCams = mp->mip->_ini.get<int>("filter.minNumOfConsistentCams", 2);
+    bool doFilterOctreeTracks = mp->_ini.get<bool>("LargeScale.doFilterOctreeTracks", true);
+    int minNumOfConsistentCams = mp->_ini.get<int>("filter.minNumOfConsistentCams", 2);
 
     /////////////////////////////////////////////////////////////////////////////////
     FILE* f = fopen(camPtsFileName.c_str(), "rb");
@@ -1665,10 +1665,10 @@ void DelaunayGraphCut::freeUnwantedFullCells(const Point3d* hexah)
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("freeUnwantedFullCells\n");
 
-    int minSegmentSize = (int)mp->mip->_ini.get<int>("hallucinationsFiltering.minSegmentSize", 10);
-    bool doRemoveBubbles = (bool)mp->mip->_ini.get<bool>("hallucinationsFiltering.doRemoveBubbles", true);
-    bool doRemoveDust = (bool)mp->mip->_ini.get<bool>("hallucinationsFiltering.doRemoveDust", true);
-    bool doLeaveLargestFullSegmentOnly = (bool)mp->mip->_ini.get<bool>("hallucinationsFiltering.doLeaveLargestFullSegmentOnly", false);
+    int minSegmentSize = (int)mp->_ini.get<int>("hallucinationsFiltering.minSegmentSize", 10);
+    bool doRemoveBubbles = (bool)mp->_ini.get<bool>("hallucinationsFiltering.doRemoveBubbles", true);
+    bool doRemoveDust = (bool)mp->_ini.get<bool>("hallucinationsFiltering.doRemoveDust", true);
+    bool doLeaveLargestFullSegmentOnly = (bool)mp->_ini.get<bool>("hallucinationsFiltering.doLeaveLargestFullSegmentOnly", false);
 
     if(doRemoveBubbles)
     {
@@ -1818,7 +1818,7 @@ void DelaunayGraphCut::reconstructVoxel(Point3d hexah[8], StaticVector<int>* vox
     // Load tracks and create tetrahedralization (into T variable)
     createTetrahedralizationFromDepthMapsCamsVoxel(cams, voxelsIds, hexah, ls);
 
-    //float nPixelSizeBehind = (float)mp->mip->_ini.get<double>("delaunaycut.filterPtsWithHigherPixSizeInDist", 5.0f)*spaceSteps.size();
+    //float nPixelSizeBehind = (float)mp->_ini.get<double>("delaunaycut.filterPtsWithHigherPixSizeInDist", 5.0f)*spaceSteps.size();
     // initTriangulationDefaults(folderName + "delaunayVerticesFiltered.wrl");
 
     computeVerticesSegSize(true, 0.0f);
@@ -1827,13 +1827,13 @@ void DelaunayGraphCut::reconstructVoxel(Point3d hexah[8], StaticVector<int>* vox
         removeSmallSegs(2500); // TODO FACA: to decide
     }
 
-    bool updateLSC = mp->mip->_ini.get<bool>("LargeScale.updateLSC", true);
+    bool updateLSC = mp->_ini.get<bool>("LargeScale.updateLSC", true);
 
     reconstructExpetiments(cams, folderName, updateLSC,
                            hexah, tmpCamsPtsFolderName,
                            spaceSteps);
 
-    bool saveOrNot = mp->mip->_ini.get<bool>("LargeScale.saveDelaunayTriangulation", false);
+    bool saveOrNot = mp->_ini.get<bool>("LargeScale.saveDelaunayTriangulation", false);
     if(saveOrNot)
     {
         std::string fileNameDh = folderName + "delaunayTriangulation.bin";
@@ -1973,23 +1973,23 @@ void DelaunayGraphCut::reconstructExpetiments(const StaticVector<int>& cams, con
     long t1;
 
     bool fixesSigma = update;
-    float sigma = (float)mp->mip->_ini.get<double>("delaunaycut.sigma", 2.0f) * spaceSteps.size();
+    float sigma = (float)mp->_ini.get<double>("delaunaycut.sigma", 2.0f) * spaceSteps.size();
 
     // 0 for distFcn equals 1 all the time
-    float distFcnHeight = (float)mp->mip->_ini.get<double>("delaunaycut.distFcnHeight", 0.0f);
+    float distFcnHeight = (float)mp->_ini.get<double>("delaunaycut.distFcnHeight", 0.0f);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    bool labatutCFG09 = mp->mip->_ini.get<bool>("global.LabatutCFG09", false);
-    bool jancosekCVPR11 = mp->mip->_ini.get<bool>("global.JancosekCVPR11", false);
+    bool labatutCFG09 = mp->_ini.get<bool>("global.LabatutCFG09", false);
+    bool jancosekCVPR11 = mp->_ini.get<bool>("global.JancosekCVPR11", false);
     // jancosekIJCV: "Exploiting Visibility Information in Surface Reconstruction to Preserve Weakly Supported Surfaces", Michal Jancosek and Tomas Pajdla, 2014
-    bool jancosekIJCV = mp->mip->_ini.get<bool>("global.JancosekIJCV", true);
+    bool jancosekIJCV = mp->_ini.get<bool>("global.JancosekIJCV", true);
 
     if(jancosekCVPR11)
     {
-        float delta = (float)mp->mip->_ini.get<double>("delaunaycut.delta", 0.1f);
+        float delta = (float)mp->_ini.get<double>("delaunaycut.delta", 0.1f);
 
         ALICEVISION_LOG_INFO("Jancosek CVPR 2011 method ( delta*100 = " << static_cast<int>(delta * 100.0f) << "):");
 
@@ -2022,7 +2022,7 @@ void DelaunayGraphCut::reconstructExpetiments(const StaticVector<int>& cams, con
 
     if(jancosekIJCV) // true by default
     {
-        float delta = (float)mp->mip->_ini.get<double>("delaunaycut.delta", 0.1f);
+        float delta = (float)mp->_ini.get<double>("delaunaycut.delta", 0.1f);
 
         ALICEVISION_LOG_INFO("Jancosek IJCV method ( delta*100 = " << static_cast<int>(delta * 100.0f) << " ): ");
 

--- a/src/aliceVision/fuseCut/LargeScale.cpp
+++ b/src/aliceVision/fuseCut/LargeScale.cpp
@@ -26,7 +26,7 @@ LargeScale::LargeScale(mvsUtils::MultiViewParams* _mp, mvsUtils::PreMatchCams* _
     bfs::create_directory(spaceFolderName);
     bfs::create_directory(spaceVoxelsFolderName);
 
-    doVisualize = mp->mip->_ini.get<bool>("LargeScale.doVisualizeOctreeTracks", false);
+    doVisualize = mp->_ini.get<bool>("LargeScale.doVisualizeOctreeTracks", false);
 }
 
 LargeScale::~LargeScale()
@@ -152,11 +152,11 @@ bool LargeScale::generateSpace(int maxPts, int ocTreeDim)
     initialEstimateSpace(maxOcTreeDim);
     maxOcTreeDim = ocTreeDim;
 
-    bool addRandomNoise = mp->mip->_ini.get<bool>("LargeScale.addRandomNoise", false);
+    bool addRandomNoise = mp->_ini.get<bool>("LargeScale.addRandomNoise", false);
     float addRandomNoisePercNoisePts =
-        (float)mp->mip->_ini.get<double>("LargeScale.addRandomNoisePercNoisePts", 10.0);
+        (float)mp->_ini.get<double>("LargeScale.addRandomNoisePercNoisePts", 10.0);
     int addRandomNoiseNoisPixSizeDistHalfThr =
-        (float)mp->mip->_ini.get<int>("LargeScale.addRandomNoiseNoisPixSizeDistHalfThr", 10);
+        (float)mp->_ini.get<int>("LargeScale.addRandomNoiseNoisPixSizeDistHalfThr", 10);
 
     std::string depthMapsPtsSimsTmpDir = generateTempPtsSimsFiles(
         spaceFolderName, mp, addRandomNoise, addRandomNoisePercNoisePts, addRandomNoiseNoisPixSizeDistHalfThr);

--- a/src/aliceVision/fuseCut/OctreeTracks.cpp
+++ b/src/aliceVision/fuseCut/OctreeTracks.cpp
@@ -486,11 +486,11 @@ OctreeTracks::OctreeTracks(const Point3d* _voxel, mvsUtils::MultiViewParams* _mp
     sy = svy / (float)numSubVoxsY;
     sz = svz / (float)numSubVoxsZ;
 
-    doFilterOctreeTracks = mp->mip->_ini.get<bool>("LargeScale.doFilterOctreeTracks", true);
-    doUseWeaklySupportedPoints = mp->mip->_ini.get<bool>("LargeScale.doUseWeaklySupportedPoints", false);
-    doUseWeaklySupportedPointCam = mp->mip->_ini.get<bool>("LargeScale.doUseWeaklySupportedPointCam", false);
-    minNumOfConsistentCams = mp->mip->_ini.get<int>("filter.minNumOfConsistentCams", 2);
-    simWspThr = (float)mp->mip->_ini.get<double>("LargeScale.simWspThr", -0.0f);
+    doFilterOctreeTracks = mp->_ini.get<bool>("LargeScale.doFilterOctreeTracks", true);
+    doUseWeaklySupportedPoints = mp->_ini.get<bool>("LargeScale.doUseWeaklySupportedPoints", false);
+    doUseWeaklySupportedPointCam = mp->_ini.get<bool>("LargeScale.doUseWeaklySupportedPointCam", false);
+    minNumOfConsistentCams = mp->_ini.get<int>("filter.minNumOfConsistentCams", 2);
+    simWspThr = (float)mp->_ini.get<double>("LargeScale.simWspThr", -0.0f);
 
     int maxNumSubVoxs = std::max(std::max(numSubVoxsX, numSubVoxsY), numSubVoxsZ);
     size_ = 2;
@@ -622,7 +622,7 @@ void OctreeTracks::filterOctreeTracks2(StaticVector<trackStruct*>* tracks)
     StaticVector<trackStruct*> tracksOut;
     tracksOut.reserve(tracks->size());
 
-    float clusterSizeThr = mp->mip->_ini.get<double>("OctreeTracks.clusterSizeThr", 2.0f);
+    float clusterSizeThr = mp->_ini.get<double>("OctreeTracks.clusterSizeThr", 2.0f);
 
     // long t1 = initEstimate();
     for(int i = 0; i < tracks->size(); i++)
@@ -684,9 +684,9 @@ StaticVector<OctreeTracks::trackStruct*>* OctreeTracks::fillOctree(int maxPts, s
     {
         int rc = cams[camid];
         StaticVector<Point3d>* pts =
-            loadArrayFromFile<Point3d>(depthMapsPtsSimsTmpDir + std::to_string(mp->mip->getViewId(rc)) + "pts.bin");
+            loadArrayFromFile<Point3d>(depthMapsPtsSimsTmpDir + std::to_string(mp->getViewId(rc)) + "pts.bin");
         StaticVector<float>* sims =
-            loadArrayFromFile<float>(depthMapsPtsSimsTmpDir + std::to_string(mp->mip->getViewId(rc)) + "sims.bin");
+            loadArrayFromFile<float>(depthMapsPtsSimsTmpDir + std::to_string(mp->getViewId(rc)) + "sims.bin");
 
         // long tpts=initEstimate();
         for(int i = 0; i < pts->size(); i++)

--- a/src/aliceVision/fuseCut/ReconstructionPlan.cpp
+++ b/src/aliceVision/fuseCut/ReconstructionPlan.cpp
@@ -281,7 +281,7 @@ void reconstructSpaceAccordingToVoxelsArray(const std::string& voxelsArrayFileNa
             StaticVector<StaticVector<int>*>* ptsCams = delaunayGC.createPtsCams();
             StaticVector<int> usedCams = delaunayGC.getSortedUsedCams();
 
-            mesh::meshPostProcessing(mesh, ptsCams, usedCams, *ls->mp, *ls->pc, ls->mp->mip->mvDir, hexahsToExcludeFromResultingMesh, hexah);
+            mesh::meshPostProcessing(mesh, ptsCams, usedCams, *ls->mp, *ls->pc, ls->mp->mvDir, hexahsToExcludeFromResultingMesh, hexah);
             mesh->saveToBin(folderName + "mesh.bin");
             mesh->saveToObj(folderName + "mesh.obj");
 
@@ -449,7 +449,7 @@ mesh::Mesh* joinMeshes(const std::vector<std::string>& recsDirs, StaticVector<Po
         }
     }
 
-    // int gridLevel = ls->mp->mip->_ini.get<int>("LargeScale.gridLevel0", 0);
+    // int gridLevel = ls->mp->_ini.get<int>("LargeScale.gridLevel0", 0);
 
     if(ls->mp->verbose)
         ALICEVISION_LOG_DEBUG("Deleting...");
@@ -473,20 +473,20 @@ mesh::Mesh* joinMeshes(int gl, LargeScale* ls)
     ReconstructionPlan* rp =
         new ReconstructionPlan(ls->dimensions, &ls->space[0], ls->mp, ls->pc, ls->spaceVoxelsFolderName);
     std::string param = "LargeScale:gridLevel" + mvsUtils::num2str(gl);
-    int gridLevel = ls->mp->mip->_ini.get<int>(param.c_str(), gl * 300);
+    int gridLevel = ls->mp->_ini.get<int>(param.c_str(), gl * 300);
 
     std::string optimalReconstructionPlanFileName =
         ls->spaceFolderName + "optimalReconstructionPlan" + mvsUtils::num2str(gridLevel) + ".bin";
     StaticVector<SortedId>* optimalReconstructionPlan = loadArrayFromFile<SortedId>(optimalReconstructionPlanFileName);
 
-    auto subFolderName = ls->mp->mip->_ini.get<std::string>("LargeScale.subFolderName", "");
+    auto subFolderName = ls->mp->_ini.get<std::string>("LargeScale.subFolderName", "");
     if(subFolderName.empty())
     {
-        if(ls->mp->mip->_ini.get<bool>("global.LabatutCFG09", false))
+        if(ls->mp->_ini.get<bool>("global.LabatutCFG09", false))
         {
             subFolderName = "LabatutCFG09";
         }
-        if(ls->mp->mip->_ini.get<bool>("global.JancosekCVPR11", true))
+        if(ls->mp->_ini.get<bool>("global.JancosekCVPR11", true))
         {
             subFolderName = "JancosekCVPR11";
         }

--- a/src/aliceVision/fuseCut/VoxelsGrid.cpp
+++ b/src/aliceVision/fuseCut/VoxelsGrid.cpp
@@ -602,7 +602,7 @@ void VoxelsGrid::generateCamsPtsFromVoxelsTracks()
                 int rc = (*cams)[c];
 
                 // open camPtsFile for append
-                std::string camPtsFileName = spaceCamsTracksDir + "camPtsGrid_" + std::to_string(mp->mip->getViewId(rc)) + ".bin";
+                std::string camPtsFileName = spaceCamsTracksDir + "camPtsGrid_" + std::to_string(mp->getViewId(rc)) + ".bin";
                 FILE* fin = fopen(camPtsFileName.c_str(), "ab");
                 StaticVector<Pixel>* camPtsIds = (*camsTracksPoints)[rc];
                 for(int j = 0; j < sizeOfStaticVector<Pixel>(camPtsIds); j++)

--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -36,12 +36,11 @@ target_include_directories(aliceVision_image
 )
 
 target_link_libraries(aliceVision_image
-  PUBLIC
-  aliceVision_numeric
-  PRIVATE
-  ${OPENIMAGEIO_LIBRARIES}
-  ${LOG_LIB}
-  ${OPENEXR_LIBRARIES}
+  PUBLIC aliceVision_numeric
+         ${OPENIMAGEIO_LIBRARIES}
+
+  PRIVATE ${OPENEXR_LIBRARIES}
+          ${LOG_LIB}
 )
 
 set_target_properties(aliceVision_image

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -19,8 +19,6 @@
 #include <iostream>
 #include <cmath>
 
-namespace oiio = OIIO;
-
 namespace aliceVision {
 namespace image {
 
@@ -162,11 +160,16 @@ void readImage(const std::string& path, oiio::TypeDesc format, int nchannels, Im
 }
 
 template<typename T>
-void writeImage(const std::string& path, oiio::TypeDesc typeDesc, int nchannels, const Image<T>& image)
+void writeImage(const std::string& path,
+                oiio::TypeDesc typeDesc,
+                int nchannels,
+                const Image<T>& image,
+                const oiio::ParamValueList& metadata = oiio::ParamValueList())
 {
   bool isEXR = (path.size() > 4 && path.compare(path.size() - 4, 4, ".exr") == 0);
 
   oiio::ImageSpec imageSpec(image.Width(), image.Height(), nchannels, typeDesc);
+  imageSpec.extra_attribs = metadata; // add custom metadata
 
   if(isEXR)
   {
@@ -222,24 +225,24 @@ void readImage(const std::string& path, Image<RGBColor>& image)
   readImage(path, oiio::TypeDesc::UINT8, 3, image);
 }
 
-void writeImage(const std::string& path, const Image<unsigned char>& image)
+void writeImage(const std::string& path, const Image<unsigned char>& image, const oiio::ParamValueList& metadata)
 {
-  writeImage(path, oiio::TypeDesc::UINT8, 1, image);
+  writeImage(path, oiio::TypeDesc::UINT8, 1, image, metadata);
 }
 
-void writeImage(const std::string& path, const Image<RGBAColor>& image)
+void writeImage(const std::string& path, const Image<RGBAColor>& image, const oiio::ParamValueList& metadata)
 {
-  writeImage(path, oiio::TypeDesc::UINT8, 4, image);
+  writeImage(path, oiio::TypeDesc::UINT8, 4, image, metadata);
 }
 
-void writeImage(const std::string& path, const Image<RGBfColor>& image)
+void writeImage(const std::string& path, const Image<RGBfColor>& image, const oiio::ParamValueList& metadata)
 {
-  writeImage(path, oiio::TypeDesc::FLOAT, 3, image);
+  writeImage(path, oiio::TypeDesc::FLOAT, 3, image, metadata);
 }
 
-void writeImage(const std::string& path, const Image<RGBColor>& image)
+void writeImage(const std::string& path, const Image<RGBColor>& image, const oiio::ParamValueList& metadata)
 {
-  writeImage(path, oiio::TypeDesc::UINT8, 3, image);
+  writeImage(path, oiio::TypeDesc::UINT8, 3, image, metadata);
 }
 
 }  // namespace image

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -10,7 +10,11 @@
 #include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/pixelTypes.hpp>
 
+#include <OpenImageIO/paramlist.h>
+
 #include <string>
+
+namespace oiio = OIIO;
 
 namespace aliceVision {
 namespace image {
@@ -87,10 +91,10 @@ void readImage(const std::string& path, Image<RGBColor>& image);
  * @param[in] path The given path to the image
  * @param[in] image The output image buffer
  */
-void writeImage(const std::string& path, const Image<unsigned char>& image);
-void writeImage(const std::string& path, const Image<RGBAColor>& image);
-void writeImage(const std::string& path, const Image<RGBfColor>& image);
-void writeImage(const std::string& path, const Image<RGBColor>& image);
+void writeImage(const std::string& path, const Image<unsigned char>& image, const oiio::ParamValueList& metadata = oiio::ParamValueList());
+void writeImage(const std::string& path, const Image<RGBAColor>& image, const oiio::ParamValueList& metadata = oiio::ParamValueList());
+void writeImage(const std::string& path, const Image<RGBfColor>& image, const oiio::ParamValueList& metadata = oiio::ParamValueList());
+void writeImage(const std::string& path, const Image<RGBColor>& image, const oiio::ParamValueList& metadata = oiio::ParamValueList());
 
 }  // namespace image
 }  // namespace aliceVision

--- a/src/aliceVision/matching/kvld/CMakeLists.txt
+++ b/src/aliceVision/matching/kvld/CMakeLists.txt
@@ -21,6 +21,10 @@ set_target_properties(aliceVision_kvld
   VERSION "${ALICEVISION_VERSION_MAJOR}.${ALICEVISION_VERSION_MINOR}"
 )
 
+target_link_libraries(aliceVision_kvld
+  PUBLIC aliceVision_image
+)
+
 set_property(TARGET aliceVision_kvld
   PROPERTY FOLDER AliceVision/AliceVision
 )

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -183,8 +183,8 @@ void Mesh::addMesh(Mesh* me)
 
 Mesh::triangle_proj Mesh::getTriangleProjection(int triid, const mvsUtils::MultiViewParams* mp, int rc, int w, int h) const
 {
-    int ow = mp->mip->getWidth(rc);
-    int oh = mp->mip->getHeight(rc);
+    int ow = mp->getWidth(rc);
+    int oh = mp->getHeight(rc);
 
     triangle_proj tp;
     for(int j = 0; j < 3; j++)
@@ -976,8 +976,8 @@ StaticVector<int>* Mesh::getVisibleTrianglesIndexes(std::string depthMapFileName
 
 StaticVector<int>* Mesh::getVisibleTrianglesIndexes(std::string tmpDir, const mvsUtils::MultiViewParams* mp, int rc, int w, int h)
 {
-    std::string depthMapFileName = tmpDir + "depthMap" + std::to_string(mp->mip->getViewId(rc)) + ".bin";
-    std::string trisMapFileName = tmpDir + "trisMap" + std::to_string(mp->mip->getViewId(rc)) + ".bin";
+    std::string depthMapFileName = tmpDir + "depthMap" + std::to_string(mp->getViewId(rc)) + ".bin";
+    std::string trisMapFileName = tmpDir + "trisMap" + std::to_string(mp->getViewId(rc)) + ".bin";
 
     StaticVector<float>* depthMap = loadArrayFromFile<float>(depthMapFileName);
     StaticVector<StaticVector<int>*>* trisMap = loadArrayOfArraysFromFile<int>(trisMapFileName);
@@ -993,8 +993,8 @@ StaticVector<int>* Mesh::getVisibleTrianglesIndexes(std::string tmpDir, const mv
 StaticVector<int>* Mesh::getVisibleTrianglesIndexes(StaticVector<float>* depthMap, const mvsUtils::MultiViewParams* mp, int rc,
                                                        int w, int h)
 {
-    int ow = mp->mip->getWidth(rc);
-    int oh = mp->mip->getHeight(rc);
+    int ow = mp->getWidth(rc);
+    int oh = mp->getHeight(rc);
 
     StaticVector<int>* out = new StaticVector<int>();
     out->reserve(tris->size());
@@ -1024,8 +1024,8 @@ StaticVector<int>* Mesh::getVisibleTrianglesIndexes(StaticVector<StaticVector<in
                                                        StaticVector<float>* depthMap, const mvsUtils::MultiViewParams* mp, int rc,
                                                        int w, int h)
 {
-    int ow = mp->mip->getWidth(rc);
-    int oh = mp->mip->getHeight(rc);
+    int ow = mp->getWidth(rc);
+    int oh = mp->getHeight(rc);
 
     StaticVectorBool* btris = new StaticVectorBool();
     btris->reserve(tris->size());
@@ -1813,8 +1813,8 @@ int Mesh::subdivideMesh(const mvsUtils::MultiViewParams* mp, float maxTriArea, f
             for(int j = 0; j < sizeOfStaticVector<int>((*trisCams)[tcid]); j++)
             {
                 int rc = (*(*trisCams)[tcid])[j];
-                int w = mp->mip->getWidth(rc);
-                int h = mp->mip->getHeight(rc);
+                int w = mp->getWidth(rc);
+                int h = mp->getHeight(rc);
                 triangle_proj tp = getTriangleProjection(i, mp, rc, w, h);
                 if(computeTriangleProjectionArea(tp) > maxTriArea)
                 {
@@ -2050,7 +2050,7 @@ StaticVector<StaticVector<int>*>* Mesh::computeTrisCams(const mvsUtils::MultiVie
     long t1 = mvsUtils::initEstimate();
     for(int rc = 0; rc < mp->ncams; ++rc)
     {
-        std::string visTrisFileName = tmpDir + "visTris" + std::to_string(mp->mip->getViewId(rc)) + ".bin";
+        std::string visTrisFileName = tmpDir + "visTris" + std::to_string(mp->getViewId(rc)) + ".bin";
         StaticVector<int>* visTris = loadArrayFromFile<int>(visTrisFileName);
         if(visTris != nullptr)
         {
@@ -2082,7 +2082,7 @@ StaticVector<StaticVector<int>*>* Mesh::computeTrisCams(const mvsUtils::MultiVie
     t1 = mvsUtils::initEstimate();
     for(int rc = 0; rc < mp->ncams; ++rc)
     {
-        std::string visTrisFileName = tmpDir + "visTris" + std::to_string(mp->mip->getViewId(rc)) + ".bin";
+        std::string visTrisFileName = tmpDir + "visTris" + std::to_string(mp->getViewId(rc)) + ".bin";
         StaticVector<int>* visTris = loadArrayFromFile<int>(visTrisFileName);
         if(visTris != nullptr)
         {
@@ -2140,8 +2140,8 @@ void Mesh::initFromDepthMap(const mvsUtils::MultiViewParams* mp, float* depthMap
 void Mesh::initFromDepthMap(int stepDetail, const mvsUtils::MultiViewParams* mp, float* depthMap, int rc, int scale, int step,
                                float alpha)
 {
-    int w = mp->mip->getWidth(rc) / (scale * step);
-    int h = mp->mip->getHeight(rc) / (scale * step);
+    int w = mp->getWidth(rc) / (scale * step);
+    int h = mp->getHeight(rc) / (scale * step);
 
     pts = new StaticVector<Point3d>();
     pts->reserve(w * h);

--- a/src/aliceVision/mesh/MeshEnergyOpt.cpp
+++ b/src/aliceVision/mesh/MeshEnergyOpt.cpp
@@ -16,7 +16,7 @@ namespace bfs = boost::filesystem;
 MeshEnergyOpt::MeshEnergyOpt(mvsUtils::MultiViewParams* _mp)
     : MeshAnalyze(_mp)
 {
-//    tmpDir = mp->mip->mvDir + "meshEnergyOpt/";
+//    tmpDir = mp->mvDir + "meshEnergyOpt/";
 //    bfs::create_directory(tmpDir);
 }
 
@@ -137,7 +137,7 @@ bool MeshEnergyOpt::optimizeSmooth(float lambda, float epsilon, int type, int ni
         return false;
     }
 
-    bool saveDebug = mp ? mp->mip->_ini.get<bool>("meshEnergyOpt.saveAllIterations", false) : false;
+    bool saveDebug = mp ? mp->_ini.get<bool>("meshEnergyOpt.saveAllIterations", false) : false;
 
     Point3d LU, RD;
     LU = (*pts)[0];
@@ -163,7 +163,7 @@ bool MeshEnergyOpt::optimizeSmooth(float lambda, float epsilon, int type, int ni
         ALICEVISION_LOG_INFO("Optimizing mesh smooth: iteration " << i);
         updateGradientParallel(lambda, epsilon, type, LU, RD, ptsCanMove);
         if(saveDebug)
-            saveToObj(mp->mip->mvDir + "mesh_smoothed_" + std::to_string(i) + ".obj");
+            saveToObj(mp->mvDir + "mesh_smoothed_" + std::to_string(i) + ".obj");
     }
 
     return true;

--- a/src/aliceVision/mesh/UVAtlas.cpp
+++ b/src/aliceVision/mesh/UVAtlas.cpp
@@ -52,7 +52,7 @@ void UVAtlas::createCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp,
         {
             int cameraID = (*cameras)[c];
             // project triangle
-            Mesh::triangle_proj tp = _mesh.getTriangleProjection(i, &mp, cameraID, mp.mip->getWidth(cameraID), mp.mip->getHeight(cameraID));
+            Mesh::triangle_proj tp = _mesh.getTriangleProjection(i, &mp, cameraID, mp.getWidth(cameraID), mp.getHeight(cameraID));
             if(!mp.isPixelInImage(Pixel(tp.tp2ds[0]), 10, cameraID)
                     || !mp.isPixelInImage(Pixel(tp.tp2ds[1]), 10, cameraID)
                     || !mp.isPixelInImage(Pixel(tp.tp2ds[2]), 10, cameraID))
@@ -187,7 +187,7 @@ void UVAtlas::finalizeCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& m
         auto it = c.triangleIDs.begin();
         while(it != c.triangleIDs.end())
         {
-            Mesh::triangle_proj tp = _mesh.getTriangleProjection(*it, &mp, c.refCameraID, mp.mip->getWidth(c.refCameraID), mp.mip->getHeight(c.refCameraID));
+            Mesh::triangle_proj tp = _mesh.getTriangleProjection(*it, &mp, c.refCameraID, mp.getWidth(c.refCameraID), mp.getHeight(c.refCameraID));
             c.sourceLU.x = min(c.sourceLU.x, tp.lu.x);
             c.sourceLU.y = min(c.sourceLU.y, tp.lu.y);
             c.sourceRD.x = max(c.sourceRD.x, tp.rd.x);

--- a/src/aliceVision/mesh/meshPostProcessing.cpp
+++ b/src/aliceVision/mesh/meshPostProcessing.cpp
@@ -46,18 +46,18 @@ void meshPostProcessing(Mesh*& inout_mesh, StaticVector<StaticVector<int>*>*& in
     ALICEVISION_LOG_INFO("Mesh post-processing.");
 
 
-    bool exportDebug = (float)mp.mip->_ini.get<bool>("delaunaycut.exportDebugGC", false);
+    bool exportDebug = (float)mp._ini.get<bool>("delaunaycut.exportDebugGC", false);
 
     if(exportDebug)
         inout_mesh->saveToObj(resultFolderName + "rawGraphCut.obj");
 
     const auto doRemoveHugeTriangles =
-            mp.mip->_ini.get<bool>("hallucinationsFiltering.doRemoveHugeTriangles", false);
+            mp._ini.get<bool>("hallucinationsFiltering.doRemoveHugeTriangles", false);
 
     if(doRemoveHugeTriangles)
     {
         filterLargeEdgeTriangles(
-            inout_mesh, (float)mp.mip->_ini.get<double>("hallucinationsFiltering.NbAverageEdgeLength", 60.0));
+            inout_mesh, (float)mp._ini.get<double>("hallucinationsFiltering.NbAverageEdgeLength", 60.0));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -69,14 +69,14 @@ void meshPostProcessing(Mesh*& inout_mesh, StaticVector<StaticVector<int>*>*& in
 
         //!!!!!!!!!!!!!
         bool doRemoveTrianglesInhexahsToExcludeFromResultingMesh =
-            (bool)mp.mip->_ini.get<bool>("LargeScale.doRemoveTrianglesInhexahsToExcludeFromResultingMesh",
+            (bool)mp._ini.get<bool>("LargeScale.doRemoveTrianglesInhexahsToExcludeFromResultingMesh",
                                        false);
         if(doRemoveTrianglesInhexahsToExcludeFromResultingMesh && hexahsToExcludeFromResultingMesh)
         {
             inout_mesh->removeTrianglesInHexahedrons(hexahsToExcludeFromResultingMesh);
         }
 
-        const auto doLeaveLargestFullSegmentOnly = (bool)mp.mip->_ini.get<bool>("hallucinationsFiltering.doLeaveLargestFullSegmentOnly", false);
+        const auto doLeaveLargestFullSegmentOnly = (bool)mp._ini.get<bool>("hallucinationsFiltering.doLeaveLargestFullSegmentOnly", false);
         if(doLeaveLargestFullSegmentOnly)
         {
             StaticVector<int>* trisIdsToStay = inout_mesh->getLargestConnectedComponentTrisIds(mp);
@@ -142,13 +142,13 @@ void meshPostProcessing(Mesh*& inout_mesh, StaticVector<StaticVector<int>*>*& in
         }
 
         /////////////////////////////
-        bool doSubdivideMesh = mp.mip->_ini.get<bool>("meshEnergyOpt.doSubdivideMesh", false);
+        bool doSubdivideMesh = mp._ini.get<bool>("meshEnergyOpt.doSubdivideMesh", false);
         if(doSubdivideMesh == true)
         {
             float subdivideMeshNTimesAvEdgeLengthThr =
-                (float)mp.mip->_ini.get<double>("meshEnergyOpt.doSubdivideMesh", 20.0);
+                (float)mp._ini.get<double>("meshEnergyOpt.doSubdivideMesh", 20.0);
             int subdivideMaxPtsThr =
-                mp.mip->_ini.get<int>("meshEnergyOpt.subdivideMaxPtsThr", 6000000);
+                mp._ini.get<int>("meshEnergyOpt.subdivideMaxPtsThr", 6000000);
 
             meOpt->subdivideMeshMaxEdgeLengthUpdatePtsCams(&mp, subdivideMeshNTimesAvEdgeLengthThr *
                                                                               meOpt->computeAverageEdgeLength(),
@@ -191,14 +191,14 @@ void meshPostProcessing(Mesh*& inout_mesh, StaticVector<StaticVector<int>*>*& in
 
         /////////////////////////////
         bool doSmoothMesh =
-            mp.mip->_ini.get<bool>("meshEnergyOpt.doSmoothMesh", true);
-        int smoothNIter = mp.mip->_ini.get<int>("meshEnergyOpt.smoothNbIterations", 10);
+            mp._ini.get<bool>("meshEnergyOpt.doSmoothMesh", true);
+        int smoothNIter = mp._ini.get<int>("meshEnergyOpt.smoothNbIterations", 10);
         if(doSmoothMesh && smoothNIter != 0)
         {
             ALICEVISION_LOG_INFO("Mesh smoothing.");
-            float lambda = (float)mp.mip->_ini.get<double>("meshEnergyOpt.lambda", 1.0f);
-            float epsilon = (float)mp.mip->_ini.get<double>("meshEnergyOpt.epsilon", 0.1f); // unused in type 3
-            int type = mp.mip->_ini.get<int>("meshEnergyOpt.smoothType", 3); // 0, 1, 2, 3, 4 => only 1 and 3 works
+            float lambda = (float)mp._ini.get<double>("meshEnergyOpt.lambda", 1.0f);
+            float epsilon = (float)mp._ini.get<double>("meshEnergyOpt.epsilon", 0.1f); // unused in type 3
+            int type = mp._ini.get<int>("meshEnergyOpt.smoothType", 3); // 0, 1, 2, 3, 4 => only 1 and 3 works
             meOpt->optimizeSmooth(lambda, epsilon, type, smoothNIter, ptsCanMove);
 
             if(exportDebug)

--- a/src/aliceVision/mvsUtils/ImagesCache.cpp
+++ b/src/aliceVision/mvsUtils/ImagesCache.cpp
@@ -13,8 +13,8 @@ namespace mvsUtils {
 int ImagesCache::getPixelId(int x, int y, int imgid)
 {
     if(!transposed)
-        return x * mp->mip->getHeight(imgid) + y;
-    return y * mp->mip->getWidth(imgid) + x;
+        return x * mp->getHeight(imgid) + y;
+    return y * mp->getWidth(imgid) + x;
 }
 
 ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType, bool _transposed)
@@ -23,7 +23,7 @@ ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType, bool _transp
     std::vector<std::string> _imagesNames;
     for(int rc = 0; rc < _mp->ncams; rc++)
     {
-        _imagesNames.push_back(mv_getFileNamePrefix(_mp->mip->mvDir, _mp->mip, rc) + "." + _mp->mip->imageExt);
+        _imagesNames.push_back(mv_getFileNamePrefix(_mp->mvDir, _mp, rc) + "." + _mp->getImageExtension());
     }
     initIC(_bandType, _imagesNames, _transposed);
 }
@@ -38,9 +38,9 @@ ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType, std::vector<
 void ImagesCache::initIC(int _bandType, std::vector<std::string>& _imagesNames,
                              bool _transposed)
 {
-    float oneimagemb = (sizeof(Color) * mp->mip->getMaxImageWidth() * mp->mip->getMaxImageHeight()) / 1024.f / 1024.f;
-    float maxmbCPU = (float)mp->mip->_ini.get<int>("images_cache.maxmbCPU", 5000);
-    int _npreload = std::max((int)(maxmbCPU / oneimagemb), mp->mip->_ini.get<int>("grow.minNumOfConsistentCams", 10));
+    float oneimagemb = (sizeof(Color) * mp->getMaxImageWidth() * mp->getMaxImageHeight()) / 1024.f / 1024.f;
+    float maxmbCPU = (float)mp->_ini.get<int>("images_cache.maxmbCPU", 5000);
+    int _npreload = std::max((int)(maxmbCPU / oneimagemb), mp->_ini.get<int>("grow.minNumOfConsistentCams", 10));
     N_PRELOADED_IMAGES = std::min(mp->ncams, _npreload);
 
     transposed = _transposed;
@@ -109,12 +109,12 @@ void ImagesCache::refreshData(int camId)
         long t1 = clock();
         if (imgs[mapId] == nullptr)
         {
-            size_t maxsize = mp->mip->getMaxImageWidth() * mp->mip->getMaxImageHeight();
-            imgs[mapId] = new Color[maxsize];
+            const std::size_t maxSize = mp->getMaxImageWidth() * mp->getMaxImageHeight();
+            imgs[mapId] = new Color[maxSize];
         }
 
         std::string imagePath = imagesNames.at(camId);
-        memcpyRGBImageFromFileToArr(camId, imgs[mapId], imagePath, mp->mip, transposed, 1, bandType);
+        memcpyRGBImageFromFileToArr(camId, imgs[mapId], imagePath, mp, transposed, bandType);
 
         if(mp->verbose)
         {

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -26,14 +26,7 @@ namespace mvsUtils {
 
 namespace bfs = boost::filesystem;
 
-MultiViewInputParams::MultiViewInputParams(const std::string& file, const std::string& depthMapFolder, const std::string& depthMapFilterFolder)
-{
-    initFromConfigFile(file);
-    _depthMapFolder = depthMapFolder + "/";
-    _depthMapFilterFolder = depthMapFilterFolder + "/";
-}
-
-void MultiViewInputParams::initFromConfigFile(const std::string& iniFile)
+void MultiViewParams::initFromConfigFile(const std::string& iniFile)
 {
     boost::property_tree::ini_parser::read_ini(iniFile, _ini);
     // debug, dump the read ini file to cout
@@ -42,16 +35,17 @@ void MultiViewInputParams::initFromConfigFile(const std::string& iniFile)
     // initialize directory names
     const auto rootPath = bfs::path(iniFile).parent_path().string() + "/";
     mvDir = rootPath;
-    _depthMapFolder = (bfs::path(rootPath) / "depthMap").string();
-    _depthMapFilterFolder = (bfs::path(rootPath) / "depthMapFilter").string();
-
-    imageExt = _ini.get<std::string>("global.imgExt", imageExt);
     prefix = _ini.get<std::string>("global.prefix", prefix);
+    verbose = _ini.get<bool>("global.verbose", true);
+    CUDADeviceNo = _ini.get<int>("global.CUDADeviceNo", 0);
+    ncams = _ini.get<int>("global.ncams", 0);
+    simThr = _ini.get<double>("global.simThr", 0.0);
+    _imageExt = _ini.get<std::string>("global.imgExt", _imageExt);
+    _useSil = _ini.get<bool>("global.use_silhouettes", _useSil);
 
-    usesil = _ini.get<bool>("global.use_silhouettes", usesil);
-    int ncams = _ini.get<int>("global.ncams", 0);
     assert(ncams > 0);
-    // Load image uid and dimensions
+
+    // load image uid and dimensions
     std::set<std::pair<int, int>> dimensions;
     {
         boost::optional<boost::property_tree::ptree&> cameras = _ini.get_child_optional("imageResolutions");
@@ -67,40 +61,88 @@ void MultiViewInputParams::initFromConfigFile(const std::string& iniFile)
             boost::split(valuesVec, values, boost::algorithm::is_any_of("x"));
             if(valuesVec.size() != 2)
                 throw std::runtime_error("Error when loading image sizes from INI file.");
-            imageParams imgParams(std::stoi(v.first), boost::lexical_cast<int>(valuesVec[0]), boost::lexical_cast<int>(valuesVec[1]));
+
+            imageParams imgParams(std::stoi(v.first),
+                                  boost::lexical_cast<int>(valuesVec[0]),
+                                  boost::lexical_cast<int>(valuesVec[1]));
+
             _imagesParams.push_back(imgParams);
-            maxImageWidth = std::max(maxImageWidth, imgParams.width);
-            maxImageHeight = std::max(maxImageHeight, imgParams.height);
             dimensions.emplace(imgParams.width, imgParams.height);
         }
     }
+
     if(getNbCameras() != ncams)
         throw std::runtime_error("Incoherent number of cameras.");
+
     ALICEVISION_LOG_INFO("Found " << dimensions.size() << " image dimension(s): ");
     for(const auto& dim : dimensions)
         ALICEVISION_LOG_INFO(" - [" << dim.first << "x" << dim.second << "]");
-    ALICEVISION_LOG_INFO("Overall maximum dimension: [" << maxImageWidth << "x" << maxImageHeight << "]");
 }
 
-MultiViewParams::MultiViewParams(int _ncams, MultiViewInputParams* _mip, float _simThr,
+
+
+MultiViewParams::MultiViewParams(const std::string& iniFile,
+                                 const std::string& depthMapFolder,
+                                 const std::string& depthMapFilterFolder,
+                                 bool readFromDepthMaps,
+                                 int downscale,
                                  StaticVector<CameraMatrices>* cameras)
+    : _depthMapFolder(depthMapFolder + "/")
+    , _depthMapFilterFolder(depthMapFilterFolder + "/")
+    , _processDownscale(downscale)
 {
-    mip = _mip;
+    // Parse the .ini file
+    initFromConfigFile(iniFile);
 
-    verbose = (bool)mip->_ini.get<bool>("global.verbose", true);
-    CUDADeviceNo = mip->_ini.get<int>("global.CUDADeviceNo", 0);
-
-    simThr = _simThr;
-
-    resizeCams(_ncams);
+    // Resize internal structures
+    resizeCams(getNbCameras());
 
     long t1 = initEstimate();
+
     for(int i = 0; i < ncams; ++i)
     {
+        std::string path;
+
+        if(!readFromDepthMaps)
+            path = mv_getFileNamePrefix(mvDir, this, i) + "." + _imageExt;
+        else
+            path = mv_getFileName(this, i, mvsUtils::EFileType::depthMap, 1);
+
+        oiio::ParamValueList metadata;
+        imageIO::readImageMetadata(path, metadata);
+
+        const auto scaleIt = metadata.find("AliceVision:downscale");
+        const auto pIt = metadata.find("AliceVision:P");
+
+        // find image scale information
+        if(scaleIt != metadata.end() && scaleIt->type() == oiio::TypeDesc::INT)
+        {
+            // use aliceVision image metadata
+            _imagesScale.at(i) = scaleIt->get_int();
+        }
+        else
+        {
+            // use image dimension
+            ALICEVISION_LOG_WARNING("Reading '" << path << "' downscale from file dimension" << std::endl
+                                  << "No 'AliceVision:downscale' metadata found.");
+            int w, h, channels;
+            imageIO::readImageSpec(path, w, h, channels);
+            const imageParams& imgParams = _imagesParams.at(i);
+            const int widthScale = imgParams.width / w;
+            const int heightScale = imgParams.height / h;
+
+            if(widthScale != heightScale)
+              throw std::runtime_error("Can't find image scale of file: '" + path + "'");
+
+            _imagesScale.at(i) = widthScale;
+        }
+
         FocK1K2Arr[i] = Point3d(-1.0f, -1.0f, -1.0f);
 
+        // load camera matrices
         if(cameras != nullptr)
         {
+            // use constructor cameras input parameter
             camArr[i] = (*cameras)[i].P;
             KArr[i] = (*cameras)[i].K;
             RArr[i] = (*cameras)[i].R;
@@ -110,23 +152,45 @@ MultiViewParams::MultiViewParams(int _ncams, MultiViewInputParams* _mip, float _
             iCamArr[i] = (*cameras)[i].iCam;
             FocK1K2Arr[i] = Point3d((*cameras)[i].f, (*cameras)[i].k1, (*cameras)[i].k2);
         }
+        else if(pIt != metadata.end() && pIt->type() == oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::MATRIX44))
+        {
+            // use aliceVision image metadata
+            Matrix3x4& pMatrix = camArr.at(i);
+            std::copy_n(static_cast<const double*>(pIt->data()), 12, pMatrix.m);
+
+            // apply scale to camera matrix (camera matrix is scale 1)
+            const int imgScale = _imagesScale.at(i) * _processDownscale;
+            for(int i=0; i< 8; ++i)
+              pMatrix.m[i] /= static_cast<double>(imgScale);
+
+            pMatrix.decomposeProjectionMatrix(KArr.at(i), RArr.at(i), CArr.at(i));
+            iKArr.at(i) = KArr.at(i).inverse();
+            iRArr.at(i) = RArr.at(i).inverse();
+            iCamArr.at(i) = iRArr.at(i) * iKArr.at(i);
+        }
         else
         {
-            std::string fileNameP = mv_getFileName(mip, i, EFileType::P);
-            std::string fileNameD = mv_getFileName(mip, i, EFileType::D);
+            // use P matrix file
+            std::string fileNameP = mv_getFileName(this, i, EFileType::P);
+            std::string fileNameD = mv_getFileName(this, i, EFileType::D);
+
+            ALICEVISION_LOG_WARNING("Reading " << getViewId(i) << " P matrix from file '" << fileNameP << "'" << std::endl
+                                    << "No 'AliceVision:P' metadata found.");
+
             loadCameraFile(i, fileNameP, fileNameD);
         }
 
-        if(KArr[i].m11 > (float)(mip->getWidth(i) * 100))
+
+        if(KArr[i].m11 > (float)(getWidth(i) * 100))
         {
             ALICEVISION_LOG_WARNING("Camera " << i << " at infinity ... setting to zero");
 
-            KArr[i].m11 = mip->getWidth(i) / 2;
+            KArr[i].m11 = getWidth(i) / 2;
             KArr[i].m12 = 0;
-            KArr[i].m13 = mip->getWidth(i) / 2;
+            KArr[i].m13 = getWidth(i) / 2;
             KArr[i].m21 = 0;
-            KArr[i].m22 = mip->getHeight(i) / 2;
-            KArr[i].m23 = mip->getHeight(i) / 2;
+            KArr[i].m22 = getHeight(i) / 2;
+            KArr[i].m23 = getHeight(i) / 2;
             KArr[i].m31 = 0;
             KArr[i].m32 = 0;
             KArr[i].m33 = 1;
@@ -160,23 +224,23 @@ MultiViewParams::MultiViewParams(int _ncams, MultiViewInputParams* _mip, float _
             camArr[i] = KArr[i] * (RArr[i] | (Point3d(0.0, 0.0, 0.0) - RArr[i] * CArr[i]));
         }
 
+        // find max width and max height
+        _maxImageWidth = std::max(_maxImageWidth, getWidth(i));
+        _maxImageHeight = std::max(_maxImageHeight, getHeight(i));
+
         printfEstimate(i, ncams, t1);
     }
-    finishEstimate();
 
-    g_border = 10;
-    g_maxPlaneNormalViewDirectionAngle = 70;
+    ALICEVISION_LOG_INFO("Overall maximum dimension: [" << _maxImageWidth << "x" << _maxImageHeight << "]");
+    finishEstimate();
 }
 
 
 void MultiViewParams::loadCameraFile(int i, const std::string& fileNameP, const std::string& fileNameD)
 {
-    // std::cout << "MultiViewParams::loadCameraFile: " << fileNameP << std::endl;
-
     if(!FileExists(fileNameP))
-    {
         throw std::runtime_error(std::string("mv_multiview_params: no such file: ") + fileNameP);
-    }
+
     FILE* f = fopen(fileNameP.c_str(), "r");
     char fc;
     fscanf(f, "%c", &fc);
@@ -194,10 +258,18 @@ void MultiViewParams::loadCameraFile(int i, const std::string& fileNameP, const 
         fclose(f);
         f = fopen(fileNameP.c_str(), "r");
     }
-    camArr[i] = load3x4MatrixFromFile(f);
+
+    Matrix3x4& pMatrix = camArr.at(i);
+
+    pMatrix = load3x4MatrixFromFile(f);
     fclose(f);
 
-    camArr[i].decomposeProjectionMatrix(KArr[i], RArr[i], CArr[i]);
+    // apply scale to camera matrix (camera matrix is scale 1)
+    const int imgScale = _imagesScale.at(i) * _processDownscale;
+    for(int i=0; i< 8; ++i)
+      pMatrix.m[i] /= static_cast<double>(imgScale);
+
+    pMatrix.decomposeProjectionMatrix(KArr[i], RArr[i], CArr[i]);
     iKArr[i] = KArr[i].inverse();
     iRArr[i] = RArr[i].inverse();
     iCamArr[i] = iRArr[i] * iKArr[i];
@@ -211,9 +283,7 @@ void MultiViewParams::loadCameraFile(int i, const std::string& fileNameP, const 
 }
 
 MultiViewParams::~MultiViewParams()
-{
-    mip = nullptr;
-}
+{}
 
 bool MultiViewParams::is3DPointInFrontOfCam(const Point3d* X, int rc) const
 {
@@ -377,12 +447,12 @@ float MultiViewParams::getCamsMinPixelSize(const Point3d& x0, StaticVector<int>&
 
 bool MultiViewParams::isPixelInImage(const Pixel& pix, int d, int camId) const
 {
-    return ((pix.x >= d) && (pix.x < mip->getWidth(camId) - d) && (pix.y >= d) && (pix.y < mip->getHeight(camId) - d));
+    return ((pix.x >= d) && (pix.x < getWidth(camId) - d) && (pix.y >= d) && (pix.y < getHeight(camId) - d));
 }
 bool MultiViewParams::isPixelInImage(const Pixel& pix, int camId) const
 {
-    return ((pix.x >= g_border) && (pix.x < mip->getWidth(camId) - g_border) && (pix.y >= g_border) &&
-            (pix.y < mip->getHeight(camId) - g_border));
+    return ((pix.x >= g_border) && (pix.x < getWidth(camId) - g_border) && (pix.y >= g_border) &&
+            (pix.y < getHeight(camId) - g_border));
 }
 
 bool MultiViewParams::isPixelInImage(const Point2d& pix, int camId) const

--- a/src/aliceVision/mvsUtils/PreMatchCams.cpp
+++ b/src/aliceVision/mvsUtils/PreMatchCams.cpp
@@ -18,8 +18,8 @@ namespace mvsUtils {
 PreMatchCams::PreMatchCams(MultiViewParams* _mp)
 {
     mp = _mp;
-    minang = (float)mp->mip->_ini.get<double>("prematching.minAngle", 2.0);
-    maxang = (float)mp->mip->_ini.get<double>("prematching.maxAngle", 70.0); // WARNING: may be too low, especially when using seeds from SFM
+    minang = (float)mp->_ini.get<double>("prematching.minAngle", 2.0);
+    maxang = (float)mp->_ini.get<double>("prematching.maxAngle", 70.0); // WARNING: may be too low, especially when using seeds from SFM
     minCamsDistance = computeMinCamsDistance();
 }
 
@@ -50,7 +50,7 @@ bool PreMatchCams::overlap(int rc, int tc)
         return false;
     }
 
-    Point2d rmid = Point2d((float)mp->mip->getWidth(rc) / 2.0f, (float)mp->mip->getHeight(rc) / 2.0f);
+    Point2d rmid = Point2d((float)mp->getWidth(rc) / 2.0f, (float)mp->getHeight(rc) / 2.0f);
     Point2d pFromTar, pToTar;
 
     if(!getTarEpipolarDirectedLine(&pFromTar, &pToTar, rmid, rc, tc, mp))
@@ -119,7 +119,7 @@ StaticVector<int> PreMatchCams::findNearestCams(int rc, int _nnearestcams)
 
 StaticVector<int>* PreMatchCams::precomputeIncidentMatrixCamsFromSeeds()
 {
-    std::string fn = mp->mip->mvDir + "camsPairsMatrixFromSeeds.bin";
+    std::string fn = mp->mvDir + "camsPairsMatrixFromSeeds.bin";
     if(FileExists(fn))
     {
         ALICEVISION_LOG_INFO("Camera pairs matrix file already computed: " << fn);
@@ -132,7 +132,7 @@ StaticVector<int>* PreMatchCams::precomputeIncidentMatrixCamsFromSeeds()
     for(int rc = 0; rc < mp->ncams; ++rc)
     {
         StaticVector<SeedPoint>* seeds;
-        loadSeedsFromFile(&seeds, rc, mp->mip, EFileType::seeds);
+        loadSeedsFromFile(&seeds, rc, mp, EFileType::seeds);
         for(int i = 0; i < seeds->size(); i++)
         {
             SeedPoint* sp = &(*seeds)[i];
@@ -150,7 +150,7 @@ StaticVector<int>* PreMatchCams::precomputeIncidentMatrixCamsFromSeeds()
 
 StaticVector<int>* PreMatchCams::loadCamPairsMatrix()
 {
-    std::string fn = mp->mip->mvDir + "camsPairsMatrixFromSeeds.bin"; // TODO: store this filename at one place
+    std::string fn = mp->mvDir + "camsPairsMatrixFromSeeds.bin"; // TODO: store this filename at one place
     if(!FileExists(fn))
         throw std::runtime_error("Missing camera pairs matrix file (see --computeCamPairs): " + fn);
     return loadArrayFromFile<int>(fn);
@@ -160,7 +160,7 @@ StaticVector<int>* PreMatchCams::loadCamPairsMatrix()
 StaticVector<int> PreMatchCams::findNearestCamsFromSeeds(int rc, int nnearestcams)
 {
     StaticVector<int> out;
-    std::string tarCamsFile = mp->mip->mvDir + "_tarCams/" + num2strFourDecimal(rc) + ".txt";
+    std::string tarCamsFile = mp->mvDir + "_tarCams/" + num2strFourDecimal(rc) + ".txt";
     if(FileExists(tarCamsFile))
     {
         FILE* f = fopen(tarCamsFile.c_str(), "r");
@@ -239,7 +239,7 @@ StaticVector<int> PreMatchCams::findCamsWhichIntersectsHexahedron(const Point3d 
     {
         float mindepth, maxdepth;
         StaticVector<int>* pscams;
-        if(getDepthMapInfo(rc, mp->mip, mindepth, maxdepth, &pscams))
+        if(getDepthMapInfo(rc, mp, mindepth, maxdepth, &pscams))
         {
             delete pscams;
             Point3d rchex[8];

--- a/src/aliceVision/mvsUtils/common.cpp
+++ b/src/aliceVision/mvsUtils/common.cpp
@@ -35,8 +35,8 @@ bool get2dLineImageIntersection(Point2d* pFrom, Point2d* pTo, Point2d linePoint1
     float c = -a * linePoint1.x - b * linePoint1.y;
 
     int intersections = 0;
-    float rw = (float)mp->mip->getWidth(camId);
-    float rh = (float)mp->mip->getHeight(camId);
+    float rw = (float)mp->getWidth(camId);
+    float rh = (float)mp->getHeight(camId);
 
     // ax + by + c = 0
 
@@ -303,8 +303,8 @@ void getHexahedronTriangles(Point3d tris[12][3], const Point3d hexah[8])
 // hexahedron format ... 0-3 frontal face, 4-7 back face
 void getCamHexahedron(const MultiViewParams* mp, Point3d hexah[8], int cam, float mind, float maxd)
 {
-    float w = (float)mp->mip->getWidth(cam);
-    float h = (float)mp->mip->getHeight(cam);
+    float w = (float)mp->getWidth(cam);
+    float h = (float)mp->getHeight(cam);
     hexah[0] = mp->CArr[cam] + (mp->iCamArr[cam] * Point2d(0.0f, 0.0f)).normalize() * mind;
     hexah[4] = mp->CArr[cam] + (mp->iCamArr[cam] * Point2d(0.0f, 0.0f)).normalize() * maxd;
     hexah[1] = mp->CArr[cam] + (mp->iCamArr[cam] * Point2d(w, 0.0f)).normalize() * mind;
@@ -651,13 +651,13 @@ StaticVector<StaticVector<Pixel>*>* convertObjectsCamsToCamsObjects(const MultiV
     return camsPts;
 }
 
-int computeStep(MultiViewInputParams* mip, int scale, int maxWidth, int maxHeight)
+int computeStep(MultiViewParams* mp, int scale, int maxWidth, int maxHeight)
 {
     int step = 1;
-    int ow = mip->getMaxImageWidth() / scale;
-    int oh = mip->getMaxImageHeight() / scale;
-    int g_Width = mip->getMaxImageWidth() / scale;
-    int g_Height = mip->getMaxImageHeight() / scale;
+    int ow = mp->getMaxImageWidth() / scale;
+    int oh = mp->getMaxImageHeight() / scale;
+    int g_Width = mp->getMaxImageWidth() / scale;
+    int g_Height = mp->getMaxImageHeight() / scale;
     while((g_Width > maxWidth) || (g_Height > maxHeight))
     {
         step++;
@@ -772,7 +772,7 @@ StaticVector<int>* createRandomArrayOfIntegers(int n)
 float getCGDepthFromSeeds(const MultiViewParams* mp, int rc)
 {
     StaticVector<SeedPoint>* seeds;
-    loadSeedsFromFile(&seeds, rc, mp->mip, EFileType::seeds);
+    loadSeedsFromFile(&seeds, rc, mp, EFileType::seeds);
 
     float midDepth = -1.0f;
 

--- a/src/aliceVision/mvsUtils/common.hpp
+++ b/src/aliceVision/mvsUtils/common.hpp
@@ -53,7 +53,7 @@ StaticVector<StaticVector<int>*>* convertObjectsCamsToCamsObjects(const MultiVie
                                                                   StaticVector<StaticVector<int>*>* ptsCams);
 StaticVector<StaticVector<Pixel>*>* convertObjectsCamsToCamsObjects(const MultiViewParams* mp,
                                                                     StaticVector<StaticVector<Pixel>*>* ptsCams);
-int computeStep(MultiViewInputParams* mip, int scale, int maxWidth, int maxHeight);
+int computeStep(MultiViewParams* mp, int scale, int maxWidth, int maxHeight);
 
 StaticVector<Point3d>* computeVoxels(const Point3d* space, const Voxel& dimensions);
 float getCGDepthFromSeeds(const MultiViewParams* mp, int rc); // TODO: require seeds vector as input param

--- a/src/aliceVision/mvsUtils/fileIO.hpp
+++ b/src/aliceVision/mvsUtils/fileIO.hpp
@@ -18,17 +18,15 @@
 namespace aliceVision {
 namespace mvsUtils {
 
-struct MultiViewInputParams;
-
 bool FileExists(const std::string& filePath);
 bool FolderExists(const std::string& folderPath);
 
-std::string mv_getFileNamePrefix(const std::string& baseDir, MultiViewInputParams* mip, int index);
-std::string mv_getFileName(MultiViewInputParams* mip, int index, EFileType mv_file_type, int scale = 0);
-FILE* mv_openFile(MultiViewInputParams* mip, int index, EFileType mv_file_type, const char* readWrite);
+std::string mv_getFileNamePrefix(const std::string& baseDir, const MultiViewParams* mp, int index);
+std::string mv_getFileName(const MultiViewParams* mp, int index, EFileType mv_file_type, int scale = 0);
+FILE* mv_openFile(const MultiViewParams* mp, int index, EFileType mv_file_type, const char* readWrite);
 Matrix3x4 load3x4MatrixFromFile(FILE* fi);
-void memcpyRGBImageFromFileToArr(int camId, Color* imgArr, const std::string& fileNameOrigStr, MultiViewInputParams* mip,
-                                 bool transpose, int scaleFactor, int bandType);
+void memcpyRGBImageFromFileToArr(int camId, Color* imgArr, const std::string& fileNameOrigStr, const MultiViewParams* mp,
+                                 bool transpose, int bandType);
 struct seed_io_block            // 80 bytes
 {
     OrientedPoint op;           // 28 bytes
@@ -42,10 +40,10 @@ struct seed_io_block            // 80 bytes
 };
 
 void saveSeedsToFile(StaticVector<SeedPoint>* seeds, const std::string& fileName);
-void saveSeedsToFile(StaticVector<SeedPoint>* seeds, int refImgFileId, MultiViewInputParams* mip, EFileType mv_file_type);
+void saveSeedsToFile(StaticVector<SeedPoint>* seeds, int refImgFileId, const MultiViewParams* mp, EFileType mv_file_type);
 bool loadSeedsFromFile(StaticVector<SeedPoint>** seeds, const std::string& fileName);
-bool loadSeedsFromFile(StaticVector<SeedPoint>** seeds, int refImgFileId, MultiViewInputParams* mip, EFileType mv_file_type);
-bool getDepthMapInfo(int refImgFileId, MultiViewInputParams* mip, float& mindepth, float& maxdepth,
+bool loadSeedsFromFile(StaticVector<SeedPoint>** seeds, int refImgFileId, const MultiViewParams* mp, EFileType mv_file_type);
+bool getDepthMapInfo(int refImgFileId, const MultiViewParams* mp, float& mindepth, float& maxdepth,
                      StaticVector<int>** tcams);
 bool DeleteDirectory(const std::string& sPath);
 

--- a/src/software/pipeline/main_cameraConnection.cpp
+++ b/src/software/pipeline/main_cameraConnection.cpp
@@ -73,10 +73,8 @@ int main(int argc, char* argv[])
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
-    // .ini parsing
-    mvsUtils::MultiViewInputParams mip(iniFilepath, "", "");
-    const double simThr = mip._ini.get<double>("global.simThr", 0.0);
-    mvsUtils::MultiViewParams mp(mip.getNbCameras(), &mip, (float) simThr);
+    // .ini and files parsing
+    mvsUtils::MultiViewParams mp(iniFilepath);
     mvsUtils::PreMatchCams pc(&mp);
 
     ALICEVISION_LOG_INFO("Compute camera pairs.");

--- a/src/software/pipeline/main_depthMapFiltering.cpp
+++ b/src/software/pipeline/main_depthMapFiltering.cpp
@@ -105,10 +105,8 @@ int main(int argc, char* argv[])
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
-    // .ini parsing
-    mvsUtils::MultiViewInputParams mip(iniFilepath, depthMapFolder, outputFolder);
-    const double simThr = mip._ini.get<double>("global.simThr", 0.0);
-    mvsUtils::MultiViewParams mp(mip.getNbCameras(), &mip, (float) simThr);
+    // .ini and files parsing
+    mvsUtils::MultiViewParams mp(iniFilepath, depthMapFolder, outputFolder, true);
     mvsUtils::PreMatchCams pc(&mp);
 
     StaticVector<int> cams;

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -130,19 +130,16 @@ int main(int argc, char* argv[])
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
-    // .ini parsing
-    mvsUtils::MultiViewInputParams mip(iniFilepath, depthMapFolder, depthMapFilterFolder);
-    const double simThr = mip._ini.get<double>("global.simThr", 0.0);
-    mvsUtils::MultiViewParams mp(mip.getNbCameras(), &mip, (float) simThr);
+    // .ini and files parsing
+    mvsUtils::MultiViewParams mp(iniFilepath, depthMapFolder, depthMapFilterFolder, true);
     mvsUtils::PreMatchCams pc(&mp);
 
-    // .ini parsing
-    int ocTreeDim = mip._ini.get<int>("LargeScale.gridLevel0", 1024);
-    const auto baseDir = mip._ini.get<std::string>("LargeScale.baseDirName", "root01024");
+    int ocTreeDim = mp._ini.get<int>("LargeScale.gridLevel0", 1024);
+    const auto baseDir = mp._ini.get<std::string>("LargeScale.baseDirName", "root01024");
 
     // semiGlobalMatching
-    mip._ini.put("meshEnergyOpt.smoothNbIterations", smoothingIteration);
-    mip._ini.put("meshEnergyOpt.lambda", smoothingWeight);
+    mp._ini.put("meshEnergyOpt.smoothNbIterations", smoothingIteration);
+    mp._ini.put("meshEnergyOpt.lambda", smoothingWeight);
 
     bfs::path outDirectory = bfs::path(outputMesh).parent_path();
     if(!bfs::is_directory(outDirectory))

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -107,10 +107,8 @@ int main(int argc, char* argv[])
     // set output texture file type
     const EImageFileType outputTextureFileType = EImageFileType_stringToEnum(outTextureFileTypeName);
 
-    // .ini parsing
-    mvsUtils::MultiViewInputParams mip(iniFilepath, "", "");
-    const double simThr = mip._ini.get<double>("global.simThr", 0.0);
-    mvsUtils::MultiViewParams mp(mip.getNbCameras(), &mip, (float) simThr);
+    // .ini and files parsing
+    mvsUtils::MultiViewParams mp(iniFilepath);
 
     mesh::Texturing mesh;
     mesh.texParams = texParams;


### PR DESCRIPTION
## Features list

#### class `MultiViewParams`:
- Merge `MultiViewInputParams` into `MultiViewParams`
- Read input (images or depthMap) information from metadata
- Add `processDownscale` option for downscaling input images during process

#### MVS software: 
- Add `downscale` input parameter in `depthMapEstimation`
- Use depthMaps as input for `MultiViewParams`in `depthMapFiltering` and `meshing`

#### software `prepareDenseScene`:
- Remove `scale` and `outputFileType` options 
- No more downscale
- File extension is now always `.exr`
- P,K,R,t are now written in output images metadata
