### PR TITLE
[cmake] use 'Boost_LIBRARIES' instead of 'BOOST_LIBRARIES'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,7 +118,7 @@ macro(UNIT_TEST NAMESPACE NAME EXTRA_LIBS)
 
     target_link_libraries(${NAMESPACE}_test_${NAME}
                           ${EXTRA_LIBS} # Extra libs MUST be first.
-                          ${BOOST_LIBRARIES} ${ALICEVISION_LIBRARY_DEPENDENCIES})
+                          ${Boost_LIBRARIES} ${ALICEVISION_LIBRARY_DEPENDENCIES})
     add_test(NAME ${NAMESPACE}_test_${NAME}
              WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
              COMMAND $<TARGET_FILE:${NAMESPACE}_test_${NAME}> --log_level=all)

--- a/src/aliceVision/calibration/CMakeLists.txt
+++ b/src/aliceVision/calibration/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(aliceVision_calibration
   PRIVATE aliceVision_image
           aliceVision_system
           aliceVision_dataio
-          ${BOOST_LIBRARIES}
+          ${Boost_LIBRARIES}
           ${LOG_LIB}
 )
 

--- a/src/aliceVision/feature/CMakeLists.txt
+++ b/src/aliceVision/feature/CMakeLists.txt
@@ -74,7 +74,7 @@ target_link_libraries(aliceVision_feature
          aliceVision_image
          aliceVision_multiview
          vlsift
-         ${BOOST_LIBRARIES}
+         ${Boost_LIBRARIES}
          ${LOG_LIB}
 
   PRIVATE ${Boost_FILESYSTEM_LIBRARIES}

--- a/src/samples/featuresRepeatability/CMakeLists.txt
+++ b/src/samples/featuresRepeatability/CMakeLists.txt
@@ -7,7 +7,7 @@ target_link_libraries(aliceVision_samples_repeatabilityDataset
   aliceVision_system
   aliceVision_multiview
   vlsift
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_samples_repeatabilityDataset

--- a/src/samples/imageDescriberMatches/CMakeLists.txt
+++ b/src/samples/imageDescriberMatches/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(aliceVision_samples_describeAndMatch
   aliceVision_feature
   aliceVision_matching
   vlsift
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_samples_describeAndMatch

--- a/src/samples/kvldFilter/CMakeLists.txt
+++ b/src/samples/kvldFilter/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(aliceVision_samples_kvldFilter
   aliceVision_feature
   aliceVision_matching
   vlsift
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_samples_kvldFilter

--- a/src/samples/robustFundamental/CMakeLists.txt
+++ b/src/samples/robustFundamental/CMakeLists.txt
@@ -7,7 +7,7 @@ target_link_libraries(aliceVision_samples_robustFundamental
   aliceVision_feature
   aliceVision_matching
   vlsift
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_samples_robustFundamental

--- a/src/samples/sensorWidthDatabase/CMakeLists.txt
+++ b/src/samples/sensorWidthDatabase/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(aliceVision_samples_parseDatabase main_parseDatabase.cpp)
 target_link_libraries(aliceVision_samples_parseDatabase
   aliceVision_system
   aliceVision_sensorDB
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_samples_parseDatabase

--- a/src/samples/undistoBrown/CMakeLists.txt
+++ b/src/samples/undistoBrown/CMakeLists.txt
@@ -5,7 +5,7 @@ target_link_libraries(aliceVision_samples_undistoBrown
   aliceVision_image
   aliceVision_multiview
   ${CERES_LIBRARIES}
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_samples_undistoBrown

--- a/src/software/convert/CMakeLists.txt
+++ b/src/software/convert/CMakeLists.txt
@@ -48,7 +48,7 @@ if(ALICEVISION_HAVE_ALEMBIC)
 		aliceVision_system
 		aliceVision_feature
 		aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
 	)
 
 	set_property(TARGET aliceVision_convertAnimatedCamera

--- a/src/software/export/CMakeLists.txt
+++ b/src/software/export/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(aliceVision_exportKeypoints
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportKeypoints
@@ -28,7 +28,7 @@ target_link_libraries(aliceVision_exportMatches
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportMatches
@@ -47,7 +47,7 @@ target_link_libraries(aliceVision_exportTracks
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportTracks
@@ -67,7 +67,7 @@ target_link_libraries(aliceVision_exportUndistortedImages
   aliceVision_image
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportUndistortedImages
@@ -87,7 +87,7 @@ target_link_libraries(aliceVision_exportPMVS
   aliceVision_image
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportPMVS
@@ -108,7 +108,7 @@ if(ALICEVISION_HAVE_ALEMBIC) # maya can read alembic file
     aliceVision_image
     aliceVision_feature
     aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
     ${OPENIMAGEIO_LIBRARIES}
   )
 
@@ -130,7 +130,7 @@ target_link_libraries(aliceVision_exportMVE2
   aliceVision_image
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportMVE2
@@ -150,7 +150,7 @@ target_link_libraries(aliceVision_exportMeshlab
   aliceVision_image
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportMeshlab
@@ -170,7 +170,7 @@ target_link_libraries(aliceVision_exportMVSTexturing
   aliceVision_image
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportMVSTexturing
@@ -190,7 +190,7 @@ target_link_libraries(aliceVision_exportMatlab
   aliceVision_image
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportMatlab
@@ -209,7 +209,7 @@ target_link_libraries(aliceVision_exportCameraFrustums
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_exportCameraFrustums

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_image
     aliceVision_feature
     aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   set_property(TARGET aliceVision_cameraInit
@@ -36,7 +36,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_multiview
     aliceVision_sfm
     vlsift
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   if(ALICEVISION_HAVE_CCTAG)
@@ -80,7 +80,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_multiview
     aliceVision_sfm
     aliceVision_matchingImageCollection
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   set_property(TARGET aliceVision_featureMatching
@@ -100,7 +100,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_image
     aliceVision_feature
     aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   set_property(TARGET aliceVision_incrementalSfM
@@ -120,7 +120,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_image
     aliceVision_feature
     aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   set_property(TARGET aliceVision_globalSfM
@@ -139,7 +139,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_system
     aliceVision_feature
     aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   set_property(TARGET aliceVision_computeStructureFromKnownPoses
@@ -159,7 +159,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_image
     aliceVision_feature
     aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   set_property(TARGET aliceVision_computeSfMColor
@@ -233,7 +233,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_image
     aliceVision_feature
     vlsift
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   if(ALICEVISION_HAVE_CCTAG)
@@ -283,7 +283,7 @@ if(ALICEVISION_BUILD_SFM)
     aliceVision_image
     aliceVision_feature
     aliceVision_sfm
-    ${BOOST_LIBRARIES}
+    ${Boost_LIBRARIES}
   )
 
   set_property(TARGET aliceVision_prepareDenseScene

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(aliceVision_utils_frustumFiltering
   aliceVision_feature
   aliceVision_sfm
   aliceVision_matchingImageCollection
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_utils_frustumFiltering
@@ -115,7 +115,7 @@ if(ALICEVISION_HAVE_ALEMBIC)
 		aliceVision_localization
 		aliceVision_dataio
 		aliceVision_rig
-		${BOOST_LIBRARIES}
+		${Boost_LIBRARIES}
 	)
 	
 	set_property(TARGET aliceVision_utils_rigTransform
@@ -136,7 +136,7 @@ target_link_libraries(aliceVision_utils_qualityEvaluation
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_utils_qualityEvaluation
@@ -155,7 +155,7 @@ target_link_libraries(aliceVision_utils_sfmAlignment
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_utils_sfmAlignment
@@ -174,7 +174,7 @@ target_link_libraries(aliceVision_utils_sfmTransform
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_utils_sfmTransform
@@ -202,7 +202,7 @@ target_link_libraries(aliceVision_utils_sfmColorHarmonize
   ${CLP_LIBRARIES}
   ${COINUTILS_LIBRARY}
   ${OSI_LIBRARY}
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_utils_sfmColorHarmonize
@@ -221,7 +221,7 @@ target_link_libraries(aliceVision_utils_sfmLocalization
   aliceVision_system
   aliceVision_feature
   aliceVision_sfm
-  ${BOOST_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_utils_sfmLocalization


### PR DESCRIPTION
## Description
Unify case of 'Boost_LIBRARIES' variable in CMake files.

## Features list
- [X] Fix a build issue when BOOST_LIBRARIES is not defined after find_package(Boost) (newer CMake version ?)
