### PR TITLE
[WIP]modifications made to make AliceVision work with latest CERES

### DIFF
--- a/src/aliceVision/localization/optimization.cpp
+++ b/src/aliceVision/localization/optimization.cpp
@@ -433,8 +433,9 @@ bool refineRigPose(const std::vector<geometry::Pose3 > &vec_subPoses,
   options.minimizer_progress_to_stdout = aliceVision_options._bVerbose;
   options.logging_type = ceres::SILENT;
   options.num_threads = 1;//aliceVision_options._nbThreads;
+#if CERES_VERSION_MAJOR < 2
   options.num_linear_solver_threads = 1;//aliceVision_options._nbThreads;
-  
+#endif
   // Solve BA
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
@@ -576,7 +577,9 @@ bool refineRigPose(const std::vector<Mat> &pts2d,
   options.minimizer_progress_to_stdout = true;
   //options.logging_type = ceres::SILENT;
   options.num_threads = 1;//aliceVision_options._nbThreads;
+#if CERES_VERSION_MAJOR < 2
   options.num_linear_solver_threads = 1;//aliceVision_options._nbThreads;
+#endif
   
   // Solve BA
   ceres::Solver::Summary summary;

--- a/src/aliceVision/multiview/rotationAveraging/l2.cpp
+++ b/src/aliceVision/multiview/rotationAveraging/l2.cpp
@@ -272,8 +272,9 @@ bool L2RotationAveraging_Refine(
   }
   // set number of threads, 1 if openMP is not enabled
   solverOptions.num_threads = omp_get_max_threads();
+#if CERES_VERSION_MAJOR < 2
   solverOptions.num_linear_solver_threads = omp_get_max_threads();
-
+#endif
 
   ceres::Solver::Summary summary;
   ceres::Solve(solverOptions, &problem, &summary);

--- a/src/aliceVision/multiview/translationAveraging/solverL1Soft.cpp
+++ b/src/aliceVision/multiview/translationAveraging/solverL1Soft.cpp
@@ -196,8 +196,9 @@ bool solve_translations_problem_softl1
 
   // set number of threads, 1 if openMP is not enabled
   options.num_threads = omp_get_max_threads();
+#if CERES_VERSION_MAJOR < 2
   options.num_linear_solver_threads = omp_get_max_threads();
-
+#endif
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
 

--- a/src/aliceVision/multiview/translationAveraging/solverL2Chordal.cpp
+++ b/src/aliceVision/multiview/translationAveraging/solverL2Chordal.cpp
@@ -107,8 +107,9 @@ bool solve_translations_problem_l2_chordal(
   Solver::Options options;
   // set number of threads, 1 if openMP is not enabled
   options.num_threads = omp_get_max_threads();
+#if CERES_VERSION_MAJOR < 2
   options.num_linear_solver_threads = omp_get_max_threads();
-
+#endif
   //options.minimizer_progress_to_stdout = true;
   options.max_num_iterations = max_iterations;
   options.function_tolerance = function_tolerance;

--- a/src/aliceVision/rig/Rig.cpp
+++ b/src/aliceVision/rig/Rig.cpp
@@ -483,8 +483,9 @@ bool Rig::optimizeCalibration()
   options.minimizer_progress_to_stdout = aliceVision_options._bVerbose;
   options.logging_type = ceres::SILENT;
   options.num_threads = 1;//aliceVision_options._nbThreads;
+#if CERES_VERSION_MAJOR < 2
   options.num_linear_solver_threads = 1;//aliceVision_options._nbThreads;
-  
+#endif
   // Solve BA
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -442,8 +442,9 @@ bool BundleAdjustmentCeres::Adjust(
   options.minimizer_progress_to_stdout = _aliceVision_options._bVerbose;
   options.logging_type = ceres::SILENT;
   options.num_threads = _aliceVision_options._nbThreads;
+#if CERES_VERSION_MAJOR < 2
   options.num_linear_solver_threads = _aliceVision_options._nbThreads;
-
+#endif
   // Solve BA
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);

--- a/src/aliceVision/sfm/LocalBundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentCeres.cpp
@@ -414,7 +414,9 @@ void LocalBundleAdjustmentCeres::setSolverOptions(ceres::Solver::Options& solver
   solver_options.minimizer_progress_to_stdout = _LBAOptions._bVerbose;
   solver_options.logging_type = ceres::SILENT;
   solver_options.num_threads = _LBAOptions._nbThreads;
+#if CERES_VERSION_MAJOR < 2
   solver_options.num_linear_solver_threads = _LBAOptions._nbThreads;
+#endif
 }
 
 bool LocalBundleAdjustmentCeres::solveBA(


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Latest Ceres has num_linear_solver_threads as [deprecated.](https://github.com/ceres-solver/ceres-solver/blob/c2f5cd10e7faf52f2a59ca55eca4307b7b6d20e8/docs/source/version_history.rst)
So, build fails if anyone has latest ceres from source. 
This PR solves the issue and maintains backward compatibility. 


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
[X] Fixes build for latest CERES

## Implementation remarks
Tested on Ubuntu 18.04 LTS
GCC: 7.3
CMake: 3.11.3

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

