### PR TITLE
[software] exportColoredPointCloud: remove uneeded dependency to 'mesh'

### DIFF
--- a/src/software/export/CMakeLists.txt
+++ b/src/software/export/CMakeLists.txt
@@ -74,7 +74,6 @@ alicevision_add_software(aliceVision_exportColoredPointCloud
         aliceVision_feature
         aliceVision_sfmData
         aliceVision_sfmDataIO
-        aliceVision_mesh
         ${Boost_LIBRARIES}
 )
 


### PR DESCRIPTION
## Description
Remove uneeded `exportColoredPointCloud` dependency to `aliceVision_mesh`
Fix SfM build without the MVS part.