### PR TITLE
[software] ConvertSfMFormat: allow regex in image white list

### DIFF
--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
       feature::EImageDescriberType_informations().c_str())
     ("imageWhiteList", po::value<std::vector<std::string>>(&imageWhiteList)->multitoken()->default_value(imageWhiteList),
-      "image white list (uid, image filename or regex on the image file path).")
+      "image white list containing uid(s), image filenames or regex(es) on the image file path (supported regex: '#' matches a single digit, '@' one or more digits, '?' one character and '*' zero or more)")
     ("views", po::value<bool>(&flagViews)->default_value(flagViews),
       "Export views.")
     ("intrinsics", po::value<bool>(&flagIntrinsics)->default_value(flagIntrinsics),

--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
       feature::EImageDescriberType_informations().c_str())
     ("imageWhiteList", po::value<std::vector<std::string>>(&imageWhiteList)->multitoken()->default_value(imageWhiteList),
-      "image white list (uids or image paths).")
+      "image white list (uid, image filename or regex on the image file path).")
     ("views", po::value<bool>(&flagViews)->default_value(flagViews),
       "Export views.")
     ("intrinsics", po::value<bool>(&flagIntrinsics)->default_value(flagIntrinsics),
@@ -167,7 +167,9 @@ int main(int argc, char **argv)
 
       for(int i = 0; i < imageWhiteList.size(); ++i)
       {
-        if (fs::path(imageWhiteList[i]).stem() == fs::path(view.getImagePath()).stem() ||
+        // Compare to filename, stem (filename without extension), view UID or regex on the full path
+        if (imageWhiteList[i] == fs::path(view.getImagePath()).filename() ||
+            imageWhiteList[i] == fs::path(view.getImagePath()).stem() ||
             imageWhiteList[i] == std::to_string(view.getViewId()) ||
             std::regex_match(view.getImagePath(), imageWhiteRegexList[i])
             )

--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
       const sfmData::View& view = *(viewPair.second);
       bool toRemove = true;
 
-      for(int i = 0; i < imageWhiteList.size(); ++i)
+      for(std::size_t i = 0; i < imageWhiteList.size(); ++i)
       {
         // Compare to filename, stem (filename without extension), view UID or regex on the full path
         if (imageWhiteList[i] == fs::path(view.getImagePath()).filename() ||


### PR DESCRIPTION

## Description

Enable to use simple regular expressions in the image white list of the ConvertSfMFormat.
For instance, it enables to keep only the images starting with "IMG_" in their filename using the following filter: ```*/IMG_*```.
