### PR TITLE
Fix: missing declaration of logging functions in MOSEK

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ AliceVision depends on:
 Other optional libraries can enable specific features (check "CMake Options" for enabling them):
 
 * OpenMP (enable multi-threading)
-* Mosek (linear programming)
+* Mosek 5 (linear programming)
 * OpenCV >= 3.0 (feature extraction, calibration module, video IO)
 * Alembic (data I/O)
 * CCTag (feature extraction/matching and localization on CPU or GPU)

--- a/src/aliceVision/linearProgramming/MOSEKSolver.cpp
+++ b/src/aliceVision/linearProgramming/MOSEKSolver.cpp
@@ -6,6 +6,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "aliceVision/linearProgramming/MOSEKSolver.hpp"
+#include "aliceVision/system/Logger.hpp"
 #include <iostream>
 
 namespace aliceVision {
@@ -72,7 +73,7 @@ inline MSKboundkey_enum convertSign(LPConstraints::eLP_SIGN sign) {
     case LPConstraints::LP_FREE:
       return MSK_BK_FR;
     default:
-      ALICEVISION_LOG_WARNING("Error unknow constraint sign : " << sign << "\n";
+      ALICEVISION_LOG_WARNING("Error unknown constraint sign: " << sign << "\n");
   }
 }
 

--- a/src/aliceVision/linearProgramming/MOSEKSolver.cpp
+++ b/src/aliceVision/linearProgramming/MOSEKSolver.cpp
@@ -72,9 +72,8 @@ inline MSKboundkey_enum convertSign(LPConstraints::eLP_SIGN sign) {
       return MSK_BK_FX;
     case LPConstraints::LP_FREE:
       return MSK_BK_FR;
-    default:
-      ALICEVISION_LOG_WARNING("Error unknown constraint sign: " << sign << "\n");
   }
+  throw std::out_of_range("Unknown constraint sign (LPConstraints enum): " + std::to_string(int(sign)));
 }
 
 bool MOSEKSolver::setup(const LPConstraints & cstraints) //cstraints <-> constraints

--- a/src/aliceVision/linearProgramming/lInfinityCV/triplet_tijsAndXis_kernel.hpp
+++ b/src/aliceVision/linearProgramming/lInfinityCV/triplet_tijsAndXis_kernel.hpp
@@ -10,6 +10,7 @@
 #include "aliceVision/numeric/numeric.hpp"
 #include <aliceVision/config.hpp>
 
+#include <aliceVision/multiview/projection.hpp>
 #include "aliceVision/multiview/conditioning.hpp"
 #include "aliceVision/multiview/triangulation/Triangulation.hpp"
 

--- a/src/aliceVision/linearProgramming/lInfinityCV/triplet_tijsAndXis_kernel.hpp
+++ b/src/aliceVision/linearProgramming/lInfinityCV/triplet_tijsAndXis_kernel.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 #include "aliceVision/numeric/numeric.hpp"
-#include <aliceVision/config.hpp>
+#include "aliceVision/config.hpp"
 
-#include <aliceVision/multiview/projection.hpp>
+#include "aliceVision/multiview/projection.hpp"
 #include "aliceVision/multiview/conditioning.hpp"
 #include "aliceVision/multiview/triangulation/Triangulation.hpp"
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Logging functions were missing declarations and one usage was missing a closing paren (with minor spelling fix).

Still missing a fix for `error: control reaches end of non-void function [-Werror=return-type]` but I will leave that for real C(++) devs.