### PR TITLE
[mvs] make search for undistorted images more robust

### DIFF
--- a/src/aliceVision/mvsData/image.cpp
+++ b/src/aliceVision/mvsData/image.cpp
@@ -6,9 +6,14 @@
 
 #include "image.hpp"
 
+#include  <boost/algorithm/string/case_conv.hpp>
+
 #include <iostream>
 #include <algorithm>
 #include <stdexcept>
+
+#include <array>
+
 
 namespace aliceVision {
 
@@ -57,6 +62,14 @@ std::istream& operator>>(std::istream& in, EImageFileType& imageFileType)
   in >> token;
   imageFileType = EImageFileType_stringToEnum(token);
   return in;
+}
+
+bool isSupportedUndistortFormat(const std::string &ext)
+{
+  static const std::array<std::string, 6> supportedExtensions = {".jpg", ".jpeg", ".png",  ".tif", ".tiff", ".exr"};
+  const auto start = supportedExtensions.begin();
+  const auto end = supportedExtensions.end();
+  return(std::find(start, end, boost::to_lower_copy(ext)) != end);
 }
 
 } // namespace aliceVision

--- a/src/aliceVision/mvsData/image.hpp
+++ b/src/aliceVision/mvsData/image.hpp
@@ -57,4 +57,11 @@ std::ostream& operator<<(std::ostream& os, EImageFileType imageFileType);
  */
 std::istream& operator>>(std::istream& in, EImageFileType& imageFileType);
 
+/**
+ * @brief Test if the extension is supported for undistorted images.
+ * @param[in] ext The extension with the dot (eg ".png")
+ * @return \p true if the extension is supported.
+ */
+bool isSupportedUndistortFormat(const std::string &ext);
+
 } // namespace aliceVision

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/mvsData/geometry.hpp>
 #include <aliceVision/mvsData/Matrix3x4.hpp>
 #include <aliceVision/mvsData/Pixel.hpp>
+#include <aliceVision/mvsData/image.hpp>
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/imageIO/image.hpp>
@@ -72,7 +73,8 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
             const fs::recursive_directory_iterator end;
             const auto findIt = std::find_if(fs::recursive_directory_iterator(_imagesFolder), end,
                                      [&view](const fs::directory_entry& e) {
-                                        return e.path().stem() == std::to_string(view.getViewId());
+                                        return (e.path().stem() == std::to_string(view.getViewId()) &&
+                                        (isSupportedUndistortFormat(e.path().extension().string())));
                                      });
 
             if(findIt == end)


### PR DESCRIPTION
Currently when DepthMap looks for the undistorted images It only checks if a file named as the view ID is inside the folder. It's better to also check that the extension is one of the supported files to avoid possible ambiguities with other files (especially if not using the UID as ID).

