### PR TITLE
[depthMap] add missing dependencies to sfmData/sfmDataIO modules

### DIFF
--- a/src/aliceVision/depthMap/CMakeLists.txt
+++ b/src/aliceVision/depthMap/CMakeLists.txt
@@ -74,6 +74,8 @@ alicevision_add_library(aliceVision_depthMap
     ${CUDA_CUBLAS_LIBRARIES} #TODO shouldn't be here, but required to build on some machines
   PRIVATE_LINKS
     aliceVision_gpu
+    aliceVision_sfmData
+    aliceVision_sfmDataIO
   PUBLIC_INCLUDE_DIRS
     ${CUDA_INCLUDE_DIRS}
 )

--- a/src/aliceVision/mvsUtils/CMakeLists.txt
+++ b/src/aliceVision/mvsUtils/CMakeLists.txt
@@ -20,6 +20,7 @@ alicevision_add_library(aliceVision_mvsUtils
     aliceVision_numeric
     aliceVision_multiview
     aliceVision_mvsData
+    aliceVision_sfmData
     aliceVision_imageIO
   PRIVATE_LINKS
     aliceVision_system


### PR DESCRIPTION
Add missing dependencies in  `depthMap` module.
## Features list
- [x] [build] fix link error 