### PR TITLE
Vertex-colored meshes

### DIFF
--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -2353,9 +2353,9 @@ StaticVector<int>* Mesh::getLargestConnectedComponentTrisIds() const
 {
     StaticVector<StaticVector<int>*>* ptsNeighPtsOrdered = getPtsNeighPtsOrdered();
 
-    StaticVector<int>* colors = new StaticVector<int>();
-    colors->reserve(pts->size());
-    colors->resize_with(pts->size(), -1);
+    StaticVector<int>* colorLabels = new StaticVector<int>();
+    colorLabels->reserve(pts->size());
+    colorLabels->resize_with(pts->size(), -1);
     StaticVector<int>* buff = new StaticVector<int>();
     buff->reserve(pts->size());
     int col = 0;
@@ -2363,7 +2363,7 @@ StaticVector<int>* Mesh::getLargestConnectedComponentTrisIds() const
     int bestCol = -1;
     for(int i = 0; i < pts->size(); ++i)
     {
-        if((*colors)[i] != -1) // already labelled with a color id
+        if((*colorLabels)[i] != -1) // already labelled with a color id
             continue;
 
         buff->resize(0);
@@ -2372,16 +2372,16 @@ StaticVector<int>* Mesh::getLargestConnectedComponentTrisIds() const
         while(buff->size() > 0)
         {
             int ptid = buff->pop();
-            if((*colors)[ptid] == -1)
+            if((*colorLabels)[ptid] == -1)
             {
-                (*colors)[ptid] = col;
+                (*colorLabels)[ptid] = col;
                 ++nptsOfCol;
             }
             else
             {
-                if((*colors)[ptid] != col)
+                if((*colorLabels)[ptid] != col)
                 {
-                    delete colors;
+                    delete colorLabels;
                     delete buff;
                     deleteArrayOfArrays<int>(&ptsNeighPtsOrdered);
                     throw std::runtime_error("getLargestConnectedComponentTrisIds: bad condition.");
@@ -2390,7 +2390,7 @@ StaticVector<int>* Mesh::getLargestConnectedComponentTrisIds() const
             for(int j = 0; j < sizeOfStaticVector<int>((*ptsNeighPtsOrdered)[ptid]); ++j)
             {
                 int nptid = (*(*ptsNeighPtsOrdered)[ptid])[j];
-                if((nptid > -1) && ((*colors)[nptid] == -1))
+                if((nptid > -1) && ((*colorLabels)[nptid] == -1))
                 {
                     if(buff->size() >= buff->capacity()) // should not happen but no problem
                     {
@@ -2415,15 +2415,15 @@ StaticVector<int>* Mesh::getLargestConnectedComponentTrisIds() const
     for(int i = 0; i < tris->size(); i++)
     {
         if(((*tris)[i].alive) &&
-           ((*colors)[(*tris)[i].v[0]] == bestCol) &&
-           ((*colors)[(*tris)[i].v[1]] == bestCol) &&
-           ((*colors)[(*tris)[i].v[2]] == bestCol))
+           ((*colorLabels)[(*tris)[i].v[0]] == bestCol) &&
+           ((*colorLabels)[(*tris)[i].v[1]] == bestCol) &&
+           ((*colorLabels)[(*tris)[i].v[2]] == bestCol))
         {
             out->push_back(i);
         }
     }
 
-    delete colors;
+    delete colorLabels;
     delete buff;
     deleteArrayOfArrays<int>(&ptsNeighPtsOrdered);
 

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -1085,12 +1085,19 @@ Mesh* Mesh::generateMeshFromTrianglesSubset(const StaticVector<int>& visTris, St
 
     outMesh->pts = new StaticVector<Point3d>();
     outMesh->pts->reserve(j);
+    
+    // also update vertex color data if any
+    const bool updateColors = _colors.size() != 0;
+    auto& outColors = outMesh->colors();
+    outColors.reserve(_colors.size());
 
     for(int i = 0; i < pts->size(); i++)
     {
         if(newIndexPerInputPts[i] > -1)
         {
             outMesh->pts->push_back((*pts)[i]);
+            if(updateColors)
+                outColors.push_back(_colors[i]);
         }
     }
 
@@ -1394,6 +1401,7 @@ void Mesh::removeFreePointsFromMesh(StaticVector<int>** out_ptIdToNewPtId)
 
     std::swap(cleanedMesh->pts, pts);
     std::swap(cleanedMesh->tris, tris);
+    std::swap(cleanedMesh->_colors, _colors);
 
     delete cleanedMesh;
 }

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -28,6 +28,7 @@ Mesh::~Mesh()
 {
     delete pts;
     delete tris;
+    delete colors;
 }
 
 void Mesh::saveToObj(const std::string& filename)

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -105,7 +105,8 @@ public:
 public:
     StaticVector<Point3d>* pts = nullptr;
     StaticVector<Mesh::triangle>* tris = nullptr;
-    Matrix3x4 transformGlobal;
+    /// Per-vertex color data
+    StaticVector<rgb>* colors = nullptr;
 
     Mesh();
     ~Mesh();

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -102,11 +102,13 @@ public:
         }
     };
 
+protected:
+    /// Per-vertex color data
+    std::vector<rgb> _colors;
+
 public:
     StaticVector<Point3d>* pts = nullptr;
     StaticVector<Mesh::triangle>* tris = nullptr;
-    /// Per-vertex color data
-    StaticVector<rgb>* colors = nullptr;
 
     Mesh();
     ~Mesh();
@@ -120,6 +122,11 @@ public:
                           StaticVector<Voxel>& trisUvIds, std::string objAsciiFileName);
 
     void addMesh(Mesh* me);
+
+    /// Per-vertex color data const accessor
+    const std::vector<rgb>& colors() const { return _colors; }
+    /// Per-vertex color data accessor
+    std::vector<rgb>& colors() { return _colors; }
 
     StaticVector<StaticVector<int>*>* getTrisMap(const mvsUtils::MultiViewParams* mp, int rc, int scale, int w, int h);
     StaticVector<StaticVector<int>*>* getTrisMap(StaticVector<int>* visTris, const mvsUtils::MultiViewParams* mp, int rc, int scale,

--- a/src/aliceVision/mesh/MeshClean.cpp
+++ b/src/aliceVision/mesh/MeshClean.cpp
@@ -898,16 +898,15 @@ int MeshClean::cleanMesh()
         nWrongPts += static_cast<int>(pth.deployAll() > 0);
     }
     // update vertex color data (if any) if points were modified
-    if(colors != nullptr && newPtsOldPtId->size() != 0)
+    if(_colors.size() > 0 && newPtsOldPtId->size() != 0)
     {
-        StaticVector<rgb>* newColors = new StaticVector<rgb>(pts->size(), {0, 0, 0});
+        std::vector<rgb> newColors(pts->size(), {0, 0, 0});
         for(std::size_t newId = 0; newId < newPtsOldPtId->size(); ++newId)
         {
             const std::size_t oldId = (*newPtsOldPtId)[newId];
-            (*newColors)[newId] = (*colors)[oldId];
+            newColors[newId] = _colors[oldId];
         }
-        delete colors;
-        colors = newColors;
+        std::swap(_colors, newColors);
     }
 
     ALICEVISION_LOG_INFO("cleanMesh:" << std::endl

--- a/src/aliceVision/mesh/MeshClean.cpp
+++ b/src/aliceVision/mesh/MeshClean.cpp
@@ -897,6 +897,19 @@ int MeshClean::cleanMesh()
         path pth(this, i);
         nWrongPts += static_cast<int>(pth.deployAll() > 0);
     }
+    // update vertex color data (if any) if points were modified
+    if(colors != nullptr && newPtsOldPtId->size() != 0)
+    {
+        StaticVector<rgb>* newColors = new StaticVector<rgb>(pts->size(), {0, 0, 0});
+        for(std::size_t newId = 0; newId < newPtsOldPtId->size(); ++newId)
+        {
+            const std::size_t oldId = (*newPtsOldPtId)[newId];
+            (*newColors)[newId] = (*colors)[oldId];
+        }
+        delete colors;
+        colors = newColors;
+    }
+
     ALICEVISION_LOG_INFO("cleanMesh:" << std::endl
                       << "\t- # wrong points: " << nWrongPts << std::endl
                       << "\t- # new points: " << (pts->size() - nv));

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -148,6 +148,9 @@ int main(int argc, char* argv[])
         delete trisIdsToStay;
         ALICEVISION_LOG_INFO("Mesh after keepLargestMeshOnly: " << meOpt.pts->size() << " vertices and " << meOpt.tris->size() << " facets.");
     }
+    
+    // clear potential free points created by triangles removal in previous cleaning operations 
+    meOpt.removeFreePointsFromMesh();
 
     mesh::Mesh outMesh;
     outMesh.addMesh(&meOpt);

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -510,14 +510,15 @@ int main(int argc, char* argv[])
                     exportPointCloud(outputDensePointCloud, mp, sfmData, mesh->pts->getData(), *ptsCams, densePointCloud, verticesMapping);
 
                     const auto& landmarks = densePointCloud.getLandmarks();
-                    mesh->colors = new StaticVector<rgb>(mesh->pts->size(), {0, 0, 0});
+                    std::vector<rgb>& colors = mesh->colors();
+                    colors.resize(mesh->pts->size(), {0, 0, 0});
                     for(std::size_t vertexId = 0; vertexId < verticesMapping.size(); ++vertexId)
                     {
                       const auto landmarkId = verticesMapping[vertexId];
                       if(landmarkId != UndefinedIndexT)
                       {
                         const auto& c = landmarks.at(landmarkId).rgb;
-                        (*mesh->colors)[vertexId] = {c.r(), c.g(), c.b()};
+                        colors[vertexId] = {c.r(), c.g(), c.b()};
                       }
                     }
 

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -82,46 +82,51 @@ inline std::istream& operator>>(std::istream& in, ERepartitionMode& out_mode)
     return in;
 }
 
-void exportPointCloud(const std::string& path,
-                      const mvsUtils::MultiViewParams& mp,
-                      const sfmData::SfMData& sfmData,
-                      const std::vector<Point3d>& vertices,
-                      const StaticVector<StaticVector<int>*> cams,
-                      bool colorize,
-                      sfmData::SfMData& densePointCloud,
-                      std::vector<IndexT>& verticesMapping
+/// Create a dense SfMData based on reference \p sfmData, 
+/// using \p vertices as landmarks and \p ptCams as observations
+void createDenseSfMData(const sfmData::SfMData& sfmData,
+                        const mvsUtils::MultiViewParams& mp,
+                        const std::vector<Point3d>& vertices,
+                        const StaticVector<StaticVector<int>*>& ptsCams,
+                        sfmData::SfMData& outSfmData
 )
 {
-  densePointCloud = sfmData;
-  densePointCloud.getLandmarks().clear();
-  std::size_t outputIndex = 0;
-  verticesMapping.clear();
-  verticesMapping.resize(vertices.size(), UndefinedIndexT);
+  outSfmData = sfmData;
+  outSfmData.getLandmarks().clear();
 
   for(std::size_t i = 0; i < vertices.size(); ++i)
   {
     const Point3d& point = vertices.at(i);
-
-    if(!cams[i]->empty())
+    const Vec3 pt3D(point.x, point.y, point.z);
+    sfmData::Landmark landmark(pt3D, feature::EImageDescriberType::UNKNOWN);
+    // set landmark observations from ptsCams if any
+    if(!ptsCams[i]->empty())
     {
-      const Vec3 pt3D(point.x, point.y, point.z);
-      sfmData::Landmark landmark(pt3D, feature::EImageDescriberType::UNKNOWN);
-      for(int cam : *(cams[i]))
+      for(int cam : *(ptsCams[i]))
       {
         const sfmData::View& view = sfmData.getView(mp.getViewId(cam));
         const camera::IntrinsicBase* intrinsicPtr = sfmData.getIntrinsicPtr(view.getIntrinsicId());
         const sfmData::Observation observation(intrinsicPtr->project(sfmData.getPose(view).getTransform(), pt3D, true), UndefinedIndexT); // apply distortion
         landmark.observations[view.getViewId()] = observation;
       }
-      densePointCloud.getLandmarks()[outputIndex] = landmark;
-      verticesMapping[i] = outputIndex;
-      ++outputIndex;
     }
+    outSfmData.getLandmarks()[i] = landmark;
   }
-  if(colorize)
-    sfmData::colorizeTracks(densePointCloud);
-  sfmDataIO::Save(densePointCloud, path, sfmDataIO::ESfMData::ALL_DENSE);
 }
+
+/// Remove all landmarks without observations from \p sfmData.
+void removeLandmarksWithoutObservations(sfmData::SfMData& sfmData)
+{
+  auto& landmarks = sfmData.getLandmarks();
+  for(auto it = landmarks.begin(); it != landmarks.end();)
+  {
+    if(it->second.observations.empty())
+      it = landmarks.erase(it);
+    else
+      ++it;
+  }
+}
+
 
 int main(int argc, char* argv[])
 {
@@ -299,6 +304,9 @@ int main(int argc, char* argv[])
     ALICEVISION_LOG_WARNING("repartitionMode: " << repartitionMode);
     ALICEVISION_LOG_WARNING("partitioningMode: " << partitioningMode);
 
+    mesh::Mesh* mesh = nullptr;
+    StaticVector<StaticVector<int>*>* ptsCams = nullptr;
+
     switch(repartitionMode)
     {
         case eRepartitionRegularGrid:
@@ -326,26 +334,9 @@ int main(int argc, char* argv[])
                         saveArrayToFile<Point3d>(voxelsArrayFileName, voxelsArray);
                     }
                     fuseCut::reconstructSpaceAccordingToVoxelsArray(voxelsArrayFileName, &lsbase);
-                    // Join meshes
+                    // Join meshes and ptsCams
                     mesh::Mesh* mesh = fuseCut::joinMeshes(voxelsArrayFileName, &lsbase);
-
-                    if(mesh->pts->empty() || mesh->tris->empty())
-                      throw std::runtime_error("Empty mesh");
-
-                    ALICEVISION_LOG_INFO("Saving joined meshes...");
-
-                    fs::path spaceBinFileName = outDirectory/"denseReconstruction.bin";
-                    mesh->saveToBin(spaceBinFileName.string());
-
-                    // Export joined mesh to obj
-                    mesh->saveToObj(outputMesh);
-
-                    delete mesh;
-
-                    // Join ptsCams
-                    StaticVector<StaticVector<int>*>* ptsCams = fuseCut::loadLargeScalePtsCams(lsbase.getRecsDirs(voxelsArray));
-                    saveArrayOfArraysToFile<int>((outDirectory/"meshPtsCamsFromDGC.bin").string(), ptsCams);
-                    deleteArrayOfArrays<int>(&ptsCams);
+                    ptsCams = fuseCut::loadLargeScalePtsCams(lsbase.getRecsDirs(voxelsArray));
                     break;
                 }
                 case ePartitioningSingleBlock:
@@ -383,7 +374,6 @@ int main(int argc, char* argv[])
                     for(int i = 0; i < voxelNeighs.size(); ++i)
                         voxelNeighs[i] = i;
 
-                    fuseCut::DelaunayGraphCut delaunayGC(lsbase.mp);
                     Point3d* hexah = &lsbase.space[0];
 
                     StaticVector<int> cams;
@@ -401,27 +391,13 @@ int main(int argc, char* argv[])
                     if(cams.size() < 1)
                         throw std::logic_error("No camera to make the reconstruction");
 
+                    fuseCut::DelaunayGraphCut delaunayGC(&mp);
                     delaunayGC.createDensePointCloudFromPrecomputedDensePoints(hexah, cams, &voxelNeighs, (fuseCut::VoxelsGrid*)&rp);
                     delaunayGC.createGraphCut(hexah, cams, (fuseCut::VoxelsGrid*)&rp, outDirectory.string()+"/", lsbase.getSpaceCamsTracksDir(), false, lsbase.getSpaceSteps());
                     delaunayGC.graphCutPostProcessing();
-
-                    // Save mesh as .bin and .obj
-                    mesh::Mesh* mesh = delaunayGC.createMesh();
-                    if(mesh->pts->empty() || mesh->tris->empty())
-                      throw std::runtime_error("Empty mesh");
-
-                    StaticVector<StaticVector<int>*>* ptsCams = delaunayGC.createPtsCams();
-
-                    StaticVector<Point3d>* hexahsToExcludeFromResultingMesh = nullptr;
-                    mesh::meshPostProcessing(mesh, ptsCams, mp, outDirectory.string()+"/", hexahsToExcludeFromResultingMesh, hexah);
-                    mesh->saveToBin((outDirectory/"denseReconstruction.bin").string());
-
-                    saveArrayOfArraysToFile<int>((outDirectory/"meshPtsCamsFromDGC.bin").string(), ptsCams);
-                    deleteArrayOfArrays<int>(&ptsCams);
-
-                    mesh->saveToObj(outputMesh);
-
-                    delete mesh;
+                    mesh = delaunayGC.createMesh();
+                    ptsCams = delaunayGC.createPtsCams();
+                    mesh::meshPostProcessing(mesh, ptsCams, mp, outDirectory.string()+"/", nullptr, hexah);
                     break;
                 }
                 case ePartitioningUndefined:
@@ -441,7 +417,6 @@ int main(int argc, char* argv[])
                 case ePartitioningSingleBlock:
                 {
                     ALICEVISION_LOG_INFO("Meshing mode: multi-resolution, partitioning: single block.");
-                    fuseCut::DelaunayGraphCut delaunayGC(&mp);
                     std::array<Point3d, 8> hexah;
 
                     float minPixSize;
@@ -471,6 +446,7 @@ int main(int argc, char* argv[])
                         spaceSteps.y = (vy.size() / (double)dimensions.y) / (double)ocTreeDim;
                         spaceSteps.z = (vz.size() / (double)dimensions.z) / (double)ocTreeDim;
                     }
+                    delete voxels;
 
                     StaticVector<int> cams;
                     if(meshingFromDepthMaps)
@@ -486,60 +462,28 @@ int main(int argc, char* argv[])
 
                     if(cams.empty())
                         throw std::logic_error("No camera to make the reconstruction");
-
+                    
+                    fuseCut::DelaunayGraphCut delaunayGC(&mp);
                     delaunayGC.createDensePointCloud(&hexah[0], cams, addLandmarksToTheDensePointCloud ? &sfmData : nullptr, meshingFromDepthMaps ? &fuseParams : nullptr);
                     if(saveRawDensePointCloud)
                     {
                       ALICEVISION_LOG_INFO("Save dense point cloud before cut and filtering.");
                       StaticVector<StaticVector<int>*>* ptsCams = delaunayGC.createPtsCams();
-                      sfmData::SfMData densePC;
-                      std::vector<IndexT> mapping;
-                      exportPointCloud((outDirectory/"densePointCloud_raw.abc").string(), mp, sfmData, delaunayGC._verticesCoords, *ptsCams, colorizeOutput, densePC, mapping);
-                      deleteArrayOfArrays<int>(&ptsCams);
+                      sfmData::SfMData densePointCloud;
+                      createDenseSfMData(sfmData, mp, delaunayGC._verticesCoords, *ptsCams, densePointCloud);
+                      removeLandmarksWithoutObservations(densePointCloud);
+                      if(colorizeOutput)
+                        sfmData::colorizeTracks(densePointCloud);
+                      sfmDataIO::Save(densePointCloud, (outDirectory/"densePointCloud_raw.abc").string(), sfmDataIO::ESfMData::ALL_DENSE);
+                      deleteArrayOfArrays(&ptsCams);
                     }
 
                     delaunayGC.createGraphCut(&hexah[0], cams, nullptr, outDirectory.string()+"/", outDirectory.string()+"/SpaceCamsTracks/", false, spaceSteps);
                     delaunayGC.graphCutPostProcessing();
+                    mesh = delaunayGC.createMesh();
+                    ptsCams = delaunayGC.createPtsCams();
+                    mesh::meshPostProcessing(mesh, ptsCams, mp, outDirectory.string()+"/", nullptr, &hexah[0]);
 
-                    // Save mesh as .bin and .obj
-                    mesh::Mesh* mesh = delaunayGC.createMesh();
-                    if(mesh->pts->empty() || mesh->tris->empty())
-                        throw std::runtime_error("Empty mesh");
-
-                    StaticVector<StaticVector<int>*>* ptsCams = delaunayGC.createPtsCams();
-
-                    StaticVector<Point3d>* hexahsToExcludeFromResultingMesh = nullptr;
-                    mesh::meshPostProcessing(mesh, ptsCams, mp, outDirectory.string()+"/", hexahsToExcludeFromResultingMesh, &hexah[0]);
-
-                    ALICEVISION_LOG_INFO("Save dense point cloud.");
-                    
-                    sfmData::SfMData densePointCloud;
-                    std::vector<IndexT> verticesMapping;
-                    exportPointCloud(outputDensePointCloud, mp, sfmData, mesh->pts->getData(), *ptsCams, colorizeOutput, densePointCloud, verticesMapping);
-
-                    if(colorizeOutput)
-                    {
-                      const auto& landmarks = densePointCloud.getLandmarks();
-                      std::vector<rgb>& colors = mesh->colors();
-                      colors.resize(mesh->pts->size(), {0, 0, 0});
-                      for(std::size_t vertexId = 0; vertexId < verticesMapping.size(); ++vertexId)
-                      {
-                        const auto landmarkId = verticesMapping[vertexId];
-                        if(landmarkId != UndefinedIndexT)
-                        {
-                          const auto& c = landmarks.at(landmarkId).rgb;
-                          colors[vertexId] = {c.r(), c.g(), c.b()};
-                        }
-                      }
-                    }
-
-                    deleteArrayOfArrays<int>(&ptsCams);
-                    delete voxels;
-
-                    ALICEVISION_LOG_INFO("Save obj mesh file.");
-                    mesh->saveToObj(outputMesh);
-
-                    delete mesh;
                     break;
                 }
                 case ePartitioningUndefined:
@@ -552,6 +496,45 @@ int main(int argc, char* argv[])
         default:
             throw std::invalid_argument("Repartition mode is not defined");
     }
