### PR TITLE
Use a temporary filename when saving a file

### DIFF
--- a/src/aliceVision/feature/CMakeLists.txt
+++ b/src/aliceVision/feature/CMakeLists.txt
@@ -76,6 +76,8 @@ target_link_libraries(aliceVision_feature
          vlsift
          ${BOOST_LIBRARIES}
          ${LOG_LIB}
+
+  PRIVATE ${Boost_FILESYSTEM_LIBRARIES}
 )
 
 # Link CCTAG library

--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -23,7 +23,11 @@
 #include <aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.hpp>
 #endif //ALICEVISION_HAVE_OPENCV
 
+#include <boost/filesystem.hpp>
+
 #include <stdexcept>
+
+namespace fs = boost::filesystem;
 
 namespace aliceVision{
 namespace feature{
@@ -69,6 +73,20 @@ std::istream& operator>>(std::istream& in, EImageDescriberPreset& p)
   in >> token;
   p = EImageDescriberPreset_stringToEnum(token);
   return in;
+}
+
+void ImageDescriber::Save(const Regions* regions, const std::string& sfileNameFeats, const std::string& sfileNameDescs) const
+{
+  const fs::path bFeatsPath = fs::path(sfileNameFeats);
+  const fs::path bDescsPath = fs::path(sfileNameDescs);
+  const std::string tmpFeatsPath = (bFeatsPath.parent_path() / bFeatsPath.stem()).string() + "." + fs::unique_path().string() + bFeatsPath.extension().string();
+  const std::string tmpDescsPath = (bDescsPath.parent_path() / bDescsPath.stem()).string() + "." + fs::unique_path().string() + bDescsPath.extension().string();
+
+  regions->Save(tmpFeatsPath, tmpDescsPath);
+
+  // rename temporay filenames
+  fs::rename(tmpFeatsPath, sfileNameFeats);
+  fs::rename(tmpDescsPath, sfileNameDescs);
 }
 
 std::unique_ptr<ImageDescriber> createImageDescriber(EImageDescriberType imageDescriberType)

--- a/src/aliceVision/feature/ImageDescriber.hpp
+++ b/src/aliceVision/feature/ImageDescriber.hpp
@@ -169,21 +169,18 @@ public:
 
   // IO - one file for region features, one file for region descriptors
 
-  virtual void Load(Regions * regions,
+  void Load(Regions* regions,
     const std::string& sfileNameFeats,
     const std::string& sfileNameDescs) const
   {
     regions->Load(sfileNameFeats, sfileNameDescs);
   }
 
-  virtual void Save(const Regions * regions,
+  void Save(const Regions* regions,
     const std::string& sfileNameFeats,
-    const std::string& sfileNameDescs) const
-  {
-    regions->Save(sfileNameFeats, sfileNameDescs);
-  }
+    const std::string& sfileNameDescs) const;
 
-  virtual void LoadFeatures(Regions * regions,
+  void LoadFeatures(Regions* regions,
     const std::string& sfileNameFeats) const
   {
     regions->LoadFeatures(sfileNameFeats);

--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(aliceVision_image
 
   PRIVATE ${OPENEXR_LIBRARIES}
           ${LOG_LIB}
+          ${Boost_FILESYSTEM_LIBRARIES}
 )
 
 set_target_properties(aliceVision_image

--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -42,6 +42,8 @@ target_link_libraries(aliceVision_image
   PRIVATE ${OPENEXR_LIBRARIES}
           ${LOG_LIB}
           ${Boost_FILESYSTEM_LIBRARIES}
+          # dependency of Boost filesystem, not always declared depending on CMake version
+          ${Boost_SYSTEM_LIBRARIES}
 )
 
 set_target_properties(aliceVision_image

--- a/src/aliceVision/imageIO/CMakeLists.txt
+++ b/src/aliceVision/imageIO/CMakeLists.txt
@@ -25,6 +25,8 @@ target_include_directories(aliceVision_imageIO
 target_link_libraries(aliceVision_imageIO
   PUBLIC aliceVision_mvsData
          ${OPENIMAGEIO_LIBRARIES}
+
+  PRIVATE ${Boost_FILESYSTEM_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_imageIO

--- a/src/aliceVision/imageIO/CMakeLists.txt
+++ b/src/aliceVision/imageIO/CMakeLists.txt
@@ -27,6 +27,8 @@ target_link_libraries(aliceVision_imageIO
          ${OPENIMAGEIO_LIBRARIES}
 
   PRIVATE ${Boost_FILESYSTEM_LIBRARIES}
+          # dependency of Boost filesystem, not always declared depending on CMake version
+          ${Boost_SYSTEM_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_imageIO


### PR DESCRIPTION
Use a temporary filename when saving:
- images files
- matches files
- feature (`.feat` & `.desc`) files
- sfmData files