### PR TITLE
Texturing: fix 2D triangle bounding box computation and mesh loading

### DIFF
--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -2450,9 +2450,9 @@ StaticVector<int>* Mesh::getLargestConnectedComponentTrisIds()
     return out;
 }
 
-bool Mesh::loadFromObjAscii(int& nmtls, StaticVector<int>** trisMtlIds, StaticVector<Point3d>** normals,
-                               StaticVector<Voxel>** trisNormalsIds, StaticVector<Point2d>** uvCoords,
-                               StaticVector<Voxel>** trisUvIds, std::string objAsciiFileName)
+bool Mesh::loadFromObjAscii(int& nmtls, StaticVector<int>& trisMtlIds, StaticVector<Point3d>& normals,
+                               StaticVector<Voxel>& trisNormalsIds, StaticVector<Point2d>& uvCoords,
+                               StaticVector<Voxel>& trisUvIds, std::string objAsciiFileName)
 {
     ALICEVISION_LOG_INFO("Loading mesh from obj file: " << objAsciiFileName);
     // read number of points, triangles, uvcoords
@@ -2505,16 +2505,11 @@ bool Mesh::loadFromObjAscii(int& nmtls, StaticVector<int>** trisMtlIds, StaticVe
     pts->reserve(npts);
     tris = new StaticVector<Mesh::triangle>();
     tris->reserve(ntris);
-    *uvCoords = new StaticVector<Point2d>();
-    (*uvCoords)->reserve(nuvs);
-    *trisUvIds = new StaticVector<Voxel>();
-    (*trisUvIds)->reserve(ntris);
-    *normals = new StaticVector<Point3d>();
-    (*normals)->reserve(nnorms);
-    *trisNormalsIds = new StaticVector<Voxel>();
-    (*trisNormalsIds)->reserve(ntris);
-    *trisMtlIds = new StaticVector<int>();
-    (*trisMtlIds)->reserve(ntris);
+    uvCoords.reserve(nuvs);
+    trisUvIds.reserve(ntris);
+    normals.reserve(nnorms);
+    trisNormalsIds.reserve(ntris);
+    trisMtlIds.reserve(ntris);
 
     std::map<std::string, int> materialCache;
 
@@ -2552,13 +2547,13 @@ bool Mesh::loadFromObjAscii(int& nmtls, StaticVector<int>** trisMtlIds, StaticVe
                 Point3d pt;
                 sscanf(line.c_str(), "vn %lf %lf %lf", &pt.x, &pt.y, &pt.z);
                 // printf("%f %f %f\n", pt.x, pt.y, pt.z);
-                (*normals)->push_back(pt);
+                normals.push_back(pt);
             }
             else if((line[0] == 'v') && (line[1] == 't') && (line[2] == ' '))
             {
                 Point2d pt;
                 sscanf(line.c_str(), "vt %lf %lf", &pt.x, &pt.y);
-                (*uvCoords)->push_back(pt);
+                uvCoords.push_back(pt);
             }
             else if((line[0] == 'f') && (line[1] == ' '))
             {
@@ -2636,14 +2631,14 @@ bool Mesh::loadFromObjAscii(int& nmtls, StaticVector<int>** trisMtlIds, StaticVe
                     t.i[2] = vertex.z - 1;
                     t.alive = true;
                     tris->push_back(t);
-                    (*trisMtlIds)->push_back(mtlId);
+                    trisMtlIds.push_back(mtlId);
                     if(withUV)
                     {
-                        (*trisUvIds)->push_back(uvCoord - Voxel(1, 1, 1));
+                        trisUvIds.push_back(uvCoord - Voxel(1, 1, 1));
                     }
                     if(withNormal)
                     {
-                        (*trisNormalsIds)->push_back(vertexNormal - Voxel(1, 1, 1));
+                        trisNormalsIds.push_back(vertexNormal - Voxel(1, 1, 1));
                     }
                 }
 
@@ -2656,10 +2651,10 @@ bool Mesh::loadFromObjAscii(int& nmtls, StaticVector<int>** trisMtlIds, StaticVe
                     t.i[2] = vertex2.z - 1;
                     t.alive = true;
                     tris->push_back(t);
-                    (*trisMtlIds)->push_back(mtlId);
+                    trisMtlIds.push_back(mtlId);
                     if(withUV)
                     {
-                        (*trisUvIds)->push_back(uvCoord2 - Voxel(1, 1, 1));
+                        trisUvIds.push_back(uvCoord2 - Voxel(1, 1, 1));
                     }
 //                    if(withNormal)
 //                    {

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -113,9 +113,9 @@ public:
 
     bool loadFromBin(std::string binFileName);
     void saveToBin(std::string binFileName);
-    bool loadFromObjAscii(int& nmtls, StaticVector<int>** trisMtlIds, StaticVector<Point3d>** normals,
-                          StaticVector<Voxel>** trisNormalsIds, StaticVector<Point2d>** uvCoords,
-                          StaticVector<Voxel>** trisUvIds, std::string objAsciiFileName);
+    bool loadFromObjAscii(int& nmtls, StaticVector<int>& trisMtlIds, StaticVector<Point3d>& normals,
+                          StaticVector<Voxel>& trisNormalsIds, StaticVector<Point2d>& uvCoords,
+                          StaticVector<Voxel>& trisUvIds, std::string objAsciiFileName);
 
     void addMesh(Mesh* me);
 

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -58,11 +58,11 @@ struct Texturing
     TexturingParams texParams;
 
     int nmtls = 0;
-    StaticVector<int>* trisMtlIds = nullptr;
-    StaticVector<Point2d>* uvCoords = nullptr;
-    StaticVector<Voxel>* trisUvIds = nullptr;
-    StaticVector<Point3d>* normals = nullptr;
-    StaticVector<Voxel>* trisNormalsIds = nullptr;
+    StaticVector<int> trisMtlIds;
+    StaticVector<Point2d> uvCoords;
+    StaticVector<Voxel> trisUvIds;
+    StaticVector<Point3d> normals;
+    StaticVector<Voxel> trisNormalsIds;
     PointsVisibility* pointsVisibilities = nullptr;
     Mesh* me = nullptr;
 
@@ -71,16 +71,16 @@ struct Texturing
 
     ~Texturing()
     {
-        delete trisMtlIds;
-        delete uvCoords;
-        delete trisUvIds;
-        delete normals;
-        delete trisNormalsIds;
-        delete pointsVisibilities;
+        if(pointsVisibilities != nullptr)
+            deleteArrayOfArrays<int>(&pointsVisibilities);
         delete me;
     }
 
 public:
+
+    /// Clear internal mesh data
+    void clear();
+
     /// Load a mesh from a .obj file and initialize internal structures
     void loadFromOBJ(const std::string& filename, bool flipNormals=false);
 
@@ -102,7 +102,7 @@ public:
     void replaceMesh(const std::string& otherMeshPath, bool flipNormals=false);
 
     /// Returns whether UV coordinates are available
-    inline bool hasUVs() const { return uvCoords != nullptr && !uvCoords->empty(); }
+    inline bool hasUVs() const { return !uvCoords.empty(); }
 
     /**
      * @brief Unwrap mesh with the given 'method'.

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -96,7 +96,6 @@ int main(int argc, char* argv[])
         bfs::create_directory(outDirectory);
 
     mesh::Texturing texturing;
-    texturing.me = new mesh::Mesh();
     texturing.loadFromOBJ(inputMeshPath);
     mesh::Mesh* mesh = texturing.me;
 

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -120,7 +120,6 @@ int main(int argc, char* argv[])
 
     mesh::Texturing mesh;
     mesh.texParams = texParams;
-    mesh.me = new mesh::Mesh();
 
     // load dense reconstruction
     const bfs::path reconstructionMeshFolder = bfs::path(inputDenseReconstruction).parent_path();


### PR DESCRIPTION
## Description
Fixes a few issues in the texturing step.

## Features list
- [X] clamp values to valid range for 2D triangles bounding box
- [X] remove useless dynamic allocation for several Texturing members
- [X] clear all mesh data before loading another mesh


