### PR TITLE
[depthMap] copy calls using cudaMemcpy2D worked only for sizeof(Type)==1

### DIFF
--- a/src/aliceVision/depthMap/cuda/commonStructures.hpp
+++ b/src/aliceVision/depthMap/cuda/commonStructures.hpp
@@ -11,6 +11,8 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include <aliceVision/system/Logger.hpp>
+
 namespace aliceVision {
 namespace depthMap {
 
@@ -196,25 +198,35 @@ public:
     if (Dim >= 3) sx = _size[2];
     if(Dim == 2)
     {
-      cudaMallocPitch<Type>(&buffer, &pitch, _size[0] * sizeof(Type), _size[1]);
+      cudaError_t err = cudaMallocPitch<Type>(&buffer, &pitch, _size[0] * sizeof(Type), _size[1]);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc failed, " << cudaGetErrorString(err) );
+      }
     }
-    if(Dim >= 3)
+    if(Dim == 3)
     {
       cudaExtent extent;
       extent.width = _size[0] * sizeof(Type);
       extent.height = _size[1];
       extent.depth = _size[2];
-      for(unsigned i = 3; i < Dim; ++i)
-        extent.depth *= _size[i];
       cudaPitchedPtr pitchDevPtr;
-      cudaMalloc3D(&pitchDevPtr, extent);
+      cudaError_t err = cudaMalloc3D(&pitchDevPtr, extent);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc failed, " << cudaGetErrorString(err) );
+      }
       buffer = (Type*)pitchDevPtr.ptr;
       pitch = pitchDevPtr.pitch;
     }
   }
   ~CudaDeviceMemoryPitched()
   {
-    cudaFree(buffer);
+      cudaError_t err = cudaFree(buffer);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device free failed, " << cudaGetErrorString(err) );
+      }
   }
   explicit inline CudaDeviceMemoryPitched(const CudaHostMemoryHeap<Type, Dim> &rhs)
   {
@@ -227,18 +239,24 @@ public:
     if (Dim >= 3) sx = rhs.getSize()[2];
     if(Dim == 2)
     {
-      cudaMallocPitch<Type>(&buffer, &pitch, size[0] * sizeof(Type), size[1]);
+      cudaError_t err = cudaMallocPitch<Type>(&buffer, &pitch, size[0] * sizeof(Type), size[1]);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc failed, " << cudaGetErrorString(err) );
+      }
     }
-    if(Dim >= 3)
+    if(Dim == 3)
     {
       cudaExtent extent;
       extent.width = size[0] * sizeof(Type);
       extent.height = size[1];
       extent.depth = size[2];
-      for(unsigned i = 3; i < Dim; ++i)
-        extent.depth *= size[i];
       cudaPitchedPtr pitchDevPtr;
-      cudaMalloc3D(&pitchDevPtr, extent);
+      cudaError_t err = cudaMalloc3D(&pitchDevPtr, extent);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc failed, " << cudaGetErrorString(err) );
+      }
       buffer = (Type*)pitchDevPtr.ptr;
       pitch = pitchDevPtr.pitch;
     }
@@ -303,11 +321,19 @@ public:
     cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<Type>();
     if(Dim == 1)
     {
-      cudaMallocArray(&array, &channelDesc, _size[0], 1, cudaArraySurfaceLoadStore);
+      cudaError_t err = cudaMallocArray(&array, &channelDesc, _size[0], 1, cudaArraySurfaceLoadStore);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 1D array failed, " << cudaGetErrorString(err) );
+      }
     }
     else if(Dim == 2)
     {
-      cudaMallocArray(&array, &channelDesc, _size[0], _size[1], cudaArraySurfaceLoadStore);
+      cudaError_t err = cudaMallocArray(&array, &channelDesc, _size[0], _size[1], cudaArraySurfaceLoadStore);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 2D array failed, " << cudaGetErrorString(err) );
+      }
     }
     else
     {
@@ -317,7 +343,11 @@ public:
       extent.depth = _size[2];
       for(unsigned i = 3; i < Dim; ++i)
         extent.depth *= _size[i];
-      cudaMalloc3DArray(&array, &channelDesc, extent);
+      cudaError_t err = cudaMalloc3DArray(&array, &channelDesc, extent);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 3D array failed, " << cudaGetErrorString(err) );
+      }
     }
   }
   explicit inline CudaArray(const CudaDeviceMemoryPitched<Type, Dim> &rhs)
