### PR TITLE
Added Camera to SensorDB

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -827,6 +827,7 @@ Epson;Epson PhotoPC L-500V;5.75
 Epson;Epson R-D1;23.7
 Epson;Epson R-D1xG;23.7
 Epson;Epson RD-1s;23.7
+Fairphone;FP2;5.33
 Fujifilm;Fujifilm A850;5.75
 Fujifilm;Fujifilm Bigjob HD-3W;5.75
 Fujifilm;Fujifilm Bigjob HD1;5.33


### PR DESCRIPTION
Added the camera of the FP2 (1/2.8") to SensorsDB after testing it.