### PR TITLE
[cmake] Minor fix for CXX11 test on OSX

### DIFF
--- a/src/cmake/CXX11.cmake
+++ b/src/cmake/CXX11.cmake
@@ -2,13 +2,15 @@ if (NOT CMAKE_CXX_COMPILER_LOADED)
   message(FATAL_ERROR "CheckCXX11Features modules only works if language CXX is enabled")
 endif ()
 
+# note: CMAKE_CXX_COMPILER_ID could be "Clang" or "AppleClang"
+
 # Determines whether or not the compiler supports C++11
 macro(check_for_cxx11_compiler _VAR)
   message(STATUS "Checking for C++11 compiler")
   set(${_VAR})
   if((MSVC AND (MSVC_VERSION GREATER 1700)) OR	# MSVC 1800: VS 12
      (CMAKE_COMPILER_IS_GNUCXX AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.6) OR
-     (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.1))
+     (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.1))
     set(${_VAR} 1)
     message(STATUS "Checking for C++11 compiler - available")
   else()
@@ -18,7 +20,7 @@ endmacro()
 
 # Sets the appropriate flag to enable C++11 support
 macro(enable_cxx11)
-  if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
+  if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag(--std=c++11 SUPPORTS_STD_CXX11)
     check_cxx_compiler_flag(--std=c++0x SUPPORTS_STD_CXX01)


### PR DESCRIPTION
fix CXX11 test: on osx CMAKE_CXX_COMPILER_ID is "AppleClang"