### PR TITLE
UVAtlas: downscale charts to fit in texture

### DIFF
--- a/src/aliceVision/mesh/UVAtlas.cpp
+++ b/src/aliceVision/mesh/UVAtlas.cpp
@@ -281,6 +281,9 @@ void UVAtlas::createTextureAtlases(vector<Chart>& charts, mvsUtils::MultiViewPar
         // fill potential empty space (i != j) in backward direction
         while(j > i && insertChart(j)) { --j; }
 
+        if(atlas.empty())
+            throw std::runtime_error("Unable to add any chart to this atlas");
+
         // atlas is full or all charts have been handled
         ALICEVISION_LOG_INFO("Filled with " << atlas.size() << " charts.");
         // store this texture

--- a/src/aliceVision/mesh/UVAtlas.cpp
+++ b/src/aliceVision/mesh/UVAtlas.cpp
@@ -226,6 +226,14 @@ void UVAtlas::finalizeCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& m
                 chart.sourceRD = sourceRD;
             }
         }
+
+        const int largerSize = std::max(chart.sourceWidth(), chart.sourceHeight());
+        if(largerSize > chartMaxSize())
+        {
+            chart.downscale = static_cast<float>(chartMaxSize()) / static_cast<float>(largerSize);
+            ALICEVISION_LOG_WARNING("Downscaling chart (by " + std::to_string(chart.downscale) + ") to fit in texture."
+                "Set higher texture size for better results.");
+        }
     }
 }
 
@@ -236,10 +244,10 @@ void UVAtlas::createTextureAtlases(vector<Chart>& charts, mvsUtils::MultiViewPar
     // sort charts by size, descending
     std::sort(charts.begin(), charts.end(), [](const Chart& a, const Chart& b)
     {
-        int wa = a.width();
-        int wb = b.width();
+        int wa = a.targetWidth();
+        int wb = b.targetWidth();
         if(wa == wb)
-            return a.height() > b.height();
+            return a.targetHeight() > b.targetHeight();
         return wa > wb;
     });
 
@@ -318,8 +326,8 @@ UVAtlas::ChartRect* UVAtlas::ChartRect::insert(Chart& chart, size_t gutter)
     }
     else
     {
-        size_t chartWidth = chart.width() + gutter * 2;
-        size_t chartHeight = chart.height() + gutter * 2;
+        size_t chartWidth = chart.targetWidth() + gutter * 2;
+        size_t chartHeight = chart.targetHeight() + gutter * 2;
         // if there is already a chart here
         if(c) return nullptr;
         // not enough space

--- a/src/aliceVision/mesh/UVAtlas.hpp
+++ b/src/aliceVision/mesh/UVAtlas.hpp
@@ -33,9 +33,17 @@ public:
         Pixel sourceLU;                                         // left-up pixel coordinates (in refCamera space)
         Pixel sourceRD;                                         // right-down pixel coordinates (in refCamera space)
         Pixel targetLU;                                         // left-up pixel coordinates (in uvatlas texture)
+        float downscale = 1.0f;                                 // downscale factor applied to this chart
         int mergedWith = -1;                                    // ID of target chart, or -1 (not merged)
-        int width() const { return sourceRD.x - sourceLU.x; }
-        int height() const { return sourceRD.y - sourceLU.y; }
+
+        /// Chart width in refCamera space
+        int sourceWidth() const { return (sourceRD.x - sourceLU.x); }
+        /// Chart height in refCamera space
+        int sourceHeight() const { return (sourceRD.y - sourceLU.y); }
+        /// Chart target width (uv space, taking downscale into account)
+        int targetWidth() const { return sourceWidth() * downscale; }
+        /// Chart target height (uv space, taking downscale into account)
+        int targetHeight() const { return sourceHeight() * downscale; }
     };
 
     struct ChartRect
@@ -57,6 +65,7 @@ public:
     const std::vector<int>& visibleCameras(int triangleID) const { return _triangleCameraIDs[triangleID]; }
     int textureSide() const { return _textureSide; }
     const Mesh& mesh() const { return _mesh; }
+    inline int chartMaxSize() const { return (_textureSide - 1) - _gutterSize * 2; }
 
 private:
     void createCharts(std::vector<Chart>& charts, mvsUtils::MultiViewParams& mp, StaticVector<StaticVector<int>*>* ptsCams);


### PR DESCRIPTION
## Description
Fix infinite loop when charts are larger than final texture size.
Fix #395 

## Features list
- [X] downscale charts to fit in texture
- [X] add sanity checks to avoid infinite loop and detect wrong configurations

## Implementation remarks
Apply downscale factor to fit larger charts into the texture, and use it when filling atlases and computing final UV textures.