+
+    // Generate output files: 
+    // - dense point-cloud with observations as sfmData
+    // - mesh as .obj
+
+    if(mesh == nullptr || mesh->pts->empty() || mesh->tris->empty())
+      throw std::runtime_error("No valid mesh was generated.");
+
+    if(ptsCams == nullptr)
+      throw std::runtime_error("Points visibilities data has not been initialized.");
+
+    sfmData::SfMData densePointCloud;
+    createDenseSfMData(sfmData, mp, mesh->pts->getData(), *ptsCams, densePointCloud);
+
+    deleteArrayOfArrays<int>(&ptsCams);
+
+    if(colorizeOutput)
+    {
+      sfmData::colorizeTracks(densePointCloud);
+      // colorize output mesh before landmarks filtering
+      // to have a 1:1 mapping between points and mesh vertices
+      const auto& landmarks = densePointCloud.getLandmarks();
+      std::vector<rgb>& colors = mesh->colors();
+      colors.resize(mesh->pts->size(), {0, 0, 0});
+      for(std::size_t i = 0; i < mesh->pts->size(); ++i)
+      {
+        const auto& c = landmarks.at(i).rgb;
+        colors[i] = {c.r(), c.g(), c.b()};
+      }
+    }
+
+    removeLandmarksWithoutObservations(densePointCloud);
+    ALICEVISION_LOG_INFO("Save dense point cloud.");
+    sfmDataIO::Save(densePointCloud, outputDensePointCloud, sfmDataIO::ESfMData::ALL_DENSE);
+
+    ALICEVISION_LOG_INFO("Save obj mesh file.");
+    mesh->saveToObj(outputMesh);
+    delete mesh;
+
 
     ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Description
This PR adds vertex color data in Mesh class, with OBJ file format IO support. Regarding software, vertex colors are written in Meshing step's output OBJ file and correctly preserved during MeshFiltering.

## Features list
- [X] [mesh] IO: read/write vertex colors from/to OBJ files
- [X] [software] Meshing: write vertex colors in output OBJ file
- [X] [mesh] preserve vertex color data in MeshClean::cleanMesh
- [X] [software] MeshFiltering: clear free points from mesh after cleaning operations
- [x] Make mesh output coloring optional

## Implementation remarks
Vertex colors are written as 3 additional floats per vertex line in OBJ files. It is not part of the official OBJ file format description but it is supported by several software.

From: https://en.wikipedia.org/wiki/Wavefront_.obj_file#Geometric_vertex
> A vertex can be specified in a line starting with the letter v. That is followed by (x,y,z[,w]) coordinates. W is optional and defaults to 1.0. Some applications support vertex colors, by putting red, green and blue values after x y and z. The color values range from 0 to 1. 
