### PR TITLE
[cleanup] Remove unused code with bug inside

### DIFF
--- a/src/aliceVision/depthMap/cuda/PlaneSweepingCuda.cpp
+++ b/src/aliceVision/depthMap/cuda/PlaneSweepingCuda.cpp
@@ -167,12 +167,16 @@ void ps_computeSimMapForRcTcDepthMap(CudaArray<uchar4, 2>** ps_texs_arr, CudaHos
                                      int width, int height, int scale, int CUDAdeviceNo, int ncamsAllocated, int scales,
                                      bool verbose, int wsh, float gammaC, float gammaP, float epipShift);
 
+/*
+ * unused, based on a buggy CUDA kernel
+ *
 extern void ps_computeRcTcPhotoErrMapReproject(
     CudaArray<uchar4, 2>** ps_texs_arr, CudaHostMemoryHeap<float4, 2>* osdpi_hmh,
     CudaHostMemoryHeap<float, 2>* oerr_hmh, CudaHostMemoryHeap<float, 2>* oderr_hmh,
     CudaHostMemoryHeap<float, 2>& rcDepthMap_hmh, CudaHostMemoryHeap<float, 2>& tcDepthMap_hmh, cameraStruct** cams,
     int ncams, int width, int height, int scale, int CUDAdeviceNo, int ncamsAllocated, int scales, bool verbose,
     int wsh, float gammaC, float gammaP, float depthMapShift);
+*/
 
 extern void ps_refineRcDepthMap(CudaArray<uchar4, 2>** ps_texs_arr, float* osimMap_hmh,
                                 float* rcDepthMap_hmh, int ntcsteps,
@@ -1357,6 +1361,7 @@ bool PlaneSweepingCuda::refineDepthMapReproject(StaticVector<float>* depthMap, S
     return true;
 }
 
+/*
 bool PlaneSweepingCuda::computeRcTcPhotoErrMapReproject(StaticVector<Point4d>* sdpiMap, StaticVector<float>* errMap,
                                                           StaticVector<float>* derrMap, StaticVector<float>* rcDepthMap,
                                                           StaticVector<float>* tcDepthMap, int rc, int tc, int wsh,
@@ -1432,6 +1437,7 @@ bool PlaneSweepingCuda::computeRcTcPhotoErrMapReproject(StaticVector<Point4d>* s
 
     return true;
 }
+*/
 
 bool PlaneSweepingCuda::computeSimMapForRcTcDepthMap(StaticVector<float>* oSimMap, StaticVector<float>* rcTcDepthMap,
                                                        int rc, int tc, int wsh, float gammaC, float gammaP,

--- a/src/aliceVision/depthMap/cuda/PlaneSweepingCuda.hpp
+++ b/src/aliceVision/depthMap/cuda/PlaneSweepingCuda.hpp
@@ -100,10 +100,10 @@ public:
                                      int scale, float igammaC, int wsh, float maxPixelSizeDist);
     bool refineDepthMapReproject(StaticVector<float>* depthMap, StaticVector<float>* simMap, int rc, int tc, int wsh,
                                  float gammaC, float gammaP, float simThr, int niters, bool moveByTcOrRc);
-    bool computeRcTcPhotoErrMapReproject(StaticVector<Point4d>* sdpiMap, StaticVector<float>* errMap,
-                                         StaticVector<float>* derrMap, StaticVector<float>* rcDepthMap,
-                                         StaticVector<float>* tcDepthMap, int rc, int tc, int wsh, float gammaC,
-                                         float gammaP, float depthMapShift);
+    // bool computeRcTcPhotoErrMapReproject(StaticVector<Point4d>* sdpiMap, StaticVector<float>* errMap,
+    //                                      StaticVector<float>* derrMap, StaticVector<float>* rcDepthMap,
+    //                                      StaticVector<float>* tcDepthMap, int rc, int tc, int wsh, float gammaC,
+    //                                      float gammaP, float depthMapShift);
 
     bool computeSimMapForRcTcDepthMap(StaticVector<float>* oSimMap, StaticVector<float>* rcTcDepthMap, int rc, int tc,
                                       int wsh, float gammaC, float gammaP, float epipShift);

--- a/src/aliceVision/depthMap/cuda/planeSweeping/device_code_refine.cu
+++ b/src/aliceVision/depthMap/cuda/planeSweeping/device_code_refine.cu
@@ -1191,6 +1191,9 @@ __global__ void refine_compPhotoErrABG_kernel(float* osimMap, int osimMap_p, int
     };
 }
 
