### PR TITLE
Correction to manufacturer

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3485,6 +3485,9 @@ Noa;Noa N8;4.73;devicespecifications
 Nokia;Nokia 220;2.83;devicespecifications
 Nokia;Nokia 225;2.83;devicespecifications
 Nokia;Nokia 225 Dual SIM;2.83;devicespecifications
+Nokia;Nokia 3;3.67;devicespecifications
+Nokia;Nokia 6;4.74;devicespecifications
+Nokia;Nokia 7 plus;5.75;devicespecifications
 HMD Global;Nokia 3;3.67;devicespecifications
 HMD Global;Nokia 6;4.74;devicespecifications
 HMD Global;Nokia 7 plus;5.75;devicespecifications

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3485,9 +3485,9 @@ Noa;Noa N8;4.73;devicespecifications
 Nokia;Nokia 220;2.83;devicespecifications
 Nokia;Nokia 225;2.83;devicespecifications
 Nokia;Nokia 225 Dual SIM;2.83;devicespecifications
-Nokia;Nokia 3;3.67;devicespecifications
-Nokia;Nokia 6;4.74;devicespecifications
-Nokia;Nokia 7 plus;5.75;devicespecifications
+HMD Global;Nokia 3;3.67;devicespecifications
+HMD Global;Nokia 6;4.74;devicespecifications
+HMD Global;Nokia 7 plus;5.75;devicespecifications
 Nokia;Nokia 808 PureView;10.67;devicespecifications
 Nokia;Nokia Asha 502;3.67;devicespecifications
 Nokia;Nokia Lumia 1020;8.8;devicespecifications


### PR DESCRIPTION
Corrected the make of following models -> Nokia; Nokia 7 plus/6/3 to HMD Global; Nokia 7 plus/6/3

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md). [X]
 - I have updated the documentation, if applicable. 
 - I have ensured that the change is tested somewhere. [X]
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance). [X]

-->
## Description

Meshroom shows a warning telling to add HMD Global; Nokia 7 plus/6/3 lens widths to the database, fixed by changing the make of refrenced models to HMD Global.

=====================================================================