### PR TITLE
Add Canon 5D Mark IV to sensor database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -307,6 +307,7 @@ Canon;Canon EOS 550D;22.3
 Canon;Canon EOS 5D;35.8
 Canon;Canon EOS 5D Mark II;36
 Canon;Canon EOS 5D Mark III;36
+Canon;Canon EOS 5D Mark IV;36
 Canon;Canon EOS 5DS;36
 Canon;Canon EOS 5DS R;36
 Canon;Canon EOS 600D;22.3


### PR DESCRIPTION
Adds the 5D Mark IV to the sensor database.


