### PR TITLE
[ci][appVeyor] use aliceVision vcpkg fork

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
         # cuda
 
 before_build:
-    - cd $(APPVEYOR_BUILD_FOLDER)
+    - cd %APPVEYOR_BUILD_FOLDER%
     - md build
     - cd build
     - cmake .. -G "Visual Studio 14 2015 Win64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,35 +2,46 @@ version: '1.0.{build}'
 
 image: Visual Studio 2015
 
+branches:
+  only:
+    - master
+    - develop  # PRs are built
+
 platform:
   - x64
+
+environment: 
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 configuration:
   - Release
   # - Debug
 
-# TODO: openimageio[libraw] (not available yet on pre-installed vcpkg)
 install:
     - git submodule update --init --recursive
-    - cmd: >-
-          call cudaInstallAppveyor.cmd
+    # - cmd: >-
+    #      call cudaInstallAppveyor.cmd
+    - cd c:\tools\vcpkg\
+    - git fetch https://github.com/aliceVision/vcpkg.git alicevision_master:alicevision_master
+    - git checkout alicevision_master
+    - .\bootstrap-vcpkg.bat
     - vcpkg upgrade --no-dry-run
     - vcpkg list
     - vcpkg install
           boost-algorithm boost-accumulators boost-atomic boost-container boost-date-time boost-exception boost-filesystem boost-graph boost-log boost-program-options boost-property-tree boost-ptr-container boost-regex boost-serialization boost-system boost-test boost-thread
-          openexr
-          openimageio
-          alembic
-          geogram
           eigen3
-          ceres[suitesparse]
-          cuda
           --triplet %PLATFORM%-windows
           --recurse
     - vcpkg list
-
+        # openexr
+        # openimageio[libraw]
+        # alembic
+        # geogram
+        # ceres[suitesparse]
+        # cuda
 
 before_build:
+    - cd $(APPVEYOR_BUILD_FOLDER)
     - md build
     - cd build
     - cmake .. -G "Visual Studio 14 2015 Win64"
@@ -41,13 +52,13 @@ before_build:
             -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
     - ls -l
 
-build:
-  project: $(APPVEYOR_BUILD_FOLDER)\build\aliceVision.sln
-  verbosity: minimal
+# build:
+#   project: $(APPVEYOR_BUILD_FOLDER)\build\aliceVision.sln
+#   verbosity: minimal
 
-# comment the above and uncomment the following to just build the dependencies
-#build_script:
-#  - echo "Dependencies installed."
+#comment the above and uncomment the following to just build the dependencies
+build_script:
+ - echo "Dependencies installed."
 
 cache:
   c:\tools\vcpkg\installed\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ branches:
 platform:
   - x64
 
-environment: 
-  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+# environment: 
+#   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 configuration:
   - Release
@@ -19,8 +19,8 @@ configuration:
 
 install:
     - git submodule update --init --recursive
-    # - cmd: >-
-    #      call cudaInstallAppveyor.cmd
+    - cmd: >-
+         call cudaInstallAppveyor.cmd
     - cd c:\tools\vcpkg\
     - git fetch https://github.com/aliceVision/vcpkg.git alicevision_master:alicevision_master
     - git checkout alicevision_master
@@ -34,11 +34,11 @@ install:
           alembic 
           geogram 
           eigen3 
-          ceres[suitesparse] 
+          ceres[suitesparse]
+          cuda
           --triplet %PLATFORM%-windows
           --recurse
     - vcpkg list
-        # cuda
 
 before_build:
     - cd %APPVEYOR_BUILD_FOLDER%
@@ -52,13 +52,13 @@ before_build:
             -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
     - ls -l
 
-# build:
-#   project: $(APPVEYOR_BUILD_FOLDER)\build\aliceVision.sln
-#   verbosity: minimal
+build:
+  project: $(APPVEYOR_BUILD_FOLDER)\build\aliceVision.sln
+  verbosity: minimal
 
 #comment the above and uncomment the following to just build the dependencies
-build_script:
- - echo "Dependencies installed."
+# build_script:
+#  - echo "Dependencies installed."
 
 cache:
   c:\tools\vcpkg\installed\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
     - vcpkg install
           boost-algorithm boost-accumulators boost-atomic boost-container boost-date-time boost-exception boost-filesystem boost-graph boost-log boost-program-options boost-property-tree boost-ptr-container boost-regex boost-serialization boost-system boost-test boost-thread
           openexr 
-          openimageio 
+          openimageio[libraw] 
           alembic 
           geogram 
           eigen3 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,15 +29,15 @@ install:
     - vcpkg list
     - vcpkg install
           boost-algorithm boost-accumulators boost-atomic boost-container boost-date-time boost-exception boost-filesystem boost-graph boost-log boost-program-options boost-property-tree boost-ptr-container boost-regex boost-serialization boost-system boost-test boost-thread
-          eigen3
+          openexr 
+          openimageio 
+          alembic 
+          geogram 
+          eigen3 
+          ceres[suitesparse] 
           --triplet %PLATFORM%-windows
           --recurse
     - vcpkg list
-        # openexr
-        # openimageio[libraw]
-        # alembic
-        # geogram
-        # ceres[suitesparse]
         # cuda
 
 before_build:


### PR DESCRIPTION
## Description
This PR aims to use AliceVision VCPKG fork on appVeyor to avoid build failures due to uncontrolled updates of preinstalled VCPKG version.


## Features list
- [X] use AliceVision VCPKG fork


## Implementation remarks