+/*
+ * Buggy code: tTexU4 returns unsigned char and not normalized float
+ *
 __device__ float2 ComputeSobelTarIm(int x, int y)
 {
     unsigned char ul = 255.0f * tex2D(tTexU4, x - 1, y - 1).x; // upper left
@@ -1207,6 +1210,7 @@ __device__ float2 ComputeSobelTarIm(int x, int y)
     int Vert = ul + 2 * um + ur - ll - 2 * lm - lr;
     return make_float2((float)Vert, (float)Horz);
 }
+*/
 
 __device__ float2 DPIXTCDRC(const float3& P)
 {
@@ -1248,6 +1252,9 @@ __device__ float2 DPIXTCDRC(const float3& P)
     return op;
 };
 
+/*
+ * Note: ComputeSobelTarIm called from here is buggy
+ *
 __global__ void refine_reprojTarSobelAndDPIXTCDRCRcTcDepthsMap_kernel(float4* tex, int tex_p, float* rcDepthMap,
                                                                       int rcDepthMap_p, int width, int height,
                                                                       float depthMapShift)
@@ -1285,13 +1292,14 @@ __global__ void refine_reprojTarSobelAndDPIXTCDRCRcTcDepthsMap_kernel(float4* te
                     float2 op = DPIXTCDRC(rpS);
                     float2 so = ComputeSobelTarIm(tpix.x, tpix.y);
                     col = make_float4(op.x, op.y, so.x, so.y);
-                };
-            };
-        };
+                }
+            }
+        }
 
         tex[y * tex_p + x] = col;
-    };
+    }
 }
+*/
 
 __global__ void refine_computeRcTcDepthMap_kernel(float* rcDepthMap, int rcDepthMap_p, int width, int height,
                                                   float pixSizeRatioThr)

--- a/src/aliceVision/depthMap/cuda/planeSweeping/plane_sweeping_cuda.cu
+++ b/src/aliceVision/depthMap/cuda/planeSweeping/plane_sweeping_cuda.cu
@@ -2491,6 +2491,7 @@ void ps_refineDepthMapReproject(CudaArray<uchar4, 2>** ps_texs_arr, CudaHostMemo
     cudaUnbindTexture(t4tex);
 };
 
+#if 0
 void ps_computeRcTcPhotoErrMapReproject(
     CudaArray<uchar4, 2>** ps_texs_arr, CudaHostMemoryHeap<float4, 2>* osdpi_hmh,
     CudaHostMemoryHeap<float, 2>* oerr_hmh, CudaHostMemoryHeap<float, 2>* oderr_hmh,
@@ -2608,7 +2609,8 @@ void ps_computeRcTcPhotoErrMapReproject(
 
     if(verbose)
         printf("gpu elapsed time: %f ms \n", toc(tall));
-};
+}
+#endif
 
 void ps_computeSimMapsForNShiftsOfRcTcDepthMap(CudaArray<uchar4, 2>** ps_texs_arr,
                                                CudaHostMemoryHeap<float2, 2>** odepthSimMaps_hmh, int ntcsteps,


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

The CUDA kernel ComputeSobelTarIm is buggy (reads uchar from a texture but treats it like
a normalized float). Following the dependency upwards exposed a dead top-level function. The
obviously dead code is now in C comments or (if C comments inside) in #if-0 statements.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

