### PR TITLE
Initial focal length

### DIFF
--- a/src/aliceVision/camera/Pinhole.hpp
+++ b/src/aliceVision/camera/Pinhole.hpp
@@ -51,7 +51,7 @@ class Pinhole : public IntrinsicBase
   virtual EINTRINSIC getType() const { return PINHOLE_CAMERA; }
   std::string getTypeStr() const { return EINTRINSIC_enumToString(getType()); }
 
-  double getPxFocalLength() const { return _K(0,0); }
+  double getFocalLengthPix() const { return _K(0,0); }
 
   Vec2 getPrincipalPoint() const { return Vec2(_K(0,2), _K(1,2)); }
 

--- a/src/aliceVision/sfm/pipeline/sequential/sequentialSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/sequentialSfM_test.cpp
@@ -143,8 +143,8 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Partially_Known_Intrinsics)
   BOOST_CHECK_EQUAL(nviews, finalSfMData.GetPoses().size());
   BOOST_CHECK_EQUAL(npoints, finalSfMData.GetLandmarks().size());
   BOOST_CHECK_NE(
-      reinterpret_cast<const camera::Pinhole*>(finalSfMData.GetIntrinsics().at(0).get())->getPxFocalLength(),
-      reinterpret_cast<const camera::Pinhole*>(finalSfMData.GetIntrinsics().at(1).get())->getPxFocalLength());
+      reinterpret_cast<const camera::Pinhole*>(finalSfMData.GetIntrinsics().at(0).get())->getFocalLengthPix(),
+      reinterpret_cast<const camera::Pinhole*>(finalSfMData.GetIntrinsics().at(1).get())->getFocalLengthPix());
 }
 
 BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Rig)

--- a/src/aliceVision/sfm/sfmDataIO_json.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_json.cpp
@@ -99,7 +99,7 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
   {
     const camera::Pinhole& pinholeIntrinsic = dynamic_cast<camera::Pinhole&>(*intrinsic);
 
-    intrinsicTree.put("pxFocalLength", pinholeIntrinsic.getPxFocalLength());
+    intrinsicTree.put("pxFocalLength", pinholeIntrinsic.getFocalLengthPix());
     saveMatrix("principalPoint", pinholeIntrinsic.getPrincipalPoint(), intrinsicTree);
 
     bpt::ptree distParamsTree;

--- a/src/aliceVision/sfm/viewIO.cpp
+++ b/src/aliceVision/sfm/viewIO.cpp
@@ -83,6 +83,7 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const View& view,
 
   float mmFocalLength = view.hasMetadata("Exif:FocalLength") ? std::stof(view.getMetadata("Exif:FocalLength")) : -1;
   double pxFocalLength;
+  bool hasFocalLengthInput = false;
 
   if(defaultFocalLengthPx > 0)
   {
@@ -138,6 +139,7 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const View& view,
   {
     // Retrieve the focal from the metadata in mm and convert to pixel.
     pxFocalLength = std::max(view.getWidth(), view.getHeight()) * mmFocalLength / sensorWidth;
+    hasFocalLengthInput = true;
   }
 
   // choose intrinsic type
@@ -165,7 +167,8 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const View& view,
 
   // create the desired intrinsic
   std::shared_ptr<camera::IntrinsicBase> intrinsic = camera::createPinholeIntrinsic(intrinsicType, view.getWidth(), view.getHeight(), pxFocalLength, ppx, ppy);
-  intrinsic->setInitialFocalLengthPix(pxFocalLength);
+  if(hasFocalLengthInput)
+    intrinsic->setInitialFocalLengthPix(pxFocalLength);
 
   // initialize distortion parameters
   switch(intrinsicType)

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-  // check if output folder exists, if no create it
+  // ensure output folder exists
   {
     const std::string outputFolderPart = fs::path(outputFilePath).parent_path().string();
 
@@ -365,10 +365,11 @@ int main(int argc, char **argv)
     // check if the view intrinsic is already defined
     if(intrinsicId != UndefinedIndexT)
     {
-      std::shared_ptr<camera::IntrinsicBase> intrinsic = sfmData.GetIntrinsicSharedPtr(view.getIntrinsicId());
+      camera::IntrinsicBase* intrinsicBase = sfmData.GetIntrinsicPtr(view.getIntrinsicId());
+      camera::Pinhole* intrinsic = dynamic_cast<camera::Pinhole*>(intrinsicBase);
       if(intrinsic != nullptr)
       {
-        if(intrinsic->initialFocalLengthPix() > 0)
+        if(intrinsic->getPxFocalLength() > 0)
         {
           // the view intrinsic is initialized
           #pragma omp atomic
@@ -419,9 +420,10 @@ int main(int argc, char **argv)
     }
 
     // build intrinsic
-    std::shared_ptr<camera::IntrinsicBase> intrinsic = getViewIntrinsic(view, sensorWidth, defaultFocalLengthPixel, defaultFieldOfView, defaultCameraModel, defaultPPx, defaultPPy);
+    std::shared_ptr<camera::IntrinsicBase> intrinsicBase = getViewIntrinsic(view, sensorWidth, defaultFocalLengthPixel, defaultFieldOfView, defaultCameraModel, defaultPPx, defaultPPy);
+    camera::Pinhole* intrinsic = dynamic_cast<camera::Pinhole*>(intrinsicBase.get());
 
-    if(intrinsic->initialFocalLengthPix() > 0)
+    if(intrinsic && intrinsic->getPxFocalLength() > 0)
     {
       // the view intrinsic is initialized
       #pragma omp atomic
@@ -457,7 +459,7 @@ int main(int argc, char **argv)
     #pragma omp critical
     {
       view.setIntrinsicId(intrinsicId);
-      sfmData.GetIntrinsics().emplace(intrinsicId, intrinsic);
+      sfmData.GetIntrinsics().emplace(intrinsicId, intrinsicBase);
     }
   }
 

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
       camera::Pinhole* intrinsic = dynamic_cast<camera::Pinhole*>(intrinsicBase);
       if(intrinsic != nullptr)
       {
-        if(intrinsic->getPxFocalLength() > 0)
+        if(intrinsic->getFocalLengthPix() > 0)
         {
           // the view intrinsic is initialized
           #pragma omp atomic
@@ -423,7 +423,7 @@ int main(int argc, char **argv)
     std::shared_ptr<camera::IntrinsicBase> intrinsicBase = getViewIntrinsic(view, sensorWidth, defaultFocalLengthPixel, defaultFieldOfView, defaultCameraModel, defaultPPx, defaultPPy);
     camera::Pinhole* intrinsic = dynamic_cast<camera::Pinhole*>(intrinsicBase.get());
 
-    if(intrinsic && intrinsic->getPxFocalLength() > 0)
+    if(intrinsic && intrinsic->getFocalLengthPix() > 0)
     {
       // the view intrinsic is initialized
       #pragma omp atomic


### PR DESCRIPTION
When we set an initial focal length it adds constraints in the BA. So we should set it only when the focal length information is reliable.
