### PR TITLE
Allows SfMTransform to use a view as the origin for the coordinate system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -237,7 +237,7 @@ endif()
 # Boost
 # ==============================================================================
 option(BOOST_NO_CXX11 "if Boost is compiled without C++11 support (as it is often the case in OS packages) this must be enabled to avoid symbol conflicts (SCOPED_ENUM)." OFF)
-find_package(Boost 1.60.0 QUIET COMPONENTS atomic date_time filesystem graph log log_setup program_options regex serialization system thread)
+find_package(Boost 1.60.0 QUIET COMPONENTS atomic container date_time filesystem graph log log_setup program_options regex serialization system thread)
 
 if(Boost_FOUND)
   message(STATUS "Boost ${Boost_LIB_VERSION} found.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -237,7 +237,7 @@ endif()
 # Boost
 # ==============================================================================
 option(BOOST_NO_CXX11 "if Boost is compiled without C++11 support (as it is often the case in OS packages) this must be enabled to avoid symbol conflicts (SCOPED_ENUM)." OFF)
-find_package(Boost 1.60.0 QUIET COMPONENTS atomic container date_time filesystem graph log log_setup program_options regex serialization system thread)
+find_package(Boost 1.60.0 QUIET COMPONENTS atomic date_time filesystem graph log log_setup program_options regex serialization system thread)
 
 if(Boost_FOUND)
   message(STATUS "Boost ${Boost_LIB_VERSION} found.")

--- a/src/aliceVision/sfm/utils/alignment.cpp
+++ b/src/aliceVision/sfm/utils/alignment.cpp
@@ -12,6 +12,7 @@
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/max.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <algorithm>
 
@@ -150,7 +151,7 @@ void computeNewCoordinateSystemFromSingleCamera(const sfmData::SfMData& sfmData,
 
   try
   {
-    viewId = lexical_cast<IndexT>(camName));
+    viewId = boost::lexical_cast<IndexT>(camName));
     if(!sfmData.getViews().count(viewId))
       viewId = -1;
   }

--- a/src/aliceVision/sfm/utils/alignment.cpp
+++ b/src/aliceVision/sfm/utils/alignment.cpp
@@ -151,11 +151,11 @@ void computeNewCoordinateSystemFromSingleCamera(const sfmData::SfMData& sfmData,
 
   try
   {
-    viewId = boost::lexical_cast<IndexT>(camName));
+    viewId = boost::lexical_cast<IndexT>(camName);
     if(!sfmData.getViews().count(viewId))
       viewId = -1;
   }
-  catch(const bad_lexical_cast &)
+  catch(const boost::bad_lexical_cast &)
   {
     viewId = -1;
   }

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -139,5 +139,22 @@ void computeNewCoordinateSystemFromLandmarks(const sfmData::SfMData& sfmData,
                                              Mat3& out_R,
                                              Vec3& out_t);
 
