### PR TITLE
Texturing: fill holes and unwrap methods

### DIFF
--- a/src/aliceVision/imageIO/image.cpp
+++ b/src/aliceVision/imageIO/image.cpp
@@ -409,12 +409,10 @@ void convolveImage(int inWidth, int inHeight, const std::vector<Color>& inBuffer
   convolveImage(oiio::TypeDesc::FLOAT, inWidth, inHeight, 3, inBuffer, outBuffer, kernel, kernelWidth, kernelHeight);
 }
 
-void fillHoles(int inWidth, int inHeight, const std::vector<Color>& colorBuffer, const std::vector<float>& alphaBuffer, std::vector<Color>& outBuffer)
+void fillHoles(int inWidth, int inHeight, std::vector<Color>& colorBuffer, const std::vector<float>& alphaBuffer)
 {
-    const oiio::ImageBuf rgbBuf(oiio::ImageSpec(inWidth, inHeight, 3, oiio::TypeDesc::FLOAT), const_cast<Color*>(colorBuffer.data()));
+    oiio::ImageBuf rgbBuf(oiio::ImageSpec(inWidth, inHeight, 3, oiio::TypeDesc::FLOAT), colorBuffer.data());
     const oiio::ImageBuf alphaBuf(oiio::ImageSpec(inWidth, inHeight, 1, oiio::TypeDesc::FLOAT), const_cast<float*>(alphaBuffer.data()));
-    outBuffer.resize(colorBuffer.size());
-    oiio::ImageBuf outBuf(rgbBuf.spec(), outBuffer.data());
 
     // Create RGBA ImageBuf from source buffers with correct channel names
     // (identified alpha channel is needed for fillholes_pushpull)
@@ -427,8 +425,8 @@ void fillHoles(int inWidth, int inHeight, const std::vector<Color>& colorBuffer,
     oiio::ImageBufAlgo::fillholes_pushpull(filledBuf, rgbaBuf);
     rgbaBuf.clear();
 
-    // Copy result to out RGB buffer
-    oiio::ImageBufAlgo::copy(outBuf, filledBuf);
+    // Copy result to original RGB buffer
+    oiio::ImageBufAlgo::copy(rgbBuf, filledBuf);
 }
 
 } // namespace imageIO

--- a/src/aliceVision/imageIO/image.hpp
+++ b/src/aliceVision/imageIO/image.hpp
@@ -151,5 +151,15 @@ void convolveImage(int inWidth, int inHeight, const std::vector<rgb>& inBuffer, 
 void convolveImage(int inWidth, int inHeight, const std::vector<float>& inBuffer, std::vector<float>& outBuffer, const std::string& kernel = "gaussian", float kernelWidth = 5.0f, float kernelHeight = 5.0f);
 void convolveImage(int inWidth, int inHeight, const std::vector<Color>& inBuffer, std::vector<Color>& outBuffer, const std::string& kernel = "gaussian", float kernelWidth = 5.0f, float kernelHeight = 5.0f);
 
+/**
+ * @brief fill holes in a given image buffer with plausible values
+ * @param[in] inWidth The input image buffer width
+ * @param[in] inHeight The input image buffer height
+ * @param[in] colorBuffer The input image buffer
+ * @param[in] alphaBuffer The input alpha buffer containing 0.0/1.0 for empty/valid pixels
+ * @param[out] outBuffer outBuffer The output image buffer
+ */
+void fillHoles(int inWidth, int inHeight, const std::vector<Color>& colorBuffer, const std::vector<float>& alphaBuffer, std::vector<Color>& outbuffer);
+
 } // namespace imageIO
 } // namespace aliceVision

