### PR TITLE
BundleAdjustmentCeres should #include alicevision_omp.hpp

### DIFF
--- a/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <aliceVision/types.hpp>
+#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/sfm/BundleAdjustment.hpp>
 #include <aliceVision/sfm/LocalBundleAdjustmentGraph.hpp>
 


### PR DESCRIPTION
## Description

Without this change, on a platform without OpenMP (and `ALICEVISION_USE_OPENMP` set to `OFF`), I get the compilation error:
```
In file included from /tmp/alicevision-20190320-90096-e7um3x/AliceVision-2.1.0/src/aliceVision/sfm/sfm.hpp:15:
/tmp/alicevision-20190320-90096-e7um3x/AliceVision-2.1.0/src/aliceVision/sfm/BundleAdjustmentCeres.hpp:35:35: error: use of undeclared identifier 'omp_get_max_threads'
      , nbThreads(multithreaded ? omp_get_max_threads() : 1) // set number of threads, 1 if OpenMP is not enabled
                                  ^
```