### PR TITLE
Texturing visibility remapping and texture fusion

### DIFF
--- a/src/aliceVision/mesh/CMakeLists.txt
+++ b/src/aliceVision/mesh/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Headers
 set(mesh_files_headers
+  geoMesh.hpp
   Mesh.hpp
   MeshAnalyze.hpp
   MeshClean.hpp

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -227,7 +227,7 @@ Mesh::triangle_proj Mesh::getTriangleProjection(int triid, const mvsUtils::Multi
     return tp;
 }
 
-bool Mesh::isTriangleProjectionInImage(Mesh::triangle_proj tp, int w, int h) const
+bool Mesh::isTriangleProjectionInImage(const Mesh::triangle_proj& tp, int w, int h) const
 {
     for(int j = 0; j < 3; j++)
     {
@@ -237,6 +237,19 @@ bool Mesh::isTriangleProjectionInImage(Mesh::triangle_proj tp, int w, int h) con
         }
     }
     return true;
+}
+
+int Mesh::getTriangleNbVertexInImage(const Mesh::triangle_proj& tp, int w, int h) const
+{
+    int nbVertexInImage = 0;
+    for (int j = 0; j < 3; j++)
+    {
+        if ((tp.tpixs[j].x > 0) && (tp.tpixs[j].x < w) && (tp.tpixs[j].y > 0) && (tp.tpixs[j].y < h))
+        {
+            ++nbVertexInImage;
+        }
+    }
+    return nbVertexInImage;
 }
 
 StaticVector<Point2d>* Mesh::getTrianglePixelIntersectionsAndInternalPoints(Mesh::triangle_proj* tp,
@@ -1417,17 +1430,17 @@ void Mesh::removeFreePointsFromMesh(StaticVector<int>** out_ptIdToNewPtId)
     delete cleanedMesh;
 }
 
-float Mesh::computeTriangleProjectionArea(triangle_proj& tp)
+double Mesh::computeTriangleProjectionArea(const triangle_proj& tp)
 {
     // return (float)((tp.rd.x-tp.lu.x+1)*(tp.rd.y-tp.lu.y+1));
 
     Point2d pa = tp.tp2ds[0];
     Point2d pb = tp.tp2ds[1];
     Point2d pc = tp.tp2ds[2];
-    float a = (pb - pa).size();
-    float b = (pc - pa).size();
-    float c = (pc - pb).size();
-    float p = (a + b + c) / 2.0;
+    double a = (pb - pa).size();
+    double b = (pc - pa).size();
+    double c = (pc - pb).size();
+    double p = (a + b + c) / 2.0;
 
     return sqrt(p * (p - a) * (p - b) * (p - c));
 
@@ -1436,15 +1449,15 @@ float Mesh::computeTriangleProjectionArea(triangle_proj& tp)
     //	return  cross(e1,e2).size()/2.0f;
 }
 
-float Mesh::computeTriangleArea(int idTri)
+double Mesh::computeTriangleArea(int idTri)
 {
     Point3d pa = (*pts)[(*tris)[idTri].v[0]];
     Point3d pb = (*pts)[(*tris)[idTri].v[1]];
     Point3d pc = (*pts)[(*tris)[idTri].v[2]];
-    float a = (pb - pa).size();
-    float b = (pc - pa).size();
-    float c = (pc - pb).size();
-    float p = (a + b + c) / 2.0;
+    double a = (pb - pa).size();
+    double b = (pc - pa).size();
+    double c = (pc - pb).size();
+    double p = (a + b + c) / 2.0;
 
     return sqrt(p * (p - a) * (p - b) * (p - c));
 }

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -227,11 +227,13 @@ Mesh::triangle_proj Mesh::getTriangleProjection(int triid, const mvsUtils::Multi
     return tp;
 }
 