@@ -332,11 +362,19 @@ public:
     cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<Type>();
     if(Dim == 1)
     {
-      cudaMallocArray(&array, &channelDesc, size[0], 1, cudaArraySurfaceLoadStore);
+      cudaError_t err = cudaMallocArray(&array, &channelDesc, size[0], 1, cudaArraySurfaceLoadStore);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 1D array failed, " << cudaGetErrorString(err) );
+      }
     }
     else if(Dim == 2)
     {
-      cudaMallocArray(&array, &channelDesc, size[0], size[1], cudaArraySurfaceLoadStore);
+      cudaError_t err = cudaMallocArray(&array, &channelDesc, size[0], size[1], cudaArraySurfaceLoadStore);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 2D array failed, " << cudaGetErrorString(err) );
+      }
     }
     else
     {
@@ -346,7 +384,11 @@ public:
       extent.depth = size[2];
       for(unsigned i = 3; i < Dim; ++i)
         extent.depth *= size[i];
-      cudaMalloc3DArray(&array, &channelDesc, extent);
+      cudaError_t err = cudaMalloc3DArray(&array, &channelDesc, extent);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 3D array failed, " << cudaGetErrorString(err) );
+      }
     }
     copy(*this, rhs);
   }
@@ -362,11 +404,19 @@ public:
     cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<Type>();
     if(Dim == 1)
     {
-      cudaMallocArray(&array, &channelDesc, size[0], 1, cudaArraySurfaceLoadStore);
+      cudaError_t err = cudaMallocArray(&array, &channelDesc, size[0], 1, cudaArraySurfaceLoadStore);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 1D array failed, " << cudaGetErrorString(err) );
+      }
     }
     else if(Dim == 2)
     {
-      cudaMallocArray(&array, &channelDesc, size[0], size[1], cudaArraySurfaceLoadStore);
+      cudaError_t err = cudaMallocArray(&array, &channelDesc, size[0], size[1], cudaArraySurfaceLoadStore);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 2D array failed, " << cudaGetErrorString(err) );
+      }
     }
     else
     {
@@ -376,7 +426,11 @@ public:
       extent.depth = size[2];
       for(unsigned i = 3; i < Dim; ++i)
         extent.depth *= size[i];
-      cudaMalloc3DArray(&array, &channelDesc, extent);
+      cudaError_t err = cudaMalloc3DArray(&array, &channelDesc, extent);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Device alloc 3D array failed, " << cudaGetErrorString(err) );
+      }
     }
     copy(*this, rhs);
   }
