### PR TITLE
Compute the scale for SfM from Kinect depthmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ install
 lib
 bin
 x64
+dist
 
 # CMake
 CMakeFiles  # intermediate folders
@@ -71,4 +72,5 @@ Production
 *.gz
 *.tgz
 *.tar*
+
 

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -220,6 +220,11 @@ void readImage(const std::string& path, Image<unsigned char>& image)
   readImage(path, oiio::TypeDesc::UINT8, 1, image);
 }
 
+void readImage(const std::string& path, Image<char16_t>& image)
+{
+	readImage(path, oiio::TypeDesc::UINT16, 1, image);
+}
+
 void readImage(const std::string& path, Image<RGBAColor>& image)
 {
   readImage(path, oiio::TypeDesc::UINT8, 4, image);

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -82,6 +82,7 @@ void readImageMetadata(const std::string& path, int& width, int& height, std::ma
  */
 void readImage(const std::string& path, Image<float>& image);
 void readImage(const std::string& path, Image<unsigned char>& image);
+void readImage(const std::string& path, Image<char16_t>& image);
 void readImage(const std::string& path, Image<RGBAColor>& image);
 void readImage(const std::string& path, Image<RGBfColor>& image);
 void readImage(const std::string& path, Image<RGBColor>& image);

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -29,6 +29,7 @@ set(sfm_files_headers
   sfm.hpp
   sfmFilters.hpp
   sfmTriangulation.hpp
+  sfmKinectRegistration.hpp
 )
 
 # Sources
@@ -53,6 +54,7 @@ set(sfm_files_sources
   generateReport.cpp
   sfmFilters.cpp
   sfmTriangulation.cpp
+  sfmKinectRegistration.cpp
 )
 
 alicevision_add_library(aliceVision_sfm
@@ -85,6 +87,9 @@ alicevision_add_test(bundleAdjustment_test.cpp
         aliceVision_feature
         aliceVision_system
 )
+
+alicevision_add_test(scaleFromKinect_test.cpp        NAME "sfm_scaleFromKinect"         LINKS aliceVision_sfm)
+
 
 add_subdirectory(pipeline)
 

--- a/src/aliceVision/sfm/scaleFromKinect_test.cpp
+++ b/src/aliceVision/sfm/scaleFromKinect_test.cpp
@@ -1,0 +1,52 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE scaleFromKinect
+
+#include <aliceVision/sfm/sfmKinectRegistration.hpp>
+
+#include <aliceVision/system/Logger.hpp>
+#include "aliceVision/image/all.hpp"
+#include <aliceVision/sfm/sfm.hpp>
+#include <boost/filesystem.hpp>
+
+#include <boost/test/included/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+#include <sstream>
+#include <cstdio>
+#include <iostream>
+#include <vector>
+#include <string>
+
+using namespace aliceVision;
+using namespace aliceVision::camera;
+using namespace aliceVision::geometry;
+using namespace aliceVision::sfmDataIO;
+using namespace aliceVision::image;
+using namespace aliceVision::sfm;
+
+BOOST_AUTO_TEST_CASE(scaleFromKinect_computeScaleForKnownDataset)
+{
+	// INPUT DATA - SFM
+	std::string filename = "d:/Help/Reconstructions/Kinect/rgbd2/AliceVision/MeshroomCache/StructureFromMotion/2e60d29117d352a99ad747548da731cdd99b03fc/sfm.abc";
+	sfmData::SfMData sfmData;
+	ESfMData flags_part = ALL;
+	BOOST_CHECK(Load(sfmData, filename, flags_part));
+
+	// INPUT DATA - IMGS PATH
+	std::string imgs_path("d:/Help/Reconstructions/Kinect/rgbd2/bigdepth");
+
+	// EXPECTED RESULT
+	double scale = 5882.8035847493;
+
+	// PROCESS
+	double out_scale = 0;
+	BOOST_CHECK(computeSfMScaleFromKinect(sfmData, imgs_path, &out_scale));
+
+	// TEST
+	BOOST_CHECK(std::abs(scale - out_scale) < (scale * 0.02));		// the error is smaller than 2%
+}

--- a/src/aliceVision/sfm/sfmKinectRegistration.cpp
+++ b/src/aliceVision/sfm/sfmKinectRegistration.cpp
@@ -1,0 +1,105 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// Copyright (c) 2012 openMVG contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfm/sfmKinectRegistration.hpp>
+
+namespace aliceVision {
+	namespace sfm {
+
+
+		bool computeSfMScaleFromKinect(const sfmData::SfMData& sfmData,
+			const std::string depthmapsPath,
+			double* out_S) 
+		{
+			// find observation in views 
+			std::map<IndexT, std::vector<ipo>> obs4views;
+			for (auto l : sfmData.structure) {				// landmarks - pts in 3D
+				for (auto o : l.second.observations) 		// observation for pt in 3D
+					obs4views[o.first].push_back(ipo(l.first, o.second.x));
+			}
+
+			// find scale for all aligned images
+			std::vector<double> scales;
+			image::Image<char16_t> image;
+			for (auto v : sfmData.views) {
+				sfmData::View view = *v.second;
+
+				/* ******************************************************** */
+				// REPLACE CONSTANTS WITH PARAMETERS FROM "intrinsic"
+				// focal = 1081.37207 is focal lenght from Microsoft
+				// pp = [959.5, 539.5] is principal point from Microsoft
+				/* ******************************************************** */
+				double focal = 1081.37207;
+				double pp[2] = { 959.5, 539.5 };
+				//camera::IntrinsicBase *intrinsic = sfmData.getIntrinsicPtr(view.getIntrinsicId());
+
+
+				if (sfmData.existsPose(view)) {
+					sfmData::CameraPose pose = sfmData.getPose(view);
+					std::vector<ipo> obs = obs4views[v.first];
+					 
+					// read depthmap
+					/* ******************************************************** */
+					// PATH SEPARATION - MAY NOT WORK ON ALL SYSTEMS AND ALL TYPES OF IMAGES (IT ASSUME SEPARATOR "/" AND 3 LETTERS AS IMAGE SUFFIX)
+					/* ******************************************************** */
+					std::string img_path = view.getImagePath();
+					size_t i = img_path.rfind("/", img_path.length());	
+					std::string img_name = img_path.substr(i + 1, img_path.length() - i - 4);
+					std::string png_filename = depthmapsPath + "/" + img_name + "png";
+					std::cout << "Computing of scale for depthmap:" << png_filename << "\n";
+					image::readImage(png_filename, image); 
+
+					// compute scale for all points in 3D
+					for (ipo idpt_obs : obs) {
+						Vec3 X = sfmData.structure.at(idpt_obs._pt3D_id).X;	// SfM
+						double u = idpt_obs._obs(0);
+						double v = idpt_obs._obs(1);
+						double d = static_cast<double>(image(round(v) + 1, round(u)));		//depth in milimeters    ( y+1 -> the depth images has one row offset )
+						double dist_from_img_center = std::sqrt((u - pp[0]) * (u - pp[0]) + (v - pp[1]) * (v - pp[1]));  // leave the values on the edges of image, they are not precise
+						
+						if ( d != 0 && dist_from_img_center < 700){
+							Vec3 Y;			// local coordiante system of kinect pointcloud, units are in milimeters
+							Y << d * (u - pp[0]) / focal,
+								 d * (v - pp[1]) / focal,
+								 d;
+						
+							geometry::Pose3 params = pose.getTransform();
+							Mat3 R = params.rotation();
+							Vec3 C = params.center();
+
+							// we assume that registered depth image is the same as the rgb one
+							// therfore, they have the same intrinsics => Kx = Ky => inv(Kx)*Ky = E_3
+							// ---> generally: S = (X - C) ./ (Rt*inv(Kx)*Ky*Y);		
+							Vec3 XC = X - C;
+							Vec3 RtY = R.transpose() * Y;
+
+							scales.push_back(XC(0) / RtY(0));
+							scales.push_back(XC(1) / RtY(1));
+							scales.push_back(XC(2) / RtY(2));
+						}
+					}
+				}
+			}
+
+
+			// compute robust mean (leave 70% of extreme values, compute mean of the remaining 30% of values) 
+			std::sort(scales.begin(), scales.end());
+			double sum_s = 0;
+			int start = std::round(scales.size() * 0.35);
+			int end = std::round(scales.size() * 0.75);
+			for (int i = start; i < end; ++i)
+				sum_s += scales[i];
+			*out_S = 1 / (sum_s / (end - start));  // we want scale of SfM => (1 / scale) of Kinect point clouds
+
+			// computation was succesfull
+			return true;
+		}
+
+		
+
+	}
+}

--- a/src/aliceVision/sfm/sfmKinectRegistration.hpp
+++ b/src/aliceVision/sfm/sfmKinectRegistration.hpp
@@ -1,0 +1,41 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// Copyright (c) 2012 openMVG contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include "aliceVision/image/all.hpp"
+
+#include <algorithm>
+
+namespace aliceVision {
+	namespace sfm {
+
+		struct ipo {
+			IndexT _pt3D_id;
+			Vec2 _obs;
+			ipo(IndexT pt3D_id, Vec2 obs) : _pt3D_id(pt3D_id), _obs(obs) {}
+		};
+
+		
+		/**
+		* @brief Compute the scale for SfM from Kinect depthmaps.
+		*
+		* @param[in] sfmData
+		* @param[in] depthmapsPath path to the folder with depthmaps registered to Kinect HD images
+		* @param[out] out_S output scale factor for SfM to be in millimeters 
+		*
+		* Kinect points in 3D can be transformed to the world coordinate system in millimeters: 
+		*			X = sfm.view.rotation.transpose() * kinect.X + out_S * sfm.view.camera_center
+		*/
+		bool computeSfMScaleFromKinect(const sfmData::SfMData& sfmData,
+			const std::string depthmapsPath,
+			double* out_S);
+
+	}
+}


### PR DESCRIPTION
## Description
The code computes the scale of SfM to be in millimeters from Kinect depthmaps.
For transformation of SfM can be used the code from alignment.cpp.



