### PR TITLE
[depthMap] volume slicing instead of sampling

### DIFF
--- a/src/aliceVision/depthMap/CMakeLists.txt
+++ b/src/aliceVision/depthMap/CMakeLists.txt
@@ -24,6 +24,7 @@ set(depthMap_files_sources
 set(depthMap_cuda_files_headers
   # Headers
   cuda/deviceCommon/device_patch_es_glob.hpp
+  cuda/images/gauss_filter.hpp
   cuda/planeSweeping/host_utils.h
   # deviceCommon
   cuda/deviceCommon/device_color.cu
@@ -52,6 +53,7 @@ set(depthMap_cuda_files_sources
   cuda/PlaneSweepingCuda.cpp
   cuda/PlaneSweepingCuda.hpp
   cuda/planeSweeping/plane_sweeping_cuda.cu
+  cuda/images/gauss_filter.cu
   ${depthMap_cuda_files_headers}
 )
 

--- a/src/aliceVision/depthMap/SemiGlobalMatchingRc.cpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingRc.cpp
@@ -22,6 +22,7 @@
 #include <boost/filesystem.hpp>
 
 #include <iostream>
+#include <sstream>
 
 namespace aliceVision {
 namespace depthMap {
@@ -567,9 +568,34 @@ bool SemiGlobalMatchingRc::sgmrc(bool checkIfExists)
     const int volDimX = w;
     const int volDimY = h;
     const int volDimZ = depths->size();
-    float volumeMBinGPUMem = 0.0f;
 
-    StaticVector<unsigned char>* simVolume = nullptr;
+    sp->cps.cameraToDevice( rc, tcams );
+
+// #define FORCE_ZDIM_LIMIT 32
+#undef  FORCE_ZDIM_LIMIT
+#ifndef FORCE_ZDIM_LIMIT
+    const long gpu_bytes_reqd_per_plane = volDimX * volDimY * sizeof(float) * 2; // safety margin 100%
+    const long gpu_bytes_free = sp->cps.getDeviceMemoryInfo().x * 1024 * 1024;
+    int        zDimsAtATime = depths->size();
+    const int  camsAtATime  = tcams.size();
+    if( gpu_bytes_reqd_per_plane * zDimsAtATime * camsAtATime > gpu_bytes_free )
+    {
+        while( zDimsAtATime > 1 && gpu_bytes_reqd_per_plane * zDimsAtATime * camsAtATime > gpu_bytes_free )
+        {
+            zDimsAtATime /= 2;
+        }
+    }
+    if(sp->mp->verbose)
+        ALICEVISION_LOG_DEBUG("bytes free on GPU: " << gpu_bytes_free
+                           << "(" << (int)(gpu_bytes_free/1024.0f/1024.0f) << " MB)"<< std::endl
+                           << "    estimated req'd bytes/plane: " << gpu_bytes_reqd_per_plane << std::endl
+                           << "    estimated dims at a time: " << zDimsAtATime << std::endl
+                           << "    cams at a time: " << camsAtATime << std::endl
+                           << "    estimated total: " << gpu_bytes_reqd_per_plane * zDimsAtATime * camsAtATime
+                           << " (" << (int)(gpu_bytes_reqd_per_plane * zDimsAtATime * camsAtATime/1024.0f/1024.0f) << " MB)" );
+#else
+    int zDimsAtATime = FORCE_ZDIM_LIMIT; // for example FORCE_ZDIM_LIMIT=32
+#endif
 
     StaticVectorBool* rcSilhoueteMap = nullptr;
     if(sp->useSilhouetteMaskCodedByColor)
@@ -580,46 +606,74 @@ bool SemiGlobalMatchingRc::sgmrc(bool checkIfExists)
         sp->cps.getSilhoueteMap(rcSilhoueteMap, scale, step, sp->silhouetteMaskColor, rc);
     }
 
+    std::vector<std::vector<float> > subDepths( tcams.size() );
+    for( int c = 0; c < tcams.size(); c++ )
     {
-        std::vector<float> subDepths;
-        getSubDepthsForTCam(0, subDepths);
-        SemiGlobalMatchingRcTc srt(subDepths, rc, tcams[0], scale, step, sp, rcSilhoueteMap);
-        simVolume = srt.computeDepthSimMapVolume(volumeMBinGPUMem, wsh, gammaC, gammaP);
+        getSubDepthsForTCam( c, subDepths[c] );
     }
 
-    // recompute to all depths
-    volumeMBinGPUMem = ((volumeMBinGPUMem / (float)depthsTcamsLimits[0].y) * (float)volDimZ);
-
-    SemiGlobalMatchingVolume* svol = new SemiGlobalMatchingVolume(volumeMBinGPUMem, volDimX, volDimY, volDimZ, sp);
-    svol->copyVolume(simVolume, depthsTcamsLimits[0].x, depthsTcamsLimits[0].y);
-    delete simVolume;
-
-    for(int c = 1; c < tcams.size(); c++)
+    if(sp->mp->verbose)
     {
-        std::vector<float> subDepths;
-        getSubDepthsForTCam(c, subDepths);
-        SemiGlobalMatchingRcTc* srt = new SemiGlobalMatchingRcTc(subDepths, rc, tcams[c], scale, step, sp, rcSilhoueteMap);
-        simVolume = srt->computeDepthSimMapVolume(volumeMBinGPUMem, wsh, gammaC, gammaP);
-        delete srt;
-        svol->addVolumeSecondMin(simVolume,depthsTcamsLimits[c].x,depthsTcamsLimits[c].y);
-        delete simVolume;
+        std::ostringstream ostr;
+        ostr << "In " << __FUNCTION__ << std::endl
+             << "    rc camera " << rc << " has depth " << depths->size() << std::endl;
+        for( int c = 0; c < tcams.size(); c++ )
+            ostr << "    tc camera " << tcams[c]
+                 << " uses " << subDepths[c].size() << " depths" << std::endl;
+
+        ALICEVISION_LOG_DEBUG( ostr.str() );
     }
+
+    std::vector<StaticVector<unsigned char> > simVolume;
+    simVolume.resize( tcams.size() );
+
+    /* request this device to allocate
+     *   (max_img - 1) * X * Y * dims_at_a_time * sizeof(float)
+     * of device memory.
+     */
+    int devid;
+    cudaGetDevice( &devid );
+    printf("Allocating %d times %d %d %d on device %d\n", tcams.size(),
+                                             volDimX,
+                                             volDimY,
+                                             zDimsAtATime, devid );
+    std::vector<CudaDeviceMemoryPitched<float, 3>*> volume_tmp_on_gpu;
+    sp->cps.allocTempVolume( volume_tmp_on_gpu,
+                             tcams.size(),
+                             volDimX,
+                             volDimY,
+                             zDimsAtATime );
+
+    std::vector<int> index_set( tcams.size() );
+    for(int c = 0; c < tcams.size(); c++)
+    {
+        index_set[c] = c;
+    }
+    SemiGlobalMatchingRcTc srt( index_set, subDepths, rc, tcams, scale, step, zDimsAtATime, sp, rcSilhoueteMap );
+    srt.computeDepthSimMapVolume( simVolume, volume_tmp_on_gpu, wsh, gammaC, gammaP );
+
+    sp->cps.freeTempVolume( volume_tmp_on_gpu );
+
+    index_set.erase( index_set.begin() );
+    SemiGlobalMatchingVolume svol( volDimX, volDimY, volDimZ, zDimsAtATime, sp );
+    svol.copyVolume( simVolume[0], depthsTcamsLimits[0].x, depthsTcamsLimits[0].y);
+    svol.addVolumeSecondMin( index_set, simVolume, depthsTcamsLimits );
 
     // Reduction of 'volume' (X, Y, Z) into 'volumeStepZ' (X, Y, Z/step)
-    svol->cloneVolumeSecondStepZ();
+    svol.cloneVolumeSecondStepZ();
 
     // Filter on the 3D volume to weight voxels based on their neighborhood strongness.
     // So it downweights local minimums that are not supported by their neighborhood.
     if(sp->doSGMoptimizeVolume) // this is here for experimental reason ... to show how SGGC work on non
                                 // optimized depthmaps ... it must equals to true in normal case
     {
-        svol->SGMoptimizeVolumeStepZ(rc, step, 0, 0, scale);
+        svol.SGMoptimizeVolumeStepZ(rc, step, scale);
     }
 
     // For each pixel: choose the voxel with the minimal similarity value
     int zborder = 2;
-    StaticVector<IdValue>* volumeBestIdVal = svol->getOrigVolumeBestIdValFromVolumeStepZ(zborder);
-    delete svol;
+    StaticVector<IdValue>* volumeBestIdVal = svol.getOrigVolumeBestIdValFromVolumeStepZ(zborder);
+    svol.freeMem();
 
     if(rcSilhoueteMap != nullptr)
     {

--- a/src/aliceVision/depthMap/SemiGlobalMatchingRcTc.hpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingRcTc.hpp
@@ -16,24 +16,36 @@ namespace depthMap {
 class SemiGlobalMatchingRcTc
 {
 public:
-    SemiGlobalMatchingRcTc(const std::vector<float>& _rcTcDepths, int _rc, int _tc, int _scale, int _step, SemiGlobalMatchingParams* _sp,
-                StaticVectorBool* _rcSilhoueteMap = NULL);
+    SemiGlobalMatchingRcTc( const std::vector<int>& index_set,
+                            const std::vector<std::vector<float> >& _rcTcDepths,
+                            int _rc,
+                            const StaticVector<int>& _tc,
+                            int _scale,
+                            int _step,
+                            int zDimsAtATime,
+                            SemiGlobalMatchingParams* _sp,
+                            StaticVectorBool* _rcSilhoueteMap = NULL );
     ~SemiGlobalMatchingRcTc(void);
 
-    StaticVector<unsigned char>* computeDepthSimMapVolume(float& volumeMBinGPUMem, int wsh, float gammaC, float gammaP);
+    void computeDepthSimMapVolume( std::vector<StaticVector<unsigned char> >& volume,
+                                   std::vector<CudaDeviceMemoryPitched<float, 3>*>& volume_tmp_on_gpu,
+                                   // float& volumeMBinGPUMem,
+                                   int wsh,
+                                   float gammaC,
+                                   float gammaP );
 
 private:
-    StaticVector<Voxel>* getPixels();
+    const std::vector<int> _index_set;
     const SemiGlobalMatchingParams* const sp;
 
     const int rc;
-
-    int tc;
-    const std::vector<float> rcTcDepths;
+    const StaticVector<int>& tc;
     const int _scale;
     const int _step;
     const int _w;
     const int _h;
+    const int _zDimsAtATime;
+    const std::vector<std::vector<float> >& rcTcDepths;
     float epipShift;
     // int w, h;
     StaticVectorBool* rcSilhoueteMap;

--- a/src/aliceVision/depthMap/SemiGlobalMatchingVolume.hpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingVolume.hpp
@@ -15,25 +15,26 @@ namespace depthMap {
 class SemiGlobalMatchingVolume
 {
 public:
-    SemiGlobalMatchingVolume(float _volGpuMB, int _volDimX, int _volDimY, int _volDimZ, SemiGlobalMatchingParams* _sp);
+    SemiGlobalMatchingVolume(int _volDimX, int _volDimY, int _volDimZ,
+                             int zDimsAtATime,
+                             SemiGlobalMatchingParams* _sp);
     ~SemiGlobalMatchingVolume(void);
 
-    void copyVolume(const StaticVector<int>* volume);
-    void copyVolume(const StaticVector<unsigned char>* volume, int zFrom, int nZSteps);
-    void addVolumeMin(const StaticVector<unsigned char>* volume, int zFrom, int nZSteps);
-    void addVolumeSecondMin(const StaticVector<unsigned char>* volume, int zFrom, int nZSteps);
-    void addVolumeAvg(int n, const StaticVector<unsigned char>* volume, int zFrom, int nZSteps);
+    void copyVolume(const StaticVector<unsigned char>& volume, int zFrom, int nZSteps);
+    void addVolumeSecondMin( const std::vector<int>& index_set, 
+                             const std::vector<StaticVector<unsigned char> >& vols,
+                             StaticVector<Pixel> z );
 
-    void cloneVolumeStepZ();
     void cloneVolumeSecondStepZ();
 
-    void SGMoptimizeVolumeStepZ(int rc, int volStepXY, int volLUX, int volLUY, int scale);
+    void SGMoptimizeVolumeStepZ(int rc, int volStepXY, int scale);
     StaticVector<IdValue>* getOrigVolumeBestIdValFromVolumeStepZ(int zborder);
+
+    void freeMem();
 
 private:
     SemiGlobalMatchingParams* sp;
 
-    float volGpuMB;
     int   volDimX;
     int   volDimY;
     int   volDimZ;

--- a/src/aliceVision/depthMap/cuda/deviceCommon/device_color.cu
+++ b/src/aliceVision/depthMap/cuda/deviceCommon/device_color.cu
@@ -260,11 +260,6 @@ __global__ void rgb2lab_kernel(uchar4* irgbaOlab, int irgbaOlab_p, int width, in
              (total filter size = 2 * radius + 1)
 */
 // use only one block
-__global__ void generateGaussian_kernel(float* og, float delta, int radius)
-{
-    int x = threadIdx.x - radius;
-    og[threadIdx.x] = __expf(-(x * x) / (2 * delta * delta));
-}
 
 /*
 __global__ void downscale_kernel(unsigned char* tex, int tex_p, int width, int height, int scale)

--- a/src/aliceVision/depthMap/cuda/deviceCommon/device_global.cu
+++ b/src/aliceVision/depthMap/cuda/deviceCommon/device_global.cu
@@ -29,49 +29,12 @@ texture<unsigned char, 2, cudaReadModeNormalizedFloat> btex;
 
 texture<uchar4, 2, cudaReadModeNormalizedFloat> r4tex;
 texture<uchar4, 2, cudaReadModeNormalizedFloat> t4tex;
-texture<float, 1, cudaReadModeElementType> gaussianTex;
 
 texture<unsigned char, 2, cudaReadModeNormalizedFloat> wshtex;
 texture<float, 2, cudaReadModeElementType> watex;
 
-CudaArray<char4, 2>** texs_arr = NULL;
-CudaArray<unsigned char, 2>** wshs_arr = NULL;
-CudaArray<float, 2>* watex_arr = NULL;
-
 ////////////////////////////////////////////////////////////////////////////////
 // CONSTANT MEMORY
-
-// cameras matrices
-
-/*
-__device__ __constant__ float rP[12];	//12*4 bytes
-__device__ __constant__ float riP[9];	//12*4 bytes
-__device__ __constant__ float rR[9];	// 9*4 bytes
-__device__ __constant__ float riR[9];	// 9*4 bytes
-__device__ __constant__ float rK[9];	// 9*4 bytes
-__device__ __constant__ float riK[9];	// 9*4 bytes
-__device__ __constant__ float3 rC;	// 3*4 bytes
-__device__ __constant__ float3 rXVect;	// 3*4 bytes
-__device__ __constant__ float3 rYVect;	// 3*4 bytes
-__device__ __constant__ float3 rZVect;	// 3*4 bytes
-
-__device__ __constant__ float tP[12];	//12*4 bytes
-__device__ __constant__ float tiP[12];	//12*4 bytes
-__device__ __constant__ float tR[9];	// 9*4 bytes
-__device__ __constant__ float tiR[9];	// 9*4 bytes
-__device__ __constant__ float tK[9];	// 9*4 bytes
-__device__ __constant__ float tiK[9];	// 9*4 bytes
-__device__ __constant__ float3 tC;	// 3*4 bytes
-__device__ __constant__ float3 tXVect;	// 3*4 bytes
-__device__ __constant__ float3 tYVect;	// 3*4 bytes
-__device__ __constant__ float3 tZVect;	// 3*4 bytes
-*/
-
-// total bytes (12+9+9+9+3)*4*2 = 168*2 = 336 bytes
-
-__device__ __constant__ float H[9]; // 9*4 bytes
-
-// total bytes (12+9+9+9+3)*4*2 = 168*2 = 336 bytes
 
 // MATLAB: x = [-2:2]; delta = 1; y = exp( - (x .* x) / (2 * delta * delta)); format long g; y
 __device__ __constant__ float gauss5[5] = {0.135335283236613f, 0.606530659712633f, 1.0f, 0.606530659712633f,
@@ -90,120 +53,11 @@ __device__ __constant__ unsigned char distFcnConst3[3] = {0, 94, 125};
 
 #define BLOCK_DIM 8
 
-__device__ __constant__ float sg_s_rP[12];  // 12*4 bytes
-__device__ __constant__ float sg_s_riP[9];  // 12*4 bytes
-__device__ __constant__ float sg_s_rR[9];   // 9*4 bytes
-__device__ __constant__ float sg_s_riR[9];  // 9*4 bytes
-__device__ __constant__ float sg_s_rK[9];   // 9*4 bytes
-__device__ __constant__ float sg_s_riK[9];  // 9*4 bytes
-__device__ __constant__ float3 sg_s_rC;     // 3*4 bytes
-__device__ __constant__ float3 sg_s_rXVect; // 3*4 bytes
-__device__ __constant__ float3 sg_s_rYVect; // 3*4 bytes
-__device__ __constant__ float3 sg_s_rZVect; // 3*4 bytes
+// cameras matrices
 
-__device__ __constant__ float sg_s_tP[12];  // 12*4 bytes
-__device__ __constant__ float sg_s_tiP[12]; // 12*4 bytes
-__device__ __constant__ float sg_s_tR[9];   // 9*4 bytes
-__device__ __constant__ float sg_s_tiR[9];  // 9*4 bytes
-__device__ __constant__ float sg_s_tK[9];   // 9*4 bytes
-__device__ __constant__ float sg_s_tiK[9];  // 9*4 bytes
-__device__ __constant__ float3 sg_s_tC;     // 3*4 bytes
-__device__ __constant__ float3 sg_s_tXVect; // 3*4 bytes
-__device__ __constant__ float3 sg_s_tYVect; // 3*4 bytes
-__device__ __constant__ float3 sg_s_tZVect; // 3*4 bytes
-
-/*
-__device__ __constant__ struct shared_rCam_tCam
-{
-        float s_rP[12];	//12*4 bytes
-        float s_riP[9];	//12*4 bytes
-        float s_rR[9];	// 9*4 bytes
-        float s_riR[9];	// 9*4 bytes
-        float s_rK[9];	// 9*4 bytes
-        float s_riK[9];	// 9*4 bytes
-        float3 s_rC;	// 3*4 bytes
-        float3 s_rXVect;	// 3*4 bytes
-        float3 s_rYVect;	// 3*4 bytes
-        float3 s_rZVect;	// 3*4 bytes
-
-        float s_tP[12];	//12*4 bytes
-        float s_tiP[12];	//12*4 bytes
-        float s_tR[9];	// 9*4 bytes
-        float s_tiR[9];	// 9*4 bytes
-        float s_tK[9];	// 9*4 bytes
-        float s_tiK[9];	// 9*4 bytes
-        float3 s_tC;	// 3*4 bytes
-        float3 s_tXVect;	// 3*4 bytes
-        float3 s_tYVect;	// 3*4 bytes
-        float3 s_tZVect;	// 3*4 bytes
-
-        __device__ void copy(shared_rCam_tCam *sg)
-        {
-                for (int i=0;i<12;i++) {
-                        s_rP[i]  = sg->s_rP[i];
-                        s_riP[i] = sg->s_riP[i];
-                        s_tP[i]  = sg->s_tP[i];
-                        s_tiP[i] = sg->s_tiP[i];
-                };
-
-                for (int i=0;i<9;i++) {
-                        s_rR[i]  = sg->s_rR[i];
-                        s_riR[i] = sg->s_riR[i];
-                        s_rK[i]  = sg->s_rK[i];
-                        s_riK[i] = sg->s_riK[i];
-                        s_tR[i]  = sg->s_tR[i];
-                        s_tiR[i] = sg->s_tiR[i];
-                        s_tK[i]  = sg->s_tK[i];
-                        s_tiK[i] = sg->s_tiK[i];
-                };
-
-                s_rC     = sg->s_rC;
-                s_rXVect = sg->s_rXVect;
-                s_rYVect = sg->s_rYVect;
-                s_rZVect = sg->s_rZVect;
-                s_tC     = sg->s_tC;
-                s_tXVect = sg->s_tXVect;
-                s_tYVect = sg->s_tYVect;
-                s_tZVect = sg->s_tZVect;
-        };
-
-        __device__ shared_rCam_tCam& operator = (const shared_rCam_tCam &param)
-        {
-                for (int i=0;i<12;i++) {
-                        s_rP[i]  = param.s_rP[i];
-                        s_riP[i] = param.s_riP[i];
-                        s_tP[i]  = param.s_tP[i];
-                        s_tiP[i] = param.s_tiP[i];
-                };
-
-                for (int i=0;i<9;i++) {
-                        s_rR[i]  = param.s_rR[i];
-                        s_riR[i] = param.s_riR[i];
-                        s_rK[i]  = param.s_rK[i];
-                        s_riK[i] = param.s_riK[i];
-                        s_tR[i]  = param.s_tR[i];
-                        s_tiR[i] = param.s_tiR[i];
-                        s_tK[i]  = param.s_tK[i];
-                        s_tiK[i] = param.s_tiK[i];
-                };
-
-                s_rC     = param.s_rC;
-                s_rXVect = param.s_rXVect;
-                s_rYVect = param.s_rYVect;
-                s_rZVect = param.s_rZVect;
-                s_tC     = param.s_tC;
-                s_tXVect = param.s_tXVect;
-                s_tYVect = param.s_tYVect;
-                s_tZVect = param.s_tZVect;
-                return *this;
-        };
-
-};
-
-
-
-__device__ __constant__ shared_rCam_tCam sg;
-*/
+__device__ __constant__ DeviceCameraStructBase sg_s_r;
+__device__ __constant__ DeviceCameraStructBase sg_s_t;
 
 } // namespace depthMap
 } // namespace aliceVision
+

--- a/src/aliceVision/depthMap/cuda/deviceCommon/device_patch_es.cu
+++ b/src/aliceVision/depthMap/cuda/deviceCommon/device_patch_es.cu
@@ -16,14 +16,17 @@
 namespace aliceVision {
 namespace depthMap {
 
-__device__ void computeRotCSEpip(patch& ptch, const float3& p)
+__device__ void computeRotCSEpip( const cameraStructBase* rc_cam_s,
+                                  const cameraStructBase* tc_cam_s,
+                                  patch& ptch,
+                                  const float3& p )
 {
     ptch.p = p;
 
     // Vector from the reference camera to the 3d point
-    float3 v1 = sg_s_rC - p;
+    float3 v1 = rc_cam_s->C - p;
     // Vector from the target camera to the 3d point
-    float3 v2 = sg_s_tC - p;
+    float3 v2 = tc_cam_s->C - p;
     normalize(v1);
     normalize(v2);
 
@@ -36,7 +39,34 @@ __device__ void computeRotCSEpip(patch& ptch, const float3& p)
 
     ptch.n = (v1 + v2) / 2.0f; // IMPORTANT !!!
     normalize(ptch.n);
-    // ptch.n = sg_s_rZVect; //IMPORTANT !!!
+    // ptch.n = sg_s_r.ZVect; //IMPORTANT !!!
+
+    ptch.x = cross(ptch.y, ptch.n);
+    normalize(ptch.x);
+}
+
+__device__ void computeRotCSEpip( patch& ptch,
+                                  const float3& p )
+{
+    ptch.p = p;
+
+    // Vector from the reference camera to the 3d point
+    float3 v1 = sg_s_r.C - p;
+    // Vector from the target camera to the 3d point
+    float3 v2 = sg_s_t.C - p;
+    normalize(v1);
+    normalize(v2);
+
+    // y has to be ortogonal to the epipolar plane
+    // n has to be on the epipolar plane
+    // x has to be on the epipolar plane
+
+    ptch.y = cross(v1, v2);
+    normalize(ptch.y);
+
+    ptch.n = (v1 + v2) / 2.0f; // IMPORTANT !!!
+    normalize(ptch.n);
+    // ptch.n = sg_s_r.ZVect; //IMPORTANT !!!
 
     ptch.x = cross(ptch.y, ptch.n);
     normalize(ptch.x);
@@ -50,14 +80,14 @@ __device__ int angleBetwUnitV1andUnitV2(float3& V1, float3& V2)
 __device__ bool checkPatch(patch& ptch, int angThr)
 {
 
-    float3 rv = (sg_s_rC - ptch.p);
-    float3 tv = (sg_s_tC - ptch.p);
+    float3 rv = (sg_s_r.C - ptch.p);
+    float3 tv = (sg_s_t.C - ptch.p);
     normalize(rv);
     normalize(tv);
 
     float3 n = ptch.n;
 
-    if(size(sg_s_rC - (ptch.p + ptch.n)) > size(sg_s_rC - (ptch.p - ptch.n)))
+    if(size(sg_s_r.C - (ptch.p + ptch.n)) > size(sg_s_r.C - (ptch.p - ptch.n)))
     {
         n.x = -n.x;
         n.y = -n.y;
@@ -70,7 +100,7 @@ __device__ bool checkPatch(patch& ptch, int angThr)
 /*
 __device__ float getRefCamPixSize(patch &ptch)
 {
-        float2 rp = project3DPoint(sg_s_rP,ptch.p);
+        float2 rp = project3DPoint(sg_s_r.P,ptch.p);
 
         float minstep=10000000.0f;
         for (int i=0;i<4;i++) {
@@ -79,8 +109,8 @@ __device__ float getRefCamPixSize(patch &ptch)
                 if (i==1) {pix.x -= 1.0f;};
                 if (i==2) {pix.y += 1.0f;};
                 if (i==3) {pix.y -= 1.0f;};
-                float3 vect = M3x3mulV2(sg_s_riP,pix);
-                float3 lpi = linePlaneIntersect(sg_s_rC, vect, ptch.p, ptch.n);
+                float3 vect = M3x3mulV2(sg_s_r.iP,pix);
+                float3 lpi = linePlaneIntersect(sg_s_r.C, vect, ptch.p, ptch.n);
                 float step = dist(lpi,ptch.p);
                 minstep = fminf(minstep,step);
         };
@@ -91,7 +121,7 @@ __device__ float getRefCamPixSize(patch &ptch)
 
 __device__ float getTarCamPixSize(patch &ptch)
 {
-        float2 tp = project3DPoint(sg_s_tP,ptch.p);
+        float2 tp = project3DPoint(sg_s_t.P,ptch.p);
 
         float minstep=10000000.0f;
         for (int i=0;i<4;i++) {
@@ -100,8 +130,8 @@ __device__ float getTarCamPixSize(patch &ptch)
                 if (i==1) {pix.x -= 1.0f;};
                 if (i==2) {pix.y += 1.0f;};
                 if (i==3) {pix.y -= 1.0f;};
-                float3 vect = M3x3mulV2(sg_s_tiP,pix);
-                float3 lpi = linePlaneIntersect(sg_s_tC, vect, ptch.p, ptch.n);
+                float3 vect = M3x3mulV2(sg_s_t.iP,pix);
+                float3 lpi = linePlaneIntersect(sg_s_t.C, vect, ptch.p, ptch.n);
                 float step = dist(lpi,ptch.p);
                 minstep = fminf(minstep,step);
         };
@@ -119,27 +149,27 @@ __device__ float getPatchPixSize(patch &ptch)
 __device__ void computeHomography(float* _H, float3& _p, float3& _n)
 {
     // hartley zisserman second edition p.327 (13.2)
-    float3 _tl = make_float3(0.0, 0.0, 0.0) - M3x3mulV3(sg_s_rR, sg_s_rC);
-    float3 _tr = make_float3(0.0, 0.0, 0.0) - M3x3mulV3(sg_s_tR, sg_s_tC);
+    float3 _tl = make_float3(0.0, 0.0, 0.0) - M3x3mulV3(sg_s_r.R, sg_s_r.C);
+    float3 _tr = make_float3(0.0, 0.0, 0.0) - M3x3mulV3(sg_s_t.R, sg_s_t.C);
 
-    float3 p = M3x3mulV3(sg_s_rR, (_p - sg_s_rC));
-    float3 n = M3x3mulV3(sg_s_rR, _n);
+    float3 p = M3x3mulV3(sg_s_r.R, (_p - sg_s_r.C));
+    float3 n = M3x3mulV3(sg_s_r.R, _n);
     normalize(n);
     float d = -dot(n, p);
 
     float RrT[9];
-    M3x3transpose(RrT, sg_s_rR);
+    M3x3transpose(RrT, sg_s_r.R);
 
     float tmpRr[9];
-    M3x3mulM3x3(tmpRr, sg_s_tR, RrT);
+    M3x3mulM3x3(tmpRr, sg_s_t.R, RrT);
     float3 tr = _tr - M3x3mulV3(tmpRr, _tl);
 
     float tmp[9];
     float tmp1[9];
     outerMultiply(tmp, tr, n / d);
     M3x3minusM3x3(tmp, tmpRr, tmp);
-    M3x3mulM3x3(tmp1, sg_s_tK, tmp);
-    M3x3mulM3x3(tmp, tmp1, sg_s_riK);
+    M3x3mulM3x3(tmp1, sg_s_t.K, tmp);
+    M3x3mulM3x3(tmp, tmp1, sg_s_r.iK);
 
     for(int i = 0; i < 9; i++)
     {
@@ -235,8 +265,8 @@ __device__ simStat compSimStat(float2& rpix, float2& tpix, int wsh)
 
 __device__ float compNCCbyH(patch& ptch, int wsh)
 {
-    float2 rpix = project3DPoint(sg_s_rP, ptch.p);
-    float2 tpix = project3DPoint(sg_s_tP, ptch.p);
+    float2 rpix = project3DPoint(sg_s_r.P, ptch.p);
+    float2 tpix = project3DPoint(sg_s_t.P, ptch.p);
 
     float H[9];
     computeHomography(H, ptch.p, ptch.n);
@@ -278,15 +308,93 @@ __device__ float compNCCbyH(patch& ptch, int wsh)
  * 
  * @return similarity value
  */
+__device__ float compNCCby3DptsYK( cudaTextureObject_t rc_tex,
+                                   cudaTextureObject_t tc_tex,
+                                   const cameraStructBase* rc_cam_s,
+                                   const cameraStructBase* tc_cam_s,
+                                   patch& ptch,
+                                   int wsh, int width, int height,
+                                   const float _gammaC, const float _gammaP,
+                                   const float epipShift )
+{
+    float3 p = ptch.p;
+    float2 rp = project3DPoint(rc_cam_s->P, p);
+    float2 tp = project3DPoint(tc_cam_s->P, p);
+
+    float3 pUp = p + ptch.y * (ptch.d * 10.0f); // assuming that ptch.y is ortogonal to epipolar plane
+    float2 tvUp = project3DPoint(tc_cam_s->P, pUp);
+    tvUp = tvUp - tp;
+    normalize(tvUp);
+    float2 vEpipShift = tvUp * epipShift;
+    tp = tp + vEpipShift;
+
+    const float dd = wsh + 2.0f;
+    if((rp.x < dd) || (rp.x > (float)(width  - 1) - dd) ||
+       (rp.y < dd) || (rp.y > (float)(height - 1) - dd) ||
+       (tp.x < dd) || (tp.x > (float)(width  - 1) - dd) ||
+       (tp.y < dd) || (tp.y > (float)(height - 1) - dd))
+    {
+        return 1.0f;
+    }
+
+    // see CUDA_C_Programming_Guide.pdf ... E.2 pp132-133 ... adding 0.5 caises that tex2D return for point i,j exactly
+    // value od I(i,j) ... it is what we want
+    float4 gcr = 255.0f * tex2D<float4>(rc_tex, rp.x + 0.5f, rp.y + 0.5f);
+    float4 gct = 255.0f * tex2D<float4>(tc_tex, tp.x + 0.5f, tp.y + 0.5f);
+    // gcr = 255.0f*tex2D(r4tex, rp.x, rp.y);
+    // gct = 255.0f*tex2D(t4tex, tp.x, tp.y);
+
+    float gammaC = _gammaC;
+    // float gammaC = ((gcr.w>0)||(gct.w>0))?sigmoid(_gammaC,25.5f,20.0f,10.0f,fmaxf(gcr.w,gct.w)):_gammaC;
+    // float gammaP = ((gcr.w>0)||(gct.w>0))?sigmoid(1.5,(float)(wsh+3),30.0f,20.0f,fmaxf(gcr.w,gct.w)):_gammaP;
+    float gammaP = _gammaP;
+
+    simStat sst = simStat();
+    for(int yp = -wsh; yp <= wsh; yp++)
+    {
+        for(int xp = -wsh; xp <= wsh; xp++)
+        {
+            p = ptch.p + ptch.x * (float)(ptch.d * (float)xp) + ptch.y * (float)(ptch.d * (float)yp);
+            float2 rp1 = project3DPoint(rc_cam_s->P, p);
+            float2 tp1 = project3DPoint(tc_cam_s->P, p) + vEpipShift;
+            // float2 rp1 = rp + rvLeft*(float)xp + rvUp*(float)yp;
+            // float2 tp1 = tp + tvLeft*(float)xp + tvUp*((float)yp+epipShift);
+
+            // see CUDA_C_Programming_Guide.pdf ... E.2 pp132-133 ... adding 0.5 caises that tex2D return for point i,j
+            // exactly value od I(i,j) ... it is what we want
+            float4 gcr1f = tex2D<float4>(rc_tex, rp1.x + 0.5f, rp1.y + 0.5f);
+            float4 gct1f = tex2D<float4>(tc_tex, tp1.x + 0.5f, tp1.y + 0.5f);
+            float4 gcr1 = 255.0f * gcr1f;
+            float4 gct1 = 255.0f * gct1f;
+            // gcr1 = 255.0f*tex2D(r4tex, rp1.x, rp1.y);
+            // gct1 = 255.0f*tex2D(t4tex, tp1.x, tp1.y);
+
+            // Weighting is based on:
+            //  * color difference to the center pixel of the patch:
+            //    ** low value (close to 0) means that the color is different from the center pixel (ie. strongly supported surface)
+            //    ** high value (close to 1) means that the color is close the center pixel (ie. uniform color)
+            //  * distance in image to the center pixel of the patch:
+            //    ** low value (close to 0) means that the pixel is close to the center of the patch
+            //    ** high value (close to 1) means that the pixel is far from the center of the patch
+            float w = CostYKfromLab(xp, yp, gcr, gcr1, gammaC, gammaP) * CostYKfromLab(xp, yp, gct, gct1, gammaC, gammaP);
+            assert(w >= 0.f);
+            assert(w <= 1.f);
+            sst.update(gcr1.x, gct1.x, w); // TODO: try with gcr1f and gtc1f
+        }
+    }
+    sst.computeWSim();
+    return sst.sim;
+}
+
 __device__ float compNCCby3DptsYK(patch& ptch, int wsh, int width, int height, const float _gammaC, const float _gammaP,
                                   const float epipShift)
 {
     float3 p = ptch.p;
-    float2 rp = project3DPoint(sg_s_rP, p);
-    float2 tp = project3DPoint(sg_s_tP, p);
+    float2 rp = project3DPoint(sg_s_r.P, p);
+    float2 tp = project3DPoint(sg_s_t.P, p);
 
     float3 pUp = p + ptch.y * (ptch.d * 10.0f); // assuming that ptch.y is ortogonal to epipolar plane
-    float2 tvUp = project3DPoint(sg_s_tP, pUp);
+    float2 tvUp = project3DPoint(sg_s_t.P, pUp);
     tvUp = tvUp - tp;
     normalize(tvUp);
     float2 vEpipShift = tvUp * epipShift;
@@ -319,8 +427,8 @@ __device__ float compNCCby3DptsYK(patch& ptch, int wsh, int width, int height, c
         for(int xp = -wsh; xp <= wsh; xp++)
         {
             p = ptch.p + ptch.x * (float)(ptch.d * (float)xp) + ptch.y * (float)(ptch.d * (float)yp);
-            float2 rp1 = project3DPoint(sg_s_rP, p);
-            float2 tp1 = project3DPoint(sg_s_tP, p) + vEpipShift;
+            float2 rp1 = project3DPoint(sg_s_r.P, p);
+            float2 tp1 = project3DPoint(sg_s_t.P, p) + vEpipShift;
             // float2 rp1 = rp + rvLeft*(float)xp + rvUp*(float)yp;
             // float2 tp1 = tp + tvLeft*(float)xp + tvUp*((float)yp+epipShift);
 
@@ -355,9 +463,9 @@ __device__ float compNCCby3DptsYK(patch &ptch, int wsh, int width, int height, c
 const float epipShift)
 {
         float3 p =  ptch.p;
-        float2 rp = project3DPoint(sg_s_rP, p);
-        float2 tp = project3DPoint(sg_s_tP, p);
-        float2 tpUp = project3DPoint(sg_s_tP, p+ptch.y*(ptch.d*10.0f)); //assuming that ptch.y is ortogonal to epipolar
+        float2 rp = project3DPoint(sg_s_r.P, p);
+        float2 tp = project3DPoint(sg_s_t.P, p);
+        float2 tpUp = project3DPoint(sg_s_t.P, p+ptch.y*(ptch.d*10.0f)); //assuming that ptch.y is ortogonal to epipolar
 plane
         float2 vEpipShift = tpUp-tp;
         normalize(vEpipShift);
@@ -399,8 +507,8 @@ plane
                                 {
                                         p =
 ptch.p+ptch.x*(float)(ptch.d*(float)(xp+xpp))+ptch.y*(float)(ptch.d*(float)(yp+ypp));
-                                        rp = project3DPoint(sg_s_rP, p);
-                                        tp = project3DPoint(sg_s_tP, p)+vEpipShift;
+                                        rp = project3DPoint(sg_s_r.P, p);
+                                        tp = project3DPoint(sg_s_t.P, p)+vEpipShift;
                                         gcr1.x = 255.0f*tex2D(rtex0, rp.x+0.5f, rp.y+0.5f);
                                         gct1.x = 255.0f*tex2D(ttex0, tp.x+0.5f, tp.y+0.5f);
                                         sst.update((float)gcr1.x, (float)gct1.x, 1.0f);
@@ -410,8 +518,8 @@ ptch.p+ptch.x*(float)(ptch.d*(float)(xp+xpp))+ptch.y*(float)(ptch.d*(float)(yp+y
 
 
                         p = ptch.p+ptch.x*(float)(ptch.d*(float)xp)+ptch.y*(float)(ptch.d*(float)yp);
-                        rp = project3DPoint(sg_s_rP, p);
-                        tp = project3DPoint(sg_s_tP, p)+vEpipShift;
+                        rp = project3DPoint(sg_s_r.P, p);
+                        tp = project3DPoint(sg_s_t.P, p)+vEpipShift;
                         gcr1.x = 255.0f*tex2D(rtex0, rp.x+0.5f, rp.y+0.5f);
                         gcr1.y = 255.0f*tex2D(rtex1, rp.x+0.5f, rp.y+0.5f);
                         gcr1.z = 255.0f*tex2D(rtex2, rp.x+0.5f, rp.y+0.5f);
@@ -441,8 +549,8 @@ gammaC, gammaP);
 __device__ float compNCCby3Dpts(patch& ptch, int wsh, int width, int height)
 {
     float3 p = ptch.p;
-    float2 rp = project3DPoint(sg_s_rP, p);
-    float2 tp = project3DPoint(sg_s_tP, p);
+    float2 rp = project3DPoint(sg_s_r.P, p);
+    float2 tp = project3DPoint(sg_s_t.P, p);
 
     float dd = (float)(wsh + 2);
     if((rp.x < dd) || (rp.x > (float)width  - 1 - dd) ||
@@ -459,8 +567,8 @@ __device__ float compNCCby3Dpts(patch& ptch, int wsh, int width, int height)
         for(int yp = -wsh; yp <= wsh; yp++)
         {
             p = ptch.p + ptch.x * (float)(ptch.d * (float)xp) + ptch.y * (float)(ptch.d * (float)yp);
-            rp = project3DPoint(sg_s_rP, p);
-            tp = project3DPoint(sg_s_tP, p);
+            rp = project3DPoint(sg_s_r.P, p);
+            tp = project3DPoint(sg_s_t.P, p);
             float2 g;
             g.x = 255.0f * tex2D(rtex, rp.x + 0.5f, rp.y + 0.5f);
             g.y = 255.0f * tex2D(ttex, tp.x + 0.5f, tp.y + 0.5f);
@@ -474,8 +582,8 @@ __device__ float compNCCby3Dpts(patch& ptch, int wsh, int width, int height)
 __device__ float compNCCby3DptsEpipOpt(patch& ptch, int width, int height)
 {
     float3 p = ptch.p;
-    float2 rp = project3DPoint(sg_s_rP, p);
-    float2 tp = project3DPoint(sg_s_tP, p);
+    float2 rp = project3DPoint(sg_s_r.P, p);
+    float2 tp = project3DPoint(sg_s_t.P, p);
 
     float dd = (float)(2 + 2);
     if(!((rp.x > dd) && (rp.x < (float)width - dd) && (rp.y > dd) && (rp.y < (float)height - dd) && (tp.x > dd) &&
@@ -494,16 +602,16 @@ __device__ float compNCCby3DptsEpipOpt(patch& ptch, int width, int height)
         for(int yp = -wsh; yp <= wsh; yp++)
         {
             p = ptch.p + ptch.x * (float)(ptch.d * (float)xp) + ptch.y * (float)(ptch.d * (float)yp);
-            rp = project3DPoint(sg_s_rP, p);
+            rp = project3DPoint(sg_s_r.P, p);
             lim[xp + wsh][yp + wsh] = 255.0f * tex2D(rtex, rp.x + 0.5f, rp.y + 0.5f);
         };
     };
 
     float2 v;
     p = ptch.p;
-    tp = project3DPoint(sg_s_tP, p);
+    tp = project3DPoint(sg_s_t.P, p);
     p = ptch.p + ptch.y * (float)(ptch.d * 5.0f); // ptch.y - normal to epipolar plane
-    v = tp - project3DPoint(sg_s_tP, p);
+    v = tp - project3DPoint(sg_s_t.P, p);
     normalize(v);
     v = v / 2.0f; // step by 0.5 pixel
 
@@ -518,7 +626,7 @@ __device__ float compNCCby3DptsEpipOpt(patch& ptch, int width, int height)
             for(int yp = -wsh; yp <= wsh; yp++)
             {
                 p = ptch.p + ptch.x * (float)(ptch.d * (float)xp) + ptch.y * (float)(ptch.d * (float)yp);
-                tp = project3DPoint(sg_s_tP, p);
+                tp = project3DPoint(sg_s_t.P, p);
                 tp = tp + v * (float(i - neer));
                 float2 g;
                 g.x = lim[xp + wsh][yp + wsh];
@@ -546,7 +654,7 @@ __device__ float compNCCby3DptsEpipOpt(patch& ptch, int width, int height)
 
 __device__ void getPixelFor3DPointRC(float2& out, float3& X)
 {
-    float3 p = M3x4mulV3(sg_s_rP, X);
+    float3 p = M3x4mulV3(sg_s_r.P, X);
     out = make_float2(p.x / p.z, p.y / p.z);
 
     if(p.z < 0.0f)
@@ -558,7 +666,7 @@ __device__ void getPixelFor3DPointRC(float2& out, float3& X)
 
 __device__ void getPixelFor3DPointTC(float2& out, float3& X)
 {
-    float3 p = M3x4mulV3(sg_s_tP, X);
+    float3 p = M3x4mulV3(sg_s_t.P, X);
     out = make_float2(p.x / p.z, p.y / p.z);
 
     if(p.z < 0.0f)
@@ -570,23 +678,43 @@ __device__ void getPixelFor3DPointTC(float2& out, float3& X)
 
 __device__ float frontoParellePlaneRCDepthFor3DPoint(const float3& p)
 {
-    return fabsf(orientedPointPlaneDistanceNormalizedNormal(p, sg_s_rC, sg_s_rZVect));
+    return fabsf(orientedPointPlaneDistanceNormalizedNormal(p, sg_s_r.C, sg_s_r.ZVect));
 }
 
 __device__ float frontoParellePlaneTCDepthFor3DPoint(const float3& p)
 {
-    return fabsf(orientedPointPlaneDistanceNormalizedNormal(p, sg_s_tC, sg_s_tZVect));
+    return fabsf(orientedPointPlaneDistanceNormalizedNormal(p, sg_s_t.C, sg_s_t.ZVect));
 }
 
-__device__ float3 get3DPointForPixelAndFrontoParellePlaneRC(float2& pix, float fpPlaneDepth)
+__device__ float3 get3DPointForPixelAndFrontoParellePlaneRC( const cameraStructBase* rc_cam_s,
+                                                             const float2& pix,
+                                                             float fpPlaneDepth)
 {
-    float3 planep = sg_s_rC + sg_s_rZVect * fpPlaneDepth;
-    float3 v = M3x3mulV2(sg_s_riP, pix);
+    float3 planep = rc_cam_s->C + rc_cam_s->ZVect * fpPlaneDepth;
+    float3 v = M3x3mulV2(rc_cam_s->iP, pix);
     normalize(v);
-    return linePlaneIntersect(sg_s_rC, v, planep, sg_s_rZVect);
+    return linePlaneIntersect(rc_cam_s->C, v, planep, rc_cam_s->ZVect);
 }
 
-__device__ float3 get3DPointForPixelAndFrontoParellePlaneRC(int2& pixi, float fpPlaneDepth)
+__device__ float3 get3DPointForPixelAndFrontoParellePlaneRC( const cameraStructBase* rc_cam_s,
+                                                             const int2& pixi,
+                                                             float fpPlaneDepth)
+{
+    float2 pix;
+    pix.x = (float)pixi.x;
+    pix.y = (float)pixi.y;
+    return get3DPointForPixelAndFrontoParellePlaneRC( rc_cam_s, pix, fpPlaneDepth);
+}
+
+__device__ float3 get3DPointForPixelAndFrontoParellePlaneRC(const float2& pix, float fpPlaneDepth)
+{
+    float3 planep = sg_s_r.C + sg_s_r.ZVect * fpPlaneDepth;
+    float3 v = M3x3mulV2(sg_s_r.iP, pix);
+    normalize(v);
+    return linePlaneIntersect(sg_s_r.C, v, planep, sg_s_r.ZVect);
+}
+
+__device__ float3 get3DPointForPixelAndFrontoParellePlaneRC(const int2& pixi, float fpPlaneDepth)
 {
     float2 pix;
     pix.x = (float)pixi.x;
@@ -596,16 +724,16 @@ __device__ float3 get3DPointForPixelAndFrontoParellePlaneRC(int2& pixi, float fp
 
 __device__ float3 get3DPointForPixelAndDepthFromRC(const float2& pix, float depth)
 {
-    float3 rpv = M3x3mulV2(sg_s_riP, pix);
+    float3 rpv = M3x3mulV2(sg_s_r.iP, pix);
     normalize(rpv);
-    return sg_s_rC + rpv * depth;
+    return sg_s_r.C + rpv * depth;
 }
 
 __device__ float3 get3DPointForPixelAndDepthFromTC(const float2& pix, float depth)
 {
-    float3 tpv = M3x3mulV2(sg_s_tiP, pix);
+    float3 tpv = M3x3mulV2(sg_s_t.iP, pix);
     normalize(tpv);
-    return sg_s_tC + tpv * depth;
+    return sg_s_t.C + tpv * depth;
 }
 
 __device__ float3 get3DPointForPixelAndDepthFromRC(const int2& pixi, float depth)
@@ -618,20 +746,20 @@ __device__ float3 get3DPointForPixelAndDepthFromRC(const int2& pixi, float depth
 
 __device__ float3 triangulateMatchRef(float2& refpix, float2& tarpix)
 {
-    float3 refvect = M3x3mulV2(sg_s_riP, refpix);
+    float3 refvect = M3x3mulV2(sg_s_r.iP, refpix);
     normalize(refvect);
-    float3 refpoint = refvect + sg_s_rC;
+    float3 refpoint = refvect + sg_s_r.C;
 
-    float3 tarvect = M3x3mulV2(sg_s_tiP, tarpix);
+    float3 tarvect = M3x3mulV2(sg_s_t.iP, tarpix);
     normalize(tarvect);
-    float3 tarpoint = tarvect + sg_s_tC;
+    float3 tarpoint = tarvect + sg_s_t.C;
 
     float k, l;
     float3 lli1, lli2;
 
-    lineLineIntersect(&k, &l, &lli1, &lli2, sg_s_rC, refpoint, sg_s_tC, tarpoint);
+    lineLineIntersect(&k, &l, &lli1, &lli2, sg_s_r.C, refpoint, sg_s_t.C, tarpoint);
 
-    return sg_s_rC + refvect * k;
+    return sg_s_r.C + refvect * k;
 }
 
 __device__ float computeRcPixSize(const float3& p)
@@ -640,45 +768,60 @@ __device__ float computeRcPixSize(const float3& p)
     patch ptcho;
     ptcho.p = p;
     computeRotCSEpip(ptcho,p);
-    float2 rp = project3DPoint(sg_s_rP, p);
+    float2 rp = project3DPoint(sg_s_r.P, p);
 
-    float dRcTc = size(sg_s_rC-sg_s_tC)/100.0f;
+    float dRcTc = size(sg_s_r.C-sg_s_t.C)/100.0f;
     float3 pLeft = ptcho.p+ptcho.x*dRcTc; //assuming that ptch.x on epipolar plane
-    float2 rvLeft = project3DPoint(sg_s_rP, pLeft); rvLeft = rvLeft-rp; normalize(rvLeft);
+    float2 rvLeft = project3DPoint(sg_s_r.P, pLeft); rvLeft = rvLeft-rp; normalize(rvLeft);
 
-    float depth = size(sg_s_rC-p);
+    float depth = size(sg_s_r.C-p);
     float2 rp1 = rp + rvLeft;
 
     //float3 p1 = get3DPointForPixelAndDepthFromRC(rp1,depth);
     //float pixSize = size(p-p1);
     //return pixSize;
 
-    float3 refvect = M3x3mulV2(sg_s_riP,rp1);
+    float3 refvect = M3x3mulV2(sg_s_r.iP,rp1);
     normalize(refvect);
-    return pointLineDistance3D(p, sg_s_rC, refvect);
+    return pointLineDistance3D(p, sg_s_r.C, refvect);
     */
 
-    float2 rp = project3DPoint(sg_s_rP, p);
+    float2 rp = project3DPoint(sg_s_r.P, p);
     float2 rp1 = rp + make_float2(1.0f, 0.0f);
 
-    float3 refvect = M3x3mulV2(sg_s_riP, rp1);
+    float3 refvect = M3x3mulV2(sg_s_r.iP, rp1);
     normalize(refvect);
-    return pointLineDistance3D(p, sg_s_rC, refvect);
+    return pointLineDistance3D(p, sg_s_r.C, refvect);
 }
 
-__device__ float computePixSize(const float3& p)
+__device__ float computeRcPixSize( const cameraStructBase* rc_cam_s, const float3& p)
 {
-    return computeRcPixSize(p);
+    float2 rp = project3DPoint(rc_cam_s->P, p);
+    float2 rp1 = rp + make_float2(1.0f, 0.0f);
+
+    float3 refvect = M3x3mulV2(rc_cam_s->iP, rp1);
+    normalize(refvect);
+    return pointLineDistance3D(p, rc_cam_s->C, refvect);
+}
+
+__device__ float computePixSize( const cameraStructBase* rc_cam_s, const float3& p)
+{
+    return computeRcPixSize( rc_cam_s, p );
+}
+
+__device__ float computePixSize( const float3& p)
+{
+    return computeRcPixSize( p );
 }
 
 __device__ float computeTcPixSize(const float3& p)
 {
-    float2 tp = project3DPoint(sg_s_tP, p);
+    float2 tp = project3DPoint(sg_s_t.P, p);
     float2 tp1 = tp + make_float2(1.0f, 0.0f);
 
-    float3 tarvect = M3x3mulV2(sg_s_tiP, tp1);
+    float3 tarvect = M3x3mulV2(sg_s_t.iP, tp1);
     normalize(tarvect);
-    return pointLineDistance3D(p, sg_s_tC, tarvect);
+    return pointLineDistance3D(p, sg_s_t.C, tarvect);
 }
 
 __device__ float refineDepthSubPixel(const float3& depths, const float3& sims)

--- a/src/aliceVision/depthMap/cuda/images/gauss_filter.cu
+++ b/src/aliceVision/depthMap/cuda/images/gauss_filter.cu
@@ -1,0 +1,182 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2018 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <cuda_runtime.h>
+
+#include <aliceVision/depthMap/cuda/images/gauss_filter.hpp>
+#include <aliceVision/depthMap/cuda/deviceCommon/device_operators.h>
+#include <aliceVision/depthMap/cuda/planeSweeping/host_utils.h>
+#include <aliceVision/depthMap/cuda/planeSweeping/device_utils.h>
+#include <aliceVision/system/Logger.hpp>
+
+namespace aliceVision {
+namespace depthMap {
+
+/*********************************************************************************
+ * global / constant data structures
+ *********************************************************************************/
+std::set<int>                 d_gaussianArrayInitialized;
+__device__ __constant__ int   d_gaussianArrayOffset[MAX_CONSTANT_GAUSS_SCALES];
+__device__ __constant__ float d_gaussianArray[MAX_CONSTANT_GAUSS_MEM_SIZE];
+
+/*********************************************************************************
+ * kernel forward declarations
+ *********************************************************************************/
+__global__ void downscale_gauss_smooth_lab_kernel(
+    cudaTextureObject_t rc_tex,
+    uchar4* texLab, int texLab_p,
+    int width, int height, int scale, int radius);
+
+/*********************************************************************************
+ * exported host function
+ *********************************************************************************/
+__host__ void ps_create_gaussian_arr( int deviceId, int scales ) // float delta, int radius)
+{
+    if( scales >= MAX_CONSTANT_GAUSS_SCALES )
+    {
+        ALICEVISION_LOG_ERROR( "Programming error: too few scales pre-computed for Gaussian kernels. Enlarge and recompile." );
+        throw std::runtime_error( "Programming error: too few scales pre-computed for Gaussian kernels. Enlarge and recompile." );
+    }
+
+    cudaError_t err;
+
+    if( d_gaussianArrayInitialized.find( deviceId ) != d_gaussianArrayInitialized.end() ) return;
+
+    d_gaussianArrayInitialized.insert( deviceId );
+
+    int*   h_gaussianArrayOffset;
+    float* h_gaussianArray;
+    err = cudaMallocHost( &h_gaussianArrayOffset, MAX_CONSTANT_GAUSS_SCALES * sizeof(int) );
+    if( err != cudaSuccess )
+    {
+        ALICEVISION_LOG_ERROR( "Failed to allocate " << MAX_CONSTANT_GAUSS_SCALES * sizeof(int) << " of CUDA host memory." );
+        throw std::runtime_error( "Failed to allocate CUDA host memory." );
+    }
+    err = cudaMallocHost( &h_gaussianArray,       MAX_CONSTANT_GAUSS_MEM_SIZE * sizeof(float) );
+    if( err != cudaSuccess )
+    {
+        ALICEVISION_LOG_ERROR( "Failed to allocate " << MAX_CONSTANT_GAUSS_MEM_SIZE * sizeof(float) << " of CUDA host memory." );
+        throw std::runtime_error( "Failed to allocate CUDA host memory." );
+    }
+
+    int sum_sizes = 0;
+    for( int scale=0; scale<MAX_CONSTANT_GAUSS_SCALES; scale++ )
+    {
+        h_gaussianArrayOffset[scale] = sum_sizes;
+        const int   radius = scale + 1;
+        const int   size   = 2 * radius + 1;
+        sum_sizes += size;
+    }
+
+    if( sum_sizes >= MAX_CONSTANT_GAUSS_MEM_SIZE )
+    {
+        ALICEVISION_LOG_ERROR( "Programming error: too little memory allocated for " << MAX_CONSTANT_GAUSS_SCALES << " Gaussian kernels. Enlarge and recompile." );
+        throw std::runtime_error( "Programming error: too little memory allocated for Gaussian kernels. Enlarge and recompile." );
+    }
+
+    for( int scale=0; scale<MAX_CONSTANT_GAUSS_SCALES; scale++ )
+    {
+        const int   radius = scale + 1;
+        const float delta  = 1.0f;
+        const int   size   = 2 * radius + 1;
+
+        for( int idx=0; idx<size; idx++ )
+        {
+            int x = idx - radius;
+            h_gaussianArray[h_gaussianArrayOffset[scale]+idx] = expf(-(x * x) / (2 * delta * delta));
+        }
+
+        // generate gaussian array
+    }
+
+
+    // create cuda array
+    err = cudaMemcpyToSymbol( d_gaussianArrayOffset,
+                              h_gaussianArrayOffset,
+                              MAX_CONSTANT_GAUSS_SCALES * sizeof(int), 0, cudaMemcpyDeviceToDevice);
+    if( err != cudaSuccess )
+    {
+        ALICEVISION_LOG_ERROR( "Failed to move Gaussian filter to symbol, " << cudaGetErrorString(err) );
+        throw std::runtime_error( "Failed to move Gaussian filter to symbol." );
+    }
+
+    err = cudaMemcpyToSymbol( d_gaussianArray,
+                              h_gaussianArray,
+                              sum_sizes * sizeof(float), 0, cudaMemcpyDeviceToDevice);
+    if( err != cudaSuccess )
+    {
+        ALICEVISION_LOG_ERROR( "Failed to move Gaussian filter to symbol, " << cudaGetErrorString(err) );
+        throw std::runtime_error( "Failed to move Gaussian filter to symbol." );
+
+    }
+
+    cudaFreeHost( h_gaussianArrayOffset );
+    cudaFreeHost( h_gaussianArray );
+}
+
+__host__ void ps_downscale_gauss( Pyramid& ps_texs_arr,
+                                  int camId, int scale,
+                                  int w, int h, int radius )
+{
+    const dim3 block(32, 2, 1);
+    const dim3 grid(divUp(w / (scale + 1), block.x), divUp(h / (scale + 1), block.y), 1);
+
+    downscale_gauss_smooth_lab_kernel
+        <<<grid, block>>>
+        ( ps_texs_arr[camId][0].tex,
+          ps_texs_arr[camId][scale].arr->getBuffer(),
+          ps_texs_arr[camId][scale].arr->getPitch(),
+          w / (scale + 1), h / (scale + 1), scale + 1,
+          radius //, 15.5f
+          );
+}
+/*********************************************************************************
+ * kernel definitions
+ *********************************************************************************/
+
+__device__ inline float getGauss( int scale, int idx )
+{
+    return d_gaussianArray[d_gaussianArrayOffset[scale] + idx];
+}
+
+__global__ void downscale_gauss_smooth_lab_kernel(
+    cudaTextureObject_t rc_tex,
+    uchar4* texLab, int texLab_p,
+    int width, int height, int scale, int radius)
+{
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if((x < width) && (y < height))
+    {
+        float4 t = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+        float sum = 0.0f;
+        for(int i = -radius; i <= radius; i++)
+        {
+            for(int j = -radius; j <= radius; j++)
+            {
+                float4 curPix = 255.0f * tex2D<float4>(rc_tex, (float)(x * scale + j) + (float)scale / 2.0f,
+                                               (float)(y * scale + i) + (float)scale / 2.0f);
+                float factor = getGauss( scale-1, i + radius )
+                             * getGauss( scale-1, j + radius ); // domain factor
+                t = t + curPix * factor;
+                sum += factor;
+            }
+        }
+        t.x = t.x / sum;
+        t.y = t.y / sum;
+        t.z = t.z / sum;
+        t.w = t.w / sum;
+
+        uchar4 tu4 = make_uchar4((unsigned char)t.x, (unsigned char)t.y, (unsigned char)t.z, (unsigned char)t.w);
+
+        BufPtr<uchar4>(texLab, texLab_p).at(x,y) = tu4;
+    }
+}
+
+} // namespace depthMap
+} // namespace aliceVision
+

--- a/src/aliceVision/depthMap/cuda/images/gauss_filter.hpp
+++ b/src/aliceVision/depthMap/cuda/images/gauss_filter.hpp
@@ -1,0 +1,25 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2018 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/depthMap/cuda/commonStructures.hpp>
+
+namespace aliceVision {
+namespace depthMap {
+
+#define MAX_CONSTANT_GAUSS_SCALES   10
+#define MAX_CONSTANT_GAUSS_MEM_SIZE 128
+
+extern void ps_create_gaussian_arr( int deviceId, int scales );
+
+extern void ps_downscale_gauss( Pyramid& ps_texs_arr,
+                                int camId, int scale,
+                                int w, int h, int radius );
+
+} // namespace depthMap
+} // namespace aliceVision
+

--- a/src/aliceVision/depthMap/cuda/planeSweeping/device_code_fuse.cu
+++ b/src/aliceVision/depthMap/cuda/planeSweeping/device_code_fuse.cu
@@ -136,12 +136,12 @@ __device__ float2 getCellSmoothStepEnergy(const int2& cell0)
     if(n > 1.0f)
     {
         cg = cg / n; // average of x, y, depth
-        float3 vcn = sg_s_rC - p0;
+        float3 vcn = sg_s_r.C - p0;
         normalize(vcn);
         // pS: projection of cg on the line from p0 to camera
         float3 pS = closestPointToLine3D(cg, p0, vcn);
         // keep the depth difference between pS and p0 as the smoothing step
-        out.x = size(sg_s_rC - pS) - d0;
+        out.x = size(sg_s_r.C - pS) - d0;
     }
 
     float e = 0.0f;

--- a/src/aliceVision/depthMap/cuda/planeSweeping/device_code_refine.cu
+++ b/src/aliceVision/depthMap/cuda/planeSweeping/device_code_refine.cu
@@ -32,8 +32,8 @@ __global__ void refine_selectPartOfDepthMapNearFPPlaneDepth_kernel(float* o0dept
             float fpPlaneDepthPix = frontoParellePlaneRCDepthFor3DPoint(p);
             if((fpPlaneDepthPix >= fpPlaneDepth - step) && (fpPlaneDepthPix < fpPlaneDepthNext))
             {
-                o0depth = size(get3DPointForPixelAndFrontoParellePlaneRC(pix, fpPlaneDepth) - sg_s_rC);
-                o1depth = size(get3DPointForPixelAndFrontoParellePlaneRC(pix, fpPlaneDepthNext) - sg_s_rC);
+                o0depth = size(get3DPointForPixelAndFrontoParellePlaneRC(pix, fpPlaneDepth) - sg_s_r.C);
+                o1depth = size(get3DPointForPixelAndFrontoParellePlaneRC(pix, fpPlaneDepthNext) - sg_s_r.C);
             };
         };
 
@@ -106,7 +106,7 @@ __global__ void refine_convertFPPlaneDepthMapToDepthMap_kernel(float* depthMap, 
         float depth = -1.0f;
         if(fpPlaneDepth > 0.0f)
         {
-            depth = size(get3DPointForPixelAndFrontoParellePlaneRC(pix, fpPlaneDepth) - sg_s_rC);
+            depth = size(get3DPointForPixelAndFrontoParellePlaneRC(pix, fpPlaneDepth) - sg_s_r.C);
         };
         depthMap[y * depthMap_p + x] = depth;
     };
@@ -143,9 +143,9 @@ __global__ void refine_computeDepthsMapFromDepthMap_kernel(float3* depthsMap, in
                 move3DPointByRcPixSize(pp1, +pixSize);
             };
 
-            depthsMap[y * depthsMap_p + x].x = size(pm1 - sg_s_rC);
-            depthsMap[y * depthsMap_p + x].y = size(p - sg_s_rC);
-            depthsMap[y * depthsMap_p + x].z = size(pp1 - sg_s_rC);
+            depthsMap[y * depthsMap_p + x].x = size(pm1 - sg_s_r.C);
+            depthsMap[y * depthsMap_p + x].y = size(p - sg_s_r.C);
+            depthsMap[y * depthsMap_p + x].z = size(pp1 - sg_s_r.C);
         };
     };
 }
@@ -178,7 +178,7 @@ __global__ void refine_reprojTarTexLABByDepthsMap_kernel(float3* depthsMap, int 
         if(depth > 0.0f)
         {
             float3 p = get3DPointForPixelAndDepthFromRC(pix, depth);
-            float2 tpc = project3DPoint(sg_s_tP, p);
+            float2 tpc = project3DPoint(sg_s_t.P, p);
 
             if(((tpc.x + 0.5f) > 0.0f) && ((tpc.y + 0.5f) > 0.0f) && ((tpc.x + 0.5f) < (float)width - 1.0f) &&
                ((tpc.y + 0.5f) < (float)height - 1.0f))
@@ -213,7 +213,7 @@ __global__ void refine_reprojTarTexLABByDepthMap_kernel(float* depthMap, int dep
         if(depth > 0.0f)
         {
             float3 p = get3DPointForPixelAndDepthFromRC(pix, depth);
-            float2 tpc = project3DPoint(sg_s_tP, p);
+            float2 tpc = project3DPoint(sg_s_t.P, p);
             if(((tpc.x + 0.5f) > 0.0f) && ((tpc.y + 0.5f) > 0.0f) && ((tpc.x + 0.5f) < (float)width - 1.0f) &&
                ((tpc.y + 0.5f) < (float)height - 1.0f))
             {
@@ -256,10 +256,10 @@ __global__ void refine_reprojTarTexLABByDepthMapMovedByStep_kernel(float* depthM
                     move3DPointByRcPixSize(p, pixSize);
                 };
 
-                depth = size(p - sg_s_rC);
+                depth = size(p - sg_s_r.C);
             };
 
-            float2 tpc = project3DPoint(sg_s_tP, p);
+            float2 tpc = project3DPoint(sg_s_t.P, p);
             if(((tpc.x + 0.5f) > 0.0f) && ((tpc.y + 0.5f) > 0.0f) && ((tpc.x + 0.5f) < (float)width - 1.0f) &&
                ((tpc.y + 0.5f) < (float)height - 1.0f))
             {
@@ -515,7 +515,7 @@ __global__ void refine_compUpdateYKNCCSimMapPatch_kernel(float* osimMap, int osi
             // move3DPointByTcPixStep(p, tcStep);
             move3DPointByTcOrRcPixStep(pix, p, tcStep, moveByTcOrRc);
 
-            odpt = size(p - sg_s_rC);
+            odpt = size(p - sg_s_r.C);
 
             patch ptch;
             ptch.p = p;
@@ -598,7 +598,7 @@ __global__ void refine_compYKNCCDepthSimMapPatch_kernel(float2* oDepthSimMap, in
             ptch.d = computePixSize(p);
             computeRotCSEpip(ptch, p);
 
-            oDepthSim.x = size(sg_s_rC - ptch.p);
+            oDepthSim.x = size(sg_s_r.C - ptch.p);
             oDepthSim.y = compNCCby3DptsYK(ptch, wsh, width, height, gammaC, gammaP, epipShift);
         };
 
@@ -723,9 +723,9 @@ __global__ void refine_computeDepthSimMapFromLastThreeSimsMap_kernel(float* osim
             move3DPointByTcOrRcPixStep(pix, pp1, +1.0f, moveByTcOrRc);
 
             float3 depths;
-            depths.x = size(pm1 - sg_s_rC);
+            depths.x = size(pm1 - sg_s_r.C);
             depths.y = midDepth;
-            depths.z = size(pp1 - sg_s_rC);
+            depths.z = size(pp1 - sg_s_r.C);
 
             float refinedDepth = refineDepthSubPixel(depths, sims);
             if(refinedDepth > 0.0f)
@@ -830,7 +830,7 @@ __global__ void refine_computeDepthSimMapFromBestStatMap_kernel(float* simMap, i
             float3 p = porig;
             // move3DPointByTcPixStep(p, tcStep);
             move3DPointByTcOrRcPixStep(pix, p, tcStep, moveByTcOrRc);
-            outDepth = size(p - sg_s_rC);
+            outDepth = size(p - sg_s_r.C);
 
             if((stat.x < 1.1f) && (stat.z < 1.1f))
             {
@@ -842,9 +842,9 @@ __global__ void refine_computeDepthSimMapFromBestStatMap_kernel(float* simMap, i
                 // move3DPointByTcPixStep(pp1, tcStep+1.0f);
                 move3DPointByTcOrRcPixStep(pix, pp1, tcStep + 1.0f, moveByTcOrRc);
 
-                depths.x = size(pm1 - sg_s_rC);
+                depths.x = size(pm1 - sg_s_r.C);
                 depths.y = outDepth;
-                depths.z = size(pp1 - sg_s_rC);
+                depths.z = size(pp1 - sg_s_r.C);
 
                 float3 sims;
                 sims.x = stat.x;
@@ -903,8 +903,8 @@ __global__ void refine_reprojTarTexLABByRcTcDepthsMap_kernel(uchar4* tex, int te
             float3 rp = get3DPointForPixelAndDepthFromRC(rpix, rcDepth);
             float3 rpS = get3DPointForPixelAndDepthFromRC(rpix, rcDepth + depthMapShift);
 
-            float2 tpc = project3DPoint(sg_s_tP, rp);
-            float2 tpcS = project3DPoint(sg_s_tP, rpS);
+            float2 tpc = project3DPoint(sg_s_t.P, rp);
+            float2 tpcS = project3DPoint(sg_s_t.P, rpS);
 
             int2 tpix = make_int2((int)(tpc.x + 0.5f), (int)(tpc.y + 0.5f));
             float tcDepth = tex2D(depthsTex, tpix.x, tpix.y);
@@ -1214,36 +1214,36 @@ __device__ float2 ComputeSobelTarIm(int x, int y)
 
 __device__ float2 DPIXTCDRC(const float3& P)
 {
-    float M3P = sg_s_tP[2] * P.x + sg_s_tP[5] * P.y + sg_s_tP[8] * P.z + sg_s_tP[11];
+    float M3P = sg_s_t.P[2] * P.x + sg_s_t.P[5] * P.y + sg_s_t.P[8] * P.z + sg_s_t.P[11];
     float M3P2 = M3P * M3P;
 
-    float m11 = ((sg_s_tP[0] * sg_s_tP[5] - sg_s_tP[2] * sg_s_tP[3]) * P.y +
-                 (sg_s_tP[0] * sg_s_tP[8] - sg_s_tP[2] * sg_s_tP[6]) * P.z +
-                 (sg_s_tP[0] * sg_s_tP[11] - sg_s_tP[2] * sg_s_tP[9])) /
+    float m11 = ((sg_s_t.P[0] * sg_s_t.P[5] - sg_s_t.P[2] * sg_s_t.P[3]) * P.y +
+                 (sg_s_t.P[0] * sg_s_t.P[8] - sg_s_t.P[2] * sg_s_t.P[6]) * P.z +
+                 (sg_s_t.P[0] * sg_s_t.P[11] - sg_s_t.P[2] * sg_s_t.P[9])) /
                 M3P2;
-    float m12 = ((sg_s_tP[3] * sg_s_tP[2] - sg_s_tP[5] * sg_s_tP[0]) * P.x +
-                 (sg_s_tP[3] * sg_s_tP[8] - sg_s_tP[5] * sg_s_tP[6]) * P.z +
-                 (sg_s_tP[3] * sg_s_tP[11] - sg_s_tP[5] * sg_s_tP[9])) /
+    float m12 = ((sg_s_t.P[3] * sg_s_t.P[2] - sg_s_t.P[5] * sg_s_t.P[0]) * P.x +
+                 (sg_s_t.P[3] * sg_s_t.P[8] - sg_s_t.P[5] * sg_s_t.P[6]) * P.z +
+                 (sg_s_t.P[3] * sg_s_t.P[11] - sg_s_t.P[5] * sg_s_t.P[9])) /
                 M3P2;
-    float m13 = ((sg_s_tP[6] * sg_s_tP[2] - sg_s_tP[8] * sg_s_tP[0]) * P.x +
-                 (sg_s_tP[6] * sg_s_tP[5] - sg_s_tP[8] * sg_s_tP[3]) * P.y +
-                 (sg_s_tP[6] * sg_s_tP[11] - sg_s_tP[8] * sg_s_tP[9])) /
-                M3P2;
-
-    float m21 = ((sg_s_tP[1] * sg_s_tP[5] - sg_s_tP[2] * sg_s_tP[4]) * P.y +
-                 (sg_s_tP[1] * sg_s_tP[8] - sg_s_tP[2] * sg_s_tP[7]) * P.z +
-                 (sg_s_tP[1] * sg_s_tP[11] - sg_s_tP[2] * sg_s_tP[10])) /
-                M3P2;
-    float m22 = ((sg_s_tP[4] * sg_s_tP[2] - sg_s_tP[5] * sg_s_tP[1]) * P.x +
-                 (sg_s_tP[4] * sg_s_tP[8] - sg_s_tP[5] * sg_s_tP[7]) * P.z +
-                 (sg_s_tP[4] * sg_s_tP[11] - sg_s_tP[5] * sg_s_tP[10])) /
-                M3P2;
-    float m23 = ((sg_s_tP[7] * sg_s_tP[2] - sg_s_tP[8] * sg_s_tP[1]) * P.x +
-                 (sg_s_tP[7] * sg_s_tP[5] - sg_s_tP[8] * sg_s_tP[4]) * P.y +
-                 (sg_s_tP[7] * sg_s_tP[11] - sg_s_tP[8] * sg_s_tP[10])) /
+    float m13 = ((sg_s_t.P[6] * sg_s_t.P[2] - sg_s_t.P[8] * sg_s_t.P[0]) * P.x +
+                 (sg_s_t.P[6] * sg_s_t.P[5] - sg_s_t.P[8] * sg_s_t.P[3]) * P.y +
+                 (sg_s_t.P[6] * sg_s_t.P[11] - sg_s_t.P[8] * sg_s_t.P[9])) /
                 M3P2;
 
-    float3 _drc = P - sg_s_rC;
+    float m21 = ((sg_s_t.P[1] * sg_s_t.P[5] - sg_s_t.P[2] * sg_s_t.P[4]) * P.y +
+                 (sg_s_t.P[1] * sg_s_t.P[8] - sg_s_t.P[2] * sg_s_t.P[7]) * P.z +
+                 (sg_s_t.P[1] * sg_s_t.P[11] - sg_s_t.P[2] * sg_s_t.P[10])) /
+                M3P2;
+    float m22 = ((sg_s_t.P[4] * sg_s_t.P[2] - sg_s_t.P[5] * sg_s_t.P[1]) * P.x +
+                 (sg_s_t.P[4] * sg_s_t.P[8] - sg_s_t.P[5] * sg_s_t.P[7]) * P.z +
+                 (sg_s_t.P[4] * sg_s_t.P[11] - sg_s_t.P[5] * sg_s_t.P[10])) /
+                M3P2;
+    float m23 = ((sg_s_t.P[7] * sg_s_t.P[2] - sg_s_t.P[8] * sg_s_t.P[1]) * P.x +
+                 (sg_s_t.P[7] * sg_s_t.P[5] - sg_s_t.P[8] * sg_s_t.P[4]) * P.y +
+                 (sg_s_t.P[7] * sg_s_t.P[11] - sg_s_t.P[8] * sg_s_t.P[10])) /
+                M3P2;
+
+    float3 _drc = P - sg_s_r.C;
 
     float2 op;
     op.x = m11 * _drc.x + m12 * _drc.y + m13;
@@ -1275,7 +1275,7 @@ __global__ void refine_reprojTarSobelAndDPIXTCDRCRcTcDepthsMap_kernel(float4* te
             float3 rp = get3DPointForPixelAndDepthFromRC(rpix, rcDepth);
             float3 rpS = get3DPointForPixelAndDepthFromRC(rpix, rcDepth + depthMapShift);
 
-            float2 tpc = project3DPoint(sg_s_tP, rp);
+            float2 tpc = project3DPoint(sg_s_t.P, rp);
             int2 tpix = make_int2((int)(tpc.x + 0.5f), (int)(tpc.y + 0.5f));
             float tcDepth = tex2D(depthsTex, tpix.x, tpix.y);
 
@@ -1317,7 +1317,7 @@ __global__ void refine_computeRcTcDepthMap_kernel(float* rcDepthMap, int rcDepth
         if(rcDepth > 0.0f)
         {
             float3 rp = get3DPointForPixelAndDepthFromRC(rpix, rcDepth);
-            float2 tpc = project3DPoint(sg_s_tP, rp);
+            float2 tpc = project3DPoint(sg_s_t.P, rp);
             int2 tpix = make_int2((int)(tpc.x + 0.5f), (int)(tpc.y + 0.5f));
             float tcDepth = tex2D(depthsTex, tpc.x + 0.5f, tpc.y + 0.5f);
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

The PR introduces one major semantic change:
Before this PR, the entire 3D volume for plane sweeping was allocated for each pair of planes. If the GPU had not enough memory, the X and Y resolution was reduced until there was sufficient memory.
After the change, GPU memory restrictions are used to "slice" the volume into intervals in the Z direction. These intervals are processed one after the other, and return values are copied into a full-sized 3D volume on the host (CPU) side before processing the following interval. The available GPU memory is roughly estimated with a 100% safety. The computation is found in SemiGlobalMatchingRc::sgmrc().

The PR contains also changes to the camera structure, textures, and CUDA memory types to reduce unnecessary copying. With a very big effort, these steps could be isolated again, but I hope that it can be verified as is.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->

- Volume slicing instead of downsampling as described above. This also simplifies some kernels that had to support strided reads.

- Cameras matrices are now moved to the GPU as structs, not as individual values, for easier readability and fewer expensive copy functions. Blurid and H in the cameraStruct were never used, so they have been removed everywhere.

- Many (but not all) texture references were replaced with texture objects. This does not provide any speedup. There are several advantages:
  - The allocated CUDA memory (pitched memory) and its texture object are kept together in a new data structure called TexturedArray. No need to do dynamic binding and unbinding.
  - One is that the texture is passed as a parameter to a CUDA kernel, instead of simply being available on the GPU do due a side-effect of a texture binding operation at an indeterminate point in time.
  - This does also help the programmer to remember the texture access mode of the specific texture when a kernel is called.
  - Finally, the tex2D() access in kernel code with unspecific return type is replaced with the template tex2D&lt;T&gt;(), which clarifies that the return type is T. Although this does _not_ allow compile-time checking, it helps the programmer.

- Extract Gaussian filtering into separate files.

- Use the CUDA function cudaOccupancyMaxPotentialBlockSize to interactively determine the card-specific optimal number of threads for the expensive kernel volume_slice_kernel.

## Implementation remarks

- I do currently not have access to a multi-card machine. The develop branch works well with multiple cards, but an earlier version of this commit did not. I believe that I have removed the problematic changes, but will be unable to test it for several weeks.

- SemiGlobalMatchingRc.cpp defines a variable FORCE_ZDIM_LIMIT, which is undefined. It can be set manually to some number, which makes it possible to test whether volume slicing works also on a GPU with a good amount of memory.

- The code computes a range of depths that need checking for every pair of RC and TC. These depths are always a subrange of the depths associated with the RC. Like in the develop branch, this code is still making a copy of each subrange instead of specifying an interval on the complete range. This prevents parallel handling of several TCs and min computation on the GPU, which must be changed in a follow-up PR.



<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

