### PR TITLE
[depthMap] fix crash if no nearby camera

### DIFF
--- a/src/aliceVision/depthMap/RefineRc.cpp
+++ b/src/aliceVision/depthMap/RefineRc.cpp
@@ -240,8 +240,7 @@ bool RefineRc::refinerc(bool checkIfExists)
     // generate default depthSimMap if rc has no tcam
     if(_refineTCams.size() == 0 || _depths == nullptr)
     {
-        DepthSimMap depthSimMapOpt(_rc, _sp->mp, 1, 1);
-        depthSimMapOpt.save(_rc, StaticVector<int>() );
+        _depthSimMapOpt = new DepthSimMap(_rc, _sp->mp, 1, 1);
         return true;
     }
 


### PR DESCRIPTION
## Description

Fix https://github.com/alicevision/meshroom/issues/409
A bug on depth map computation has been introduced in AliceVision-2.1.0 release (corresponding to Meshroom-2019.1).
This problem only happens when badly connected cameras have been reconstructed in the SfM.

## Implementation remarks

The function "refinerc" do not deal with files anymore. The file manipulation has been moved to a more high-level function. Unfortunately, one early-exit condition has not been updated during this refactoring. This PR fixes this mistake.
