### PR TITLE
Fix LocalBA intrinsics edges management

### DIFF
--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(matchingImageCollection_centerMatrix)
 BOOST_AUTO_TEST_CASE(matchingImageCollection_similarityEstimation)
 {
   // same point should give the identity matrix
-  const feature::SIOPointFeature feat1 {1.0, 5.0, 1, 0.1};
+  const feature::SIOPointFeature feat1 {1.0f, 5.0f, 1.0f, 0.1f};
   Mat3 S;
   matchingImageCollection::computeSimilarity(feat1, feat1, S);
 

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -743,5 +743,21 @@ std::size_t LocalBundleAdjustmentGraph::updateRigEdgesToTheGraph(const sfmData::
   return numAddedEdges;
 }
 
+unsigned int LocalBundleAdjustmentGraph::countNodes() const
+{
+  unsigned int count = 0;
+  for(lemon::ListGraph::NodeIt n(_graph); n != lemon::INVALID; ++n)
+    ++count;
+  return count;
+}
+
+unsigned int LocalBundleAdjustmentGraph::countEdges() const
+{
+  unsigned int count = 0;
+  for(lemon::ListGraph::EdgeIt e(_graph); e != lemon::INVALID; ++e)
+    ++count;
+  return count;
+}
+
 } // namespace sfm
 } // namespace aliceVision

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -164,7 +164,7 @@ bool LocalBundleAdjustmentGraph::removeViews(const sfmData::SfMData& sfmData, co
     
     _graph.erase(it->second); // this function erase a node with its incident arcs
     _viewIdPerNode.erase(it->second);
-    _nodePerViewId.erase(it->first);
+    _nodePerViewId.erase(it->first); // warning: invalidates the iterator "it", so it can not be used after this line
 
     ++numRemovedNode;
     ALICEVISION_LOG_DEBUG("The view #" << viewId << " has been successfully removed to the distance graph.");
@@ -655,12 +655,15 @@ std::size_t LocalBundleAdjustmentGraph::addIntrinsicEdgesToTheGraph(const sfmDat
     if(isFocalLengthConstant(newViewIntrinsicId)) // do not add edges for a constant intrinsic
       continue;
 
-    for(const auto& x : _nodePerViewId) // for each reconstructed view in the graph
+    // for each reconstructed view in the graph
+    // warning: at this point, "_nodePerViewId" already contains the "newReconstructedViews"
+    for(const auto& x : _nodePerViewId)
     {
       const auto& otherViewId = x.first;
 
       // if the new view share the same intrinsic than previously reconstructed views
-      if(newViewId != otherViewId  // do not compare a view with itself
+      // note: do not compare a view with itself (must be tested since "_nodePerViewId" contains "newReconstructedViews")
+      if(newViewId != otherViewId
          && newViewIntrinsicId == sfmData.getViews().at(otherViewId)->getIntrinsicId())
       {
         // register a new intrinsic edge between those views

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -140,9 +140,9 @@ bool LocalBundleAdjustmentGraph::removeViewsToTheGraph(const std::set<IndexT>& r
     auto it = _nodePerViewId.find(viewId);
     if(it != _nodePerViewId.end())
     {
-      _graph.erase(it->second); // this function erase a node with its incident arcs
-      _nodePerViewId.erase(it->first);
-      _viewIdPerNode.erase(it->second);
+    _graph.erase(it->second); // this function erase a node with its incident arcs
+    _viewIdPerNode.erase(it->second);
+    _nodePerViewId.erase(it->first);
 
       numRemovedNode++;
       ALICEVISION_LOG_DEBUG("The view #" << viewId << " has been successfully removed to the distance graph.");

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -140,7 +140,7 @@ bool LocalBundleAdjustmentGraph::removeViews(const sfmData::SfMData& sfmData, co
 
   for(const IndexT& viewId : removedViewsId)
   {
-    auto it = _nodePerViewId.find(viewId);
+    const auto it = _nodePerViewId.find(viewId);
     if(it == _nodePerViewId.end())
     {
       ALICEVISION_LOG_WARNING("The view id: " << viewId << " does not exist in the graph, cannot remove it.");
@@ -150,8 +150,8 @@ bool LocalBundleAdjustmentGraph::removeViews(const sfmData::SfMData& sfmData, co
     // keep track of node incident edges that are going to be removed
     // in order to update _intrinsicEdgesId accordingly
     { 
-      IndexT intrinsicId = sfmData.getView(viewId).getIntrinsicId();
-      auto intrinsicIt = _intrinsicEdgesId.find(intrinsicId);
+      const IndexT intrinsicId = sfmData.getView(viewId).getIntrinsicId();
+      const auto intrinsicIt = _intrinsicEdgesId.find(intrinsicId);
       if(intrinsicIt != _intrinsicEdgesId.end())
       {
         // store incident edge ids before removal
@@ -166,7 +166,7 @@ bool LocalBundleAdjustmentGraph::removeViews(const sfmData::SfMData& sfmData, co
     _viewIdPerNode.erase(it->second);
     _nodePerViewId.erase(it->first);
 
-    numRemovedNode++;
+    ++numRemovedNode;
     ALICEVISION_LOG_DEBUG("The view #" << viewId << " has been successfully removed to the distance graph.");
   }
 
@@ -673,7 +673,7 @@ std::size_t LocalBundleAdjustmentGraph::addIntrinsicEdgesToTheGraph(const sfmDat
   // and update _intrinsicEdgesId accordingly
   for(const auto& newEdge : newIntrinsicEdges)
   {
-    lemon::ListGraph::Edge edge = _graph.addEdge(_nodePerViewId[newEdge.first.first], _nodePerViewId[newEdge.first.second]);
+    const lemon::ListGraph::Edge edge = _graph.addEdge(_nodePerViewId[newEdge.first.first], _nodePerViewId[newEdge.first.second]);
     _intrinsicEdgesId[newEdge.second].push_back(_graph.id(edge));
   }
   return newIntrinsicEdges.size();
@@ -683,7 +683,7 @@ void LocalBundleAdjustmentGraph::removeIntrinsicEdgesFromTheGraph(IndexT intrins
 {
   if(_intrinsicEdgesId.count(intrinsicId) == 0)
     return;
-  for(int edgeId : _intrinsicEdgesId.at(intrinsicId))
+  for(const int edgeId : _intrinsicEdgesId.at(intrinsicId))
   {
     const auto& edge = _graph.edgeFromId(edgeId);
     assert(_graph.valid(edge));
@@ -700,7 +700,7 @@ std::size_t LocalBundleAdjustmentGraph::updateRigEdgesToTheGraph(const sfmData::
   // remove all rig edges
   for(auto& edgesPerRid: _rigEdgesId)
   {
-    for(int edgeId : edgesPerRid.second)
+    for(const int edgeId : edgesPerRid.second)
     {
       const auto& edge = _graph.edgeFromId(edgeId);
       assert(_graph.valid(edge));

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -682,8 +682,11 @@ void LocalBundleAdjustmentGraph::removeIntrinsicEdgesFromTheGraph(IndexT intrins
   if(_intrinsicEdgesId.count(intrinsicId) == 0)
     return;
   for(int edgeId : _intrinsicEdgesId.at(intrinsicId))
-    _graph.erase(_graph.fromId(edgeId, lemon::ListGraph::Edge()));
-
+  {
+    const auto& edge = _graph.edgeFromId(edgeId);
+    assert(_graph.valid(edge));
+    _graph.erase(edge);
+  }
   _intrinsicEdgesId.erase(intrinsicId);
 }
 
@@ -697,7 +700,9 @@ std::size_t LocalBundleAdjustmentGraph::updateRigEdgesToTheGraph(const sfmData::
   {
     for(int edgeId : edgesPerRid.second)
     {
-      _graph.erase(_graph.fromId(edgeId, lemon::ListGraph::Edge()));
+      const auto& edge = _graph.edgeFromId(edgeId);
+      assert(_graph.valid(edge));
+      _graph.erase(edge);
     }
   }
   _rigEdgesId.clear();

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
@@ -149,7 +149,7 @@ public:
    * @param[in] removedViewsId Set of views index to remove
    * @return true if the number of removed node is equal to the size of \c removedViewsId
    */
-  bool removeViewsToTheGraph(const std::set<IndexT>& removedViewsId);
+  bool removeViews(const sfmData::SfMData& sfmData, const std::set<IndexT>& removedViewsId);
 
   /**
    * @brief Complete the graph with the newly resected views or all the posed views if the graph is empty.

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
@@ -145,7 +145,9 @@ public:
   void exportIntrinsicsHistory(const std::string& folder, const std::string& filename);
 
   /**
-   * @brief Remove some views to the graph. It delete the node and all the incident edges for each removed view.
+   * @brief Remove specific views from the LocalBA graph. 
+   * @details Delete the nodes corresponding to those views and all their incident edges.
+   * @param[in] sfmData contains all the information about the reconstruction
    * @param[in] removedViewsId Set of views index to remove
    * @return true if the number of removed node is equal to the size of \c removedViewsId
    */

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
@@ -200,7 +200,19 @@ public:
    * @return
    */
   std::size_t updateRigEdgesToTheGraph(const sfmData::SfMData& sfmData);
-   
+
+  /**
+   * @brief Count and return the number of nodes in the underlying lemon graph.
+   * @return The number of nodes in the graph.
+   */
+  unsigned int countNodes() const;
+
+  /**
+   * @brief Count and return the number of edges in the underlying lemon graph.
+   * @return The number of edges in the graph.
+   */
+  unsigned int countEdges() const;
+
 private:
   
   /**

--- a/src/aliceVision/sfm/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundleAdjustment_test.cpp
@@ -208,6 +208,9 @@ BOOST_AUTO_TEST_CASE(LOCAL_BUNDLE_ADJUSTMENT_EffectiveMinimization_Pinhole_Camer
   // 3. Use the graph-distances to assign a LBA state (Refine, Constant & Ignore) for each parameter (poses, intrinsics & landmarks)
   localBAGraph->convertDistancesToStates(sfmData);
 
+  BOOST_CHECK_EQUAL(localBAGraph->countNodes(), 4); // 4 views => 4 nodes
+  BOOST_CHECK_EQUAL(localBAGraph->countEdges(), 6); // landmarks connections: 6 edges created (see scheme)
+
   BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(BundleAdjustment::EParameterState::REFINED), 2);     // v0 & v1
   BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(BundleAdjustment::EParameterState::CONSTANT), 1);    // v2
   BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(BundleAdjustment::EParameterState::IGNORED), 1);     // v3

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -695,9 +695,9 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
 
     if(_params.useLocalBundleAdjustment && !removedViewsIdIteration.empty())
     {
-      // remove removed views to the graph
-      _localStrategyGraph->removeViewsToTheGraph(removedViewsIdIteration);
-      ALICEVISION_LOG_DEBUG("Removed views to the local strategy graph: " << removedViewsIdIteration);
+      // remove views from localBA graph
+      _localStrategyGraph->removeViews(_sfmData, removedViewsIdIteration);
+      ALICEVISION_LOG_DEBUG("Removed views from local strategy graph: " << removedViewsIdIteration);
     }
 
     ALICEVISION_LOG_INFO("Bundle adjustment iteration: " << iteration << " took " << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - chronoItStart).count() << " msec.");

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -697,7 +697,7 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
     {
       // remove views from localBA graph
       _localStrategyGraph->removeViews(_sfmData, removedViewsIdIteration);
-      ALICEVISION_LOG_DEBUG("Removed views from local strategy graph: " << removedViewsIdIteration);
+      ALICEVISION_LOG_DEBUG("Views removed from the local BA graph: " << removedViewsIdIteration);
     }
 
     ALICEVISION_LOG_INFO("Bundle adjustment iteration: " << iteration << " took " << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - chronoItStart).count() << " msec.");


### PR DESCRIPTION
## Description
This PR fixes management of intrinsics related connections in the local bundle adjustment graph which could lead to removal of wrong edges and potential corruption of the graph. This could end up with the SfM going in an infinite loop and/or undefined behavior.

## Features list
- [X] Update internal map `_intrinsicEdgesId` when a view is removed from the graph
- [X] Don't duplicate connections between new poses when adding them to the graph
- [X] Add `LocalBundleAdjustmentGraph::countEdges/countNodes` methods

## Implementation details
Internal data structure containing edge IDs by intrinsic (`_intrinsicEdgesId`) is now properly updated to match changes in the underlying lemon graph when a view is removed from it. This avoids removing wrong edges (leading to potential corruption of the graph) when locking an intrinsics.