@@ -414,15 +468,38 @@ template<class Type, unsigned Dim> void copy(CudaHostMemoryHeap<Type, Dim>& _dst
 {
   cudaMemcpyKind kind = cudaMemcpyDeviceToHost;
   if(Dim == 1) {
-    cudaMemcpy(_dst.getBuffer(), _src.getBuffer(), _src.getBytes(), kind);
+    cudaError_t err = cudaMemcpy(_dst.getBuffer(), _src.getBuffer(), _src.getBytes(), kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 2) {
-    cudaMemcpy2D(_dst.getBuffer(), _dst.getSize()[0] * sizeof (Type), _src.getBuffer(), _src.getPitch(), _dst.getSize()[0] * sizeof (Type), _dst.getSize()[1], kind);
+    cudaError_t err = cudaMemcpy2D(_dst.getBuffer(),
+                                   _dst.getSize()[0] * sizeof (Type),
+                                   _src.getBuffer(),
+                                   _src.getPitch(),
+                                   _dst.getSize()[0] * sizeof (Type),
+                                   _dst.getSize()[1], kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim >= 3) {
     for (unsigned int slice=0; slice<_dst.getSize()[2]; slice++)
     {
-      cudaMemcpy2D( _dst.getBuffer() + slice * _dst.getSize()[0] * _dst.getSize()[1], _dst.getSize()[0] * sizeof (Type), &_src.getBuffer()[slice * _src.stride()[1]], _src.getPitch(), _dst.getSize()[0] * sizeof (Type), _dst.getSize()[1], kind);
+      cudaError_t err = cudaMemcpy2D( _dst.getBuffer() + slice * _dst.getSize()[0] * _dst.getSize()[1],
+                                      _dst.getSize()[0] * sizeof (Type),
+                                      (unsigned char*)_src.getBuffer() + slice * _src.stride()[1],
+                                      _src.getPitch(),
+                                      _dst.getSize()[0] * sizeof (Type),
+                                      _dst.getSize()[1],
+                                      kind);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+      }
     }
   }
 }
@@ -431,10 +508,25 @@ template<class Type, unsigned Dim> void copy(CudaHostMemoryHeap<Type, Dim>& _dst
 {
   cudaMemcpyKind kind = cudaMemcpyDeviceToHost;
   if(Dim == 1) {
-    cudaMemcpyFromArray(_dst.getBuffer(), _src.getArray(), 0, 0, _dst.getSize()[0] * sizeof (Type), kind);
+    cudaError_t err = cudaMemcpyFromArray(_dst.getBuffer(), _src.getArray(), 0, 0, _dst.getSize()[0] * sizeof (Type), kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 2) {
-    cudaMemcpy2DFromArray(_dst.getBuffer(), _dst.getSize()[0] * sizeof (Type), _src.getArray(), 0, 0, _dst.getSize()[0] * sizeof (Type), _dst.getSize()[1], kind);
+    cudaError_t err = cudaMemcpy2DFromArray(_dst.getBuffer(),
+                                            _dst.getSize()[0] * sizeof (Type),
+                                            _src.getArray(),
+                                            0,
+                                            0,
+                                            _dst.getSize()[0] * sizeof (Type),
+                                            _dst.getSize()[1],
+                                            kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 3) {
     cudaMemcpy3DParms p = { 0 };
@@ -452,7 +544,11 @@ template<class Type, unsigned Dim> void copy(CudaHostMemoryHeap<Type, Dim>& _dst
     for(unsigned i = 3; i < Dim; ++i)
       p.extent.depth *= _src.getSize()[i];
     p.kind = kind;
-    cudaMemcpy3D(&p);
+    cudaError_t err = cudaMemcpy3D(&p);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
 }
 
@@ -460,15 +556,39 @@ template<class Type, unsigned Dim> void copy(CudaDeviceMemoryPitched<Type, Dim>&
 {
   cudaMemcpyKind kind = cudaMemcpyHostToDevice;
   if(Dim == 1) {
-    cudaMemcpy(_dst.getBuffer(), _src.getBuffer(), _src.getBytes(), kind);
+    cudaError_t err = cudaMemcpy(_dst.getBuffer(), _src.getBuffer(), _src.getBytes(), kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 2) {
-    cudaMemcpy2D(_dst.getBuffer(), _dst.getPitch(), _src.getBuffer(), _src.getSize()[0] * sizeof (Type), _src.getSize()[0] * sizeof (Type), _src.getSize()[1], kind);
+    cudaError_t err = cudaMemcpy2D(_dst.getBuffer(),
+                                   _dst.getPitch(),
+                                   _src.getBuffer(),
+                                   _src.getSize()[0] * sizeof (Type),
+                                   _src.getSize()[0] * sizeof (Type),
+                                   _src.getSize()[1],
+                                   kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim >= 3) {
     for (unsigned int slice=0; slice<_src.getSize()[2]; slice++)
     {
-      cudaMemcpy2D( &_dst.getBuffer()[slice * _dst.stride()[1]], _dst.getPitch(), _src.getBuffer() + slice * _src.getSize()[0] * _src.getSize()[1], _src.getSize()[0] * sizeof (Type), _src.getSize()[0] * sizeof (Type), _src.getSize()[1], kind);
+      cudaError_t err = cudaMemcpy2D( &_dst.getBuffer()[slice * _dst.stride()[1]],
+                                      _dst.getPitch(),
+                                      _src.getBuffer() + slice * _src.getSize()[0] * _src.getSize()[1],
+                                      _src.getSize()[0] * sizeof (Type),
+                                      _src.getSize()[0] * sizeof (Type),
+                                      _src.getSize()[1],
+                                      kind);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+      }
     }
   }
 }
@@ -477,15 +597,39 @@ template<class Type, unsigned Dim> void copy(CudaDeviceMemoryPitched<Type, Dim>&
 {
   cudaMemcpyKind kind = cudaMemcpyDeviceToDevice;
   if(Dim == 1) {
-    cudaMemcpy(_dst.getBuffer(), _src.getBuffer(), _src.getBytes(), kind);
+    cudaError_t err = cudaMemcpy(_dst.getBuffer(), _src.getBuffer(), _src.getBytes(), kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 2) {
-    cudaMemcpy2D(_dst.getBuffer(), _dst.getPitch(), _src.getBuffer(), _src.getPitch(), _src.getSize()[0] * sizeof(Type), _src.getSize()[1], kind);
+    cudaError_t err = cudaMemcpy2D(_dst.getBuffer(),
+                                   _dst.getPitch(),
+                                   _src.getBuffer(),
+                                   _src.getPitch(),
+                                   _src.getSize()[0] * sizeof(Type),
+                                   _src.getSize()[1],
+                                   kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim >= 3) {
     for (unsigned int slice=0; slice<_src.getSize()[2]; slice++)
     {
-      cudaMemcpy2D( &_dst.getBuffer()[slice * _dst.stride()[1]], _dst.getPitch(), &_src.getBuffer()[slice * _src.stride()[1]], _src.getPitch(), _src.getSize()[0] * sizeof(Type), _src.getSize()[1], kind);
+      cudaError_t err = cudaMemcpy2D( &_dst.getBuffer()[slice * _dst.stride()[1]],
+                                      _dst.getPitch(),
+                                      (unsigned char*)_src.getBuffer() + slice * _src.stride()[1],
+                                      _src.getPitch(),
+                                      _src.getSize()[0] * sizeof(Type),
+                                      _src.getSize()[1],
+                                      kind);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+      }
     }
   }
 }
@@ -494,10 +638,25 @@ template<class Type, unsigned Dim> void copy(CudaDeviceMemoryPitched<Type, Dim>&
 {
   cudaMemcpyKind kind = cudaMemcpyDeviceToDevice;
   if(Dim == 1) {
-    cudaMemcpyFromArray(_dst.getBuffer(), _src.getArray(), 0, 0, _src.getSize()[0] * sizeof(Type), kind);
+    cudaError_t err = cudaMemcpyFromArray(_dst.getBuffer(), _src.getArray(), 0, 0, _src.getSize()[0] * sizeof(Type), kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 2) {
-    cudaMemcpy2DFromArray(_dst.getBuffer(), _dst.getPitch(), _src.getArray(), 0, 0, _src.getSize()[0] * sizeof(Type), _src.getSize()[1], kind);
+    cudaError_t err = cudaMemcpy2DFromArray(_dst.getBuffer(),
+                                            _dst.getPitch(),
+                                            _src.getArray(),
+                                            0,
+                                            0,
+                                            _src.getSize()[0] * sizeof(Type),
+                                            _src.getSize()[1],
+                                            kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 3) {
     cudaMemcpy3DParms p = { 0 };
@@ -515,7 +674,11 @@ template<class Type, unsigned Dim> void copy(CudaDeviceMemoryPitched<Type, Dim>&
     for(unsigned i = 3; i < Dim; ++i)
       p.extent.depth *= _src.getSize()[i];
     p.kind = kind;
-    cudaMemcpy3D(&p);
+    cudaError_t err = cudaMemcpy3D(&p);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
 }
 
@@ -523,10 +686,25 @@ template<class Type, unsigned Dim> void copy(CudaArray<Type, Dim>& _dst, const C
 {
   cudaMemcpyKind kind = cudaMemcpyHostToDevice;
   if(Dim == 1) {
-    cudaMemcpyToArray(_dst.getArray(), 0, 0, _src.getBuffer(), _src.getSize()[0] * sizeof (Type), kind);
+    cudaError_t err = cudaMemcpyToArray(_dst.getArray(), 0, 0, _src.getBuffer(), _src.getSize()[0] * sizeof (Type), kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 2) {
-    cudaMemcpy2DToArray(_dst.getArray(), 0, 0, _src.getBuffer(), _src.getSize()[0] * sizeof (Type), _src.getSize()[0] * sizeof (Type), _src.getSize()[1], kind);
+    cudaError_t err = cudaMemcpy2DToArray(_dst.getArray(),
+                                          0,
+                                          0,
+                                          _src.getBuffer(),
+                                          _src.getSize()[0] * sizeof (Type),
+                                          _src.getSize()[0] * sizeof (Type),
+                                          _src.getSize()[1],
+                                          kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 3) {
     cudaMemcpy3DParms p = { 0 };
@@ -544,7 +722,11 @@ template<class Type, unsigned Dim> void copy(CudaArray<Type, Dim>& _dst, const C
     for(unsigned i = 3; i < Dim; ++i)
       p.extent.depth *= _src.getSize()[i];
     p.kind = kind;
-    cudaMemcpy3D(&p);
+    cudaError_t err = cudaMemcpy3D(&p);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
 }
 
@@ -552,10 +734,25 @@ template<class Type, unsigned Dim> void copy(CudaArray<Type, Dim>& _dst, const C
 {
   cudaMemcpyKind kind = cudaMemcpyDeviceToDevice;
   if(Dim == 1) {
-    cudaMemcpyToArray(_dst.getArray(), 0, 0, _src.getBuffer(), _src.getSize()[0] * sizeof(Type), kind);
+    cudaError_t err = cudaMemcpyToArray(_dst.getArray(), 0, 0, _src.getBuffer(), _src.getSize()[0] * sizeof(Type), kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 2) {
-    cudaMemcpy2DToArray(_dst.getArray(), 0, 0, _src.getBuffer(), _src.getPitch(), _src.getSize()[0] * sizeof(Type), _src.getSize()[1], kind);
+    cudaError_t err = cudaMemcpy2DToArray(_dst.getArray(),
+                                          0,
+                                          0,
+                                          _src.getBuffer(),
+                                          _src.getPitch(),
+                                          _src.getSize()[0] * sizeof(Type),
+                                          _src.getSize()[1],
+                                          kind);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
   else if(Dim == 3) {
     cudaMemcpy3DParms p = { 0 };
@@ -573,21 +770,33 @@ template<class Type, unsigned Dim> void copy(CudaArray<Type, Dim>& _dst, const C
     for(unsigned i = 3; i < Dim; ++i)
       p.extent.depth *= _src.getSize()[i];
     p.kind = kind;
-    cudaMemcpy3D(&p);
+    cudaError_t err = cudaMemcpy3D(&p);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
 }
 
 template<class Type, unsigned Dim> void copy(Type* _dst, size_t sx, size_t sy, const CudaDeviceMemoryPitched<Type, Dim>& _src)
 {
   if(Dim == 2) {
-    cudaMemcpy2D(_dst, sx * sizeof (Type), _src.getBuffer(), _src.getPitch(), sx * sizeof (Type), sy, cudaMemcpyDeviceToHost);
+    cudaError_t err = cudaMemcpy2D(_dst, sx * sizeof (Type), _src.getBuffer(), _src.getPitch(), sx * sizeof (Type), sy, cudaMemcpyDeviceToHost);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
 }
 
 template<class Type, unsigned Dim> void copy(CudaDeviceMemoryPitched<Type, Dim>& _dst, const Type* _src, size_t sx, size_t sy)
 {
   if(Dim == 2) {
-    cudaMemcpy2D(_dst.getBuffer(), _dst.getPitch(), _src, sx * sizeof (Type), sx * sizeof(Type), sy, cudaMemcpyHostToDevice);
+    cudaError_t err = cudaMemcpy2D(_dst.getBuffer(), _dst.getPitch(), _src, sx * sizeof (Type), sx * sizeof(Type), sy, cudaMemcpyHostToDevice);
+    if( err != cudaSuccess )
+    {
+      ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+    }
   }
 }
 
@@ -596,7 +805,19 @@ template<class Type, unsigned Dim> void copy(Type* _dst, size_t sx, size_t sy, s
   if(Dim >= 3) {
     for (unsigned int slice=0; slice<sz; slice++)
     {
-      cudaMemcpy2D( _dst + sx * sy * slice, sx * sizeof (Type), &_src.getBuffer()[slice * _src.stride()[1]], _src.getPitch(), sx * sizeof (Type), sy, cudaMemcpyDeviceToHost);
+      cudaError_t err = cudaMemcpy2D( _dst + sx * sy * slice,
+                                      sx * sizeof (Type),
+                                      (unsigned char*)_src.getBuffer() + slice * _src.stride()[1],
+                                      _src.stride()[0], // _src.getPitch(),
+                                      sx * sizeof (Type),
+                                      sy,
+                                      cudaMemcpyDeviceToHost);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Failed to copy : " << std::endl
+            << "    " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+        throw std::runtime_error("Failed to copy.");
+      }
     }
   }
 }
@@ -606,7 +827,17 @@ template<class Type, unsigned Dim> void copy(CudaDeviceMemoryPitched<Type, Dim>&
   if(Dim >= 3) {
     for (unsigned int slice=0; slice<sz; slice++)
     {
-      cudaMemcpy2D( &_dst.getBuffer()[slice * _dst.stride()[1]], _dst.getPitch(), _src + sx * sy * slice, sx * sizeof (Type), sx * sizeof(Type), sy, cudaMemcpyHostToDevice);
+      cudaError_t err = cudaMemcpy2D( (unsigned char*)_dst.getBuffer() + slice * _dst.stride()[1],
+                                      _dst.getPitch(),
+                                      _src + sx * sy * slice,
+                                      sx * sizeof (Type),
+                                      sx * sizeof(Type),
+                                      sy,
+                                      cudaMemcpyHostToDevice);
+      if( err != cudaSuccess )
+      {
+        ALICEVISION_LOG_ERROR( "Failed to copy : " << __FILE__ << " " << __LINE__ << ", " << cudaGetErrorString(err) );
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Fixes a bug that appeared when changing the depth volume from uchar to int. All Memcpy2D used in loops to copy slices computed offsets by taking base address incorrectly as basePtr + z*sliceByteSize, must be (uchar*)basePtr + z*sliceByteSize 

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

