### PR TITLE
Typo fix 2

### DIFF
--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
           "Filename should be the image uid.")
         ("outputTextureFileType", po::value<std::string>(&outTextureFileTypeName)->default_value(outTextureFileTypeName),
           EImageFileType_informations().c_str())
-        ("textureSide", po::value<unsigned int>(&texParams.textureSide)->default_value(texParams.textureSide),
+        ("textureSize", po::value<unsigned int>(&texParams.textureSize)->default_value(texParams.textureSize),
             "Output texture size")
         ("downscale", po::value<unsigned int>(&texParams.downscale)->default_value(texParams.downscale),
             "Texture downscale factor")


### PR DESCRIPTION
Changed Side to Size ("textureSize", po::value<unsigned int>(&texParams.textureSize)->default_value(texParams.textureSize),
corresponding to Typo Side->Size [MR#321](https://github.com/alicevision/meshroom/pull/321#issuecomment-448661955)

