### PR TITLE
[cmake] add missing cublas link for depthMap

### DIFF
--- a/src/aliceVision/depthMap/CMakeLists.txt
+++ b/src/aliceVision/depthMap/CMakeLists.txt
@@ -93,6 +93,7 @@ target_link_libraries(aliceVision_depthMap
   aliceVision_mvsUtils
   ${Boost_FILESYSTEM_LIBRARIES}
   ${CUDA_CUDADEVRT_LIBRARY}
+  ${CUDA_CUBLAS_LIBRARIES}
 )
 
 set_property(TARGET aliceVision_depthMap

--- a/src/aliceVision/fuseCut/CMakeLists.txt
+++ b/src/aliceVision/fuseCut/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(aliceVision_fuseCut
   PUBLIC $<BUILD_INTERFACE:${ALICEVISION_INCLUDE_DIR}>
          $<BUILD_INTERFACE:${generatedDir}>
          $<INSTALL_INTERFACE:include>
+  PRIVATE $<BUILD_INTERFACE:${NANOFLANN_INCLUDE_DIR}>
 )
 
 target_link_libraries(aliceVision_fuseCut

--- a/src/dependencies/CMakeLists.txt
+++ b/src/dependencies/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 # Add nanoflann (header-only)
 add_library(nanoflann INTERFACE IMPORTED GLOBAL)
+set(NANOFLANN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/nanoflann/include")
 set_target_properties(nanoflann PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/nanoflann/include"
-)
+    INTERFACE_INCLUDE_DIRECTORIES "${NANOFLANN_INCLUDE_DIR}")
 
 # libs should be static
 set(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
## Implementation remarks

- [X] fix compilation on some windows machines due to a missing link to cublas

