### PR TITLE
[depthMap] bug fix: use RAII instead of pointers

### DIFF
--- a/src/aliceVision/depthMap/RefineRc.cpp
+++ b/src/aliceVision/depthMap/RefineRc.cpp
@@ -57,12 +57,12 @@ DepthSimMap* RefineRc::getDepthPixSizeMapFromSGM()
     StaticVector<IdValue> volumeBestIdVal;
     volumeBestIdVal.reserve(_width * _height);
 
-    for(int i = 0; i < _volumeBestIdVal->size(); i++)
+    for(int i = 0; i < _volumeBestIdVal.size(); i++)
     {
         // float sim = (*depthSimMapFinal->dsm)[i].y;
         // sim = std::min(sim,mp->simThr);
         const float sim = _sp->mp->simThr - 0.0001;
-        const int id = (*_volumeBestIdVal)[i].id;
+        const int id = _volumeBestIdVal[i].id;
 
         if(id > 0)
           volumeBestIdVal.push_back(IdValue(id, sim));

--- a/src/aliceVision/depthMap/SemiGlobalMatchingRc.cpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingRc.cpp
@@ -46,7 +46,6 @@ SemiGlobalMatchingRc::SemiGlobalMatchingRc(int rc, int scale, int step, SemiGlob
 
 SemiGlobalMatchingRc::~SemiGlobalMatchingRc()
 {
-    delete _volumeBestIdVal;
 }
 
 bool SemiGlobalMatchingRc::selectBestDepthsRange(int nDepthsThr, StaticVector<float>* rcSeedsDistsAsc)
@@ -498,7 +497,7 @@ bool SemiGlobalMatchingRc::sgmrc(bool checkIfExists)
 
     // for each pixel: choose the voxel with the minimal similarity value
     const int zborder = 2;
-    _volumeBestIdVal = svol->getOrigVolumeBestIdValFromVolumeStepZ(zborder);
+    svol->getOrigVolumeBestIdValFromVolumeStepZ(_volumeBestIdVal, zborder);
 
     delete svol;
 
@@ -508,8 +507,8 @@ bool SemiGlobalMatchingRc::sgmrc(bool checkIfExists)
         {
             if((*rcSilhoueteMap)[i])
             {
-                (*_volumeBestIdVal)[i].id = 0;
-                (*_volumeBestIdVal)[i].value = 1.0f;
+                _volumeBestIdVal[i].id = 0;
+                _volumeBestIdVal[i].value = 1.0f;
             }
         }
         delete rcSilhoueteMap;
@@ -520,13 +519,13 @@ bool SemiGlobalMatchingRc::sgmrc(bool checkIfExists)
 
     if(_sp->exportIntermediateResults)
     {
-        DepthSimMap* depthSimMapFinal = _sp->getDepthSimMapFromBestIdVal(_width, _height, _volumeBestIdVal, _scale, _step, _rc, zborder, _depths);
+        DepthSimMap* depthSimMapFinal = _sp->getDepthSimMapFromBestIdVal(_width, _height, &_volumeBestIdVal, _scale, _step, _rc, zborder, _depths);
         depthSimMapFinal->saveToImage(_sp->mp->getDepthMapsFolder() + "sgm_" + std::to_string(_sp->mp->getViewId(_rc)) + "_" + "scale" + mvsUtils::num2str(depthSimMapFinal->scale) + "_step" + mvsUtils::num2str(depthSimMapFinal->step) + ".png", 1.0f);
         delete depthSimMapFinal;
 
-        std::vector<unsigned short> volumeBestId(_volumeBestIdVal->size());
-        for(int i = 0; i < _volumeBestIdVal->size(); i++)
-          volumeBestId.at(i) = std::max(0, (*_volumeBestIdVal)[i].id);
+        std::vector<unsigned short> volumeBestId(_volumeBestIdVal.size());
+        for(int i = 0; i < _volumeBestIdVal.size(); i++)
+          volumeBestId.at(i) = std::max(0, _volumeBestIdVal[i].id);
 
         using namespace imageIO;
         OutputFileColorSpace colorspace(EImageColorSpace::NO_CONVERSION);

--- a/src/aliceVision/depthMap/SemiGlobalMatchingRc.hpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingRc.hpp
@@ -35,7 +35,7 @@ protected:
 
     StaticVector<int> _sgmTCams;
     StaticVector<Pixel> _depthsTcamsLimits;
-    StaticVector<IdValue>* _volumeBestIdVal = nullptr;
+    StaticVector<IdValue> _volumeBestIdVal;
     StaticVector<float> _depths;
 
     SemiGlobalMatchingParams* _sp;

--- a/src/aliceVision/depthMap/SemiGlobalMatchingVolume.cpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingVolume.cpp
@@ -271,16 +271,15 @@ void SemiGlobalMatchingVolume::SGMoptimizeVolumeStepZ(int rc, int volStepXY, int
         mvsUtils::printfElapsedTime(tall, "SemiGlobalMatchingVolume::SGMoptimizeVolumeStepZ");
 }
 
-StaticVector<IdValue>* SemiGlobalMatchingVolume::getOrigVolumeBestIdValFromVolumeStepZ(int zborder)
+void SemiGlobalMatchingVolume::getOrigVolumeBestIdValFromVolumeStepZ(StaticVector<IdValue>& out_volumeBestIdVal, int zborder)
 {
     long tall = clock();
 
-    StaticVector<IdValue>* volumeBestIdVal = new StaticVector<IdValue>();
-    volumeBestIdVal->reserve(volDimX * volDimY);
-    volumeBestIdVal->resize_with(volDimX * volDimY, IdValue(-1, 1.0f));
+    out_volumeBestIdVal.reserve(volDimX * volDimY);
+    out_volumeBestIdVal.resize_with(volDimX * volDimY, IdValue(-1, 1.0f));
     unsigned char* _volumeStepZPtr = _volumeStepZ->getDataWritable().data();
     int* _volumeBestZPtr = _volumeBestZ->getDataWritable().data();
-    IdValue* volumeBestIdValPtr = volumeBestIdVal->getDataWritable().data();
+    IdValue* out_volumeBestIdValPtr = out_volumeBestIdVal.getDataWritable().data();
     for(int z = zborder; z < volDimZ / volStepZ - zborder; z++)
     {
         for(int y = 1; y < volDimY - 1; y++)
@@ -291,7 +290,7 @@ StaticVector<IdValue>* SemiGlobalMatchingVolume::getOrigVolumeBestIdValFromVolum
                 // value from volumeStepZ converted from (0, 255) to (-1, +1)
                 float val = (((float)_volumeStepZPtr[volumeIndex]) / 255.0f) * 2.0f - 1.0f;
                 int bestZ = _volumeBestZPtr[volumeIndex]; // TODO: what is bestZ?
-                IdValue& idVal = volumeBestIdValPtr[y * volDimX + x];
+                IdValue& idVal = out_volumeBestIdValPtr[y * volDimX + x];
                 assert(bestZ >= 0);
 
                 if(idVal.id == -1)
@@ -312,8 +311,6 @@ StaticVector<IdValue>* SemiGlobalMatchingVolume::getOrigVolumeBestIdValFromVolum
 
     if(sp->mp->verbose)
         mvsUtils::printfElapsedTime(tall, "SemiGlobalMatchingVolume::getOrigVolumeBestIdValFromVolumeStepZ ");
-
-    return volumeBestIdVal;
 }
 
 void SemiGlobalMatchingVolume::copyVolume(const StaticVector<unsigned char>* volume, int zFrom, int nZSteps)

--- a/src/aliceVision/depthMap/SemiGlobalMatchingVolume.hpp
+++ b/src/aliceVision/depthMap/SemiGlobalMatchingVolume.hpp
@@ -28,7 +28,7 @@ public:
     void cloneVolumeSecondStepZ();
 
     void SGMoptimizeVolumeStepZ(int rc, int volStepXY, int volLUX, int volLUY, int scale);
-    StaticVector<IdValue>* getOrigVolumeBestIdValFromVolumeStepZ(int zborder);
+    void getOrigVolumeBestIdValFromVolumeStepZ(StaticVector<IdValue>& out_volumeBestIdVal, int zborder);
 
     void exportVolume(StaticVector<float>& depths, int camIndex, int scale, int step, const std::string& filepath) const;
     void exportVolumeStep(StaticVector<float>& depths, int camIndex, int scale, int step, const std::string& filepath) const;


### PR DESCRIPTION
In particular configurations (failed to find Tc cameras), `sgmrc` can stop early before allocating the `_volumeBestIdVal`, which is later used in the refine step.

This bug fix in combination with #616 and #642, should fix the issues reported in https://github.com/alicevision/meshroom/issues/504, https://github.com/alicevision/meshroom/issues/481, https://github.com/alicevision/meshroom/issues/458, https://github.com/alicevision/meshroom/issues/431, https://github.com/alicevision/meshroom/issues/425.