### PR TITLE
std::shared_ptr replaced with `IDoubleArrayProperty::sample_ptr_type` alias

### DIFF
--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -439,7 +439,7 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfmData::SfMData& sfmDat
       if(userProps.getPropertyHeader("mvg_intrinsicParams"))
       {
         Alembic::Abc::IDoubleArrayProperty prop(userProps, "mvg_intrinsicParams");
-        std::shared_ptr<DoubleArraySample> sample;
+        Alembic::Abc::IDoubleArrayProperty::sample_ptr_type sample;
         prop.get(sample, ISampleSelector(sampleFrame));
         mvg_intrinsicParams.assign(sample->get(), sample->get()+sample->size());
       }


### PR DESCRIPTION
## Description

Fixing errors related to Alembic built with boost.

## Implementation remarks

When Alembic is configured to use boost it creates an alias for `shared_ptr` from boost library. This causes compilation error, `std::shared_ptr` can not be converted to `boost::shared_ptr`.

Instead of relying explicitly on the `std::shared_ptr` type, we can use an alias from `Alembic::Abc::IDoubleArrayProperty::sample_ptr_type`.