--- a/src/aliceVision/imageIO/image.hpp
+++ b/src/aliceVision/imageIO/image.hpp
@@ -155,11 +155,10 @@ void convolveImage(int inWidth, int inHeight, const std::vector<Color>& inBuffer
  * @brief fill holes in a given image buffer with plausible values
  * @param[in] inWidth The input image buffer width
  * @param[in] inHeight The input image buffer height
- * @param[in] colorBuffer The input image buffer
+ * @param[in,out] colorBuffer The image buffer to fill
  * @param[in] alphaBuffer The input alpha buffer containing 0.0/1.0 for empty/valid pixels
- * @param[out] outBuffer outBuffer The output image buffer
  */
-void fillHoles(int inWidth, int inHeight, const std::vector<Color>& colorBuffer, const std::vector<float>& alphaBuffer, std::vector<Color>& outbuffer);
+void fillHoles(int inWidth, int inHeight, std::vector<Color>& colorBuffer, const std::vector<float>& alphaBuffer);
 
 } // namespace imageIO
 } // namespace aliceVision

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -389,9 +389,8 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp, StaticVecto
     if(texParams.fillHoles)
     {
         ALICEVISION_LOG_INFO("Filling texture holes.");
-        std::vector<Color> filledColorBuffer;
-        imageIO::fillHoles(texParams.textureSide, texParams.textureSide, colorBuffer, alphaBuffer, filledColorBuffer);
-        std::swap(filledColorBuffer, colorBuffer);
+        imageIO::fillHoles(texParams.textureSide, texParams.textureSide, colorBuffer, alphaBuffer);
+        alphaBuffer.clear();
     }
     // downscale texture if required
     if(texParams.downscale > 1)

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -313,40 +313,43 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp, StaticVecto
     }
     camTriangles.clear();
 
-    ALICEVISION_LOG_INFO("Edge padding (" << texParams.padding << " pixels).");
-    // edge padding (dilate gutter)
-    for(unsigned int g = 0; g < texParams.padding; ++g)
+    if(!texParams.fillHoles)
     {
-        for(unsigned int y = 1; y < texParams.textureSide-1; ++y)
+        ALICEVISION_LOG_INFO("Edge padding (" << texParams.padding << " pixels).");
+        // edge padding (dilate gutter)
+        for(unsigned int g = 0; g < texParams.padding; ++g)
         {
-            unsigned int yoffset = y * texParams.textureSide;
-            for(unsigned int x = 1; x < texParams.textureSide-1; ++x)
+            for(unsigned int y = 1; y < texParams.textureSide-1; ++y)
             {
-                unsigned int xyoffset = yoffset + x;
-                if(colorIDs[xyoffset] > 0)
-                    continue;
-                else if(colorIDs[xyoffset-1] > 0)
+                unsigned int yoffset = y * texParams.textureSide;
+                for(unsigned int x = 1; x < texParams.textureSide-1; ++x)
                 {
-                    colorIDs[xyoffset] = (xyoffset-1)*-1;
-                }
-                else if(colorIDs[xyoffset+1] > 0)
-                {
-                    colorIDs[xyoffset] = (xyoffset+1)*-1;
-                }
-                else if(colorIDs[xyoffset+texParams.textureSide] > 0)
-                {
-                    colorIDs[xyoffset] = (xyoffset+texParams.textureSide)*-1;
-                }
-                else if(colorIDs[xyoffset-texParams.textureSide] > 0)
-                {
-                    colorIDs[xyoffset] = (xyoffset-texParams.textureSide)*-1;
+                    unsigned int xyoffset = yoffset + x;
+                    if(colorIDs[xyoffset] > 0)
+                        continue;
+                    else if(colorIDs[xyoffset-1] > 0)
+                    {
+                        colorIDs[xyoffset] = (xyoffset-1)*-1;
+                    }
+                    else if(colorIDs[xyoffset+1] > 0)
+                    {
+                        colorIDs[xyoffset] = (xyoffset+1)*-1;
+                    }
+                    else if(colorIDs[xyoffset+texParams.textureSide] > 0)
+                    {
+                        colorIDs[xyoffset] = (xyoffset+texParams.textureSide)*-1;
+                    }
+                    else if(colorIDs[xyoffset-texParams.textureSide] > 0)
+                    {
+                        colorIDs[xyoffset] = (xyoffset-texParams.textureSide)*-1;
+                    }
                 }
             }
-        }
-        for(unsigned int i=0; i < textureSize; ++i)
-        {
-            if(colorIDs[i] < 0)
-                colorIDs[i] = colorIDs[colorIDs[i]*-1];
+            for(unsigned int i=0; i < textureSize; ++i)
+            {
+                if(colorIDs[i] < 0)
+                    colorIDs[i] = colorIDs[colorIDs[i]*-1];
+            }
         }
     }
 

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -329,12 +329,13 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
                 triPixs[k] = (*uvCoords)[uvPointIndex] * texParams.textureSide;   // UV coordinates
             }
 
