### PR TITLE
FeatureExtraction: don't call CUDA code if no GPU feature  is available

### DIFF
--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -9,7 +9,11 @@
 #include <aliceVision/sfm/sfm.hpp>
 #include <aliceVision/feature/imageDescriberCommon.hpp>
 #include <aliceVision/feature/feature.hpp>
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_POPSIFT) \
+ || ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
+#define ALICEVISION_HAVE_GPU_FEATURES
 #include <aliceVision/system/gpu.hpp>
+#endif
 #include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
@@ -340,8 +344,10 @@ int main(int argc, char **argv)
     }
   }
 
+#ifdef ALICEVISION_HAVE_GPU_FEATURES
   // Print GPU Information
   ALICEVISION_LOG_INFO(system::gpuInformationCUDA());
+#endif
 
   // load input scene
   sfm::SfMData sfmData;


### PR DESCRIPTION
## Description
Fix build when neither POPSIFT nor CCTAG (based on CUDA) is built.

