### PR TITLE
FeatureMatching: Prefix output matches files when using "ranges" to avoid overwrites

### DIFF
--- a/src/aliceVision/matching/io.cpp
+++ b/src/aliceVision/matching/io.cpp
@@ -234,7 +234,12 @@ bool Load(
   std::size_t nbLoadedMatchFiles = 0;
   const std::string pattern = "matches.txt";
 
-  for(const std::string& folder : folders)
+  // build up a set with normalized paths to remove duplicates
+  std::set<std::string> foldersSet;
+  for(const auto& folder : folders)
+    foldersSet.insert(fs::canonical(folder).string());
+
+  for(const auto& folder : foldersSet)
   {
     nbLoadedMatchFiles += LoadMatchesFromFolder(matches, folder, pattern);
   }

--- a/src/aliceVision/matching/io.cpp
+++ b/src/aliceVision/matching/io.cpp
@@ -171,19 +171,22 @@ std::size_t LoadMatchFilePerImage(
   return nbLoadedMatchFiles;
 }
 
-std::size_t LoadMatchesFromFolder(
-  PairwiseMatches& matches, 
-  const std::string& folder, 
-  const std::string& pattern)
+/**
+ * Load and add pair-wise matches to \p matches from all files in \p folder matching \p pattern.
+ * @param[out] matches PairwiseMatches to add loaded matches to
+ * @param[in] folder Folder to load matches files from
+ * @param[in] pattern Pattern that files must respect to be loaded
+ */
+std::size_t loadMatchesFromFolder(PairwiseMatches& matches, const std::string& folder, const std::string& pattern)
 {
   std::size_t nbLoadedMatchFiles = 0;
   std::vector<std::string> matchFiles;
   // list all matches files in 'folder' matching (i.e containing) 'pattern'
-  for(auto& entry : boost::make_iterator_range(fs::directory_iterator(folder), {}))
+  for(const auto& entry : boost::make_iterator_range(fs::directory_iterator(folder), {}))
   {
     if(entry.path().string().find(pattern) != std::string::npos)
     {
-      matchFiles.emplace_back(entry.path().string());
+      matchFiles.push_back(entry.path().string());
     }
   }
 
@@ -241,7 +244,7 @@ bool Load(
 
   for(const auto& folder : foldersSet)
   {
-    nbLoadedMatchFiles += LoadMatchesFromFolder(matches, folder, pattern);
+    nbLoadedMatchFiles += loadMatchesFromFolder(matches, folder, pattern);
   }
 
   if(!nbLoadedMatchFiles)

--- a/src/aliceVision/matching/io.hpp
+++ b/src/aliceVision/matching/io.hpp
@@ -75,12 +75,14 @@ void filterTopMatches(
  * @param[in] extension: txt or bin file format
  * @param[in] matchFilePerImage: do we store a global match file
  *            or one match file per image
+ * @param[in] prefix: optional prefix for the output file(s)
  */
 bool Save(
   const PairwiseMatches& matches,
   const std::string& folder,
   const std::string& extension,
-  bool matchFilePerImage);
+  bool matchFilePerImage,
+  const std::string& prefix="");
 
 }  // namespace matching
 }  // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -84,7 +84,12 @@ std::unique_ptr<feature::Regions> loadFeatures(const std::vector<std::string>& f
 
   std::string featFilename;
 
-  for(const std::string& folder : folders)
+  // build up a set with normalized paths to remove duplicates
+  std::set<std::string> foldersSet;
+  for(const auto& folder : folders)
+    foldersSet.insert(fs::canonical(folder).string());
+
+  for(const auto& folder : foldersSet)
   {
     const fs::path featPath = fs::path(folder) / std::string(basename + "." + imageDescriberTypeName + ".feat");
     if(fs::exists(featPath))

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -30,3 +30,9 @@ alicevision_add_library(aliceVision_sfmData
 )
 
 # Unit tests
+
+alicevision_add_test(sfmData_test.cpp
+  NAME "sfmData"
+  LINKS aliceVision_sfmData
+        aliceVision_system
+)

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -298,49 +298,74 @@ public:
   }
 
   /**
-   * @brief Add the given features Folder
-   * @param[in] featuresFolder The given features folder
+   * @brief Add the given \p folder to features folders.
+   * @note If SfmData's absolutePath has been set, 
+   *       an absolute path will be converted to a relative one.
+   * @param[in] folder path to a folder containing features
    */
-  void addFeaturesFolder(const std::string& featuresFolder)
+  inline void addFeaturesFolder(const std::string& folder)
   {
-    _featuresFolders.emplace_back(featuresFolder);
+    addFeaturesFolders({folder});
   }
 
   /**
-   * @brief A the given matches Folder
-   * @param[in] matchesFolder The given mathes folder
+   * @brief Add the given \p folders to features folders.
+   * @note If SfmData's absolutePath has been set, 
+   *       absolute paths will be converted to relative ones.
+   * @param[in] folders paths to folders containing features
    */
-  void addMatchesFolder(const std::string& matchesFolder)
+  void addFeaturesFolders(const std::vector<std::string>& folders);
+
+  /**
+   * @brief Add the given \p folder to matches folders.
+   * @note If SfmData's absolutePath has been set, 
+   *       an absolute path will be converted to a relative one.
+   * @param[in] folder path to a folder containing matches
+   */
+  inline void addMatchesFolder(const std::string& folder)
   {
-    _matchesFolders.emplace_back(matchesFolder);
+    addMatchesFolders({folder});
   }
 
   /**
-   * @brief Set the given features folders
-   * @param[in] featuresFolders The given features folders
+   * @brief Add the given \p folders to matches folders.
+   * @note If SfmData's absolutePath has been set, 
+   *       absolute paths will be converted to relative ones.
+   * @param[in] folders paths to folders containing matches
    */
-  void setFeaturesFolders(const std::vector<std::string>& featuresFolders)
+  void addMatchesFolders(const std::vector<std::string>& folders);
+
+  /**
+   * @brief Replace the current features folders by the given ones.
+   * @note If SfmData's absolutePath has been set, 
+   *       absolute paths will be converted to relative ones.
+   * @param[in] folders paths to folders containing features
+   */
+  inline void setFeaturesFolders(const std::vector<std::string>& folders)
   {
-    _featuresFolders = featuresFolders;
+    _featuresFolders.clear();
+    addFeaturesFolders(folders);
   }
 
   /**
-   * @brief Set the given mathes folders
-   * @param[in] matchesFolders The given mathes folders
+   * @brief Replace the current matches folders by the given ones.
+   * @note If SfmData's absolutePath has been set, 
+   *       absolute paths will be converted to relative ones.
+   * @param[in] folders paths to folders containing matches
    */
-  void setMatchesFolders(const std::vector<std::string>& matchesFolders)
+  inline void setMatchesFolders(const std::vector<std::string>& folders)
   {
-    _matchesFolders = matchesFolders;
+    _matchesFolders.clear();
+    addMatchesFolders(folders);
   }
 
   /**
-   * @brief Set the SfMData file folder absolute path
+   * @brief Set the SfMData file absolute path.
+   * @note Internal relative features/matches folders will be remapped 
+   *       to be relative to the new absolute \p path.
    * @param[in] path The absolute path to the SfMData file folder
    */
-  void setAbsolutePath(const std::string& path)
-  {
-    _absolutePath = path;
-  }
+  void setAbsolutePath(const std::string& path);
 
   /**
    * @brief Set the given pose for the given view

--- a/src/aliceVision/sfmData/sfmData_test.cpp
+++ b/src/aliceVision/sfmData/sfmData_test.cpp
@@ -1,0 +1,52 @@
+
+#include <boost/filesystem.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+
+#define BOOST_TEST_MODULE sfmData
+#include <boost/test/included/unit_test.hpp>
+
+using namespace aliceVision;
+namespace fs = boost::filesystem;
+
+BOOST_AUTO_TEST_CASE(SfMData_InternalFolders)
+{
+  const std::string filename = "InternalFolders.sfm";
+  sfmData::SfMData sfmData;
+
+  // add relative features/matches folders with duplicates
+  std::string refFolder("..");
+  sfmData.addFeaturesFolders({refFolder, refFolder});
+  sfmData.addMatchesFolders({refFolder, refFolder});
+  auto featuresFolders = sfmData.getFeaturesFolders();
+  auto matchesFolders = sfmData.getMatchesFolders();
+  // ensure duplicates were removed
+  BOOST_CHECK_EQUAL(featuresFolders.size(), 1);
+  BOOST_CHECK_EQUAL(matchesFolders.size(), 1);
+  // sfmData has no absolute path set, folders are still in relative form
+  BOOST_CHECK_EQUAL(featuresFolders[0], refFolder);
+  BOOST_CHECK_EQUAL(matchesFolders[0], refFolder);
+
+  // set absolutePath to current filename
+  sfmData.setAbsolutePath(fs::absolute(filename).string());
+  featuresFolders = sfmData.getFeaturesFolders();
+  matchesFolders = sfmData.getMatchesFolders();
+  // internal folders were kept...
+  BOOST_CHECK_EQUAL(featuresFolders.size(), 1);
+  BOOST_CHECK_EQUAL(matchesFolders.size(), 1);
+  // ... and are now absolute paths
+  BOOST_CHECK(fs::path(featuresFolders[0]).is_absolute());
+  BOOST_CHECK(fs::equivalent(featuresFolders[0], refFolder));
+  BOOST_CHECK(fs::path(matchesFolders[0]).is_absolute());
+  BOOST_CHECK(fs::equivalent(matchesFolders[0], refFolder));
+
+  // update sfm absolute path to be in parent/parent folder
+  fs::path otherFolder = fs::path("../..");
+  std::string updatedFilename = ( otherFolder / filename).string();
+  sfmData.setAbsolutePath(updatedFilename);
+  // internal folders still reference the same folder as before
+  BOOST_CHECK(fs::equivalent(featuresFolders[0], refFolder));
+  BOOST_CHECK(fs::equivalent(matchesFolders[0], refFolder));
+  BOOST_CHECK_EQUAL(sfmData.getRelativeFeaturesFolders()[0], fs::relative(refFolder, otherFolder));
+  BOOST_CHECK_EQUAL(sfmData.getRelativeMatchesFolders()[0], fs::relative(refFolder, otherFolder));
+}
+

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
   bool savePutativeMatches = false;
   bool guidedMatching = false;
   int maxIteration = 2048;
-  bool matchFilePerImage = true;
+  bool matchFilePerImage = false;
   size_t numMatchesToKeep = 0;
   bool useGridSort = true;
   bool exportDebugFiles = false;

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -39,7 +39,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -340,6 +340,11 @@ int main(int argc, char **argv)
     }
   }
 
+  // when a range is specified, generate a file prefix to reflect the current iteration (rangeStart/rangeSize)
+  // => with matchFilePerImage: avoids overwriting files if a view is present in several iterations
+  // => without matchFilePerImage: avoids overwriting the unique resulting file
+  const std::string filePrefix = rangeSize > 0 ? std::to_string(rangeStart/rangeSize) + "." : "";
+
   ALICEVISION_LOG_INFO(std::to_string(mapPutativesMatches.size()) << " putative image pair matches");
 
   for(const auto& imageMatch: mapPutativesMatches)
@@ -347,7 +352,7 @@ int main(int argc, char **argv)
 
   // export putative matches
   if(savePutativeMatches)
-    Save(mapPutativesMatches, (fs::path(matchesFolder) / "putativeMatches").string(), fileExtension, matchFilePerImage);
+    Save(mapPutativesMatches, (fs::path(matchesFolder) / "putativeMatches").string(), fileExtension, matchFilePerImage, filePrefix);
 
   ALICEVISION_LOG_INFO("Task (Regions Matching) done in (s): " + std::to_string(timer.elapsed()));
 
@@ -522,7 +527,7 @@ int main(int argc, char **argv)
 
   // export geometric filtered matches
   ALICEVISION_LOG_INFO("Save geometric matches.");
-  Save(finalMatches, matchesFolder, fileExtension, matchFilePerImage);
+  Save(finalMatches, matchesFolder, fileExtension, matchFilePerImage, filePrefix);
   ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
 
   // d. Export some statistics

--- a/src/software/pipeline/main_globalSfM.cpp
+++ b/src/software/pipeline/main_globalSfM.cpp
@@ -206,12 +206,8 @@ int main(int argc, char **argv)
 
   // set featuresFolders and matchesFolders relative paths
   {
-    for(const std::string& featuresFolder : featuresFolders)
-       sfmEngine.getSfMData().addFeaturesFolder(fs::relative(fs::path(featuresFolder), outDirectory).string());
-
-    for(const std::string& matchesFolder : matchesFolders)
-       sfmEngine.getSfMData().addMatchesFolder(fs::relative(fs::path(matchesFolder), outDirectory).string());
-
+    sfmEngine.getSfMData().addFeaturesFolders(featuresFolders);
+    sfmEngine.getSfMData().addMatchesFolders(matchesFolders);
     sfmEngine.getSfMData().setAbsolutePath(outDirectory);
   }
 

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -303,14 +303,8 @@ int main(int argc, char **argv)
 
   // set featuresFolders and matchesFolders relative paths
   {
-    const fs::path sfmFolder = fs::path(outputSfM).remove_filename();
-
-    for(const std::string& featuresFolder : featuresFolders)
-       sfmEngine.getSfMData().addFeaturesFolder(fs::relative(fs::path(featuresFolder), sfmFolder).string());
-
-    for(const std::string& matchesFolder : matchesFolders)
-       sfmEngine.getSfMData().addMatchesFolder(fs::relative(fs::path(matchesFolder), sfmFolder).string());
-
+    sfmEngine.getSfMData().addFeaturesFolders(featuresFolders);
+    sfmEngine.getSfMData().addMatchesFolders(matchesFolders);
     sfmEngine.getSfMData().setAbsolutePath(outputSfM);
   }
 


### PR DESCRIPTION
## Description
Introduce an automatic prefix system for matches files when using "range" command-line parameters. The goal of this PR is to ensure a file created for one iteration does not get overwritten in another one.

When generating matches files per image, we rely on minimal viewId of each image pair to create the filename (minViewId.txt). By iterating over sorted viewIds which only match with greater viewIds, this guarantees that files are written only once. 
However, the latter condition can be broken in the current pipeline when the file generated by the ImageMatching step declares for one view [B] a match with a view [A] that has an inferior viewId. This occurs when [A] has reached max view matches; the [A,B] view match is moved to [B]. If [A] and [B] are handled in two distinct iterations (1) and (2), "A.txt" will be first written in (1) and overwritten in (2). All matches from (1) are then lost.

By automatically prefixing matches files based on "range" parameters and generating only one matches file per execution by default, this guarantees uniqueness of generated files. 
This also changes the loading of matches files, which will now consider all "*matches.txt" files in the given folder. This behavior is retro-compatible with previously generated files.

## Features list

- [X] FeatureMatching: Generate a prefix for matches files based on range parameter
- [X] FeatureMatching: Generate only one matches file per execution by default
- [X] IO: Load all '*.matches.txt" file in given folder and accumulate matches
- [X] IO: Update IndMatch_IO test
- [X] IO: Remove duplicated input folders when loading matches/features
- [x] SfmData: manage features/matches folders internally (relative paths, duplicates removal...)

## Implementation remarks
Prefix is created by dividing rangeStart/rangeSize which reflects the iteration number when working by chunks. This is preferred to random naming for debug purposes.
