### PR TITLE
Update cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1665,6 +1665,7 @@ Leica;Leica X Vario;23.6
 Leica;Leica X-E;23.6
 Leica;Leica X1;23.6
 Leica;Leica X2;23.6
+LG Electronics;LG-H932;5.822
 Microsoft;Lumia 950 Dual SIM;5.76
 Minolta;Minolta DiMAGE 2300;7.53
 Minolta;Minolta DiMAGE 2330;7.53

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1665,7 +1665,7 @@ Leica;Leica X Vario;23.6
 Leica;Leica X-E;23.6
 Leica;Leica X1;23.6
 Leica;Leica X2;23.6
-LG Electronics;LG-H932;5.822
+LG Electronics;LG-H932;5.893
 Microsoft;Lumia 950 Dual SIM;5.76
 Minolta;Minolta DiMAGE 2300;7.53
 Minolta;Minolta DiMAGE 2330;7.53


### PR DESCRIPTION
Adding support for the LG-V30.  This is the model I own and tested.  Passes Camera init test.  I am not able to complete render as I do not have an nvidia card that is cuda capable to try.  Here is sony spec for the camera: https://www.sony-semicon.co.jp/products_en/IS/sensor1/img/products/ProductBrief_IMX351_20171109.pdf

Also this is for the main camera only not the wide camera

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Adding support for LG-V30 Phone Main Rear camera.  This is not for the rear wide camera and is not useful for this type of application.


## Features list

Adds support for the LG-V30 main rear camera


## Implementation remarks

Let me know if I should run more testing with a full render.  I just do not have an nvidia card at the moment.  As I have said before this was tested on Linux Mint 18 (Ubuntu) and all the init camera tests passed and it got to cuda section and could not proceed as this computer I have does not have nvidia chipset.