### PR TITLE
[sensorDB] Added OnePlus 6

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -2356,6 +2356,7 @@ Olympus;Olympus X-905;6.16
 Olympus;Olympus X-920;6.16
 Olympus;Olympus XZ-1;7.85
 Olympus;Olympus XZ-2 iHS;7.53
+OnePlus;ONEPLUS A6000;5.5
 Panasonic;Panasonic D-snap SV-AS10;4.5
 Panasonic;Panasonic D-snap SV-AS3;4.5
 Panasonic;Panasonic D-snap SV-AS30;4.5


### PR DESCRIPTION
sensor width of 5.5, being the sensor a 1/2.6" (https://www.devicespecifications.com/en/model/c01c49b8) and according to this http://photoseek.com/2013/compare-digital-camera-sensor-sizes-full-frame-35mm-aps-c-micro-four-thirds-1-inch-type/

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

