### PR TITLE
Update camera sensor database for RaspberryPi cameras

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4896,7 +4896,8 @@ Qmobile;Qmobile Noir S6;4.69;devicespecifications
 Ramos;Ramos M7;4.82;devicespecifications
 Ramos;Ramos MOS1 Max;4.69;devicespecifications
 Ramos;Ramos R9;4.69;devicespecifications
-RaspberryPi;RP_OV5647;3.76;
+RaspberryPi;RP_imx219;3.6736;devicespecifications
+RaspberryPi;RP_OV5647;3.6288;devicespecifications
 Realme;Realme 2 Pro;5.22;devicespecifications
 Red;Epic Dragon;30.7;
 Red;Red Dragon 4K HD;19.19;


### PR DESCRIPTION
Updated the camera sensor database file with values for the two versions of RaspberryPi cameras. The sensor width values are derived from the sensor device datasheets:

v1 (OmniVision OV5647): 2592 active pixels * 1.4 micron unit cell size
v2 (Sony IMX219): 3280 active pixels * 1.12 micron unit cell size