-            // compute triangle bounding box
-            // cast to int (floor) to get pixel indexes based on their top-left corners
-            unsigned int LUx = static_cast<unsigned int>(std::min(std::min(triPixs[0].x, triPixs[1].x), triPixs[2].x));
-            unsigned int LUy = static_cast<unsigned int>(std::min(std::min(triPixs[0].y, triPixs[1].y), triPixs[2].y));
-            unsigned int RDx = static_cast<unsigned int>(std::max(std::max(triPixs[0].x, triPixs[1].x), triPixs[2].x));
-            unsigned int RDy = static_cast<unsigned int>(std::max(std::max(triPixs[0].y, triPixs[1].y), triPixs[2].y));
+            // compute triangle bounding box in pixel indexes
+            // min values: floor(value)
+            // max values: ceil(value) - 1 (ensure resulting value is in valid index range [0; textureSide-1])
+            unsigned int LUx = static_cast<unsigned int>(std::floor(std::min(std::min(triPixs[0].x, triPixs[1].x), triPixs[2].x)));
+            unsigned int LUy = static_cast<unsigned int>(std::floor(std::min(std::min(triPixs[0].y, triPixs[1].y), triPixs[2].y)));
+            unsigned int RDx = static_cast<unsigned int>(std::ceil(std::max(std::max(triPixs[0].x, triPixs[1].x), triPixs[2].x))) - 1;
+            unsigned int RDy = static_cast<unsigned int>(std::ceil(std::max(std::max(triPixs[0].y, triPixs[1].y), triPixs[2].y))) - 1;
 
             // iterate over bounding box's pixels
             for(unsigned int y = LUy; y <= RDy; y++)

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -25,6 +25,7 @@ struct TexturingParams
     unsigned int textureSide = 8192;
     unsigned int padding = 15;
     unsigned int downscale = 2;
+    bool fillHoles = false;
 };
 
 struct Texturing

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -12,6 +12,7 @@
 #include <aliceVision/mvsData/Voxel.hpp>
 #include <aliceVision/mvsUtils/ImagesCache.hpp>
 #include <aliceVision/mesh/Mesh.hpp>
