### PR TITLE
[sfmDataIO] fix missing `Boost_REGEX` build error

### DIFF
--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -73,8 +73,6 @@ alicevision_add_library(aliceVision_sfm
     aliceVision_sfmDataIO
     ${Boost_FILESYSTEM_LIBRARY}
     ${CERES_LIBRARIES}
-  PRIVATE_LINKS
-    ${Boost_REGEX_LIBRARY}
 )
 
 # Unit tests

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -34,6 +34,8 @@ alicevision_add_library(aliceVision_sfmDataIO
   PUBLIC_LINKS
     aliceVision_sfmData
     ${Boost_FILESYSTEM_LIBRARY}
+  PRIVATE_LINKS
+    ${Boost_REGEX_LIBRARY}
 )
 
 


### PR DESCRIPTION
Fix a CMake mistake with `Boost_REGEX_LIBRARY` in #455 
Fix #471 
