### PR TITLE
AKAZE: sort keypoints by size before grid filtering

### DIFF
--- a/src/aliceVision/feature/akaze/AKAZE.cpp
+++ b/src/aliceVision/feature/akaze/AKAZE.cpp
@@ -373,6 +373,11 @@ void AKAZE::gridFiltering(std::vector<AKAZEKeypoint>& keypoints) const
   if(keypoints.size() <= _options.maxTotalKeypoints)
     return;
 
+  // sort keypoints by size to guarantee best points are kept
+  // note: reordering keypoints also helps preventing grid-filtering from creating a 
+  //       non-uniform distribution within cells when input keypoints are sorted by spatial coordinates
+  std::sort(keypoints.begin(), keypoints.end(), [](const AKAZEKeypoint& a, const AKAZEKeypoint& b){ return a.size > b.size; });
+
   std::vector<AKAZEKeypoint> out_keypoints;
   out_keypoints.reserve(keypoints.size());
 


### PR DESCRIPTION
## Description
Sort keypoints by size to guarantee best points are kept. Reordering keypoints also helps preventing grid-filtering from creating a non-uniform distribution within cells when input keypoints are sorted by spatial coordinates.
**Before**
![current](https://user-images.githubusercontent.com/1674646/57716268-e4e6e100-7678-11e9-8d5b-5687d5336b16.png)
**After**
![fixed](https://user-images.githubusercontent.com/1674646/57716290-ef08df80-7678-11e9-9fac-70ed1866e922.png)

## Features list

- [X] Improve AKAZE grid filtering


