### PR TITLE
[structure from motion] Add option to lock previously reconstructed scene in augmentation

### DIFF
--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -34,6 +34,15 @@ struct IntrinsicBase
   virtual void assign(const IntrinsicBase& other) = 0;
 
   virtual bool isValid() const { return _w != 0 && _h != 0; }
+
+  /**
+   * @brief Get the lock state of the intrinsic
+   * @return true if the intrinsic is locked
+   */
+  inline bool isLocked() const
+  {
+    return _locked;
+  }
   
   unsigned int w() const {return _w;}
   unsigned int h() const {return _h;}
@@ -148,6 +157,26 @@ struct IntrinsicBase
       stl::hash_combine(seed, params[i]);
     return seed;
   }
+
+  /**
+   * @brief lock the intrinsic
+   */
+  inline void lock()
+  {
+    _locked  = true;
+  }
+
+  /**
+   * @brief unlock the intrinsic
+   */
+  inline void unlock()
+  {
+    _locked  = false;
+  }
+
+private:
+  /// intrinsic lock
+  bool _locked = false;
 };
 
 /// Return the angle (degree) between two bearing vector rays

--- a/src/aliceVision/localization/VoctreeLocalizer.cpp
+++ b/src/aliceVision/localization/VoctreeLocalizer.cpp
@@ -586,7 +586,7 @@ bool VoctreeLocalizer::localizeFirstBestResult(const feature::MapRegionsPerDesc 
     
     {
       // just temporary code to evaluate the estimated pose @todo remove it
-      const geometry::Pose3 &referencePose = _sfm_data.getPose(*_sfm_data.views.at(matchedViewId));
+      const geometry::Pose3 referencePose = _sfm_data.getPose(*_sfm_data.views.at(matchedViewId)).getTransform();
       ALICEVISION_LOG_DEBUG("R refined\n" << pose.rotation());
       ALICEVISION_LOG_DEBUG("t refined\n" << pose.translation());
       ALICEVISION_LOG_DEBUG("K refined\n" << queryIntrinsics.K());

--- a/src/aliceVision/localization/optimization.cpp
+++ b/src/aliceVision/localization/optimization.cpp
@@ -5,13 +5,12 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "optimization.hpp"
-#include "aliceVision/sfm/sfmDataIO.hpp"
+#include <aliceVision/sfm/sfmDataIO.hpp>
 #include <aliceVision/sfm/BundleAdjustmentCeres.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/rig/ResidualError.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
-
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
@@ -116,7 +115,7 @@ bool refineSequence(std::vector<LocalizationResult> & vec_localizationResult,
     std::shared_ptr<sfm::View> view = std::make_shared<sfm::View>("",viewID, intrinsicID, viewID);
     tinyScene.views.insert( std::make_pair(viewID, view));
     // pose
-    tinyScene.setPose(*view, currResult.getPose());
+    tinyScene.setPose(*view, sfm::CameraPose(currResult.getPose()));
 
     
     if(!allTheSameIntrinsics)
@@ -281,7 +280,7 @@ bool refineSequence(std::vector<LocalizationResult> & vec_localizationResult,
     for(const auto &pose : tinyScene.getPoses())
     {
       const IndexT idPose = pose.first;
-      vec_localizationResult[idPose].setPose(pose.second);
+      vec_localizationResult[idPose].setPose(pose.second.getTransform());
     }
 
     if(!outputFilename.empty())

--- a/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
+++ b/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
@@ -43,7 +43,7 @@ bool refinePoseAsItShouldbe(const Mat & pt3D,
                             const Mat & pt2D,
                             const std::vector<std::size_t> & vec_inliers,
                             camera::IntrinsicBase * intrinsics,
-                            geometry::Pose3 & pose,
+                            geometry::Pose3& pose,
                             bool b_refine_pose,
                             bool b_refine_intrinsic)
 {
@@ -55,7 +55,7 @@ bool refinePoseAsItShouldbe(const Mat & pt3D,
   std::shared_ptr<View> view = std::make_shared<View>("", 0, 0, 0);
   sfm_data.views.emplace(0, view);
   // pose
-  sfm_data.setPose(*view, pose);
+  sfm_data.setPose(*view, CameraPose(pose));
   // intrinsic (the shared_ptr does not take the ownership, will not release the input pointer)
   sfm_data.intrinsics[0] = std::shared_ptr<camera::IntrinsicBase>(intrinsics, [](camera::IntrinsicBase*)
   {
@@ -79,7 +79,7 @@ bool refinePoseAsItShouldbe(const Mat & pt3D,
   const bool b_BA_Status = bundle_adjustment_obj.Adjust(sfm_data, refineOptions);
   if(b_BA_Status)
   {
-    pose = sfm_data.getPose(*view);
+    pose = sfm_data.getPose(*view).getTransform();
   }
   return b_BA_Status;
 }

--- a/src/aliceVision/sfm/AlembicExporter.cpp
+++ b/src/aliceVision/sfm/AlembicExporter.cpp
@@ -212,6 +212,7 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
     OUInt32ArrayProperty(userProps, "mvg_sensorSizePix").set(sensorSize_pix);
     OStringProperty(userProps, "mvg_intrinsicType").set(pinhole->getTypeStr());
     ODoubleArrayProperty(userProps, "mvg_intrinsicParams").set(pinhole->getParams());
+    OBoolProperty(userProps, "mvg_intrinsicLocked").set(pinhole->isLocked());
 
     camObj.getSchema().set(camSample);
   }

--- a/src/aliceVision/sfm/AlembicExporter.cpp
+++ b/src/aliceVision/sfm/AlembicExporter.cpp
@@ -211,6 +211,7 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
 
     OUInt32ArrayProperty(userProps, "mvg_sensorSizePix").set(sensorSize_pix);
     OStringProperty(userProps, "mvg_intrinsicType").set(pinhole->getTypeStr());
+    ODoubleProperty(userProps, "mvg_initialFocalLengthPix").set(pinhole->initialFocalLengthPix());
     ODoubleArrayProperty(userProps, "mvg_intrinsicParams").set(pinhole->getParams());
     OBoolProperty(userProps, "mvg_intrinsicLocked").set(pinhole->isLocked());
 

--- a/src/aliceVision/sfm/AlembicExporter.cpp
+++ b/src/aliceVision/sfm/AlembicExporter.cpp
@@ -60,7 +60,7 @@ struct AlembicExporter::DataImpl
    */
   void addCamera(const std::string& name,
                const View& view,
-               const geometry::Pose3* pose = nullptr,
+               const CameraPose* pose = nullptr,
                const camera::IntrinsicBase* intrinsic = nullptr,
                const Vec6* uncertainty = nullptr,
                Alembic::Abc::OObject* parent = nullptr);
@@ -85,7 +85,7 @@ struct AlembicExporter::DataImpl
 
 void AlembicExporter::DataImpl::addCamera(const std::string& name,
                const View& view,
-               const geometry::Pose3* pose,
+               const CameraPose* pose,
                const camera::IntrinsicBase* intrinsic,
                const Vec6* uncertainty,
                Alembic::Abc::OObject* parent)
@@ -93,13 +93,25 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
   if(parent == nullptr)
     parent = &_mvgCameras;
 
+
+  std::stringstream ssLabel;
+  ssLabel << "camxform_" << std::setfill('0') << std::setw(5) << view.getResectionId() << "_" << view.getPoseId();
+  ssLabel << "_" << name << "_" << view.getViewId();
+
+  Alembic::AbcGeom::OXform xform(*parent, ssLabel.str());
+  OCamera camObj(xform, "camera_" + ssLabel.str());
+
+  auto userProps = camObj.getSchema().getUserProperties();
+
   XformSample xformsample;
 
   // set camera pose
   if(pose != nullptr)
   {
-    const Mat3& R = pose->rotation();
-    const Vec3& center = pose->center();
+    OBoolProperty(userProps, "mvg_poseLocked").set(pose->isLocked());
+
+    const Mat3& R = pose->getTransform().rotation();
+    const Vec3& center = pose->getTransform().center();
 
     // compensate translation with rotation
     // build transform matrix
@@ -128,15 +140,7 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
     xformsample.setMatrix(xformMatrix);
   }
 
-  std::stringstream ssLabel;
-  ssLabel << "camxform_" << std::setfill('0') << std::setw(5) << view.getResectionId() << "_" << view.getPoseId();
-  ssLabel << "_" << name << "_" << view.getViewId();
-
-  Alembic::AbcGeom::OXform xform(*parent, ssLabel.str());
   xform.getSchema().set(xformsample);
-
-  OCamera camObj(xform, "camera_" + ssLabel.str());
-  auto userProps = camObj.getSchema().getUserProperties();
 
   // set view custom properties
   if(!view.getImagePath().empty())
@@ -285,8 +289,8 @@ void AlembicExporter::addSfM(const SfMData& sfmData, ESfMData flagsPart)
 void AlembicExporter::addSfMSingleCamera(const SfMData& sfmData, const View& view)
 {
   const std::string name = fs::path(view.getImagePath()).stem().string();
-  const geometry::Pose3* pose = (sfmData.existsPose(view)) ? &(sfmData.getPoses().at(view.getPoseId())) :  nullptr;
-  const camera::IntrinsicBase* intrinsic = sfmData.getIntrinsicPtr(view.getIntrinsicId());
+  const CameraPose* pose = (sfmData.existsPose(view)) ? &(sfmData.getPoses().at(view.getPoseId())) :  nullptr;
+  const camera::IntrinsicBase* intrinsic = sfmData.getIntrinsicPtr(view.getIntrinsicId()); 
 
   if(sfmData.isPoseAndIntrinsicDefined(&view))
     _dataImpl->addCamera(name, view, pose, intrinsic, nullptr, &_dataImpl->_mvgCameras);
@@ -307,14 +311,17 @@ void AlembicExporter::addSfMCameraRig(const SfMData& sfmData, IndexT rigId, cons
 
   XformSample xformsample;
   const IndexT rigPoseId = firstView.getPoseId();
+  bool rigPoseLocked = false;
 
   if(sfmData.getPoses().find(rigPoseId) != sfmData.getPoses().end())
   {
     // rig pose
-    const geometry::Pose3 rigPose = sfmData.getPoses().at(rigPoseId);
+    const CameraPose& rigPose = sfmData.getAbsolutePose(rigPoseId);
+    const geometry::Pose3& rigTransform = rigPose.getTransform();
+    rigPoseLocked = rigPose.isLocked();
 
-    const aliceVision::Mat3& R = rigPose.rotation();
-    const aliceVision::Vec3& center = rigPose.center();
+    const aliceVision::Mat3& R = rigTransform.rotation();
+    const aliceVision::Vec3& center = rigTransform.center();
 
     Abc::M44d xformMatrix;
 
@@ -347,8 +354,13 @@ void AlembicExporter::addSfMCameraRig(const SfMData& sfmData, IndexT rigId, cons
     const RigSubPose& rigSubPose = rig.getSubPose(view.getSubPoseId());
     const bool isReconstructed = (rigSubPose.status != ERigSubPoseStatus::UNINITIALIZED);
     const std::string name = fs::path(view.getImagePath()).stem().string();
-    const geometry::Pose3* subPose = isReconstructed ? &(rigSubPose.pose) : nullptr;
     const camera::IntrinsicBase* intrinsic = sfmData.getIntrinsicPtr(view.getIntrinsicId());
+    std::unique_ptr<CameraPose> subPosePtr;
+
+    if(isReconstructed)
+    {
+      subPosePtr = std::unique_ptr<CameraPose>(new CameraPose(rigSubPose.pose));
+    }
 
     Alembic::Abc::OObject& parent = isReconstructed ? _dataImpl->_mvgCameras : _dataImpl->_mvgCamerasUndefined;
 
@@ -364,9 +376,10 @@ void AlembicExporter::addSfMCameraRig(const SfMData& sfmData, IndexT rigId, cons
         OUInt32Property(userProps, "mvg_rigId").set(rigId);
         OUInt32Property(userProps, "mvg_poseId").set(rigPoseId);
         OUInt16Property(userProps, "mvg_nbSubPoses").set(nbSubPoses);
+        OBoolProperty(userProps, "mvg_rigPoseLocked").set(rigPoseLocked);
       }
     }
-    _dataImpl->addCamera(name, view, subPose, intrinsic, nullptr, &(rigObj.at(isReconstructed)));
+    _dataImpl->addCamera(name, view, subPosePtr.get(), intrinsic, nullptr, &(rigObj.at(isReconstructed)));
   }
 }
 
@@ -468,7 +481,7 @@ void AlembicExporter::addLandmarks(const Landmarks& landmarks, const sfm::Landma
 
 void AlembicExporter::addCamera(const std::string& name,
                                 const View& view,
-                                const geometry::Pose3* pose,
+                                const CameraPose* pose,
                                 const camera::IntrinsicBase* intrinsic,
                                 const Vec6* uncertainty)
 {

--- a/src/aliceVision/sfm/AlembicExporter.hpp
+++ b/src/aliceVision/sfm/AlembicExporter.hpp
@@ -76,7 +76,7 @@ public:
    */
   void addCamera(const std::string& name,
                  const View& view,
-                 const geometry::Pose3* pose = nullptr,
+                 const CameraPose* pose = nullptr,
                  const camera::IntrinsicBase* intrinsic = nullptr,
                  const Vec6* uncertainty = nullptr);
 

--- a/src/aliceVision/sfm/AlembicImporter.cpp
+++ b/src/aliceVision/sfm/AlembicImporter.cpp
@@ -225,6 +225,7 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfm::SfMData& sfmData, s
   IndexT subPoseId = UndefinedIndexT;
   IndexT resectionId = UndefinedIndexT;
   bool poseLocked = false;
+  bool intrinsicLocked = false;
 
   if(userProps)
   {
@@ -303,6 +304,10 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfm::SfMData& sfmData, s
       {
         poseLocked = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_poseLocked", sampleFrame);
       }
+      if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_poseLocked"))
+      {
+        intrinsicLocked = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_intrinsicLocked", sampleFrame);
+      }
       if(userProps.getPropertyHeader("mvg_sensorSizePix"))
       {
         getAbcArrayProp<Alembic::Abc::IStringArrayProperty>(userProps, "mvg_metadata", sampleFrame, rawMetadata);
@@ -351,6 +356,10 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfm::SfMData& sfmData, s
     pinholeIntrinsic->setWidth(sensorSize_pix.at(0));
     pinholeIntrinsic->setHeight(sensorSize_pix.at(1));
     pinholeIntrinsic->updateFromParams(mvg_intrinsicParams);
+    if(intrinsicLocked)
+      pinholeIntrinsic->lock();
+    else
+      pinholeIntrinsic->unlock();
 
     sfmData.intrinsics[intrinsicId] = pinholeIntrinsic;
   }

--- a/src/aliceVision/sfm/AlembicImporter.cpp
+++ b/src/aliceVision/sfm/AlembicImporter.cpp
@@ -217,6 +217,7 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfm::SfMData& sfmData, s
   std::vector<unsigned int> sensorSize_pix = {0, 0};
   std::string mvg_intrinsicType = EINTRINSIC_enumToString(PINHOLE_CAMERA);
   std::vector<double> mvg_intrinsicParams;
+  double initialFocalLengthPix = -1;
   std::vector<std::string> rawMetadata;
   IndexT viewId = sfmData.getViews().size();
   IndexT poseId = sfmData.getViews().size();
@@ -329,6 +330,10 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfm::SfMData& sfmData, s
       {
         mvg_intrinsicType = getAbcProp<Alembic::Abc::IStringProperty>(userProps, *propHeader, "mvg_intrinsicType", sampleFrame);
       }
+      if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_initialFocalLengthPix"))
+      {
+        initialFocalLengthPix = getAbcProp<Alembic::Abc::IDoubleProperty>(userProps, *propHeader, "mvg_initialFocalLengthPix", sampleFrame);
+      }
       if(userProps.getPropertyHeader("mvg_intrinsicParams"))
       {
         Alembic::Abc::IDoubleArrayProperty prop(userProps, "mvg_intrinsicParams");
@@ -356,6 +361,8 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfm::SfMData& sfmData, s
     pinholeIntrinsic->setWidth(sensorSize_pix.at(0));
     pinholeIntrinsic->setHeight(sensorSize_pix.at(1));
     pinholeIntrinsic->updateFromParams(mvg_intrinsicParams);
+    pinholeIntrinsic->setInitialFocalLengthPix(initialFocalLengthPix);
+
     if(intrinsicLocked)
       pinholeIntrinsic->lock();
     else

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -110,7 +110,7 @@ void addPose(ceres::Problem& problem,
      (!(refineOptions & BA_REFINE_TRANSLATION) &&
      !(refineOptions & BA_REFINE_ROTATION)))
   {
-    //set the whole parameter block as constant for best performance or if it's locked.
+    //set the whole parameter block as constant for best performance or because it's locked.
     problem.SetParameterBlockConstant(parameter_block);
   }
   else
@@ -281,10 +281,10 @@ void BundleAdjustmentCeres::createProblem(SfMData & sfm_data, BA_Refine refineOp
 
     double * parameter_block = &map_intrinsics[idIntrinsics][0];
     problem.AddParameterBlock(parameter_block, map_intrinsics[idIntrinsics].size());
-    if (!refineIntrinsics)
+    if((!refineIntrinsics) || itIntrinsic.second->isLocked())
     {
       // Nothing to refine in the intrinsics,
-      // so set the whole parameter block as constant with better performances.
+      //set the whole parameter block as constant for best performance or because it's locked.
       problem.SetParameterBlockConstant(parameter_block);
     }
     else

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -84,12 +84,12 @@ ceres::CostFunction * createRigCostFunctionFromIntrinsics(IntrinsicBase * intrin
 
 void addPose(ceres::Problem& problem,
              BA_Refine refineOptions,
-             const Pose3 & pose,
+             const CameraPose& cameraPose,
              std::vector<double*>& out_parameterBlocks,
              std::vector<double>& out_poseParams)
 {
-  const Mat3 R = pose.rotation();
-  const Vec3 t = pose.translation();
+  const Mat3& R = cameraPose.getTransform().rotation();
+  const Vec3& t = cameraPose.getTransform().translation();
 
   double angleAxis[3];
   ceres::RotationMatrixToAngleAxis((const double*)R.data(), angleAxis);
@@ -105,9 +105,12 @@ void addPose(ceres::Problem& problem,
   problem.AddParameterBlock(parameter_block, 6);
   out_parameterBlocks.push_back(parameter_block);
   // Keep the camera extrinsics constants
-  if (!(refineOptions & BA_REFINE_TRANSLATION) && !(refineOptions & BA_REFINE_ROTATION))
+
+  if(cameraPose.isLocked() ||
+     (!(refineOptions & BA_REFINE_TRANSLATION) &&
+     !(refineOptions & BA_REFINE_ROTATION)))
   {
-    //set the whole parameter block as constant for best performance.
+    //set the whole parameter block as constant for best performance or if it's locked.
     problem.SetParameterBlockConstant(parameter_block);
   }
   else
@@ -217,9 +220,9 @@ void BundleAdjustmentCeres::createProblem(SfMData & sfm_data, BA_Refine refineOp
   for (Poses::const_iterator itPose = sfm_data.getPoses().begin(); itPose != sfm_data.getPoses().end(); ++itPose)
   {
     const IndexT indexPose = itPose->first;
-    const Pose3& pose = itPose->second;
+    const CameraPose& cameraPose = itPose->second;
 
-    addPose(problem, refineOptions, pose, parameterBlocks, map_poses[indexPose]);
+    addPose(problem, refineOptions, cameraPose, parameterBlocks, map_poses[indexPose]);
   }
 
   for(const auto& rigIt : sfm_data.getRigs())
@@ -235,7 +238,9 @@ void BundleAdjustmentCeres::createProblem(SfMData & sfm_data, BA_Refine refineOp
       if(rigSubPose.status == ERigSubPoseStatus::UNINITIALIZED)
         continue;
 
-      addPose(problem, refineOptions, rigSubPose.pose, parameterBlocks, map_subposes[rigId][subPoseId]);
+     const bool locked = (rigSubPose.status == ERigSubPoseStatus::CONSTANT);
+
+      addPose(problem, refineOptions, CameraPose(rigSubPose.pose, locked), parameterBlocks, map_subposes[rigId][subPoseId]);
     }
   }
 
@@ -485,8 +490,7 @@ bool BundleAdjustmentCeres::Adjust(
       ceres::AngleAxisToRotationMatrix(&map_poses[indexPose][0], R_refined.data());
       Vec3 t_refined(map_poses[indexPose][3], map_poses[indexPose][4], map_poses[indexPose][5]);
       // Update the pose
-      Pose3 & pose = itPose->second;
-      pose = poseFromRT(R_refined, t_refined);
+      itPose->second.setTransform(poseFromRT(R_refined, t_refined));
     }
 
     for(const auto& rigIt : map_subposes)

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -34,6 +34,7 @@ set(sfm_files_headers
   generateReport.hpp
   View.hpp
   viewIO.hpp
+  CameraPose.hpp
   Rig.hpp
   utils/alignment.hpp
   utils/uid.hpp

--- a/src/aliceVision/sfm/CameraPose.hpp
+++ b/src/aliceVision/sfm/CameraPose.hpp
@@ -1,0 +1,93 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2018 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/geometry/Pose3.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+class CameraPose
+{
+public:
+
+  /**
+   * @brief CameraPose default constructor
+   */
+  CameraPose() = default;
+
+  /**
+   * @brief CameraPose constructor
+   * @param[in] transform The camera initial 3d transformation
+   * @param[in] locked If enable the camera pose is locked
+   */
+  explicit CameraPose(const geometry::Pose3& transform, bool locked = false)
+    : _transform(transform)
+    , _locked(locked)
+  {}
+
+  /**
+   * @brief Get the 3d transformation of the camera
+   * @return 3d transformation
+   */
+  inline const geometry::Pose3& getTransform() const
+  {
+    return _transform;
+  }
+
+  /**
+   * @brief Get the lock state of the camera
+   * @return true if the camera pose is locked
+   */
+  inline bool isLocked() const
+  {
+    return _locked;
+  }
+
+  /**
+   * @brief operator ==
+   */
+  inline bool operator==(const CameraPose& other) const
+  {
+    return (_transform == other._transform &&
+            _locked == other._locked);
+  }
+
+  /**
+   * @brief Set the 3d transformation of the camera
+   * @param[in] 3d transformation
+   */
+  inline void setTransform(const geometry::Pose3& transform)
+  {
+    _transform = transform;
+  }
+
+  /**
+   * @brief lock the camera pose
+   */
+  inline void lock()
+  {
+    _locked  = true;
+  }
+
+  /**
+   * @brief unlock the camera pose
+   */
+  inline void unlock()
+  {
+    _locked  = false;
+  }
+
+private:
+  /// camera 3d transformation
+  geometry::Pose3 _transform;
+  /// camera lock
+  bool _locked = false;
+};
+
+} // namespace sfm
+} // namespace aliceVision

--- a/src/aliceVision/sfm/FrustumFilter.cpp
+++ b/src/aliceVision/sfm/FrustumFilter.cpp
@@ -47,7 +47,7 @@ void FrustumFilter::initFrustum(const SfMData & sfm_data)
     if (!isPinhole(iterIntrinsic->second.get()->getType()))
       continue;
 
-    const Pose3 pose = sfm_data.getPose(*view);
+    const Pose3 pose = sfm_data.getPose(*view).getTransform();
 
     const Pinhole * cam = dynamic_cast<const Pinhole*>(iterIntrinsic->second.get());
     if (cam == nullptr)
@@ -203,7 +203,7 @@ void FrustumFilter::init_z_near_z_far_depth(const SfMData & sfm_data,
           continue;
 
         Intrinsics::const_iterator iterIntrinsic = sfm_data.getIntrinsics().find(view->getIntrinsicId());
-        const Pose3 pose = sfm_data.getPose(*view);
+        const Pose3 pose = sfm_data.getPose(*view).getTransform();
         const double z = pose.depth(X);
         NearFarPlanesT::iterator itZ = z_near_z_far_perView.find(id_view);
         if (itZ != z_near_z_far_perView.end())

--- a/src/aliceVision/sfm/LocalBundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentCeres.cpp
@@ -311,9 +311,9 @@ std::map<IndexT, std::vector<double> > LocalBundleAdjustmentCeres::addPosesToCer
   {
     const IndexT poseId = itPose->first;
     
-    const Pose3 & pose = itPose->second;
-    const Mat3 R = pose.rotation();
-    const Vec3 t = pose.translation();
+    const CameraPose& cameraPose = itPose->second;
+    const Mat3& R = cameraPose.getTransform().rotation();
+    const Vec3& t = cameraPose.getTransform().translation();
     
     double angleAxis[3];
     ceres::RotationMatrixToAngleAxis((const double*)R.data(), angleAxis);
@@ -327,6 +327,9 @@ std::map<IndexT, std::vector<double> > LocalBundleAdjustmentCeres::addPosesToCer
     
     double * parameter_block = &map_poses[poseId][0];
     problem.AddParameterBlock(parameter_block, 6);
+
+    if(cameraPose.isLocked()) //set the whole parameter block as constant.
+      problem.SetParameterBlockConstant(parameter_block);
   }
   return map_poses;
 }
@@ -468,9 +471,9 @@ void LocalBundleAdjustmentCeres::updateCameraPoses(
     Mat3 R_refined;
     ceres::AngleAxisToRotationMatrix(&map_poseblocks.at(poseId)[0], R_refined.data());
     Vec3 t_refined(map_poseblocks.at(poseId)[3], map_poseblocks.at(poseId)[4], map_poseblocks.at(poseId)[5]);
+
     // Update the pose
-    Pose3 & pose = itPose->second;
-    pose = Pose3(R_refined, -R_refined.transpose() * t_refined);
+    itPose->second.setTransform(Pose3(R_refined, -R_refined.transpose() * t_refined));
   }
 }
 

--- a/src/aliceVision/sfm/LocalBundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentCeres.cpp
@@ -373,7 +373,14 @@ std::map<IndexT, std::vector<double>> LocalBundleAdjustmentCeres::addIntrinsicsT
     
     double * parameter_block = &map_intrinsics[intrinsicIds][0];
     problem.AddParameterBlock(parameter_block, map_intrinsics[intrinsicIds].size());
-    
+
+    if(itIntrinsic.second->isLocked())
+    {
+      //set the whole parameter block as constant.
+      problem.SetParameterBlockConstant(parameter_block);
+      continue;
+    }
+
     // Refine the focal length
     if(itIntrinsic.second->initialFocalLengthPix() > 0)
     {

--- a/src/aliceVision/sfm/SfMData.cpp
+++ b/src/aliceVision/sfm/SfMData.cpp
@@ -141,15 +141,15 @@ std::set<IndexT> SfMData::getReconstructedIntrinsics() const
   return valid_idx;
 }
 
-void SfMData::setPose(const View& view, const geometry::Pose3& absolutePose)
+void SfMData::setPose(const View& view, const CameraPose& absolutePose)
 {
   const bool knownPose = existsPose(view);
-  Pose3& viewPose = _poses[view.getPoseId()];
+  CameraPose& viewPose = _poses[view.getPoseId()];
 
   // view is not part of a rig
   if(!view.isPartOfRig())
   {
-    viewPose = absolutePose;
+    viewPose.setTransform(absolutePose.getTransform());//todo locked
     return;
   }
 
@@ -163,7 +163,7 @@ void SfMData::setPose(const View& view, const geometry::Pose3& absolutePose)
 
     subPose.status = ERigSubPoseStatus::ESTIMATED; // sub-pose initialized
     subPose.pose = Pose3();  // the first sub-pose is set to identity
-    viewPose = absolutePose; // so the pose of the rig is the same than the pose
+    viewPose.setTransform(absolutePose.getTransform()); // so the pose of the rig is the same than the pose
   }
   else
   {
@@ -180,7 +180,7 @@ void SfMData::setPose(const View& view, const geometry::Pose3& absolutePose)
       subPose.status = ERigSubPoseStatus::ESTIMATED;
 
       // convert absolute pose to RigSubPose
-      subPose.pose = absolutePose * viewPose.inverse();
+      subPose.pose = absolutePose.getTransform() * viewPose.getTransform().inverse();
 
     }
     else
@@ -193,7 +193,7 @@ void SfMData::setPose(const View& view, const geometry::Pose3& absolutePose)
       }
 
       //convert absolute pose to rig Pose
-      viewPose = subPose.pose.inverse() * absolutePose;
+      viewPose.setTransform(subPose.pose.inverse() * absolutePose.getTransform());
     }
   }
 }

--- a/src/aliceVision/sfm/alembicIO_test.cpp
+++ b/src/aliceVision/sfm/alembicIO_test.cpp
@@ -48,7 +48,7 @@ SfMData createTestScene(IndexT singleViewsCount,
     // Add poses
     const Mat3 r = Mat3::Random();
     const Vec3 c = Vec3::Random();
-    sfm_data.setPose(*view, geometry::Pose3(r, c));
+    sfm_data.setPose(*view, CameraPose(geometry::Pose3(r, c)));
 
     // Add intrinsics
     if (bSharedIntrinsic)
@@ -96,7 +96,7 @@ SfMData createTestScene(IndexT singleViewsCount,
         {
           const Mat3 r = Mat3::Random();
           const Vec3 c = Vec3::Random();
-          sfm_data.setPose(*view, geometry::Pose3(r, c));
+          sfm_data.setPose(*view, CameraPose(geometry::Pose3(r, c)));
         }
 
         sfm_data.views[nbViews] = view;

--- a/src/aliceVision/sfm/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundleAdjustment_test.cpp
@@ -248,7 +248,7 @@ double RMSE(const SfMData & sfm_data)
       itObs != observations.end(); ++itObs)
     {
       const View * view = sfm_data.getViews().find(itObs->first)->second.get();
-      const Pose3 pose = sfm_data.getPose(*view);
+      const Pose3 pose = sfm_data.getPose(*view).getTransform();
       const std::shared_ptr<IntrinsicBase> intrinsic = sfm_data.getIntrinsics().find(view->getIntrinsicId())->second;
       const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x);
       vec.push_back( residual(0) );
@@ -287,7 +287,7 @@ SfMData getInputScene(const NViewDataSet & d, const NViewDatasetConfigurator & c
   for (int i = 0; i < nviews; ++i)
   {
     Pose3 pose(d._R[i], d._C[i]);
-    sfm_data.setPose(*sfm_data.views.at(i), pose);
+    sfm_data.setPose(*sfm_data.views.at(i), CameraPose(pose));
   }
 
   // 3. Intrinsic data (shared, so only one camera intrinsic is defined)

--- a/src/aliceVision/sfm/generateReport.cpp
+++ b/src/aliceVision/sfm/generateReport.cpp
@@ -34,7 +34,7 @@ bool generateSfMReport(const SfMData& sfmData,
       itObs != observations.end(); ++itObs)
     {
       const View * view = sfmData.getViews().at(itObs->first).get();
-      const geometry::Pose3 pose = sfmData.getPose(*view);
+      const geometry::Pose3 pose = sfmData.getPose(*view).getTransform();
       const camera::IntrinsicBase * intrinsic = sfmData.getIntrinsics().at(view->getIntrinsicId()).get();
       // Use absolute values
       const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x).array().abs();

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
@@ -186,7 +186,7 @@ bool GlobalSfMTranslationAveragingSolver::Translation_averaging(
           const Vec3 t(vec_camTranslation[i*3], vec_camTranslation[i*3+1], vec_camTranslation[i*3+2]);
           const IndexT pose_id = _reindexBackward[i];
           const Mat3 & Ri = map_globalR.at(pose_id);
-          sfm_data.setAbsolutePose(pose_id, Pose3(Ri, -Ri.transpose()*t));
+          sfm_data.setAbsolutePose(pose_id, CameraPose(Pose3(Ri, -Ri.transpose()*t)));
         }
       }
       break;
@@ -208,7 +208,7 @@ bool GlobalSfMTranslationAveragingSolver::Translation_averaging(
           const Vec3 & t = vec_translations[i];
           const IndexT pose_id = _reindexBackward[i];
           const Mat3 & Ri = map_globalR.at(pose_id);
-          sfm_data.setAbsolutePose(pose_id, Pose3(Ri, -Ri.transpose()*t));
+          sfm_data.setAbsolutePose(pose_id, CameraPose(Pose3(Ri, -Ri.transpose()*t)));
         }
       }
       break;
@@ -267,7 +267,7 @@ bool GlobalSfMTranslationAveragingSolver::Translation_averaging(
           const Vec3 C(X[i*3], X[i*3+1], X[i*3+2]);
           const IndexT pose_id = _reindexBackward[i]; // undo the reindexing
           const Mat3 & Ri = map_globalR.at(pose_id);
-          sfm_data.setAbsolutePose(pose_id, Pose3(Ri, C));
+          sfm_data.setAbsolutePose(pose_id, CameraPose(Pose3(Ri, C)));
         }
       }
       break;

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -91,10 +91,10 @@ void StructureEstimationFromKnownPoses::match(
     // - by considering geometric error and descriptor distance ratio.
 
     const View * viewL = sfm_data.getViews().at(it->first).get();
-    const Pose3 poseL = sfm_data.getPose(*viewL);
+    const Pose3 poseL = sfm_data.getPose(*viewL).getTransform();
     const Intrinsics::const_iterator iterIntrinsicL = sfm_data.getIntrinsics().find(viewL->getIntrinsicId());
     const View * viewR = sfm_data.getViews().at(it->second).get();
-    const Pose3 poseR = sfm_data.getPose(*viewR);
+    const Pose3 poseR = sfm_data.getPose(*viewR).getTransform();
     const Intrinsics::const_iterator iterIntrinsicR = sfm_data.getIntrinsics().find(viewR->getIntrinsicId());
 
     if (sfm_data.getIntrinsics().count(viewL->getIntrinsicId()) != 0 ||
@@ -213,7 +213,7 @@ void StructureEstimationFromKnownPoses::filter(
               const size_t featIndex = iter->second;
               const View * view = sfm_data.getViews().at(imaIndex).get();
               const IntrinsicBase * cam = sfm_data.getIntrinsics().at(view->getIntrinsicId()).get();
-              const Pose3 pose = sfm_data.getPose(*view);
+              const Pose3 pose = sfm_data.getPose(*view).getTransform();
               const Vec2 pt = regionsPerView.getRegions(imaIndex, subTrack.descType).GetRegionPosition(featIndex);
               trianObj.add(cam->get_projective_equivalent(pose), cam->get_ud_pixel(pt));
             }

--- a/src/aliceVision/sfm/rig_test.cpp
+++ b/src/aliceVision/sfm/rig_test.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(rig_initialization)
 
   const Mat3 r = Mat3::Random();
   const Vec3 c = Vec3::Random();
-  const geometry::Pose3 firstPose = geometry::Pose3(r, c);
+  const geometry::Pose3 firstPose(r, c);
   const IndexT firstPoseId = std::rand() % nbSubPoses;
 
   const Rig& rig = sfmData.getRig(rigViews.front());
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(rig_initialization)
   // rig uninitialized
   BOOST_CHECK(!rig.isInitialized());
 
-  sfmData.setPose(rigViews.at(firstPoseId), firstPose);
+  sfmData.setPose(rigViews.at(firstPoseId), CameraPose(firstPose));
 
   // setPose done, rig initialized
   BOOST_CHECK(rig.isInitialized());
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(rig_initialization)
   for(std::size_t subPoseId = 0; subPoseId < nbSubPoses; ++subPoseId)
   {
     const View& view = rigViews.at(subPoseId);
-    BOOST_CHECK(sfmData.getPose(view) == firstPose);
+    BOOST_CHECK(sfmData.getPose(view).getTransform() == firstPose);
   }
 }
 
@@ -137,14 +137,14 @@ BOOST_AUTO_TEST_CASE(rig_setPose)
         const Vec3 c = Vec3::Random();
         const geometry::Pose3 firstPose = geometry::Pose3(r, c);
 
-        sfmData.setPose(view, firstPose);
+        sfmData.setPose(view, CameraPose(firstPose));
 
         // setPose done, sub-pose must be initialized
         BOOST_CHECK(subPose.status != ERigSubPoseStatus::UNINITIALIZED);
 
         // setPose done, rig initialized
         BOOST_CHECK(sfmData.existsPose(view));
-        BOOST_CHECK(sfmData.getPose(view) == firstPose);
+        BOOST_CHECK(sfmData.getPose(view).getTransform() == firstPose);
       }
       else
       {
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(rig_setPose)
           // first rig pose, sub-pose must be uninitialized
           BOOST_CHECK(subPose.status == ERigSubPoseStatus::UNINITIALIZED);
 
-          sfmData.setPose(view, pose);
+          sfmData.setPose(view, CameraPose(pose));
 
           // setPose done, sub-pose must be initialized
           BOOST_CHECK(subPose.status != ERigSubPoseStatus::UNINITIALIZED);
@@ -214,24 +214,24 @@ BOOST_AUTO_TEST_CASE(rig_getPose)
         const Vec3 c = Vec3::Random();
         const geometry::Pose3 firstPose = geometry::Pose3(r, c);
 
-        sfmData.setPose(view, firstPose);
+        sfmData.setPose(view, CameraPose(firstPose));
 
         // setPose done, rig initialized
         if(poseId == 0)
         {
           // the rig pose is the first pose
-          BOOST_CHECK(sfmData.getPose(view) == firstPose);
+          BOOST_CHECK(sfmData.getPose(view).getTransform() == firstPose);
         }
         else
         {
           // the rig pose is the sub-pose inverse multiply by the rig pose
-          BOOST_CHECK(sfmData.getPose(view) == (subPose.pose.inverse() * firstPose));
+          BOOST_CHECK(sfmData.getPose(view).getTransform() == (subPose.pose.inverse() * firstPose));
         }
 
       }
       else
       {
-        const geometry::Pose3& rigPose = sfmData.getPose(view);
+        const geometry::Pose3& rigPose = sfmData.getPose(view).getTransform();
 
         if(poseId == 0) //other poses are redundant
         {
@@ -239,14 +239,14 @@ BOOST_AUTO_TEST_CASE(rig_getPose)
           const Vec3 c = Vec3::Random();
           const geometry::Pose3 absolutePose = geometry::Pose3(r, c);
 
-          sfmData.setPose(view, absolutePose);
+          sfmData.setPose(view, CameraPose(absolutePose));
 
           // the view sub-pose is the absolute pose multiply by the rig pose inverse
           BOOST_CHECK(subPose.pose == (absolutePose * rigPose.inverse()));
         }
 
         // the view absolute pose is the sub-pose multiply by the rig pose
-        BOOST_CHECK(sfmData.getPose(view) == (subPose.pose * sfmData.getPoses().at(view.getPoseId())));
+        BOOST_CHECK(sfmData.getPose(view).getTransform() == (subPose.pose * sfmData.getAbsolutePose(view.getPoseId()).getTransform()));
       }
     }
   }

--- a/src/aliceVision/sfm/rig_test.cpp
+++ b/src/aliceVision/sfm/rig_test.cpp
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(rig_getPose)
       }
       else
       {
-        const geometry::Pose3& rigPose = sfmData.getPose(view).getTransform();
+        const geometry::Pose3 rigPose = sfmData.getPose(view).getTransform();
 
         if(poseId == 0) //other poses are redundant
         {

--- a/src/aliceVision/sfm/sfmDataFilters.cpp
+++ b/src/aliceVision/sfm/sfmDataFilters.cpp
@@ -30,7 +30,7 @@ IndexT RemoveOutliers_PixelResidualError
     while (itObs != observations.end())
     {
       const View * view = sfm_data.views.at(itObs->first).get();
-      const geometry::Pose3 pose = sfm_data.getPose(*view);
+      const geometry::Pose3 pose = sfm_data.getPose(*view).getTransform();
       const camera::IntrinsicBase * intrinsic = sfm_data.intrinsics.at(view->getIntrinsicId()).get();
       const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x);
       if((pose.depth(iterTracks->second.X) < 0) ||
@@ -62,7 +62,7 @@ IndexT RemoveOutliers_AngleError(SfMData& sfm_data, const double dMinAcceptedAng
       itObs1 != observations.end(); ++itObs1)
     {
       const View * view1 = sfm_data.views.at(itObs1->first).get();
-      const geometry::Pose3 pose1 = sfm_data.getPose(*view1);
+      const geometry::Pose3 pose1 = sfm_data.getPose(*view1).getTransform();
       const camera::IntrinsicBase * intrinsic1 = sfm_data.intrinsics.at(view1->getIntrinsicId()).get();
 
       Observations::const_iterator itObs2 = itObs1;
@@ -70,7 +70,7 @@ IndexT RemoveOutliers_AngleError(SfMData& sfm_data, const double dMinAcceptedAng
       for (; itObs2 != observations.end(); ++itObs2)
       {
         const View * view2 = sfm_data.views.at(itObs2->first).get();
-        const geometry::Pose3 pose2 = sfm_data.getPose(*view2);
+        const geometry::Pose3 pose2 = sfm_data.getPose(*view2).getTransform();
         const camera::IntrinsicBase * intrinsic2 = sfm_data.intrinsics.at(view2->getIntrinsicId()).get();
 
         const double angle = AngleBetweenRays(

--- a/src/aliceVision/sfm/sfmDataIO_baf.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_baf.cpp
@@ -62,9 +62,9 @@ bool saveBAF(
       else
       {
         // [Rotation col major 3x3; camera center 3x1]
-        const double * rotation = poses.at(view->getPoseId()).rotation().data();
+        const double * rotation = poses.at(view->getPoseId()).getTransform().rotation().data();
         std::copy(rotation, rotation+9, std::ostream_iterator<double>(stream, " "));
-        const double * center = poses.at(view->getPoseId()).center().data();
+        const double * center = poses.at(view->getPoseId()).getTransform().center().data();
         std::copy(center, center+3, std::ostream_iterator<double>(stream, " "));
         stream << '\n';
       }

--- a/src/aliceVision/sfm/sfmDataIO_gt.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_gt.cpp
@@ -218,7 +218,7 @@ bool readGt(const std::string & sRootPath, SfMData & sfm_data, bool useUID)
 
     // Update intrinsics with width and height of image
     sfm_data.views.emplace(viewPtr->getViewId(), viewPtr);
-    sfm_data.setPose(*sfm_data.views.at(viewPtr->getViewId()), pose);
+    sfm_data.setPose(*sfm_data.views.at(viewPtr->getViewId()), CameraPose(pose));
     sfm_data.intrinsics.emplace(index, pinholeIntrinsic);
   }
   return true;

--- a/src/aliceVision/sfm/sfmDataIO_json.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_json.cpp
@@ -324,7 +324,7 @@ bool saveJSON(const SfMData& sfmData, const std::string& filename, ESfMData part
         bpt::ptree poseTree;
 
         poseTree.put("poseId", posePair.first);
-        savePose3("pose", posePair.second, poseTree);
+        saveCameraPose("pose", posePair.second, poseTree);
         posesTree.push_back(std::make_pair("", poseTree));
       }
 
@@ -466,9 +466,9 @@ bool loadJSON(SfMData& sfmData, const std::string& filename, ESfMData partFlag, 
       for(bpt::ptree::value_type &poseNode : fileTree.get_child("poses"))
       {
         bpt::ptree& poseTree = poseNode.second;
-        geometry::Pose3 pose;
+        CameraPose pose;
 
-        loadPose3("pose", pose, poseTree);
+        loadCameraPose("pose", pose, poseTree);
 
         poses.emplace(poseTree.get<IndexT>("poseId"), pose);
       }

--- a/src/aliceVision/sfm/sfmDataIO_json.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_json.cpp
@@ -113,6 +113,8 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
     intrinsicTree.add_child("distortionParams", distParamsTree);
   }
 
+  intrinsicTree.put("locked", intrinsic->isLocked());
+
   parentTree.push_back(std::make_pair(name, intrinsicTree));
 }
 
@@ -144,6 +146,12 @@ void loadIntrinsic(IndexT& intrinsicId, std::shared_ptr<camera::IntrinsicBase>& 
 
   pinholeIntrinsic->setDistortionParams(distortionParams);
   intrinsic = std::static_pointer_cast<camera::IntrinsicBase>(pinholeIntrinsic);
+
+  // intrinsic lock
+  if(intrinsicTree.get<bool>("locked", false))
+    intrinsic->lock();
+  else
+    intrinsic->unlock();
 }
 
 void saveRig(const std::string& name, IndexT rigId, const Rig& rig, bpt::ptree& parentTree)

--- a/src/aliceVision/sfm/sfmDataIO_json.hpp
+++ b/src/aliceVision/sfm/sfmDataIO_json.hpp
@@ -95,6 +95,41 @@ inline void loadPose3(const std::string& name, geometry::Pose3& pose, bpt::ptree
 }
 
 /**
+ * @brief Save a Pose3 in a boost property tree.
+ * @param[in] name The node name ( "" = no name )
+ * @param[in] pose The input pose3
+ * @param[out] parentTree The parent tree
+ */
+inline void saveCameraPose(const std::string& name, const CameraPose& cameraPose, bpt::ptree& parentTree)
+{
+  bpt::ptree cameraPoseTree;
+
+  savePose3("transform", cameraPose.getTransform(), cameraPoseTree);
+  cameraPoseTree.put("locked", cameraPose.isLocked());
+
+  parentTree.add_child(name, cameraPoseTree);
+}
+
+/**
+ * @brief Load a Pose3 from a boost property tree.
+ * @param[in] name The Pose3 name ( "" = no name )
+ * @param[out] pose The output Pose3
+ * @param[in,out] pose3Tree The input tree
+ */
+inline void loadCameraPose(const std::string& name, CameraPose& cameraPose, bpt::ptree& cameraPoseTree)
+{
+  geometry::Pose3 pose;
+
+  loadPose3(name + ".transform", pose, cameraPoseTree);
+  cameraPose.setTransform(pose);
+
+  if(cameraPoseTree.get<bool>("locked", false))
+    cameraPose.lock();
+  else
+    cameraPose.unlock();
+}
+
+/**
  * @brief Save a View in a boost property tree.
  * @param[in] name The node name ( "" = no name )
  * @param[in] view The input View

--- a/src/aliceVision/sfm/sfmDataIO_ply.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_ply.cpp
@@ -59,7 +59,7 @@ bool savePLY(
         {
           if (sfmData.isPoseAndIntrinsicDefined(view.second.get()))
           {
-            const geometry::Pose3 pose = sfmData.getPose(*(view.second.get()));
+            const geometry::Pose3 pose = sfmData.getPose(*(view.second.get())).getTransform();
             stream << pose.center().transpose()
               << " 0 255 0" << "\n";
           }

--- a/src/aliceVision/sfm/sfmDataIO_test.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_test.cpp
@@ -41,7 +41,7 @@ SfMData createTestScene(std::size_t viewsCount = 2, std::size_t observationCount
     sfm_data.views[id_view] = view;
 
     // Add poses
-    sfm_data.setPose(*view, Pose3());
+    sfm_data.setPose(*view, CameraPose());
 
     // Add intrinsics
     if (sharedIntrinsic)

--- a/src/aliceVision/sfm/sfmDataTriangulation.cpp
+++ b/src/aliceVision/sfm/sfmDataTriangulation.cpp
@@ -62,7 +62,7 @@ void StructureComputation_blind::triangulate(SfMData & sfm_data) const
         if (sfm_data.isPoseAndIntrinsicDefined(view))
         {
           const IntrinsicBase * cam = sfm_data.getIntrinsics().at(view->getIntrinsicId()).get();
-          const Pose3 pose = sfm_data.getPose(*view);
+          const Pose3 pose = sfm_data.getPose(*view).getTransform();
           trianObj.add(
             cam->get_projective_equivalent(pose),
             cam->get_ud_pixel(itObs.second.x));
@@ -200,7 +200,7 @@ bool StructureComputation_robust::robust_triangulation(
       std::advance(itObs, it);
       const View * view = sfm_data.views.at(itObs->first).get();
       const IntrinsicBase * cam = sfm_data.getIntrinsics().at(view->getIntrinsicId()).get();
-      const Pose3 pose = sfm_data.getPose(*view);
+      const Pose3 pose = sfm_data.getPose(*view).getTransform();
       const double z = pose.depth(current_model); // TODO: cam->depth(pose(X));
       bChierality &= z > 0;
     }
@@ -216,7 +216,7 @@ bool StructureComputation_robust::robust_triangulation(
     {
       const View * view = sfm_data.views.at(itObs.first).get();
       const IntrinsicBase * intrinsic = sfm_data.getIntrinsics().at(view->getIntrinsicId()).get();
-      const Pose3 pose = sfm_data.getPose(*view);
+      const Pose3 pose = sfm_data.getPose(*view).getTransform();
       const Vec2 residual = intrinsic->residual(pose, current_model, itObs.second.x);
       const double residual_d = residual.norm();
 
@@ -256,7 +256,7 @@ Vec3 StructureComputation_robust::track_sample_triangulation(
     std::advance(itObs, idx);
     const View * view = sfm_data.views.at(itObs->first).get();
     const IntrinsicBase * cam = sfm_data.getIntrinsics().at(view->getIntrinsicId()).get();
-    const Pose3 pose = sfm_data.getPose(*view);
+    const Pose3 pose = sfm_data.getPose(*view).getTransform();
     trianObj.add(
       cam->get_projective_equivalent(pose),
       cam->get_ud_pixel(itObs->second.x));

--- a/src/aliceVision/sfm/utils/alignment.cpp
+++ b/src/aliceVision/sfm/utils/alignment.cpp
@@ -45,8 +45,8 @@ bool computeSimilarity(const SfMData & sfmDataA,
   for (size_t i = 0; i  < commonViewIds.size(); ++i)
   {
     IndexT viewId = commonViewIds[i];
-    xA.col(i) = sfmDataA.getPoses().at(sfmDataA.getViews().at(viewId)->getPoseId()).center();
-    xB.col(i) = sfmDataB.getPoses().at(sfmDataB.getViews().at(viewId)->getPoseId()).center();
+    xA.col(i) = sfmDataA.getAbsolutePose(sfmDataA.getViews().at(viewId)->getPoseId()).getTransform().center();
+    xB.col(i) = sfmDataB.getAbsolutePose(sfmDataB.getViews().at(viewId)->getPoseId()).getTransform().center();
   }
 
   // Compute rigid transformation p'i = S R pi + t
@@ -87,8 +87,9 @@ void computeNewCoordinateSystemFromCameras(const SfMData& sfmData,
   i=0;
   for(const auto & pose : sfmData.getPoses())
   {
-    vCamCenter.col(i) = pose.second.center();
-    meanPoints +=  pose.second.center();
+    const Vec3 center = pose.second.getTransform().center();
+    vCamCenter.col(i) = center;
+    meanPoints +=  center;
     ++i;
   }
 
@@ -103,7 +104,7 @@ void computeNewCoordinateSystemFromCameras(const SfMData& sfmData,
     Vec3 camCenterMean = vCamCenter.col(i) - meanPoints;
     rms += camCenterMean.transpose() * camCenterMean; // squared dist to the mean of camera centers
 
-    vCamRotation.push_back(pose.second.rotation().transpose()); // Rotation in the world coordinate system
+    vCamRotation.push_back(pose.second.getTransform().rotation().transpose()); // Rotation in the world coordinate system
     ++i;
   }
   rms /= nbCameras;

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -82,9 +82,9 @@ inline void applyTransform(SfMData& sfmData,
     const View& view = *viewPair.second;
     if(sfmData.existsPose(view))
     {
-      geometry::Pose3 pose = sfmData.getPose(view);
+      geometry::Pose3 pose = sfmData.getPose(view).getTransform();
       pose = pose.transformSRt(S, R, t);
-      sfmData.setPose(view, pose);
+      sfmData.setPose(view, CameraPose(pose));
     }
   }
   

--- a/src/aliceVision/sfm/utils/statistics.cpp
+++ b/src/aliceVision/sfm/utils/statistics.cpp
@@ -25,7 +25,7 @@ double RMSE(const SfMData& sfmData)
       itObs != obs.end(); ++itObs)
     {
       const View * view = sfmData.getViews().find(itObs->first)->second.get();
-      const geometry::Pose3 pose = sfmData.getPose(*view);
+      const geometry::Pose3 pose = sfmData.getPose(*view).getTransform();
       const std::shared_ptr<camera::IntrinsicBase> intrinsic = sfmData.getIntrinsics().at(view->getIntrinsicId());
       const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x);
       //ALICEVISION_LOG_DEBUG(residual);

--- a/src/aliceVision/sfm/utils/syntheticScene.cpp
+++ b/src/aliceVision/sfm/utils/syntheticScene.cpp
@@ -74,7 +74,7 @@ SfMData getInputScene
   // 2. Poses
   for (int i = 0; i < nviews; ++i)
   {
-    sfm_data.setPose(*sfm_data.views.at(i), geometry::Pose3(d._R[i], d._C[i]));
+    sfm_data.setPose(*sfm_data.views.at(i), CameraPose(geometry::Pose3(d._R[i], d._C[i])));
   }
 
   // 3. Intrinsic data (shared, so only one camera intrinsic is defined)
@@ -161,9 +161,9 @@ SfMData getInputRigScene(const NViewDataSet& d,
   const std::size_t nbViews = sfmData.views.size();
 
   // 3. Poses
-  for (int poseId = 0; poseId < nbPoses; ++poseId)
+  for(int poseId = 0; poseId < nbPoses; ++poseId)
   {
-    sfmData.getPoses()[poseId] = geometry::Pose3(d._R[poseId], d._C[poseId]);
+    sfmData.setAbsolutePose(static_cast<IndexT>(poseId), CameraPose(geometry::Pose3(d._R[poseId], d._C[poseId])));
   }
 
   // 4. Intrinsic data (shared, so only one camera intrinsic is defined)
@@ -198,7 +198,7 @@ SfMData getInputRigScene(const NViewDataSet& d,
     for(int viewId = 0; viewId < nbViews; ++viewId)
     {
       const View& view = *sfmData.views.at(viewId);
-      geometry::Pose3 camPose = sfmData.getPose(view);
+      const geometry::Pose3 camPose = sfmData.getPose(view).getTransform();
       const Vec2 pt = Project(sfmData.intrinsics.at(0)->get_projective_equivalent(camPose), landmark.X);
       landmark.observations[viewId] = Observation(pt, landmarkId);
     }

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -231,8 +231,8 @@ int main() {
     const Pose3 pose0 = Pose3(Mat3::Identity(), Vec3::Zero());
     const Pose3 pose1 = relativePose_info.relativePose;
 
-    tinyScene.setPose(*tinyScene.views.at(0), pose0);
-    tinyScene.setPose(*tinyScene.views.at(1), pose1);
+    tinyScene.setPose(*tinyScene.views.at(0), CameraPose(pose0));
+    tinyScene.setPose(*tinyScene.views.at(1), CameraPose(pose1));
 
     // Init structure by inlier triangulation
     const Mat34 P1 = tinyScene.intrinsics[tinyScene.views[0]->getIntrinsicId()]->get_projective_equivalent(pose0);

--- a/src/software/convert/main_convertAnimatedCamera.cpp
+++ b/src/software/convert/main_convertAnimatedCamera.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
   for(const auto &iter : sfmData.getViews())
   {
     const auto &view = iter.second;
-    const geometry::Pose3 pose_gt = sfmData.getPoses().at(view->getPoseId());
+    const geometry::Pose3 pose_gt = sfmData.getPose(*view).getTransform();
     std::shared_ptr<camera::IntrinsicBase> intrinsic_gt = std::make_shared<camera::Pinhole>();
     intrinsic_gt = sfmData.getIntrinsics().at(view->getIntrinsicId());
     exporter.addCameraKeyframe(pose_gt, dynamic_cast<camera::Pinhole*>(intrinsic_gt.get()), view->getImagePath(), view->getViewId(), view->getIntrinsicId());

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
             ALICEVISION_LOG_DEBUG("Add Camera Keyframe");
             const IndexT intrinsicId = findViewIt->second->getIntrinsicId();
             const camera::Pinhole* cam = dynamic_cast<camera::Pinhole*>(sfmData.getIntrinsicPtr(intrinsicId));
-            const geometry::Pose3 pose = sfmData.getPose(*findViewIt->second);
+            const geometry::Pose3 pose = sfmData.getPose(*findViewIt->second).getTransform();
             exporter.addCameraKeyframe(pose,
                                        cam,
                                        findViewIt->second->getImagePath(),

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -151,11 +151,11 @@ bool exportToMVE2Format(
       }
 
       // Prepare to write an MVE 'meta.ini' file for the current view
-      const Pose3 pose = sfm_data.getPose(*view);
+      const Pose3 pose = sfm_data.getPose(*view).getTransform();
       const Pinhole * pinhole_cam = static_cast<const Pinhole *>(cam);
 
-      const Mat3 rotation = pose.rotation();
-      const Vec3 translation = pose.translation();
+      const Mat3& rotation = pose.rotation();
+      const Vec3& translation = pose.translation();
       // Pixel aspect: assuming square pixels
       const float pixelAspect = 1.f;
       // Focal length and principal point must be normalized (0..1)

--- a/src/software/export/main_exportMVSTexturing.cpp
+++ b/src/software/export/main_exportMVSTexturing.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
         continue;
     
     // Valid view, we can ask a pose & intrinsic data
-    const Pose3 pose = sfm_data.getPose(*view);
+    const Pose3 pose = sfm_data.getPose(*view).getTransform();
     Intrinsics::const_iterator iterIntrinsic = sfm_data.getIntrinsics().find(view->getIntrinsicId());
     const IntrinsicBase * cam = iterIntrinsic->second.get();
     
@@ -103,8 +103,8 @@ int main(int argc, char **argv)
     const Pinhole * pinhole_cam = static_cast<const Pinhole *>(cam);
     
     // Extrinsic
-    const Vec3 t = pose.translation();
-    const Mat3 R = pose.rotation();
+    const Vec3& t = pose.translation();
+    const Mat3& R = pose.rotation();
     // Intrinsic
     const double f = pinhole_cam->focal();
     const Vec2 pp = pinhole_cam->principal_point();

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -79,7 +79,8 @@ bool exportToMatlab(
       const View& view = *v.second.get();
       if(!sfm_data.isPoseAndIntrinsicDefined(&view))
         continue;
-      const Pose3& pose = sfm_data.getPoses().at(view.getPoseId());
+
+      const Pose3 pose = sfm_data.getPose(view).getTransform();
       cameraPosesFile << view.getViewId()
         << " " << pose.rotation()(0, 0)
         << " " << pose.rotation()(0, 1)

--- a/src/software/export/main_exportMeshlab.cpp
+++ b/src/software/export/main_exportMeshlab.cpp
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     if (!sfm_data.isPoseAndIntrinsicDefined(view))
       continue;
 
-    const Pose3 pose = sfm_data.getPose(*view);
+    const Pose3 pose = sfm_data.getPose(*view).getTransform();
     Intrinsics::const_iterator iterIntrinsic = sfm_data.getIntrinsics().find(view->getIntrinsicId());
 
     // We have a valid view with a corresponding camera & pose

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -73,7 +73,7 @@ bool exportToPMVSFormat(
       if (!sfm_data.isPoseAndIntrinsicDefined(view))
         continue;
 
-      const Pose3 pose = sfm_data.getPose(*view);
+      const Pose3 pose = sfm_data.getPose(*view).getTransform();
       Intrinsics::const_iterator iterIntrinsic = sfm_data.getIntrinsics().find(view->getIntrinsicId());
 
       // View Id re-indexing
@@ -240,7 +240,7 @@ bool exportToBundlerFormat(
       if (!sfm_data.isPoseAndIntrinsicDefined(view))
         continue;
 
-      const Pose3 pose = sfm_data.getPose(*view);
+      const Pose3 pose = sfm_data.getPose(*view).getTransform();
       Intrinsics::const_iterator iterIntrinsic = sfm_data.getIntrinsics().find(view->getIntrinsicId());
 
       // Must export focal, k1, k2, R, t

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -112,7 +112,7 @@ void retrieveSeedsPerView(
       if(obsACamId_it == viewIds.end())
         continue; // this view cannot be exported to mvs, so we skip the observation
       const View& viewA = *sfmData.getViews().at(obsA.first).get();
-      const geometry::Pose3& poseA = sfmData.getPoses().at(viewA.getPoseId());
+      const geometry::Pose3 poseA = sfmData.getPose(viewA).getTransform();
       const Pinhole * intrinsicsA = dynamic_cast<const Pinhole*>(sfmData.getIntrinsics().at(viewA.getIntrinsicId()).get());
       
       for(const auto& obsB: landmark.observations)
@@ -125,7 +125,7 @@ void retrieveSeedsPerView(
           continue; // this view cannot be exported to mvs, so we skip the observation
         const unsigned short indexB = std::distance(viewIds.begin(), obsBCamId_it);
         const View& viewB = *sfmData.getViews().at(obsB.first).get();
-        const geometry::Pose3& poseB = sfmData.getPoses().at(viewB.getPoseId());
+        const geometry::Pose3 poseB = sfmData.getPose(viewB).getTransform();
         const Pinhole * intrinsicsB = dynamic_cast<const Pinhole*>(sfmData.getIntrinsics().at(viewB.getIntrinsicId()).get());
 
         const double angle = AngleBetweenRays(
@@ -192,7 +192,7 @@ bool prepareDenseScene(const SfMData& sfmData, const std::string& outFolder)
     // Export camera
     {
       // Export camera pose
-      const Pose3 pose = sfmData.getPose(*view);
+      const Pose3 pose = sfmData.getPose(*view).getTransform();
       Mat34 P = iterIntrinsic->second.get()->get_projective_equivalent(pose);
       std::ofstream fileP((fs::path(outFolder) / (baseFilename + "_P.txt")).string());
       fileP << std::setprecision(10)
@@ -210,8 +210,8 @@ bool prepareDenseScene(const SfMData& sfmData, const std::string& outFolder)
 
       // Export camera intrinsics
       const Mat3 K = dynamic_cast<const Pinhole*>(sfmData.getIntrinsicPtr(view->getIntrinsicId()))->K();
-      const Mat3 R = pose.rotation();
-      const Vec3 t = pose.translation();
+      const Mat3& R = pose.rotation();
+      const Vec3& t = pose.translation();
       std::ofstream fileKRt((fs::path(outFolder) / (baseFilename + "_KRt.txt")).string());
       fileKRt << std::setprecision(10)
            << K(0, 0) << " " << K(0, 1) << " " << K(0, 2) << "\n"

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -385,6 +385,7 @@ int main(int argc, char** argv)
                                           localizationResult);
       assert( ok == localizationResult.isValid() );
       vLocalizationResults.emplace_back(localizationResult);
+      sfm::CameraPose pose(localizationResult.getPose());
       auto detect_end = std::chrono::steady_clock::now();
       auto detect_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(detect_end - detect_start);
       ALICEVISION_COUT("Localization took  " << detect_elapsed.count() << " [ms]");
@@ -395,7 +396,7 @@ int main(int argc, char** argv)
       {
         exporter.addCamera("camera"+std::to_string(idCamera)+"."+myToString(currentFrame,4),
                            sfm::View(subMediaFilepath, currentFrame, currentFrame),
-                           &localizationResult.getPose(),
+                           &pose,
                            &queryIntrinsics);
       }
       else
@@ -403,7 +404,7 @@ int main(int argc, char** argv)
         // @fixme for now just add a fake camera so that it still can be see in MAYA
         exporter.addCamera("camera"+std::to_string(idCamera)+".V."+myToString(currentFrame,4),
                            sfm::View(subMediaFilepath, currentFrame, currentFrame),
-                           &localizationResult.getPose(),
+                           &pose,
                            &queryIntrinsics);
       }
 #endif

--- a/src/software/utils/main_qualityEvaluation.cpp
+++ b/src/software/utils/main_qualityEvaluation.cpp
@@ -135,12 +135,12 @@ int main(int argc, char **argv)
     const int idPoseGT = sfmData_gt.getViews().at(view->getViewId())->getPoseId();
 
     // gt
-    const geometry::Pose3 pose_gt = sfmData_gt.getPoses().at(idPoseGT);
+    const geometry::Pose3& pose_gt = sfmData_gt.getAbsolutePose(idPoseGT).getTransform();
     vec_camPosGT.push_back(pose_gt.center());
     vec_camRotGT.push_back(pose_gt.rotation());
 
     // data to evaluate
-    const geometry::Pose3 pose_eval = sfmData.getPoses().at(view->getPoseId());
+    const geometry::Pose3 pose_eval = sfmData.getPose(*view).getTransform();
     vec_C.push_back(pose_eval.center());
     vec_camRot.push_back(pose_eval.rotation());
   }

--- a/src/software/utils/main_rigTransform.cpp
+++ b/src/software/utils/main_rigTransform.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
   std::size_t idx = 0;
   for (auto &p : sfmData.getPoses())
   {
-    const aliceVision::geometry::Pose3 rigPose = extrinsics[0].inverse() * p.second;
+    const aliceVision::geometry::Pose3 rigPose = extrinsics[0].inverse() * p.second.getTransform();
     exporter.addCameraKeyframe(rigPose, &intrinsics, "", idx, idx);
     ++idx;
   }


### PR DESCRIPTION
## Features list

- [x] Can lock camera poses
- [x] Can lock camera intrinsics
- [x] Add missing field `initialFocalLengthPix` in `Alembic I/O`
- [x] Add `lockScenePreviouslyReconstructed`  option in `incrementalSfM` software


