### PR TITLE
[sfmDataIO] Alembic: use XForms instead of untyped objects for root n…

### DIFF
--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -31,11 +31,11 @@ struct AlembicExporter::DataImpl
     , _topObj(_archive, Alembic::Abc::kTop)
   {
   // create MVG hierarchy
-    _mvgRoot = Alembic::Abc::OObject(_topObj, "mvgRoot");
-    _mvgCameras = Alembic::Abc::OObject(_mvgRoot, "mvgCameras");
-    _mvgCamerasUndefined = Alembic::Abc::OObject(_mvgRoot, "mvgCamerasUndefined");
-    _mvgCloud = Alembic::Abc::OObject(_mvgRoot, "mvgCloud");
-    _mvgPointCloud = Alembic::Abc::OObject(_mvgCloud, "mvgPointCloud");
+    _mvgRoot = Alembic::AbcGeom::OXform(_topObj, "mvgRoot");
+    _mvgCameras = Alembic::AbcGeom::OXform(_mvgRoot, "mvgCameras");
+    _mvgCamerasUndefined = Alembic::AbcGeom::OXform(_mvgRoot, "mvgCamerasUndefined");
+    _mvgCloud = Alembic::AbcGeom::OXform(_mvgRoot, "mvgCloud");
+    _mvgPointCloud = Alembic::AbcGeom::OXform(_mvgCloud, "mvgPointCloud");
 
     // add version as custom property
     const std::vector<::uint32_t> abcVersion = {1, 1};
@@ -67,11 +67,11 @@ struct AlembicExporter::DataImpl
   
   Alembic::Abc::OArchive _archive;
   Alembic::Abc::OObject _topObj;
-  Alembic::Abc::OObject _mvgRoot;
-  Alembic::Abc::OObject _mvgCameras;
-  Alembic::Abc::OObject _mvgCamerasUndefined;
-  Alembic::Abc::OObject _mvgCloud;
-  Alembic::Abc::OObject _mvgPointCloud;
+  Alembic::AbcGeom::OXform _mvgRoot;
+  Alembic::AbcGeom::OXform _mvgCameras;
+  Alembic::AbcGeom::OXform _mvgCamerasUndefined;
+  Alembic::AbcGeom::OXform _mvgCloud;
+  Alembic::AbcGeom::OXform _mvgPointCloud;
   Alembic::AbcGeom::OXform _xform;
   Alembic::AbcGeom::OCamera _camObj;
   Alembic::AbcGeom::OUInt32ArrayProperty _propSensorSize_pix;


### PR DESCRIPTION
## Description
This PR makes root nodes of Alembic SfmData file XForms instead of untyped objects. This ensures better interoperability with other 3D graphics applications, because there is no standard way to handle Alembic nodes without type information.  This was, for example, resulting in potential crashes or incorrect hierarchies when importing our Alembic files into Blender. 
Using XForms guarantees that the generated Alembic file can be properly loaded into other applications, and with the correct hierarchy:

![image](https://user-images.githubusercontent.com/1674646/60888250-a7f13200-a256-11e9-8f87-711678a75b3c.png)
_Imported Alembic file in current Blender 2.8 beta after this fix_

Fix https://github.com/alicevision/meshroom/issues/170 https://github.com/alicevision/meshroom/issues/460

## Features list
- [X] [sfmDataIO] AlembicExporter: Make root nodes XForms instead of untyped objects

## Implementation remarks
This does not introduce compatibility issues: the AlembicImporter does not require root nodes to be untyped objects to parse an Alembic sfmData file.

