### PR TITLE
[sensorDB] Add `OLYMPUS E-M1 Mark II` to the sensor database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4044,6 +4044,7 @@ Olympus;Olympus X-935;6.17;dpreview
 Olympus;Olympus XZ-1;7.85;digicamdb
 Olympus;Olympus XZ-2 iHS;7.44;dpreview,digicamdb,dxomark
 Olympus;Olympus XZ1;7.9;dxomark
+OLYMPUS CORPORATION;E-M1MarkII;17.4;dpreview,imaging-resource,dxomark,olympus
 OLYMPUS IMAGING CORP.;E-M10;17.3;olympus
 Onda;Onda V975i;3.67;devicespecifications
 Onda;Onda V989;3.68;devicespecifications


### PR DESCRIPTION
Fix #524