### PR TITLE
[sfmDataIO]  `jsonIO` Fix: write bool as `0` or `1`

### DIFF
--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -113,7 +113,7 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
     intrinsicTree.add_child("distortionParams", distParamsTree);
   }
 
-  intrinsicTree.put("locked", intrinsic->isLocked());
+  intrinsicTree.put("locked", static_cast<int>(intrinsic->isLocked()));
 
   parentTree.push_back(std::make_pair(name, intrinsicTree));
 }

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -113,7 +113,7 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
     intrinsicTree.add_child("distortionParams", distParamsTree);
   }
 
-  intrinsicTree.put("locked", static_cast<int>(intrinsic->isLocked()));
+  intrinsicTree.put("locked", static_cast<int>(intrinsic->isLocked())); // convert bool to integer to avoid using "true/false" in exported file instead of "1/0".
 
   parentTree.push_back(std::make_pair(name, intrinsicTree));
 }

--- a/src/aliceVision/sfmDataIO/jsonIO.hpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.hpp
@@ -105,7 +105,7 @@ inline void saveCameraPose(const std::string& name, const sfmData::CameraPose& c
   bpt::ptree cameraPoseTree;
 
   savePose3("transform", cameraPose.getTransform(), cameraPoseTree);
-  cameraPoseTree.put("locked", static_cast<int>(cameraPose.isLocked()));
+  cameraPoseTree.put("locked", static_cast<int>(cameraPose.isLocked())); // convert bool to integer to avoid using "true/false" in exported file instead of "1/0".
 
   parentTree.add_child(name, cameraPoseTree);
 }

--- a/src/aliceVision/sfmDataIO/jsonIO.hpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.hpp
@@ -105,7 +105,7 @@ inline void saveCameraPose(const std::string& name, const sfmData::CameraPose& c
   bpt::ptree cameraPoseTree;
 
   savePose3("transform", cameraPose.getTransform(), cameraPoseTree);
-  cameraPoseTree.put("locked", cameraPose.isLocked());
+  cameraPoseTree.put("locked", static_cast<int>(cameraPose.isLocked()));
 
   parentTree.add_child(name, cameraPoseTree);
 }


### PR DESCRIPTION
This commit does not break compatibility with previous scenes.
Previous json files with bool write as string are still readable.