### PR TITLE
Update cameraSensors.db with Fujifilm FinePix XP90

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1117,6 +1117,8 @@ Fujifilm;Fujifilm FinePix XP50;6.16
 Fujifilm;Fujifilm FinePix XP60;6.16
 Fujifilm;Fujifilm FinePix XP70;6.16
 Fujifilm;Fujifilm FinePix XP80;6.16
+Fujifilm;Fujifilm FinePix XP90;6.16
+Fujifilm;Fujifilm FinePix XP90 XP91 XP95;6.16
 Fujifilm;Fujifilm FinePix Z1;5.75
 Fujifilm;Fujifilm FinePix Z1000EXR;6.4
 Fujifilm;Fujifilm FinePix Z100fd;5.75

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1118,6 +1118,7 @@ Fujifilm;Fujifilm FinePix XP60;6.16
 Fujifilm;Fujifilm FinePix XP70;6.16
 Fujifilm;Fujifilm FinePix XP80;6.16
 Fujifilm;Fujifilm FinePix XP90;6.16
+Fujifilm;Fujifilm FinePix XP90 XP91 XP95;6.16
 Fujifilm;Fujifilm FinePix Z1;5.75
 Fujifilm;Fujifilm FinePix Z1000EXR;6.4
 Fujifilm;Fujifilm FinePix Z100fd;5.75

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1118,7 +1118,6 @@ Fujifilm;Fujifilm FinePix XP60;6.16
 Fujifilm;Fujifilm FinePix XP70;6.16
 Fujifilm;Fujifilm FinePix XP80;6.16
 Fujifilm;Fujifilm FinePix XP90;6.16
-Fujifilm;Fujifilm FinePix XP90 XP91 XP95;6.16
 Fujifilm;Fujifilm FinePix Z1;5.75
 Fujifilm;Fujifilm FinePix Z1000EXR;6.4
 Fujifilm;Fujifilm FinePix Z100fd;5.75


### PR DESCRIPTION
## Description

add the Fujifilm FinePix XP90 to cameraSensors.db

To fix error:

```
[error] Sensor width doesn't exist in the database for image(s) :
[error] image: 'DSCF0690.JPG'
        - camera brand: FUJIFILM
        - camera model: FinePix XP90 XP91 XP95

[error] Please add camera model(s) and sensor width(s) in the database.
```