-bool Mesh::isTriangleProjectionInImage(const Mesh::triangle_proj& tp, int w, int h) const
+bool Mesh::isTriangleProjectionInImage(const Mesh::triangle_proj& tp, int width, int height, int margin) const
 {
+    int w = width - margin;
+    int h = height - margin;
     for(int j = 0; j < 3; j++)
     {
-        if(!((tp.tpixs[j].x > 0) && (tp.tpixs[j].x < w) && (tp.tpixs[j].y > 0) && (tp.tpixs[j].y < h)))
+        if(!((tp.tpixs[j].x > margin) && (tp.tpixs[j].x < w) && (tp.tpixs[j].y > margin) && (tp.tpixs[j].y < h)))
         {
             return false;
         }
@@ -239,12 +241,14 @@ bool Mesh::isTriangleProjectionInImage(const Mesh::triangle_proj& tp, int w, int
     return true;
 }
 
-int Mesh::getTriangleNbVertexInImage(const Mesh::triangle_proj& tp, int w, int h) const
+int Mesh::getTriangleNbVertexInImage(const Mesh::triangle_proj& tp, int width, int height, int margin) const
 {
     int nbVertexInImage = 0;
+    int w = width - margin;
+    int h = height - margin;
     for (int j = 0; j < 3; j++)
     {
-        if ((tp.tpixs[j].x > 0) && (tp.tpixs[j].x < w) && (tp.tpixs[j].y > 0) && (tp.tpixs[j].y < h))
+        if ((tp.tpixs[j].x > margin) && (tp.tpixs[j].x < w) && (tp.tpixs[j].y > margin) && (tp.tpixs[j].y < h))
         {
             ++nbVertexInImage;
         }
@@ -661,7 +665,7 @@ StaticVector<StaticVector<int>*>* Mesh::getTrisMap(const mvsUtils::MultiViewPara
     for(int i = 0; i < tris->size(); i++)
     {
         triangle_proj tp = getTriangleProjection(i, mp, rc, w, h);
-        if((isTriangleProjectionInImage(tp, w, h)))
+        if((isTriangleProjectionInImage(tp, w, h, 0)))
         {
             Pixel pix;
             for(pix.x = tp.lu.x; pix.x <= tp.rd.x; pix.x++)
@@ -701,7 +705,7 @@ StaticVector<StaticVector<int>*>* Mesh::getTrisMap(const mvsUtils::MultiViewPara
     for(int i = 0; i < tris->size(); i++)
     {
         triangle_proj tp = getTriangleProjection(i, mp, rc, w, h);
-        if((isTriangleProjectionInImage(tp, w, h)))
+        if((isTriangleProjectionInImage(tp, w, h, 0)))
         {
             Pixel pix;
             for(pix.x = tp.lu.x; pix.x <= tp.rd.x; pix.x++)
@@ -740,7 +744,7 @@ StaticVector<StaticVector<int>*>* Mesh::getTrisMap(StaticVector<int>* visTris, c
     {
         int i = (*visTris)[m];
         triangle_proj tp = getTriangleProjection(i, mp, rc, w, h);
-        if((isTriangleProjectionInImage(tp, w, h)))
+        if((isTriangleProjectionInImage(tp, w, h, 0)))
         {
             Pixel pix;
             for(pix.x = tp.lu.x; pix.x <= tp.rd.x; pix.x++)
@@ -781,7 +785,7 @@ StaticVector<StaticVector<int>*>* Mesh::getTrisMap(StaticVector<int>* visTris, c
     {
         int i = (*visTris)[m];
         triangle_proj tp = getTriangleProjection(i, mp, rc, w, h);
-        if((isTriangleProjectionInImage(tp, w, h)))
+        if((isTriangleProjectionInImage(tp, w, h, 0)))
         {
             Pixel pix;
             for(pix.x = tp.lu.x; pix.x <= tp.rd.x; pix.x++)

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -165,13 +165,12 @@ public:
     bool isTriangleObtuse(int triId);
 
 public:
-    float computeTriangleProjectionArea(triangle_proj& tp);
-    float computeTriangleArea(int idTri);
+    double computeTriangleProjectionArea(const triangle_proj& tp);
+    double computeTriangleArea(int idTri);
     Mesh::triangle_proj getTriangleProjection(int triid, const mvsUtils::MultiViewParams* mp, int rc, int w, int h) const;
-    bool isTriangleProjectionInImage(Mesh::triangle_proj tp, int w, int h) const;
+    bool isTriangleProjectionInImage(const Mesh::triangle_proj& tp, int w, int h) const;
+    int getTriangleNbVertexInImage(const Mesh::triangle_proj& tp, int w, int h) const;
     bool doesTriangleIntersectsRectangle(Mesh::triangle_proj* tp, Mesh::rectangle* re);
-    bool doesTriangleIntersect4Poly(Point2d* _p, Point2d* A, Point2d* B, Point2d* C, Point2d* P0, Point2d* P1,
-                                    Point2d* P2, Point2d* P3);
     StaticVector<Point2d>* getTrianglePixelIntersectionsAndInternalPoints(Mesh::triangle_proj* tp,
                                                                           Mesh::rectangle* re);
     StaticVector<Point3d>* getTrianglePixelIntersectionsAndInternalPoints(const mvsUtils::MultiViewParams* mp, int idTri, Pixel& pix,
@@ -209,15 +208,11 @@ public:
     void changeTriPtId(int triId, int oldPtId, int newPtId);
     int getTriPtIndex(int triId, int ptId, bool failIfDoesNotExists = true);
     Pixel getTriOtherPtsIds(int triId, int _ptId);
-    int getTri1EdgeIdWRTNeighTri2(int triId1, int triId2);
     bool areTwoTrisSameOriented(int triId1, int triId2, int edgePtId1, int edgePtId2);
-    bool checkPtsForNaN();
-    void filterWrongTriangles();
     StaticVector<int>* getLargestConnectedComponentTrisIds();
 
     bool getEdgeNeighTrisInterval(Pixel& itr, Pixel edge, StaticVector<Voxel>* edgesXStat,
                                   StaticVector<Voxel>* edgesXYStat);
-    void Transform(Matrix3x3 Rs, Point3d t);
 };
 
 } // namespace mesh

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -168,8 +168,8 @@ public:
     double computeTriangleProjectionArea(const triangle_proj& tp);
     double computeTriangleArea(int idTri);
     Mesh::triangle_proj getTriangleProjection(int triid, const mvsUtils::MultiViewParams* mp, int rc, int w, int h) const;
-    bool isTriangleProjectionInImage(const Mesh::triangle_proj& tp, int w, int h) const;
-    int getTriangleNbVertexInImage(const Mesh::triangle_proj& tp, int w, int h) const;
+    bool isTriangleProjectionInImage(const Mesh::triangle_proj& tp, int width, int height, int margin) const;
+    int getTriangleNbVertexInImage(const Mesh::triangle_proj& tp, int width, int height, int margin) const;
     bool doesTriangleIntersectsRectangle(Mesh::triangle_proj* tp, Mesh::rectangle* re);
     StaticVector<Point2d>* getTrianglePixelIntersectionsAndInternalPoints(Mesh::triangle_proj* tp,
                                                                           Mesh::rectangle* re);

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -282,8 +282,11 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
     {
         ALICEVISION_LOG_INFO(" - camera " << camId + 1 << "/" << mp.ncams << " (" << triangles.size() << " triangles)");
 
-        for(const auto& triangleId : triangles)
+        imageCache.refreshData(camId);
+        #pragma omp parallel for
+        for(int ti = 0; ti < triangles.size(); ++ti)
         {
+            const unsigned int triangleId = triangles[ti];
             // retrieve triangle 3D and UV coordinates
             Point2d triPixs[3];
             Point3d triPts[3];

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -314,7 +314,7 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
             const int h = mp.getHeight(camId);
 
             const Mesh::triangle_proj tProj = me->getTriangleProjection(triangleId, &mp, camId, w, h);
-            const int nbVertex = me->getTriangleNbVertexInImage(tProj, w, h);
+            const int nbVertex = me->getTriangleNbVertexInImage(tProj, w, h, 20);
             if(nbVertex == 0)
                 // No triangle vertex in the image
                 continue;

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -465,6 +465,9 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
                     if(!mp.isPixelInImage(pixRC, camId))
                         continue;
                     Color color = imageCache.getPixelValueInterpolated(&pixRC, camId);
+                    // If the color is pure zero, we consider it as an invalid pixel.
+                    // After correction of radial distortion, some pixels are invalid.
+                    // TODO: use an alpha channel instead.
                     if(color == Color(0.f, 0.f, 0.f))
                         continue;
                     // fill the accumulated color map for this pixel

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -15,6 +15,7 @@
 #include <aliceVision/mvsData/Pixel.hpp>
 #include <aliceVision/imageIO/image.hpp>
 
+#include <geogram/basic/common.h>
 #include <geogram/basic/geometry_nd.h>
 #include <geogram/mesh/mesh.h>
 #include <geogram/mesh/mesh_io.h>
@@ -221,7 +222,7 @@ struct AccuColor {
     }
 
     Color average() const {
-        return count > 0 ? colorSum / count : colorSum;
+        return count > 0 ? colorSum / (float)count : colorSum;
     }
 
     void operator+(const Color& other)

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -293,8 +293,13 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
             continue;
 
         // Select the N best views for texturing
-        Point3d triangleNormal = me->computeTriangleNormal(triangleId);
-        std::vector<std::pair<double, int>> scorePerCamId;
+        Point3d triangleNormal;
+        Point3d triangleCenter;
+        if (texParams.angleHardThreshold != 0.0)
+        {
+            triangleNormal = me->computeTriangleNormal(triangleId);
+            triangleCenter = me->computeTriangleCenterOfGravity(triangleId);
+        }
         for (const auto& itCamVis: selectedTriCams)
         {
             const int camId = itCamVis.first;
@@ -304,8 +309,8 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
 
             if (texParams.angleHardThreshold != 0.0)
             {
-                const Point3d camInvDir = mp.iRArr[camId] * Point3d(0.0, 0.0, -1.0);
-                const double angle = angleBetwV1andV2(triangleNormal, camInvDir);
+                const Point3d vecPointToCam = (mp.CArr[camId] - triangleCenter).normalize();
+                const double angle = angleBetwV1andV2(triangleNormal, vecPointToCam);
                 if(angle > texParams.angleHardThreshold)
                     continue;
             }

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -464,10 +464,13 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
                     // exclude out of bounds pixels
                     if(!mp.isPixelInImage(pixRC, camId))
                         continue;
+                    Color color = imageCache.getPixelValueInterpolated(&pixRC, camId);
+                    if(color == Color(0.f, 0.f, 0.f))
+                        continue;
+                    // fill the accumulated color map for this pixel
+                    perPixelColors[xyoffset] += color;
                     // fill the colorID map
                     colorIDs[xyoffset] = xyoffset;
-                    // fill the accumulated color map for this pixel
-                    perPixelColors[xyoffset] += imageCache.getPixelValueInterpolated(&pixRC, camId);
                 }
             }
         }

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -304,7 +304,7 @@ void Texturing::generateTexture(const mvsUtils::MultiViewParams& mp,
 
             if (texParams.angleHardThreshold != 0.0)
             {
-                const Point3d camInvDir = mp.RArr[camId] * Point3d(0.0, 0.0, -1.0);
+                const Point3d camInvDir = mp.iRArr[camId] * Point3d(0.0, 0.0, -1.0);
                 const double angle = angleBetwV1andV2(triangleNormal, camInvDir);
                 if(angle > texParams.angleHardThreshold)
                     continue;

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -65,7 +65,7 @@ EVisibilityRemappingMethod EVisibilityRemappingMethod_stringToEnum(const std::st
 struct TexturingParams
 {
     int maxNbImagesForFusion = 3; //< max number of images to combine to create the final texture
-    double bestScoreThreshold = 0.8; //< 0.0 to disable filtering based on threshold to relative best score
+    double bestScoreThreshold = 0.0; //< 0.0 to disable filtering based on threshold to relative best score
     double angleHardThreshold = 90.0; //< 0.0 to disable angle hard threshold filtering
     bool forceVisibleByAllVertices = false; //< triangle visibility is based on the union of vertices visiblity
     EVisibilityRemappingMethod visibilityRemappingMethod = EVisibilityRemappingMethod::PullPush;

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -50,7 +50,7 @@ struct TexturingParams
 {
     int maxNbImagesForFusion = 3; //< max number of images to combine to create the final texture
     double bestScoreThreshold = 0.8; //< 0.0 to disable filtering based on threshold to relative best score
-    double angleHardThreshold = 90.0; //< 0.0 to disable angle hard threshold filtering
+    double angleHardThreshold = 0.0; //< 0.0 to disable angle hard threshold filtering
     bool forceVisibleByAllVertices = false; //< triangle visibility is based on the union of vertices visiblity
 
     unsigned int textureSide = 8192;

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -48,6 +48,11 @@ std::string EUnwrapMethod_enumToString(EUnwrapMethod method);
 
 struct TexturingParams
 {
+    int maxNbImagesForFusion = 3; //< max number of images to combine to create the final texture
+    double bestScoreThreshold = 0.8; //< 0.0 to disable filtering based on threshold to relative best score
+    double angleHardThreshold = 90.0; //< 0.0 to disable angle hard threshold filtering
+    bool forceVisibleByAllVertices = false; //< triangle visibility is based on the union of vertices visiblity
+
     unsigned int textureSide = 8192;
     unsigned int padding = 15;
     unsigned int downscale = 2;

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -14,6 +14,7 @@
 #include <aliceVision/mvsUtils/ImagesCache.hpp>
 #include <aliceVision/mesh/Mesh.hpp>
 #include <aliceVision/mesh/meshVisibility.hpp>
+#include <aliceVision/stl/bitmask.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -26,9 +27,9 @@ namespace mesh {
  * @brief Available mesh unwrapping methods
  */
 enum class EUnwrapMethod {
-    Basic = 0, // Basic unwrapping based on visibilities
-    ABF = 1,   // Geogram: ABF++
-    LSCM = 2   // Geogram: Spectral LSCM
+    Basic = 0, //< Basic unwrapping based on visibilities
+    ABF = 1,   //< Geogram: ABF++
+    LSCM = 2   //< Geogram: Spectral LSCM
 };
 
 /**
@@ -46,12 +47,28 @@ EUnwrapMethod EUnwrapMethod_stringToEnum(const std::string& method);
 std::string EUnwrapMethod_enumToString(EUnwrapMethod method);
 
 
+/**
+ * @brief Method to remap visibilities from the reconstruction onto an other mesh.
+ */
+enum EVisibilityRemappingMethod {
+    Pull = 1,    //< For each vertex of the input mesh, pull the visibilities from the closest vertex in the reconstruction.
+    Push = 2,    //< For each vertex of the reconstruction, push the visibilities to the closest triangle in the input mesh.
+    PullPush = Pull | Push  //< Combine results from Pull and Push results.
+};
+
+ALICEVISION_BITMASK(EVisibilityRemappingMethod);
+
+std::string EVisibilityRemappingMethod_enumToString(EVisibilityRemappingMethod method);
+EVisibilityRemappingMethod EVisibilityRemappingMethod_stringToEnum(const std::string& method);
+
+
 struct TexturingParams
 {
     int maxNbImagesForFusion = 3; //< max number of images to combine to create the final texture
     double bestScoreThreshold = 0.8; //< 0.0 to disable filtering based on threshold to relative best score
     double angleHardThreshold = 90.0; //< 0.0 to disable angle hard threshold filtering
     bool forceVisibleByAllVertices = false; //< triangle visibility is based on the union of vertices visiblity
+    EVisibilityRemappingMethod visibilityRemappingMethod = EVisibilityRemappingMethod::PullPush;
 
     unsigned int textureSide = 8192;
     unsigned int padding = 15;

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -50,7 +50,7 @@ struct TexturingParams
 {
     int maxNbImagesForFusion = 3; //< max number of images to combine to create the final texture
     double bestScoreThreshold = 0.8; //< 0.0 to disable filtering based on threshold to relative best score
-    double angleHardThreshold = 0.0; //< 0.0 to disable angle hard threshold filtering
+    double angleHardThreshold = 90.0; //< 0.0 to disable angle hard threshold filtering
     bool forceVisibleByAllVertices = false; //< triangle visibility is based on the union of vertices visiblity
 
     unsigned int textureSide = 8192;

--- a/src/aliceVision/mesh/geoMesh.hpp
+++ b/src/aliceVision/mesh/geoMesh.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <aliceVision/mesh/Mesh.hpp>
+
+#include <geogram/mesh/mesh.h>
+
+
+namespace aliceVision {
+namespace mesh {
+
+/**
+* @brief Create a Geogram GEO::Mesh from an aliceVision::Mesh
+*
+* @note only initialize vertices and facets
+* @param[in] the source aliceVision mesh
+* @param[out] the destination GEO::Mesh
+*/
+inline void toGeoMesh(const Mesh& src, GEO::Mesh& dst)
+{
+    GEO::vector<double> vertices;
+    vertices.reserve(src.pts->size() * 3);
+    GEO::vector<GEO::index_t> facets;
+    facets.reserve(src.tris->size() * 3);
+
+    for (unsigned int i = 0; i < src.pts->size(); ++i)
+    {
+        const auto& point = (*src.pts)[i];
+        vertices.insert(vertices.end(), std::begin(point.m), std::end(point.m));
+    }
+
+    for (unsigned int i = 0; i < src.tris->size(); ++i)
+    {
+        const auto& tri = (*src.tris)[i];
+        facets.insert(facets.end(), std::begin(tri.v), std::end(tri.v));
+    }
+
+    dst.facets.assign_triangle_mesh(3, vertices, facets, true);
+    dst.facets.connect();
+
+    assert(src.pts->size() == dst.vertices.nb());
+    assert(src.tris->size() == dst.facets.nb());
+}
+
+}
+}

--- a/src/aliceVision/mesh/meshVisibility.cpp
+++ b/src/aliceVision/mesh/meshVisibility.cpp
@@ -5,9 +5,16 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "meshVisibility.hpp"
+#include "geoMesh.hpp"
+
 #include <aliceVision/system/Logger.hpp>
 
+#include <geogram/basic/permutation.h>
+#include <geogram/basic/attributes.h>
 #include <geogram/points/kd_tree.h>
+#include <geogram/mesh/mesh_AABB.h>
+#include <geogram/mesh/mesh_reorder.h>
+
 
 namespace aliceVision {
 namespace mesh {
@@ -30,11 +37,11 @@ int getNearestVertices(const Mesh& refMesh, const Mesh& mesh, StaticVector<int>&
 }
 
 
-void remapMeshVisibilities(
+void remapMeshVisibilities_pullVerticesVisibility(
     const Mesh& refMesh, const PointsVisibility& refPtsVisibilities,
     const Mesh& mesh, PointsVisibility& out_ptsVisibilities)
 {
-    ALICEVISION_LOG_DEBUG("remapMeshVisibility start.");
+    ALICEVISION_LOG_DEBUG("remapMeshVisibility based on closest vertex start.");
 
     GEO::AdaptiveKdTree refMesh_kdTree(3);
     refMesh_kdTree.set_points(refMesh.pts->size(), refMesh.pts->front().m);
@@ -58,6 +65,79 @@ void remapMeshVisibilities(
     }
 
     ALICEVISION_LOG_DEBUG("remapMeshVisibility done.");
+}
+
+
+double mesh_facet_edges_length(const GEO::Mesh &M, GEO::index_t f)
+{
+    const GEO::vec3& p0 = M.vertices.point(M.facets.vertex(f, 0));
+    const GEO::vec3& p1 = M.vertices.point(M.facets.vertex(f, 1));
+    const GEO::vec3& p2 = M.vertices.point(M.facets.vertex(f, 2));
+    return (p1 - p0).length() + (p2 - p1).length() + (p0 - p2).length();
+}
+
+void remapMeshVisibilities_pushVerticesVisibilityToTriangles(
+    const Mesh& refMesh, const PointsVisibility& refPtsVisibilities,
+    const Mesh& mesh, PointsVisibility& out_ptsVisibilities)
+{
+    ALICEVISION_LOG_INFO("remapMeshVisibility based on triangles start.");
+
+    GEO::initialize();
+    GEO::Mesh meshG;
+    toGeoMesh(mesh, meshG);
+
+    // MeshFacetAABB will reorder the mesh, so we need to keep indices
+    GEO::Attribute<GEO::index_t> reorderedVerticesAttr(meshG.vertices.attributes(), "reorder");
+    for(int i = 0; i < meshG.vertices.nb(); ++i)
+        reorderedVerticesAttr[i] = i;
+
+    GEO::MeshFacetsAABB meshAABB(meshG);  // warning: mesh_reorder called inside
+
+    GEO::vector<GEO::index_t> reorderedVertices = reorderedVerticesAttr.get_vector();
+
+    out_ptsVisibilities.resize(mesh.pts->size(), nullptr);
+    for (int vi = 0; vi < mesh.pts->size(); ++vi)
+    {
+        if(out_ptsVisibilities[vi] == nullptr)
+            out_ptsVisibilities[vi] = new StaticVector<int>(); // create and give ownership
+    }
+
+    #pragma omp parallel for
+    for (int rvi = 0; rvi < refMesh.pts->size(); ++rvi)
+    {
+        PointVisibility* rpVis = refPtsVisibilities[rvi];
+        if (rpVis == nullptr)
+            continue;
+
+        const GEO::vec3 rp((*refMesh.pts)[rvi].m);
+        GEO::vec3 nearestPoint;
+        double dist2 = 0.0;
+        GEO::index_t f = meshAABB.nearest_facet(rp, nearestPoint, dist2);
+        if(f == GEO::NO_FACET)
+            continue;
+
+        double avgEdgeLength = mesh_facet_edges_length(meshG, f) / 3.0;
+        // if average edge length is larger than the distance between the output mesh
+        // and the closest point in the reference mesh.
+        if(std::sqrt(dist2) > avgEdgeLength)
+            continue;
+
+        #pragma omp critical
+        {
+            for (int i = 0; i < 3; ++i)
+            {
+                GEO::index_t v = meshG.facets.vertex(f, i);
+                if (v == GEO::NO_VERTEX)
+                    continue;
+                PointVisibility* pOut = out_ptsVisibilities[reorderedVertices[v]];
+                
+                for(int j = 0; j < rpVis->size(); ++j)
+                    pOut->push_back_distinct((*rpVis)[j]);
+            }
+        }
+    }
+
+    ALICEVISION_LOG_INFO("remapMeshVisibility done.");
 }
 
 } // namespace mesh

--- a/src/aliceVision/mesh/meshVisibility.hpp
+++ b/src/aliceVision/mesh/meshVisibility.hpp
@@ -27,16 +27,31 @@ int getNearestVertices(const Mesh& refMesh, const Mesh& mesh, StaticVector<int>&
 /**
  * @brief Transfer the visibility per vertex from one mesh to another.
  * For each vertex of the @p mesh, we search the nearest neighbor vertex in the @p refMesh and copy its visibility information.
- * @note The visibility information is a list of camera IDs which are seeing the vertex.
+ * @note The visibility information is a list of camera IDs seeing the vertex.
  *
  * @param[in] refMesh input reference mesh
  * @param[in] refPtsVisibilities visibility array per vertex of @p refMesh
  * @param[in] mesh input target mesh
  * @param[out] out_ptsVisibilities visibility array per vertex of @p mesh
  */
-void remapMeshVisibilities(
+void remapMeshVisibilities_pullVerticesVisibility(
     const Mesh& refMesh, const PointsVisibility& refPtsVisibilities,
     const Mesh& mesh, PointsVisibility& out_ptsVisibilities);
+
+/**
+* @brief Transfer the visibility per vertex from one mesh to another.
+* For each vertex of the @p refMesh, we search the closest triangle in the @p mesh and copy its visibility information to each vertex of the triangle.
+* @note The visibility information is a list of camera IDs seeing the vertex.
+*
+* @param[in] refMesh input reference mesh
+* @param[in] refPtsVisibilities visibility array per vertex of @p refMesh
+* @param[in] mesh input target mesh
+* @param[out] out_ptsVisibilities visibility array per vertex of @p mesh
+*/
+void remapMeshVisibilities_pushVerticesVisibilityToTriangles(
+    const Mesh& refMesh, const PointsVisibility& refPtsVisibilities,
+    const Mesh& mesh, PointsVisibility& out_ptsVisibilities);
+
 
 } // namespace mesh
 } // namespace aliceVision

--- a/src/aliceVision/mvsData/Pixel.hpp
+++ b/src/aliceVision/mvsData/Pixel.hpp
@@ -86,9 +86,13 @@ struct Pixel
         };
     }
 
-    inline float size()
+    inline double size()
     {
-        return sqrt((float)(x * x + y * y));
+        return sqrt((double)(x * x + y * y));
+    }
+    inline int size2()
+    {
+        return x * x + y * y;
     }
 
     friend int dot(const Pixel& p1, const Pixel& p2)

--- a/src/aliceVision/mvsData/geometry.cpp
+++ b/src/aliceVision/mvsData/geometry.cpp
@@ -197,11 +197,9 @@ double angleBetwV1andV2(const Point3d& iV1, const Point3d& iV2)
     V1 = iV1.normalize();
     V2 = iV2.normalize();
 
-    double a = acos((double)(V1.x * V2.x + V1.y * V2.y + V1.z * V2.z));
+    const double a = acos((double)(V1.x * V2.x + V1.y * V2.y + V1.z * V2.z));
     if(std::isnan(a))
-    {
-        a = 0.0;
-    }
+        return 0.0;
 
     return fabs(a / (M_PI / 180.0));
 }

--- a/src/aliceVision/mvsData/geometry.cpp
+++ b/src/aliceVision/mvsData/geometry.cpp
@@ -208,19 +208,9 @@ double angleBetwV1andV2(const Point3d& iV1, const Point3d& iV2)
 
 double angleBetwABandAC(const Point3d& A, const Point3d& B, const Point3d& C)
 {
-    Point3d V1, V2;
-    V1 = B - A;
-    V2 = C - A;
-    V1 = V1.normalize();
-    V2 = V2.normalize();
-
-    double a = acos((double)(V1.x * V2.x + V1.y * V2.y + V1.z * V2.z));
-    if(std::isnan(a))
-    {
-        a = 0.0;
-    }
-
-    return fabs(a) / (M_PI / 180.0);
+    Point3d V1 = B - A;
+    Point3d V2 = C - A;
+    return angleBetwV1andV2(V1, V2);
 }
 
 void rotPointAroundVect(double* out, const double* X, const double* vect, const double angle)

--- a/src/aliceVision/mvsUtils/ImagesCache.cpp
+++ b/src/aliceVision/mvsUtils/ImagesCache.cpp
@@ -114,14 +114,10 @@ void ImagesCache::refreshData(int camId)
             imgs[mapId] = new Color[maxSize];
         }
 
-        std::string imagePath = imagesNames.at(camId);
+        const std::string imagePath = imagesNames.at(camId);
         memcpyRGBImageFromFileToArr(camId, imgs[mapId], imagePath, mp, transposed, bandType);
 
-        if(mp->verbose)
-        {
-            std::string basename = imagePath.substr(imagePath.find_last_of("/\\") + 1);
-            printfElapsedTime(t1, "add "+ basename +" to image cache");
-        }
+        ALICEVISION_LOG_DEBUG("Add " << imagePath << " to image cache. " << formatElapsedTime(t1));
     }
 }
 

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -447,8 +447,8 @@ bool MultiViewParams::isPixelInImage(const Pixel& pix, int d, int camId) const
 }
 bool MultiViewParams::isPixelInImage(const Pixel& pix, int camId) const
 {
-    return ((pix.x >= g_border) && (pix.x < getWidth(camId) - g_border) && (pix.y >= g_border) &&
-            (pix.y < getHeight(camId) - g_border));
+    return ((pix.x >= g_border) && (pix.x < getWidth(camId) - g_border) &&
+            (pix.y >= g_border) && (pix.y < getHeight(camId) - g_border));
 }
 
 bool MultiViewParams::isPixelInImage(const Point2d& pix, int camId) const

--- a/src/aliceVision/mvsUtils/MultiViewParams.hpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.hpp
@@ -96,7 +96,7 @@ public:
     int CUDADeviceNo;
     ///
     float simThr;
-    int g_border = 10;
+    int g_border = 2;
     bool verbose;
 
     boost::property_tree::ptree _ini;

--- a/src/aliceVision/mvsUtils/MultiViewParams.hpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.hpp
@@ -97,7 +97,6 @@ public:
     ///
     float simThr;
     int g_border = 10;
-    int g_maxPlaneNormalViewDirectionAngle = 70;
     bool verbose;
 
     boost::property_tree::ptree _ini;

--- a/src/aliceVision/mvsUtils/common.cpp
+++ b/src/aliceVision/mvsUtils/common.cpp
@@ -206,7 +206,7 @@ void finishEstimate()
 {
 }
 
-std::string printfElapsedTime(long t1, std::string prefix)
+std::string formatElapsedTime(long t1)
 {
     long t2 = clock();
     float d1 = (float)(t2 - t1) / (float)CLOCKS_PER_SEC;
@@ -215,10 +215,9 @@ std::string printfElapsedTime(long t1, std::string prefix)
     int sec = (int)d1 - (int)floor(d1 / 60.0) * 60;
     int mil = (int)((d1 - (int)floor(d1)) * 1000);
 
-    std::string out = prefix + " elapsed time " + num2strTwoDecimal(min) + " minutes " + num2strTwoDecimal(sec) +
-                      " seconds " + num2strThreeDigits(mil) + " miliseconds\n";
-
-    ALICEVISION_LOG_DEBUG(out);
+    std::string out = "Elapsed time: " + num2strTwoDecimal(min) + " minutes " +
+                                         num2strTwoDecimal(sec) + " seconds " +
+                                         num2strThreeDigits(mil) + " miliseconds\n";
 
     return out;
 }

--- a/src/aliceVision/mvsUtils/common.hpp
+++ b/src/aliceVision/mvsUtils/common.hpp
@@ -31,7 +31,11 @@ void printfPercent(int i, int n);
 long initEstimate();
 void printfEstimate(int i, int n, long startTime);
 void finishEstimate();
-std::string printfElapsedTime(long t1, std::string prefix = "");
+std::string formatElapsedTime(long t1);
+inline void printfElapsedTime(long t1, std::string prefix = "")
+{
+    ALICEVISION_LOG_DEBUG(prefix << " " << formatElapsedTime(t1));
+}
 // SampleCnt calculates number of samples needed to be done
 int gaussKernelVoting(StaticVector<OrientedPoint*>* pts, float sigma);
 float angularDistnace(OrientedPoint* op1, OrientedPoint* op2);

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -19,7 +19,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -45,6 +45,7 @@ int main(int argc, char* argv[])
     bool flipNormals = false;
     mesh::TexturingParams texParams;
     std::string unwrapMethod = mesh::EUnwrapMethod_enumToString(mesh::EUnwrapMethod::Basic);
+    std::string visibilityRemappingMethod = mesh::EVisibilityRemappingMethod_enumToString(texParams.visibilityRemappingMethod);
 
     po::options_description allParams("AliceVision texturing");
 
@@ -85,7 +86,12 @@ int main(int argc, char* argv[])
         ("angleHardThreshold", po::value<double>(&texParams.angleHardThreshold)->default_value(texParams.angleHardThreshold),
             "(0.0 to disable angle hard threshold filtering).")
         ("forceVisibleByAllVertices", po::value<bool>(&texParams.forceVisibleByAllVertices)->default_value(texParams.forceVisibleByAllVertices),
-            "triangle visibility is based on the union of vertices visiblity.");
+            "triangle visibility is based on the union of vertices visiblity.")
+        ("visibilityRemappingMethod", po::value<std::string>(&visibilityRemappingMethod)->default_value(visibilityRemappingMethod),
+            "Method to remap visibilities from the reconstruction to the input mesh.\n"
+            " * Pull: For each vertex of the input mesh, pull the visibilities from the closest vertex in the reconstruction.\n"
+            " * Push: For each vertex of the reconstruction, push the visibilities to the closest triangle in the input mesh.\n"
+            " * PullPush: Combine results from Pull and Push results.'");
 
     po::options_description logParams("Log parameters");
     logParams.add_options()
@@ -127,6 +133,7 @@ int main(int argc, char* argv[])
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
+    texParams.visibilityRemappingMethod = mesh::EVisibilityRemappingMethod_stringToEnum(visibilityRemappingMethod);
     // set output texture file type
     const EImageFileType outputTextureFileType = EImageFileType_stringToEnum(outTextureFileTypeName);
 

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -77,7 +77,15 @@ int main(int argc, char* argv[])
         ("inputMesh", po::value<std::string>(&inputMeshFilepath),
             "Optional input mesh to texture. By default, it will texture the inputReconstructionMesh.")
         ("flipNormals", po::value<bool>(&flipNormals)->default_value(flipNormals),
-            "Option to flip face normals. It can be needed as it depends on the vertices order in triangles and the convention change from one software to another.");
+            "Option to flip face normals. It can be needed as it depends on the vertices order in triangles and the convention change from one software to another.")
+        ("maxNbImagesForFusion", po::value<int>(&texParams.maxNbImagesForFusion)->default_value(texParams.maxNbImagesForFusion),
+            "Max number of images to combine to create the final texture.")
+        ("bestScoreThreshold", po::value<double>(&texParams.bestScoreThreshold)->default_value(texParams.bestScoreThreshold),
+            "(0.0 to disable filtering based on threshold to relative best score).")
+        ("angleHardThreshold", po::value<double>(&texParams.angleHardThreshold)->default_value(texParams.angleHardThreshold),
+            "(0.0 to disable angle hard threshold filtering).")
+        ("forceVisibleByAllVertices", po::value<bool>(&texParams.forceVisibleByAllVertices)->default_value(texParams.forceVisibleByAllVertices),
+            "triangle visibility is based on the union of vertices visiblity.");
 
     po::options_description logParams("Log parameters");
     logParams.add_options()


### PR DESCRIPTION
## Description

Major texturing quality improvement by scoring the image contributions and selecting the best ones.
Improve re-texturing of user mesh after retopology by improving reconstruction visibility remapping to the user mesh.

## Features list

- [X] New visibility remapping
Instead of pulling visibilities from vertices to vertices, we push the vertices visibilities from the original mesh to the triangles of the user mesh (low poly).

- [X] Select the best images for texturing
For each triangle, score each image contribution based on projected area to select the best ones. Option to limit the number of image contribution to the N best ones. Option to select a score ratio regarding the best one.

## Implementation remarks

Use geogram Mesh_AABB (Axis Aligned Bounding Box) trees to search for the closest triangle.
