### PR TITLE
Fix missing VERSION in src/software/utils/main_computeUncertainty.cpp

### DIFF
--- a/src/software/utils/main_computeUncertainty.cpp
+++ b/src/software/utils/main_computeUncertainty.cpp
@@ -17,6 +17,11 @@
 #include <sstream>
 #include <vector>
 
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
 using namespace aliceVision;
 using namespace aliceVision::sfm;
 namespace po = boost::program_options;


### PR DESCRIPTION
`src/software/utils/main_computeUncertainty.cpp` is missing VERSION tags witch prevents cmake from getting through the configuration pass. 