+#include <aliceVision/mesh/meshVisibility.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -19,6 +20,30 @@ namespace bfs = boost::filesystem;
 
 namespace aliceVision {
 namespace mesh {
+
+/**
+ * @brief Available mesh unwrapping methods
+ */
+enum class EUnwrapMethod {
+    Basic = 0, // Basic unwrapping based on visibilities
+    ABF = 1,   // Geogram: ABF++
+    LSCM = 2   // Geogram: Spectral LSCM
+};
+
+/**
+ * @brief returns the EUnwrapMethod enum from a string.
+ * @param[in] method the input string.
+ * @return the associated EUnwrapMethod enum.
+ */
+EUnwrapMethod EUnwrapMethod_stringToEnum(const std::string& method);
+
+/**
+ * @brief converts an EUnwrapMethod enum to a string.
+ * @param[in] method the EUnwrapMethod enum to convert.
+ * @return the string associated to the EUnwrapMethod enum.
+ */
+std::string EUnwrapMethod_enumToString(EUnwrapMethod method);
+
 
 struct TexturingParams
 {
@@ -38,6 +63,7 @@ struct Texturing
     StaticVector<Voxel>* trisUvIds = nullptr;
     StaticVector<Point3d>* normals = nullptr;
     StaticVector<Voxel>* trisNormalsIds = nullptr;
+    PointsVisibility* pointsVisibilities = nullptr;
     Mesh* me = nullptr;
 
     /// texture atlas to 3D triangle ids
@@ -50,6 +76,7 @@ struct Texturing
         delete trisUvIds;
         delete normals;
         delete trisNormalsIds;
+        delete pointsVisibilities;
         delete me;
     }
 
@@ -57,26 +84,48 @@ public:
     /// Load a mesh from a .obj file and initialize internal structures
     void loadFromOBJ(const std::string& filename, bool flipNormals=false);
 
+    /**
+     * @brief Load a mesh from a dense reconstruction.
+     *
+     * @param meshFilepath the path to the .bin mesh file
+     * @param visibilitiesFilepath the path to the .bin points visibilities file
+     */
+    void loadFromMeshing(const std::string& meshFilepath, const std::string& visibilitiesFilepath);
+
+    /**
+     * @brief Replace inner mesh with the mesh loaded from 'otherMeshPath'
+     *        and remap visibilities from the first to the second
+     *
+     * @param otherMeshPath the mesh to load
+     * @param flipNormals whether to flip normals when loading the mesh
+     */
+    void replaceMesh(const std::string& otherMeshPath, bool flipNormals=false);
+
+    /// Returns whether UV coordinates are available
     inline bool hasUVs() const { return uvCoords != nullptr && !uvCoords->empty(); }
+
+    /**
+     * @brief Unwrap mesh with the given 'method'.
+     *
+     * Requires internal mesh 'me' to be initialized.
+     */
+    void unwrap(mvsUtils::MultiViewParams& mp, EUnwrapMethod method);
 
     /**
      * @brief Generate automatic texture atlasing and UV coordinates based on points visibilities
      *
      * Requires internal mesh 'me' to be initialized.
-     * Note that mesh data will be updated by this process so that only textured triangles are kept.
      *
      * @param mp
-     * @param ptsCams visibilities of internal mesh's points
-     * @return visibilities of new internal mesh's points
      */
-    StaticVector<StaticVector<int>*>* generateUVs(mvsUtils::MultiViewParams &mp, StaticVector<StaticVector<int> *> *ptsCams);
+    void generateUVs(mvsUtils::MultiViewParams &mp);
 
     /// Generate texture files for all texture atlases
-    void generateTextures(const mvsUtils::MultiViewParams& mp, StaticVector<StaticVector<int>*>* ptsCams,
+    void generateTextures(const mvsUtils::MultiViewParams& mp,
                           const bfs::path &outPath, EImageFileType textureFileType = EImageFileType::PNG);
 
     /// Generate texture files for the given texture atlas index
-    void generateTexture(const mvsUtils::MultiViewParams& mp, StaticVector<StaticVector<int>*>* ptsCams,
+    void generateTexture(const mvsUtils::MultiViewParams& mp,
                          size_t atlasID, mvsUtils::ImagesCache& imageCache,
                          const bfs::path &outPath, EImageFileType textureFileType = EImageFileType::PNG);
 

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -59,6 +59,8 @@ int main(int argc, char* argv[])
             "Texture edge padding size in pixel")
         ("downscale", po::value<unsigned int>(&texParams.downscale)->default_value(texParams.downscale),
             "Texture downscale factor")
+        ("fillHoles", po::value<bool>(&texParams.fillHoles)->default_value(texParams.fillHoles),
+            "Fill texture holes with plausible values.")
         ("inputMesh", po::value<std::string>(&inputMeshFilepath),
             "Optional input mesh to texture. By default, it will texture the inputReconstructionMesh.")
         ("flipNormals", po::value<bool>(&flipNormals)->default_value(flipNormals),

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -37,6 +37,7 @@ int main(int argc, char* argv[])
     std::string outTextureFileTypeName = EImageFileType_enumToString(EImageFileType::PNG);
     bool flipNormals = false;
     mesh::TexturingParams texParams;
+    std::string unwrapMethod = mesh::EUnwrapMethod_enumToString(mesh::EUnwrapMethod::Basic);
 
     po::options_description allParams("AliceVision texturing");
 
@@ -55,12 +56,17 @@ int main(int argc, char* argv[])
           EImageFileType_informations().c_str())
         ("textureSide", po::value<unsigned int>(&texParams.textureSide)->default_value(texParams.textureSide),
             "Output texture size")
-        ("padding", po::value<unsigned int>(&texParams.padding)->default_value(texParams.padding),
-            "Texture edge padding size in pixel")
         ("downscale", po::value<unsigned int>(&texParams.downscale)->default_value(texParams.downscale),
             "Texture downscale factor")
+        ("unwrapMethod", po::value<std::string>(&unwrapMethod)->default_value(unwrapMethod),
+            "Method to unwrap input mesh if it does not have UV coordinates.\n"
+            " * Basic (> 600k faces) fast and simple. Can generate multiple atlases.\n"
+            " * LSCM (<= 600k faces): optimize space. Generates one atlas.\n"
+            " * ABF (<= 300k faces): optimize space and stretch. Generates one atlas.'")
         ("fillHoles", po::value<bool>(&texParams.fillHoles)->default_value(texParams.fillHoles),
             "Fill texture holes with plausible values.")
+        ("padding", po::value<unsigned int>(&texParams.padding)->default_value(texParams.padding),
+            "Texture edge padding size in pixel")
         ("inputMesh", po::value<std::string>(&inputMeshFilepath),
             "Optional input mesh to texture. By default, it will texture the inputReconstructionMesh.")
         ("flipNormals", po::value<bool>(&flipNormals)->default_value(flipNormals),
@@ -116,51 +122,31 @@ int main(int argc, char* argv[])
     mesh.texParams = texParams;
     mesh.me = new mesh::Mesh();
 
-    if(!mesh.me->loadFromBin(inputDenseReconstruction))
-    {
-        ALICEVISION_LOG_ERROR("Unable to load: " << inputDenseReconstruction);
-        return EXIT_FAILURE;
-    }
+    // load dense reconstruction
+    const bfs::path reconstructionMeshFolder = bfs::path(inputDenseReconstruction).parent_path();
+    mesh.loadFromMeshing(inputDenseReconstruction, (reconstructionMeshFolder/"meshPtsCamsFromDGC.bin").string());
 
-    bfs::path reconstructionMeshFolder = bfs::path(inputDenseReconstruction).parent_path();
-
-    mesh::PointsVisibility* ptsCams = loadArrayOfArraysFromFile<int>((reconstructionMeshFolder/"meshPtsCamsFromDGC.bin").string());
-    if(ptsCams->size() != mesh.me->pts->size())
-        throw std::runtime_error("Error: Reference mesh and associated visibilities don't have the same size.");
-    // filterPtsCamsByMinimalPixelSize(refMesh, refPtsCams, &mp);
     bfs::create_directory(outputFolder);
-
-    //std::cout << "Points with no visibilities " << std::count(ptsCams->begin(), ptsCams->end(), nullptr) << std::endl;
 
     // texturing from input mesh
     if(!inputMeshFilepath.empty())
     {
-        ALICEVISION_LOG_INFO("An external input mesh is provided, so we remap the visibility from the reconstruction on it.");
-        // keep previous mesh as reference
-        mesh::Mesh* refMesh = mesh.me;
-        // load input obj file
-        mesh.me = new mesh::Mesh();
-        mesh.loadFromOBJ(inputMeshFilepath, flipNormals);
-        // remap visibilities from reconstruction onto input mesh
-        mesh::PointsVisibility otherPtsVisibilities;
-        mesh::remapMeshVisibilities(*refMesh, *ptsCams, *mesh.me, otherPtsVisibilities);
-
-        delete refMesh;
-        ptsCams->swap(otherPtsVisibilities);
+       mesh.replaceMesh(inputMeshFilepath, flipNormals);
     }
+
     if(!mesh.hasUVs())
     {
-        ALICEVISION_LOG_INFO("The input mesh has no UV, so we generate them.");
-        // generate UV coordinates based on automatic uv atlas
-        auto* updatedPtsCams = mesh.generateUVs(mp, ptsCams);
-        std::swap(ptsCams, updatedPtsCams);
-        deleteArrayOfArrays<int>(&updatedPtsCams);
-        mesh.saveAsOBJ(outputFolder, "texturedMesh", outputTextureFileType);
+        ALICEVISION_LOG_INFO("Input mesh has no UV coordinates, start unwrapping (" + unwrapMethod +")");
+        mesh.unwrap(mp, mesh::EUnwrapMethod_stringToEnum(unwrapMethod));
+        ALICEVISION_LOG_INFO("Unwrapping done.");
     }
+
+    // save final obj file
+    mesh.saveAsOBJ(outputFolder, "texturedMesh", outputTextureFileType);
 
     // generate textures
     ALICEVISION_LOG_INFO("Generate textures.");
-    mesh.generateTextures(mp, ptsCams, outputFolder, outputTextureFileType);
+    mesh.generateTextures(mp, outputFolder, outputTextureFileType);
 
     ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Description
Add additional options to texturing 

## Features list
- [X] Add `--fillHoles` option: fill texture holes with plausible values using openimageio `fillholes_pushpull`
- [x] Add `--unwrapMethod`: expose available unwrap methods (Basic, Geogram::ABF++, Geogram::SPECTRAL_LSCM)
