### PR TITLE
[sfm] update view's width and height 

### DIFF
--- a/src/aliceVision/sfm/sfmDataIO_json.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_json.cpp
@@ -445,7 +445,27 @@ bool loadJSON(SfMData& sfmData, const std::string& filename, ESfMData partFlag, 
       // update incomplete views
       #pragma omp parallel for
       for(int i = 0; i < incompleteViews.size(); ++i)
+      {
+        View& v = incompleteViews.at(i);
+        // if we have the intrinsics and the view has an valid associated intrinsics
+        // update the width and height field of View (they are mirrored)
+        if (loadIntrinsics && v.getIntrinsicId() != UndefinedIndexT)
+        {
+          const auto intrinsics = sfmData.getIntrinsicPtr(v.getIntrinsicId());
+
+          if(intrinsics == nullptr)
+          {
+            throw std::logic_error("View " + std::to_string(v.getViewId())
+                                   + " has a intrinsics id " +std::to_string(v.getIntrinsicId())
+                                   + " that cannot be found or the intrinsics are not correctly "
+                                     "loaded from the json file.");
+          }
+
+          v.setWidth(intrinsics->w());
+          v.setHeight(intrinsics->h());
+        }
         updateIncompleteView(incompleteViews.at(i));
+      }
 
       // copy complete views in the SfMData views map
       for(const View& view : incompleteViews)

--- a/src/aliceVision/sfm/sfmDataIO_json.cpp
+++ b/src/aliceVision/sfm/sfmDataIO_json.cpp
@@ -409,6 +409,22 @@ bool loadJSON(SfMData& sfmData, const std::string& filename, ESfMData partFlag, 
     for(bpt::ptree::value_type& matchingFolderNode : fileTree.get_child("matchesFolders"))
       sfmData.addMatchesFolder(matchingFolderNode.second.get_value<std::string>());
 
+  // intrinsics
+  if(loadIntrinsics && fileTree.count("intrinsics"))
+  {
+    Intrinsics& intrinsics = sfmData.getIntrinsics();
+
+    for(bpt::ptree::value_type &intrinsicNode : fileTree.get_child("intrinsics"))
+    {
+      IndexT intrinsicId;
+      std::shared_ptr<camera::IntrinsicBase> intrinsic;
+
+      loadIntrinsic(intrinsicId, intrinsic, intrinsicNode.second);
+
+      intrinsics.emplace(intrinsicId, intrinsic);
+    }
+  }
+
   // views
   if(loadViews && fileTree.count("views"))
   {
@@ -444,22 +460,6 @@ bool loadJSON(SfMData& sfmData, const std::string& filename, ESfMData partFlag, 
         loadView(view, viewNode.second);
         views.emplace(view.getViewId(), std::make_shared<View>(view));
       }
-    }
-  }
-
-  // intrinsics
-  if(loadIntrinsics && fileTree.count("intrinsics"))
-  {
-    Intrinsics& intrinsics = sfmData.getIntrinsics();
-
-    for(bpt::ptree::value_type &intrinsicNode : fileTree.get_child("intrinsics"))
-    {
-      IndexT intrinsicId;
-      std::shared_ptr<camera::IntrinsicBase> intrinsic;
-
-      loadIntrinsic(intrinsicId, intrinsic, intrinsicNode.second);
-
-      intrinsics.emplace(intrinsicId, intrinsic);
     }
   }
 


### PR DESCRIPTION
When loading data from json (`loadJSON()`), the view has no height and width on the json file so it is set to 0. 
This leads `updateIncompleteView()` to recompute the UID and all the other information (even if all the data is correct and complete). 
This is a bit of waste of time and, above all, it is not guaranteed that across platforms or compilers the computed UID is the same, thus leading to an exception/error in `updateIncompleteView()` because the new UID is different from the previously UID assigned to the pose. 
see here
 https://github.com/alicevision/AliceVision/blob/develop/src/aliceVision/sfm/viewIO.cpp#L62

The proposed solution is to update view's width and height before calling `updateIncompleteView()` by getting the values from the relevant intrinsics (if any).
This also implies that the intrinsics are loaded before the views.
