### PR TITLE
Added Microsoft Lumia 950 Dual SIM to cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1665,6 +1665,7 @@ Leica;Leica X Vario;23.6
 Leica;Leica X-E;23.6
 Leica;Leica X1;23.6
 Leica;Leica X2;23.6
+Microsoft;Lumia 950 Dual SIM;5.76
 Minolta;Minolta DiMAGE 2300;7.53
 Minolta;Minolta DiMAGE 2330;7.53
 Minolta;Minolta DiMAGE 5;7.11


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Added Microsoft Lumia 950 Dual SIM to cameraSensors.db to fix the following error:

>[error] Sensor width doesn't exist in the database for image(s) :
>[error] image: 'WP_20180904_21_11_38_Rich.jpg'
>        - camera brand: Microsoft
>        - camera model: Lumia 950 Dual SIM
>
>[error] Please add camera model(s) and sensor width(s) in the database.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

