### PR TITLE
[fusecut] fix iteration over tcdepthmap in filterGroupsRC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -496,7 +496,13 @@ set(ALICEVISION_HAVE_OCVSIFT 0)
 if(ALICEVISION_BUILD_SFM)
   if(NOT ALICEVISION_USE_OPENCV STREQUAL "OFF")
     find_package(OpenCV COMPONENTS core imgproc video imgcodecs videoio features2d xfeatures2d)
-
+    
+    # We do not set the minimal version directly in find_package
+    # due to this issue in opencv: https://github.com/opencv/opencv/issues/5931
+    # which considers major version as exact requirement.
+    if(OpenCV_VERSION VERSION_LESS "3.2.0")
+        message(SEND_ERROR "Failed to find OpenCV 3.2.0+")
+    endif()
     if(OpenCV_FOUND)
       set(ALICEVISION_HAVE_OPENCV 1)
       message(STATUS "OpenCV found.")

--- a/src/aliceVision/dataio/VideoFeed.cpp
+++ b/src/aliceVision/dataio/VideoFeed.cpp
@@ -12,7 +12,7 @@
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/core/eigen.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/videoio.hpp>
 
 #include <iostream>
 #include <exception>

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -191,24 +191,23 @@ bool Fuser::filterGroupsRC(int rc, int pixSizeBall, int pixSizeBallWSP, int nNea
 
         StaticVector<float> tcdepthMap;
 
-        {
-            int width, height;
-            imageIO::readImage(getFileNameFromIndex(mp, tc, mvsUtils::EFileType::depthMap, 1), width, height, tcdepthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
-        }
+        int tcWidth, tcHeight;
+        imageIO::readImage(getFileNameFromIndex(mp, tc, mvsUtils::EFileType::depthMap, 1), tcWidth, tcHeight, tcdepthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
 
         if(!tcdepthMap.empty())
         {
-            for(int y = 0; y < h; ++y)
-                for(int x = 0; x < w; ++x)
+            for(int y = 0; y < tcHeight; ++y)
+            {
+                for(int x = 0; x < tcWidth; ++x)
                 {
-                    float depth = tcdepthMap[y * w + x];
+                    float depth = tcdepthMap[y * tcWidth + x];
                     if(depth > 0.0f)
                     {
                       Point3d p = mp->CArr[tc] + (mp->iCamArr[tc] * Point2d((float)x, (float)y)).normalize() * depth;
                       updateInSurr(pixSizeBall, pixSizeBallWSP, p, rc, tc, numOfPtsMap, &depthMap, &simMap, 1);
                     }
                 }
-
+            }
 
             for(int i = 0; i < w * h; i++)
             {


### PR DESCRIPTION
## Description

Fix iteration over tcdepthmap in filterGroupsRC - Solve segmentation fault in DepthMapFiltering when using images of different sizes

