### PR TITLE
Added Google Pixel 2 to database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1248,6 +1248,7 @@ GE;GE X3;6.08
 GE;GE X500;6.16
 GE;GE X550;6.16
 GE;GE X600;6.16
+Google;Pixel 2;5.5
 Google;Google Pixel XL;6.25
 GoPro;HERO;6.17
 GoPro;HERO3+ Black Edition;6.17


### PR DESCRIPTION
per this site: https://www.imaging-resource.com/PRODS/google-pixel-2/google-pixel-2A.HTM
Google pixel 2 sensor is 5.5mm.
This setting worked on my system.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

