### PR TITLE
Build with OpenCV 4

### DIFF
--- a/src/aliceVision/calibration/calibration.cpp
+++ b/src/aliceVision/calibration/calibration.cpp
@@ -6,6 +6,10 @@
 
 #include "aliceVision/calibration/calibration.hpp"
 
+#if CV_VERSION_MAJOR > 3
+#include "opencv2/calib3d/calib3d_c.h"
+#endif
+
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
 

--- a/src/aliceVision/calibration/exportData.cpp
+++ b/src/aliceVision/calibration/exportData.cpp
@@ -10,6 +10,11 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/camera/cameraUndistortImage.hpp>
 
+#if CV_VERSION_MAJOR > 3
+#include <opencv2/calib3d/calib3d_c.h>
+#include <opencv2/imgcodecs/imgcodecs_c.h>
+#endif
+
 #include <boost/filesystem/path.hpp>
 
 #include <fstream>

--- a/src/aliceVision/calibration/patternDetect.cpp
+++ b/src/aliceVision/calibration/patternDetect.cpp
@@ -19,6 +19,10 @@
 #include <cctag/utils/LogTime.hpp>
 #endif
 
+#if CV_VERSION_MAJOR > 3
+#include <opencv2/calib3d/calib3d_c.h>
+#endif
+
 #include <string>
 #include <ctime>
 #include <cctype>

--- a/src/aliceVision/dataio/VideoFeed.cpp
+++ b/src/aliceVision/dataio/VideoFeed.cpp
@@ -14,6 +14,10 @@
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/highgui.hpp>
 
+#if CV_VERSION_MAJOR > 3
+#include <opencv2/imgproc/types_c.h>
+#endif
+
 #include <iostream>
 #include <exception>
 

--- a/src/software/pipeline/main_cameraCalibration.cpp
+++ b/src/software/pipeline/main_cameraCalibration.cpp
@@ -27,6 +27,9 @@
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
+#if CV_VERSION_MAJOR > 3
+#include <opencv2/calib3d/calib3d_c.h>
+#endif
 
 #include <stdio.h>
 #include <ctime>


### PR DESCRIPTION
CV 4 removed C compatibility headers, so include manually but guard against CV 3.

Pretty straight-forward: include headers that were included in CV 3, but excluded in CV 4.