### PR TITLE
correctly recognize EOS 100D

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -324,6 +324,7 @@ Canon;Canon EOS D60;22.7
 Canon;Canon EOS Kiss X4;22.3
 Canon;Canon EOS M;22.3
 Canon;Canon EOS M3;22.3
+Canon;Canon EOS REBEL SL1;22.3
 Canon;Canon EOS Rebel SL1 / 100D;22.3
 Canon;Canon EOS Rebel T2i;22.3
 Canon;Canon EOS Rebel T2i / 550D;22.3


### PR DESCRIPTION
The existing 100D line did not recognize my camera. Perhaps a firmware update has changed the string, but this added line works. (I'm on firmware 1.0.1 and use magic lantern, in case that matters.)
