### PR TITLE
[mesh]  texturing: performance optimization of image fusion

### DIFF
--- a/src/aliceVision/depthMap/RefineRc.cpp
+++ b/src/aliceVision/depthMap/RefineRc.cpp
@@ -356,7 +356,7 @@ void estimateAndRefineDepthMaps(int cudaDeviceNo, mvsUtils::MultiViewParams* mp,
   const int bandType = 0;
 
   // load images from files into RAM
-  mvsUtils::ImagesCache ic(mp, bandType, true);
+  mvsUtils::ImagesCache ic(mp, bandType);
   // load stuff on GPU memory and creates multi-level images and computes gradients
   PlaneSweepingCuda cps(cudaDeviceNo, ic, mp, sgmScale);
   // init plane sweeping parameters
@@ -389,7 +389,7 @@ void computeNormalMaps(int CUDADeviceNo, mvsUtils::MultiViewParams* mp, const St
   const int bandType = 0;
   const int wsh = 3;
 
-  mvsUtils::ImagesCache ic(mp, bandType, true);
+  mvsUtils::ImagesCache ic(mp, bandType);
   PlaneSweepingCuda cps(CUDADeviceNo, ic, mp, 1);
 
   for(const int rc : cams)

--- a/src/aliceVision/depthMap/cuda/PlaneSweepingCuda.cpp
+++ b/src/aliceVision/depthMap/cuda/PlaneSweepingCuda.cpp
@@ -145,8 +145,8 @@ void cps_fillCameraData(mvsUtils::ImagesCache* ic, cameraStruct* cam, int c, mvs
         {
             for(pix.x = 0; pix.x < mp->getWidth(c); pix.x++)
             {
-                uchar4& pix_rgba = ic->transposed ? (*cam->tex_rgba_hmh)(pix.x, pix.y) : (*cam->tex_rgba_hmh)(pix.y, pix.x);
-                const uchar4 pc = get( img, pix.x, pix.y ); //  ic.getPixelValue(pix, c);
+                uchar4& pix_rgba = (*cam->tex_rgba_hmh)(pix.x, pix.y);
+                const uchar4 pc = get( img, pix.x, pix.y );
                 pix_rgba = pc;
             }
         }

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -542,7 +542,7 @@ void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
                        if(color == Color(0.f, 0.f, 0.f))
                            continue;
                        // fill the accumulated color map for this pixel
-                       accuImage.img[xyoffset] = accuImage.img[xyoffset] + color;
+                       accuImage.img[xyoffset] += color;
                        accuImage.imgCount[xyoffset] += 1;
                    }
                }
@@ -566,7 +566,7 @@ void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
             {
                 unsigned int xyoffset = yoffset + xp;
                 if(accuImage.imgCount[xyoffset])
-                    accuImage.img[xyoffset] = accuImage.img[xyoffset] / accuImage.imgCount[xyoffset];
+                    accuImage.img[xyoffset] /= accuImage.imgCount[xyoffset];
             }
         }
 

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -589,20 +589,23 @@ void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
                         else if(accuImage.imgCount[xyoffset-1] > 0)
                         {
                             accuImage.img[xyoffset] = accuImage.img[xyoffset-1];
+                            accuImage.imgCount[xyoffset] += 1;
                         }
                         else if(accuImage.imgCount[xyoffset+1] > 0)
                         {
                             accuImage.img[xyoffset] = accuImage.img[xyoffset+1];
+                            accuImage.imgCount[xyoffset] += 1;
                         }
                         else if(accuImage.imgCount[xyoffset+texParams.textureSide] > 0)
                         {
                             accuImage.img[xyoffset] = accuImage.img[xyoffset+texParams.textureSide];
+                            accuImage.imgCount[xyoffset] += 1;
                         }
                         else if(accuImage.imgCount[xyoffset-texParams.textureSide] > 0)
                         {
                             accuImage.img[xyoffset] = accuImage.img[xyoffset-texParams.textureSide];
+                            accuImage.imgCount[xyoffset] += 1;
                         }
