### PR TITLE
Fixes to the all-in-one build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,7 @@ ExternalProject_Add(opencv_contrib
   URL https://github.com/opencv/opencv_contrib/archive/4.1.0.zip
   URL_MD5 3cd00bbfdebb69ad24756ccfb801ebac
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencv_contrib
+  BUILD_ALWAYS 0
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
@@ -462,11 +463,15 @@ ExternalProject_Add(${OPENCV_TARGET}
   URL https://github.com/opencv/opencv/archive/4.1.0.zip
   URL_MD5 5c5a9ce3519415b263d512e7f6a1e2af
   UPDATE_COMMAND ""
+  BUILD_IN_SOURCE 0
+  BUILD_ALWAYS 0
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencv
   BINARY_DIR ${BUILD_DIR}/opencv_build
   INSTALL_DIR ${BUILD_DIR}/opencv_install
   CONFIGURE_COMMAND ${CMAKE_COMMAND} ${CMAKE_CORE_BUILD_FLAGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> <SOURCE_DIR>
     -DOPENCV_EXTRA_MODULES_PATH=${CMAKE_CURRENT_BINARY_DIR}/opencv_contrib/modules
+    ${ZLIB_CMAKE_FLAGS}
+    ${TBB_CMAKE_FLAGS}
     -DWITH_TBB=ON
     -DBUILD_opencv_python2=OFF
     -DBUILD_opencv_python3=OFF

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,8 @@ ENV AV_DEV=/opt/AliceVision_git \
     AV_BUILD=/tmp/AliceVision_build \
     AV_INSTALL=/opt/AliceVision_install \
     AV_BUNDLE=/opt/AliceVision_bundle \
-    PATH="${PATH}:${AV_BUNDLE}"
-
-COPY . "${AV_DEV}"
+    PATH="${PATH}:${AV_BUNDLE}" \
+    VERBOSE=1
 
 # Install all compilation tools
 # - file and openssl are needed for cmake
@@ -45,6 +44,8 @@ RUN yum -y install \
 # Manually install cmake 3.14
 WORKDIR /opt
 RUN wget https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz && tar zxvf cmake-3.14.5.tar.gz && cd cmake-3.14.5 && ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && make -j8 && make install
+
+COPY . "${AV_DEV}"
 
 WORKDIR "${AV_BUILD}"
 RUN cmake "${AV_DEV}" -DCMAKE_BUILD_TYPE=Release -DALICEVISION_BUILD_DEPENDENCIES:BOOL=ON -DINSTALL_DEPS_BUILD:BOOL=ON -DCMAKE_INSTALL_PREFIX="${AV_INSTALL}" -DALICEVISION_BUNDLE_PREFIX="${AV_BUNDLE}"


### PR DESCRIPTION
- [X] OpenCV was using the system libz library instead of the built one.
- [X] Import source code later in Dockerfile, to invalidate less code on changes
