### PR TITLE
[matchingImageCollection] fix clang constness issue

### DIFF
--- a/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
@@ -77,7 +77,7 @@ void robustModelEstimation(
 
 #pragma omp critical
         {
-          out_geometricMatches.insert(std::make_pair(currentPair, std::move(inliers)));
+          out_geometricMatches.emplace(currentPair, std::move(inliers));
         }
 
       }


### PR DESCRIPTION
## Description

Clang 3.9 complains about the constness violation of `std::make_pair` for 
```c+++
out_geometricMatches.insert(std::make_pair(currentPair, std::move(inliers)));
```
as `currentPair` is declared as const.

Using emplace is better than insert and it fixes the problem.

Here the log errro
```
In file included from 
AliceVision/src/software/pipeline/main_featureMatching.cpp:19:
AliceVision/src/aliceVision/matchingImageCollection/GeometricFilter.hpp:80:54: error: binding value of type 'const pair<...>' to reference to type 'pair<...>' drops
      'const' qualifier
          out_geometricMatches.insert(std::make_pair(currentPair, std::move(inliers)));
                                                     ^~~~~~~~~~~
AliceVision/src/software/pipeline/main_featureMatching.cpp:398:32: note: in instantiation of function template specialization
      'aliceVision::matchingImageCollection::robustModelEstimation<aliceVision::matchingImageCollection::GeometricFilterMatrix_F_AC>' requested here
      matchingImageCollection::robustModelEstimation(geometricMatches,
                               ^
/usr/local/Cellar/llvm@3.9/3.9.1_1/bin/../include/c++/v1/utility:522:17: note: passing argument to parameter '__t1' here
make_pair(_T1&& __t1, _T2&& __t2)
```