-                        accuImage.imgCount[xyoffset] += 1;
                     }
                 }
             }

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -253,7 +253,7 @@ void Texturing::generateUVsBasicMethod(mvsUtils::MultiViewParams& mp)
 void Texturing::generateTextures(const mvsUtils::MultiViewParams &mp,
                                  const boost::filesystem::path &outPath, EImageFileType textureFileType)
 {
-    mvsUtils::ImagesCache imageCache(&mp, 0, false);
+    mvsUtils::ImagesCache imageCache(&mp, 0);
     system::MemoryInfo memInfo = system::getMemoryInfo();
 
     //calculate the maximum number of atlases in memory in Mb

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -137,21 +137,21 @@ public:
     void unwrap(mvsUtils::MultiViewParams& mp, EUnwrapMethod method);
 
     /**
-     * @brief Generate automatic texture atlasing and UV coordinates based on points visibilities
+     * @brief Generate automatic texture atlasing and UV coordinates based on points visibilities with the "Basic" method.
      *
      * Requires internal mesh 'me' to be initialized.
      *
      * @param mp
      */
-    void generateUVs(mvsUtils::MultiViewParams &mp);
+    void generateUVsBasicMethod(mvsUtils::MultiViewParams &mp);
 
     /// Generate texture files for all texture atlases
     void generateTextures(const mvsUtils::MultiViewParams& mp,
                           const bfs::path &outPath, EImageFileType textureFileType = EImageFileType::PNG);
 
-    /// Generate texture files for the given texture atlas index
-    void generateTexture(const mvsUtils::MultiViewParams& mp,
-                         size_t atlasID, mvsUtils::ImagesCache& imageCache,
+    /// Generate texture files for the given sub-set of texture atlases
+    void generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
+                         std::vector<size_t> atlasIDs, mvsUtils::ImagesCache& imageCache,
                          const bfs::path &outPath, EImageFileType textureFileType = EImageFileType::PNG);
 
     /// Save textured mesh as an OBJ + MTL file

--- a/src/aliceVision/mvsData/Color.hpp
+++ b/src/aliceVision/mvsData/Color.hpp
@@ -74,6 +74,22 @@ public:
         return Color(r / d, g / d, b / d);
     }
 
+    inline Color& operator+=(const Color& _p)
+    {
+        r += _p.r;
+        g += _p.g;
+        b += _p.b;
+        return *this;
+    }
+
+    inline Color& operator/=(const int d)
+    {
+        r /= d;
+        g /= d;
+        b /= d;
+        return *this;
+    }
+
     inline Color normalize() const
     {
         float d = std::sqrt(r * r + g * g + b * b);

--- a/src/aliceVision/mvsUtils/ImagesCache.cpp
+++ b/src/aliceVision/mvsUtils/ImagesCache.cpp
@@ -13,10 +13,9 @@
 namespace aliceVision {
 namespace mvsUtils {
 
-ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType, bool _transposed)
+ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType)
   : mp(_mp)
   , bandType( _bandType )
-  , transposed( _transposed )
 {
     std::vector<std::string> _imagesNames;
     for(int rc = 0; rc < _mp->getNbCameras(); rc++)
@@ -26,11 +25,9 @@ ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType, bool _transp
     initIC( _imagesNames );
 }
 
-ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType, std::vector<std::string>& _imagesNames,
-                                 bool _transposed)
+ImagesCache::ImagesCache(const MultiViewParams* _mp, int _bandType, std::vector<std::string>& _imagesNames)
   : mp(_mp)
   , bandType( _bandType )
-  , transposed( _transposed )
 {
     initIC( _imagesNames );
 }

--- a/src/aliceVision/mvsUtils/ImagesCache.hpp
+++ b/src/aliceVision/mvsUtils/ImagesCache.hpp
@@ -46,12 +46,12 @@ public:
 
         inline Color& at( int x, int y )
         {
-            return data[x * _height + y];
+            return data[y * _width + x];
         }
 
         inline const Color& at( int x, int y ) const
         {
-            return data[x * _height + y];
+            return data[y * _width + x];
         }
 
         Color* data;
@@ -76,14 +76,10 @@ private:
     std::vector<std::string> imagesNames;
 
     const int  bandType;
-public:
-    const bool transposed;
 
 public:
-    ImagesCache( const MultiViewParams* _mp, int _bandType,
-                 bool _transposed = false);
-    ImagesCache( const MultiViewParams* _mp, int _bandType, std::vector<std::string>& _imagesNames,
-                 bool _transposed = false);
+    ImagesCache( const MultiViewParams* _mp, int _bandType);
+    ImagesCache( const MultiViewParams* _mp, int _bandType, std::vector<std::string>& _imagesNames);
     void initIC( std::vector<std::string>& _imagesNames );
     ~ImagesCache();
 

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -385,9 +385,7 @@ void memcpyRGBImageFromFileToArr(int camId, Color* imgArr, const std::string& fi
         for(int x = 0; x < width; x++)
         {
             const Color color = cimg.at(y * width + x);
-
-            imgArr[x * height + y] = color;
-
+            imgArr[y * width + x] = color;
         }
     }
 }


### PR DESCRIPTION
## Description

[X] Contribution to multiple textures per image. It limits the number of images reloads from files. Around 3x speedup on a dataset of 250 images.
[X]  Texture padding speedup: Create the padding with only `2` loops over the texture instead of
`2*padding` loops. So the performance cost does not depend on the size of the padding anymore. 28% speedup on a small dataset of 12 images. Of course, the speedup be smaller on large datasets as the largest part of the processing will be the image contributions.
