### PR TITLE
Build fixes included in the binaries of the release 2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,7 @@ if(AV_BUILD_CCTAG)
 set(CCTAG_TARGET cctag)
 ExternalProject_Add(${CCTAG_TARGET}
       GIT_REPOSITORY https://github.com/alicevision/CCTag
-      GIT_TAG develop
+      GIT_TAG 027c3b396c318150670852900abc81cd4415970b
       PREFIX ${BUILD_DIR}
       BUILD_IN_SOURCE 0
       BUILD_ALWAYS 0
@@ -519,7 +519,7 @@ if(AV_BUILD_POPSIFT)
 set(POPSIFT_TARGET popsift)
 ExternalProject_Add(${POPSIFT_TARGET}
       GIT_REPOSITORY https://github.com/alicevision/popsift
-      GIT_TAG aa77bd6d308ad9fced2d5ba63e02f2f10873479b
+      GIT_TAG fd3ad34d31009e0c098034c23d7f14cd8e1a197e
       PREFIX ${BUILD_DIR}
       BUILD_IN_SOURCE 0
       BUILD_ALWAYS 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ endif()
 # Add Tbb
 set(TBB_TARGET tbb)
 ExternalProject_Add(${TBB_TARGET}
-       URL https://github.com/01org/tbb/archive/2018_U5.tar.gz
+       URL https://github.com/01org/tbb/archive/2019_U6.tar.gz
        PREFIX ${BUILD_DIR}
        BUILD_IN_SOURCE 0
        BUILD_ALWAYS 0
@@ -433,7 +433,7 @@ set(OPENIMAGEIO_CMAKE_FLAGS -DOPENIMAGEIO_LIBRARY_DIR_HINTS=${BUILD_DIR}/openima
 # Add Alembic: I/O for Point Cloud and Cameras
 set(ALEMBIC_TARGET alembic)
 ExternalProject_Add(${ALEMBIC_TARGET}
-      URL https://github.com/alembic/alembic/archive/1.7.10.tar.gz
+      URL https://github.com/alembic/alembic/archive/1.7.11.tar.gz
       PREFIX ${BUILD_DIR}
       BUILD_IN_SOURCE 0
       BUILD_ALWAYS 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CUDA_TAG=8.0
+ARG CUDA_TAG=7.0
 ARG OS_TAG=7
 ARG NPROC=1
 FROM nvidia/cuda:${CUDA_TAG}-devel-centos${OS_TAG}


### PR DESCRIPTION
Go back to cuda-7.0 to create binaries to reduce incompatibilities.
Use a specific commit in CCTag to avoid runtime incompatibilities.