+/**
+ * @brief Compute the new coordinate system in the given reconstruction so that the given camera is the
+ * origin of the world coordinate system. If this camera (view) does not exist, the transformation
+ * remains unchanged.
+ *
+ * @param[in] sfmData
+ * @param[in] cameraName name of the reference picture (e.g. "cam_1.png")
+ * @param[out] out_S scale
+ * @param[out] out_R rotation
+ * @param[out] out_t translation
+ */
+void computeNewCoordinateSystemFromSingleCamera(const sfmData::SfMData& sfmData,
+                                                const std::string& cameraName,
+                                                double& out_S,
+                                                Mat3& out_R,
+                                                Vec3& out_t);
+
 } // namespace sfm
 } // namespace aliceVision

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -16,6 +16,22 @@ namespace aliceVision {
 namespace sfmData {
 
 /**
+ * @brief EXIF Orientation to names
+ */
+enum class EEXIFOrientation
+{
+  NONE = 1
+  , REVERSED = 2
+  , UPSIDEDOWN = 3
+  , UPSIDEDOWN_REVERSED = 4
+  , LEFT_REVERSED = 5
+  , LEFT = 6  
+  , RIGHT_REVERSED = 7
+  , RIGHT = 8
+  , UNKNOWN = -1
+};
+
+/**
  * @brief A view define an image by a string and unique indexes for
  * the view, the camera intrinsic, the pose and the subpose if the camera is part of a rig
  */
@@ -305,13 +321,13 @@ public:
 
   /**
    * @brief Get the corresponding "Orientation" metadata value
-   * @return the metadata value int or -1 if no corresponding value
+   * @return the enum EEXIFOrientation
    */
-    int getMetadataOrientation() const
+  EEXIFOrientation getMetadataOrientation() const
   {
     if(hasDigitMetadata("Orientation"))
-      return  std::stoi(getMetadata("Orientation"));
-    return -1;
+      return  static_cast<EEXIFOrientation>(std::stoi(getMetadata("Orientation")));
+    return EEXIFOrientation::UNKNOWN;
   }
 
   /**

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -304,6 +304,17 @@ public:
   }
 
   /**
+   * @brief Get the corresponding "Orientation" metadata value
+   * @return the metadata value int or -1 if no corresponding value
+   */
+    int getMetadataOrientation() const
+  {
+    if(hasDigitMetadata("Orientation"))
+      return  std::stoi(getMetadata("Orientation"));
+    return -1;
+  }
+
+  /**
    * @brief Get the view metadata structure
    * @return the view metadata
    */

--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 
   // user optional parameters
 
-  std::string transformationYAlignScale;
+  std::string transform;
   std::string landmarksDescriberTypesName;
   double userScale = 1;
 
@@ -124,10 +124,10 @@ int main(int argc, char **argv)
 
   po::options_description optionalParams("Optional parameters");
   optionalParams.add_options()
-    ("transformation", po::value<std::string>(&transformationYAlignScale)->default_value(transformationYAlignScale),
+    ("transformation", po::value<std::string>(&transform)->default_value(transform),
       "required only for 'transformation' and 'single camera' methods:\n"
       "Transformation: Align [X,Y,Z] to +Y-axis, rotate around Y by R deg, scale by S; syntax: X,Y,Z;R;S\n"
-      "Single camera: Image name")
+      "Single camera: camera UID or image filename")
     ("landmarksDescriberTypes,d", po::value<std::string>(&landmarksDescriberTypesName)->default_value(landmarksDescriberTypesName),
       ("optional for 'landmarks' method:\n"
       "Image describer types used to compute the mean of the point cloud\n"
@@ -177,9 +177,10 @@ int main(int argc, char **argv)
   // set alignment method
   const EAlignmentMethod alignmentMethod = EAlignmentMethod_stringToEnum(alignmentMethodName);
 
-  if(alignmentMethod == EAlignmentMethod::TRANSFOMATION &&
-     alignmentMethod == EAlignmentMethod::FROM_SINGLE_CAMERA &&
-     transformationYAlignScale.empty())
+  if(transform.empty() && (
+     alignmentMethod == EAlignmentMethod::TRANSFOMATION ||
+     alignmentMethod == EAlignmentMethod::FROM_SINGLE_CAMERA)
+    )
   {
     ALICEVISION_LOG_ERROR("Missing --transformation option");
     return EXIT_FAILURE;
@@ -201,7 +202,7 @@ int main(int argc, char **argv)
   {
     case EAlignmentMethod::TRANSFOMATION:
     {
-      if(!parseAlignScale(transformationYAlignScale, S, R, t))
+      if(!parseAlignScale(transform, S, R, t))
       {
          ALICEVISION_LOG_ERROR("Failed to parse align/scale argument");
          return EXIT_FAILURE;
@@ -218,7 +219,7 @@ int main(int argc, char **argv)
     break;
 
     case EAlignmentMethod::FROM_SINGLE_CAMERA:
-      sfm::computeNewCoordinateSystemFromSingleCamera(sfmDataIn,transformationYAlignScale, S, R, t);
+      sfm::computeNewCoordinateSystemFromSingleCamera(sfmDataIn,transform, S, R, t);
     break;
   }
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Enable the specification of one view as the origin of the coordinate system.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->

Alignement.cpp contains a new function "computeNewCoordinateSystemFromSingleCamera". The name of the view to be used as the origin is a parameter of this function.

## Implementation remarks

The meshroom python interface has been updated to support this feature.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

