### PR TITLE
Coordinate system alignment to specific markers or between scenes

### DIFF
--- a/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.hpp
+++ b/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.hpp
@@ -16,7 +16,7 @@
 #include <numeric>
 
 namespace cctag {
-  class Parameters; // Hidden implementation
+  struct Parameters; // Hidden implementation
 }
 
 namespace aliceVision {

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -67,6 +67,15 @@ EImageDescriberType EImageDescriberType_stringToEnum(const std::string& imageDes
   */
 std::vector<EImageDescriberType> EImageDescriberType_stringToEnums(const std::string& describerMethods);
 
+inline bool isMarker(EImageDescriberType imageDescriberType)
+{
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
+    return imageDescriberType == EImageDescriberType::CCTAG3 || imageDescriberType == EImageDescriberType::CCTAG4;
+#else
+    return false;
+#endif
+}
+
 /**
  * @brief getStrongSupportCoeff
  * @param imageDescriberType

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -881,6 +881,9 @@ void Texturing::loadFromOBJ(const std::string& filename, bool flipNormals)
 
 void Texturing::remapVisibilities(EVisibilityRemappingMethod remappingMethod, const Mesh& refMesh, const mesh::PointsVisibility& refPointsVisibilities)
 {
+  if (refPointsVisibilities.empty())
+    throw std::runtime_error("Texturing: Cannot remap visibilities as there is no reference points.");
+
   assert(pointsVisibilities == nullptr);
   pointsVisibilities = new mesh::PointsVisibility();
 

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -38,6 +38,7 @@ set(sfm_files_sources
   pipeline/localization/SfMLocalizer.cpp
   pipeline/localization/SfMLocalizationSingle3DTrackObservationDatabase.cpp
   pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+  pipeline/ReconstructionEngine.cpp
   pipeline/RigSequence.cpp
   pipeline/RelativePoseInfo.cpp
   pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp

--- a/src/aliceVision/sfm/pipeline/ReconstructionEngine.cpp
+++ b/src/aliceVision/sfm/pipeline/ReconstructionEngine.cpp
@@ -1,0 +1,77 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2019 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ReconstructionEngine.hpp"
+
+#include <aliceVision/feature/RegionsPerView.hpp>
+#include <aliceVision/sfm/pipeline/regionsIO.hpp>
+
+
+namespace aliceVision {
+namespace sfm {
+
+
+void retrieveMarkersId(sfmData::SfMData& sfmData)
+{
+    std::set<feature::EImageDescriberType> allMarkerDescTypes;
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
+    allMarkerDescTypes.insert(feature::EImageDescriberType::CCTAG3);
+    allMarkerDescTypes.insert(feature::EImageDescriberType::CCTAG4);
+#endif
+    if (allMarkerDescTypes.empty())
+        return;
+
+    std::set<feature::EImageDescriberType> usedDescTypes = sfmData.getLandmarkDescTypes();
+
+    std::vector<feature::EImageDescriberType> markerDescTypes;
+    std::set_intersection(allMarkerDescTypes.begin(), allMarkerDescTypes.end(),
+        usedDescTypes.begin(), usedDescTypes.end(),
+        std::back_inserter(markerDescTypes));
+
+    std::set<feature::EImageDescriberType> markerDescTypes_set(markerDescTypes.begin(), markerDescTypes.end());
+
+    if(markerDescTypes.empty())
+        return;
+
+    // load the corresponding view regions
+    feature::RegionsPerView regionPerView;
+    std::set<IndexT> filter;
+    // It could be optimized by loading only the minimal number of desc files,
+    // but as we are only retrieving them for markers, the performance impact is limited.
+    if (!sfm::loadRegionsPerView(regionPerView, sfmData, sfmData.getFeaturesFolders(), markerDescTypes, filter))
+    {
+        ALICEVISION_THROW_ERROR("Error while loading markers regions.");
+    }
+    for (auto& landmarkIt : sfmData.getLandmarks())
+    {
+        auto& landmark = landmarkIt.second;
+        if (landmark.observations.empty())
+            continue;
+        if (markerDescTypes_set.find(landmark.descType) == markerDescTypes_set.end())
+            continue;
+        landmark.rgb = image::BLACK;
+
+        const auto obs = landmark.observations.begin();
+        const feature::Regions& regions = regionPerView.getRegions(obs->first, landmark.descType);
+        const feature::CCTAG_Regions& cctagRegions = dynamic_cast<const feature::CCTAG_Regions&>(regions);
+        const auto& d = cctagRegions.Descriptors()[obs->second.id_feat];
+        for (int i = 0; i < d.size(); ++i)
+        {
+            if (d[i] == 255)
+            {
+                ALICEVISION_LOG_TRACE("Found marker: " << i << " (landmarkId: " << landmarkIt.first << ").");
+                landmark.rgb.r() = i;
+                break;
+            }
+        }
+    }
+}
+
+
+} // namespace sfm
+} // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/ReconstructionEngine.hpp
+++ b/src/aliceVision/sfm/pipeline/ReconstructionEngine.hpp
@@ -15,6 +15,9 @@
 namespace aliceVision {
 namespace sfm {
 
+void retrieveMarkersId(sfmData::SfMData& sfmData);
+
+
 /**
  * @brief Basic Reconstruction Engine.
  * Process Function handle the reconstruction.
@@ -68,12 +71,18 @@ public:
     sfmData::colorizeTracks(_sfmData);
   }
 
+  void retrieveMarkersId()
+  {
+      aliceVision::sfm::retrieveMarkersId(_sfmData);
+  }
+
 protected:
   /// Output folder where outputs will be stored
   std::string _outputFolder;
   /// Internal SfMData
   sfmData::SfMData _sfmData;
 };
+
 
 } // namespace sfm
 } // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -246,6 +246,13 @@ std::size_t ReconstructionEngine_sequentialSfM::fuseMatchesIntoTracks()
     // build tracks with STL compliant type
     tracksBuilder.exportToSTL(_map_tracks);
     ALICEVISION_LOG_DEBUG("Build tracks per view");
+
+    // Init tracksPerView to have an entry in the map for each view (even if there is no track at all)
+    for(const auto& viewIt: _sfmData.views)
+    {
+        // create an entry in the map
+        _map_tracksPerView[viewIt.first];
+    }
     track::tracksUtilsMap::computeTracksPerView(_map_tracks, _map_tracksPerView);
     ALICEVISION_LOG_DEBUG("Build tracks pyramid per view");
     computeTracksPyramidPerView(
@@ -849,11 +856,7 @@ bool ReconstructionEngine_sequentialSfM::findConnectedViews(
     const bool isIntrinsicsReconstructed = reconstructedIntrinsics.count(intrinsicId);
 
     // Compute 2D - 3D possible content
-    aliceVision::track::TracksPerView::const_iterator tracksIdsIt = _map_tracksPerView.find(viewId);
-    if(tracksIdsIt == _map_tracksPerView.end())
-      continue;
-
-    const aliceVision::track::TrackIdSet& set_tracksIds = tracksIdsIt->second;
+    const aliceVision::track::TrackIdSet& set_tracksIds = _map_tracksPerView.at(viewId);
     if (set_tracksIds.empty())
       continue;
 

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -722,6 +722,12 @@ void ReconstructionEngine_sequentialSfM::exportStatistics(double reconstructionT
     << "\t- elapsed time: " << reconstructionTime << std::endl
     << "\t- residual RMSE: " <<  residual);
 
+  std::map<feature::EImageDescriberType, int> descTypeUsage = _sfmData.getLandmarkDescTypesUsages();
+  for(const auto& d: descTypeUsage)
+  {
+    ALICEVISION_LOG_INFO(" - # " << EImageDescriberType_enumToString(d.first) << ": " << d.second);
+  }
+
   // residual histogram
   Histogram<double> residualHistogram;
   computeResidualsHistogram(&residualHistogram);

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -659,7 +659,8 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
     // - the number of cameras to refine cannot be < to the number of newly added cameras (set to 'refine' by default)
     if((nbRefinedPoses <= newReconstructedViews.size()) && _sfmData.getRigs().empty())
     {
-      throw std::runtime_error("The local bundle adjustment refinement has not been done: the new cameras are not connected to the rest of the graph.");
+      ALICEVISION_LOG_INFO("Local bundle adjustment: the new cameras are not connected to the rest of the graph"
+                           " (nbRefinedPoses: " << nbRefinedPoses << ", newReconstructedViews.size(): " << newReconstructedViews.size() << ").");
     }
   }
 

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -156,5 +156,26 @@ void computeNewCoordinateSystemFromSingleCamera(const sfmData::SfMData& sfmData,
                                                 Mat3& out_R,
                                                 Vec3& out_t);
 
+using MarkerWithCoord = std::pair<int, Vec3>;
+
+/**
+* @brief Compute a new coordinate system so that markers are aligned with the target coordinates.
+*
+* @param[in] sfmData
+* @param[in] imageDescriberType
+* @param[in] markers: markers id associated to a target 3D coordinate
+* @param[in] withScaling
+* @param[out] out_S scale
+* @param[out] out_R rotation
+* @param[out] out_t translation
+*/
+bool computeNewCoordinateSystemFromSpecificMarkers(const sfmData::SfMData& sfmData,
+    const feature::EImageDescriberType& imageDescriberType,
+    const std::vector<MarkerWithCoord>& markers,
+    bool withScaling,
+    double& out_S,
+    Mat3& out_R,
+    Vec3& out_t);
+
 } // namespace sfm
 } // namespace aliceVision

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -225,7 +225,15 @@ void computeNewCoordinateSystemFromSingleCamera(const sfmData::SfMData& sfmData,
                                                 Mat3& out_R,
                                                 Vec3& out_t);
 
-using MarkerWithCoord = std::pair<int, Vec3>;
+struct MarkerWithCoord
+{
+    int id;
+    Vec3 coord;
+};
+
+std::istream& operator>>(std::istream& in, MarkerWithCoord& marker);
+
+std::ostream& operator<<(std::ostream& os, const MarkerWithCoord& marker);
 
 /**
 * @brief Compute a new coordinate system so that markers are aligned with the target coordinates.

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -59,6 +59,20 @@ inline void getCommonPoseId(const sfmData::SfMData& sfmDataA,
 }
 
 
+void matchViewsByFilePattern(
+    const sfmData::SfMData& sfmDataA,
+    const sfmData::SfMData& sfmDataB,
+    const std::string& filePatternMatching,
+    std::vector<std::pair<IndexT, IndexT>>& out_commonViewIds);
+
+
+void matchViewsByMetadataMatching(
+    const sfmData::SfMData& sfmDataA,
+    const sfmData::SfMData& sfmDataB,
+    const std::vector<std::string>& metadataList,
+    std::vector<std::pair<IndexT, IndexT>>& out_commonViewIds);
+
+
 /**
  * @brief Compute a 5DOF rigid transform between the two set of cameras based on common viewIds.
  *

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -45,8 +45,22 @@ inline void getCommonViewsWithPoses(const sfmData::SfMData& sfmDataA,
   }
 }
 
+inline void getCommonPoseId(const sfmData::SfMData& sfmDataA,
+                            const sfmData::SfMData& sfmDataB,
+                            std::vector<IndexT>& outIndexes)
+{
+    for (const auto& poseA : sfmDataA.getPoses())
+    {
+        if (sfmDataB.getPoses().find(poseA.first) != sfmDataB.getPoses().end())
+        {
+            outIndexes.push_back(poseA.first);
+        }
+    }
+}
+
+
 /**
- * @brief Compute a 5DOF rigid transform between the two set of cameras.
+ * @brief Compute a 5DOF rigid transform between the two set of cameras based on common viewIds.
  *
  * @param[in] sfmDataA
  * @param[in] sfmDataB
@@ -55,11 +69,52 @@ inline void getCommonViewsWithPoses(const sfmData::SfMData& sfmDataA,
  * @param[out] out_t output translation vector
  * @return true if it finds a similarity transformation
  */
-bool computeSimilarity(const sfmData::SfMData& sfmDataA,
+bool computeSimilarityFromCommonCameras_viewId(const sfmData::SfMData& sfmDataA,
                        const sfmData::SfMData& sfmDataB,
                        double* out_S,
                        Mat3* out_R,
                        Vec3* out_t);
+
+/**
+* @brief Compute a 5DOF rigid transform between the two set of cameras based on common poseIds.
+*
+* @param[in] sfmDataA
+* @param[in] sfmDataB
+* @param[out] out_S output scale factor
+* @param[out] out_R output rotation 3x3 matrix
+* @param[out] out_t output translation vector
+* @return true if it finds a similarity transformation
+*/
+bool computeSimilarityFromCommonCameras_poseId(
+    const sfmData::SfMData& sfmDataA,
+    const sfmData::SfMData& sfmDataB,
+    double* out_S,
+    Mat3* out_R,
+    Vec3* out_t);
+
+bool computeSimilarityFromCommonCameras_imageFileMatching(
+    const sfmData::SfMData& sfmDataA,
+    const sfmData::SfMData& sfmDataB,
+    const std::string& filePatternMatching,
+    double* out_S,
+    Mat3* out_R,
+    Vec3* out_t);
+
+bool computeSimilarityFromCommonCameras_metadataMatching(
+    const sfmData::SfMData& sfmDataA,
+    const sfmData::SfMData& sfmDataB,
+    const std::vector<std::string>& metadataList,
+    double* out_S,
+    Mat3* out_R,
+    Vec3* out_t);
+
+
+bool computeSimilarityFromCommonMarkers(
+    const sfmData::SfMData& sfmDataA,
+    const sfmData::SfMData& sfmDataB,
+    double* out_S,
+    Mat3* out_R,
+    Vec3* out_t);
 
 
 /**

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -297,6 +297,33 @@ public:
     return _rigs.at(view.getRigId());
   }
 
+  std::set<feature::EImageDescriberType> getLandmarkDescTypes() const
+  {
+    std::set<feature::EImageDescriberType> output;
+    for (auto s : getLandmarks())
+    {
+      output.insert(s.second.descType);
+    }
+    return output;
+  }
+
+  std::map<feature::EImageDescriberType, int> getLandmarkDescTypesUsages() const
+  {
+    std::map<feature::EImageDescriberType, int> output;
+    for (auto s : getLandmarks())
+    {
+      if (output.find(s.second.descType) == output.end())
+      {
+        output[s.second.descType] = 1;
+      }
+      else
+      {
+        ++output[s.second.descType];
+      }
+    }
+    return output;
+  }
+
   /**
    * @brief Get the median Exposure Value (Ev) of
    * @return

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -298,15 +298,16 @@ int main(int argc, char **argv)
   if(!sfmEngine.process())
     return EXIT_FAILURE;
 
-  // get the color for the 3D points
-  sfmEngine.colorize();
-
   // set featuresFolders and matchesFolders relative paths
   {
-    sfmEngine.getSfMData().addFeaturesFolders(featuresFolders);
-    sfmEngine.getSfMData().addMatchesFolders(matchesFolders);
-    sfmEngine.getSfMData().setAbsolutePath(outputSfM);
+      sfmEngine.getSfMData().addFeaturesFolders(featuresFolders);
+      sfmEngine.getSfMData().addMatchesFolders(matchesFolders);
+      sfmEngine.getSfMData().setAbsolutePath(outputSfM);
   }
+
+  // get the color for the 3D points
+  sfmEngine.colorize();
+  sfmEngine.retrieveMarkersId();
 
   ALICEVISION_LOG_INFO("Structure from motion took (s): " + std::to_string(timer.elapsed()));
   ALICEVISION_LOG_INFO("Generating HTML report...");

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -107,6 +107,18 @@ alicevision_add_software(aliceVision_utils_sfmAlignment
         ${Boost_LIBRARIES}
 )
 
+# SfM transfer
+alicevision_add_software(aliceVision_utils_sfmTransfer
+  SOURCE main_sfmTransfer.cpp
+  FOLDER ${FOLDER_SOFTWARE_UTILS}
+  LINKS aliceVision_system
+        aliceVision_feature
+        aliceVision_sfm
+        aliceVision_sfmData
+        aliceVision_sfmDataIO
+        ${Boost_LIBRARIES}
+)
+
 # SfM transform
 alicevision_add_software(aliceVision_utils_sfmTransform
   SOURCE main_sfmTransform.cpp

--- a/src/software/utils/main_sfmAlignment.cpp
+++ b/src/software/utils/main_sfmAlignment.cpp
@@ -83,6 +83,10 @@ inline std::istream& operator>>(std::istream& in, EAlignmentMethod& alignment)
     return in;
 }
 
+inline std::ostream& operator<<(std::ostream& os, EAlignmentMethod e)
+{
+    return os << EAlignmentMethod_enumToString(e);
+}
 
 
 int main(int argc, char **argv)

--- a/src/software/utils/main_sfmAlignment.cpp
+++ b/src/software/utils/main_sfmAlignment.cpp
@@ -26,6 +26,65 @@ using namespace aliceVision::sfm;
 
 namespace po = boost::program_options;
 
+
+/**
+* @brief Alignment method enum
+*/
+enum class EAlignmentMethod : unsigned char
+{
+    FROM_CAMERAS_VIEWID = 0
+    , FROM_CAMERAS_POSEID
+    , FROM_CAMERAS_FILEPATH
+    , FROM_CAMERAS_METADATA
+    , FROM_MARKERS
+};
+
+/**
+* @brief Convert an EAlignmentMethod enum to its corresponding string
+* @param[in] alignmentMethod The given EAlignmentMethod enum
+* @return string
+*/
+std::string EAlignmentMethod_enumToString(EAlignmentMethod alignmentMethod)
+{
+    switch (alignmentMethod)
+    {
+    case EAlignmentMethod::FROM_CAMERAS_VIEWID:   return "from_cameras_viewid";
+    case EAlignmentMethod::FROM_CAMERAS_POSEID:   return "from_cameras_poseid";
+    case EAlignmentMethod::FROM_CAMERAS_FILEPATH: return "from_cameras_filepath";
+    case EAlignmentMethod::FROM_CAMERAS_METADATA: return "from_cameras_metadata";
+    case EAlignmentMethod::FROM_MARKERS:          return "from_markers";
+    }
+    throw std::out_of_range("Invalid EAlignmentMethod enum");
+}
+
+/**
+* @brief Convert a string to its corresponding EAlignmentMethod enum
+* @param[in] alignmentMethod The given string
+* @return EAlignmentMethod enum
+*/
+EAlignmentMethod EAlignmentMethod_stringToEnum(const std::string& alignmentMethod)
+{
+    std::string method = alignmentMethod;
+    std::transform(method.begin(), method.end(), method.begin(), ::tolower); //tolower
+
+    if (method == "from_cameras_viewid")   return EAlignmentMethod::FROM_CAMERAS_VIEWID;
+    if (method == "from_cameras_poseid")   return EAlignmentMethod::FROM_CAMERAS_POSEID;
+    if (method == "from_cameras_filepath") return EAlignmentMethod::FROM_CAMERAS_FILEPATH;
+    if (method == "from_cameras_metadata") return EAlignmentMethod::FROM_CAMERAS_METADATA;
+    if (method == "from_markers")          return EAlignmentMethod::FROM_MARKERS;
+    throw std::out_of_range("Invalid SfM alignment method : " + alignmentMethod);
+}
+
+inline std::istream& operator>>(std::istream& in, EAlignmentMethod& alignment)
+{
+    std::string token;
+    in >> token;
+    alignment = EAlignmentMethod_stringToEnum(token);
+    return in;
+}
+
+
+
 int main(int argc, char **argv)
 {
   // command-line parameters
@@ -34,6 +93,12 @@ int main(int argc, char **argv)
   std::string sfmDataFilename;
   std::string outSfMDataFilename;
   std::string sfmDataReferenceFilename;
+  bool applyScale = true;
+  bool applyRotation = true;
+  bool applyTranslation = true;
+  EAlignmentMethod alignmentMethod = EAlignmentMethod::FROM_CAMERAS_VIEWID;
+  std::string fileMatchingPattern;
+  std::vector<std::string> metadataMatchingList = {"Make", "Model", "Exif:BodySerialNumber" , "Exif:LensSerialNumber" };
 
   po::options_description allParams("AliceVision sfmAlignment");
 
@@ -46,12 +111,33 @@ int main(int argc, char **argv)
     ("reference,r", po::value<std::string>(&sfmDataReferenceFilename)->required(),
       "Path to the scene used as the reference coordinate system.");
 
+  po::options_description optionalParams("Optional parameters");
+  optionalParams.add_options()
+    ("method", po::value<EAlignmentMethod>(&alignmentMethod)->default_value(alignmentMethod),
+        "Alignment Method:\n"
+        "\t- from_cameras_viewid: Align cameras with same view Id\n"
+        "\t- from_cameras_poseid: Align cameras with same pose Id\n"
+        "\t- from_cameras_filepath: Align cameras with a filepath matching, using --fileMatchingPattern\n"
+        "\t- from_cameras_metadata: Align cameras with matching metadata, using --metadataMatchingList\n"
+        "\t- from_markers: Align from markers with the same Id\n")
+    ("fileMatchingPattern", po::value<std::string>(&fileMatchingPattern)->default_value(fileMatchingPattern),
+        "Matching pattern for the from_cameras_filepath method.\n")
+    ("metadataMatchingList", po::value<std::vector<std::string>>(&metadataMatchingList)->multitoken()->default_value(metadataMatchingList),
+        "List of metadata that should match to create the correspondences.\n")
+    ("applyScale", po::value<bool>(&applyScale)->default_value(applyScale),
+      "Apply scale transformation.")
+    ("applyRotation", po::value<bool>(&applyRotation)->default_value(applyRotation),
+      "Apply rotation transformation.")
+    ("applyTranslation", po::value<bool>(&applyTranslation)->default_value(applyTranslation),
+      "Apply translation transformation.")
+    ;
+
   po::options_description logParams("Log parameters");
   logParams.add_options()
     ("verboseLevel,v", po::value<std::string>(&verboseLevel)->default_value(verboseLevel),
       "verbosity level (fatal,  error, warning, info, debug, trace).");
 
-  allParams.add(requiredParams).add(logParams);
+  allParams.add(requiredParams).add(optionalParams).add(logParams);
 
   po::variables_map vm;
   try
@@ -105,7 +191,36 @@ int main(int argc, char **argv)
   double S;
   Mat3 R;
   Vec3 t;
-  bool hasValidSimilarity = sfm::computeSimilarity(sfmDataIn, sfmDataInRef, &S, &R, &t);
+  bool hasValidSimilarity = false;
+  
+  switch(alignmentMethod)
+  {
+    case EAlignmentMethod::FROM_CAMERAS_VIEWID:
+    {
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_viewId(sfmDataIn, sfmDataInRef, &S, &R, &t);
+      break;
+    }
+    case EAlignmentMethod::FROM_CAMERAS_POSEID:
+    {
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_poseId(sfmDataIn, sfmDataInRef, &S, &R, &t);
+      break;
+    }
+    case EAlignmentMethod::FROM_CAMERAS_FILEPATH:
+    {
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_imageFileMatching(sfmDataIn, sfmDataInRef, fileMatchingPattern, &S, &R, &t);
+      break;
+    }
+    case EAlignmentMethod::FROM_CAMERAS_METADATA:
+    {
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_metadataMatching(sfmDataIn, sfmDataInRef, metadataMatchingList, &S, &R, &t);
+      break;
+    }
+    case EAlignmentMethod::FROM_MARKERS:
+    {
+      hasValidSimilarity = sfm::computeSimilarityFromCommonMarkers(sfmDataIn, sfmDataInRef, &S, &R, &t);
+      break;
+    }
+  }
 
   if(!hasValidSimilarity)
   {
@@ -125,6 +240,13 @@ int main(int argc, char **argv)
     ss << "\t- Translate: " << t.transpose() << std::endl;
     ALICEVISION_LOG_INFO(ss.str());
   }
+
+  if (!applyScale)
+      S = 1;
+  if (!applyRotation)
+      R = Mat3::Identity();
+  if (!applyTranslation)
+      t = Vec3::Zero();
 
   sfm::applyTransform(sfmDataIn, S, R, t);
 

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -1,0 +1,255 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfm/utils/alignment.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/config.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <string>
+#include <sstream>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+using namespace aliceVision::sfm;
+
+namespace po = boost::program_options;
+
+
+/**
+* @brief Matching Views method enum
+*/
+enum class EMatchingMethod : unsigned char
+{
+    FROM_VIEWID = 0
+    , FROM_FILEPATH
+    , FROM_METADATA
+};
+
+/**
+* @brief Convert an EMatchingMethod enum to its corresponding string
+* @param[in] matchingMethod The given EMatchingMethod enum
+* @return string
+*/
+std::string EMatchingMethod_enumToString(EMatchingMethod alignmentMethod)
+{
+    switch (alignmentMethod)
+    {
+    case EMatchingMethod::FROM_VIEWID:   return "from_viewid";
+    case EMatchingMethod::FROM_FILEPATH: return "from_filepath";
+    case EMatchingMethod::FROM_METADATA: return "from_metadata";
+    }
+    throw std::out_of_range("Invalid EMatchingMethod enum");
+}
+
+/**
+* @brief Convert a string to its corresponding EMatchingMethod enum
+* @param[in] matchingMethod The given string
+* @return EMatchingMethod enum
+*/
+EMatchingMethod EMatchingMethod_stringToEnum(const std::string& alignmentMethod)
+{
+    std::string method = alignmentMethod;
+    std::transform(method.begin(), method.end(), method.begin(), ::tolower); //tolower
+
+    if (method == "from_viewid")   return EMatchingMethod::FROM_VIEWID;
+    if (method == "from_filepath") return EMatchingMethod::FROM_FILEPATH;
+    if (method == "from_metadata") return EMatchingMethod::FROM_METADATA;
+    throw std::out_of_range("Invalid SfM alignment method : " + alignmentMethod);
+}
+
+inline std::istream& operator>>(std::istream& in, EMatchingMethod& alignment)
+{
+    std::string token;
+    in >> token;
+    alignment = EMatchingMethod_stringToEnum(token);
+    return in;
+}
+
+
+
+int main(int argc, char **argv)
+{
+    // command-line parameters
+
+    std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+    std::string sfmDataFilename;
+    std::string outSfMDataFilename;
+    std::string sfmDataReferenceFilename;
+    bool transferPoses = true;
+    bool transferIntrinsics = true;
+    EMatchingMethod matchingMethod = EMatchingMethod::FROM_VIEWID;
+    std::string fileMatchingPattern;
+    std::vector<std::string> metadataMatchingList = { "Make", "Model", "Exif:BodySerialNumber" , "Exif:LensSerialNumber" };
+
+    po::options_description allParams("AliceVision sfmAlignment");
+
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(),
+             "SfMData file to align.")
+        ("output,o", po::value<std::string>(&outSfMDataFilename)->required(),
+            "Output SfMData scene.")
+        ("reference,r", po::value<std::string>(&sfmDataReferenceFilename)->required(),
+            "Path to the scene used as the reference coordinate system.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("method", po::value<EMatchingMethod>(&matchingMethod)->default_value(matchingMethod),
+            "Matching Method:\n"
+            "\t- from_viewid: Align cameras with same view Id\n"
+            "\t- from_filepath: Align cameras with a filepath matching, using --fileMatchingPattern\n"
+            "\t- from_metadata: Align cameras with matching metadata, using --metadataMatchingList\n")
+        ("fileMatchingPattern", po::value<std::string>(&fileMatchingPattern)->default_value(fileMatchingPattern),
+            "Matching pattern for the from_filepath method.\n")
+        ("metadataMatchingList", po::value<std::vector<std::string>>(&metadataMatchingList)->multitoken()->default_value(metadataMatchingList),
+            "List of metadata that should match to create the correspondences.\n")
+        ("transferPoses", po::value<bool>(&transferPoses)->default_value(transferPoses),
+            "Transfer poses.")
+        ("transferIntrinsics", po::value<bool>(&transferIntrinsics)->default_value(transferIntrinsics),
+            "Transfer intrinsics.")
+        ;
+
+    po::options_description logParams("Log parameters");
+    logParams.add_options()
+        ("verboseLevel,v", po::value<std::string>(&verboseLevel)->default_value(verboseLevel),
+            "verbosity level (fatal,  error, warning, info, debug, trace).");
+
+    allParams.add(requiredParams).add(optionalParams).add(logParams);
+
+    po::variables_map vm;
+    try
+    {
+        po::store(po::parse_command_line(argc, argv, allParams), vm);
+
+        if (vm.count("help") || (argc == 1))
+        {
+            ALICEVISION_COUT(allParams);
+            return EXIT_SUCCESS;
+        }
+        po::notify(vm);
+    }
+    catch (boost::program_options::required_option& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
+        return EXIT_FAILURE;
+    }
+    catch (boost::program_options::error& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_COUT("Program called with the following parameters:");
+    ALICEVISION_COUT(vm);
+
+    // set verbose level
+    system::Logger::get()->setLogLevel(verboseLevel);
+
+    // Load input scene
+    sfmData::SfMData sfmDataIn;
+    if (!sfmDataIO::Load(sfmDataIn, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    // Load reference scene
+    sfmData::SfMData sfmDataInRef;
+    if (!sfmDataIO::Load(sfmDataInRef, sfmDataReferenceFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The reference SfMData file '" << sfmDataReferenceFilename << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_LOG_INFO("Search similarity transformation.");
+
+    std::vector<std::pair<IndexT, IndexT>> commonViewIds;
+    switch (matchingMethod)
+    {
+        case EMatchingMethod::FROM_VIEWID:
+        {
+            std::vector<IndexT> commonViewIdsTmp;
+            getCommonViews(sfmDataIn, sfmDataInRef, commonViewIdsTmp);
+            for (IndexT id : commonViewIdsTmp)
+            {
+                commonViewIds.push_back(std::make_pair(id, id));
+            }
+            break;
+        }
+        case EMatchingMethod::FROM_FILEPATH:
+        {
+            sfm::matchViewsByFilePattern(sfmDataIn, sfmDataInRef, fileMatchingPattern, commonViewIds);
+            break;
+        }
+        case EMatchingMethod::FROM_METADATA:
+        {
+            sfm::matchViewsByMetadataMatching(sfmDataIn, sfmDataInRef, metadataMatchingList, commonViewIds);
+            break;
+        }
+    }
+    ALICEVISION_LOG_DEBUG("Found " << commonViewIds.size() << " common views.");
+
+    if (commonViewIds.empty())
+    {
+        ALICEVISION_LOG_ERROR("Failed to find matching Views between the 2 SfmData.");
+        return EXIT_FAILURE;
+    }
+
+    if (!transferPoses && !transferIntrinsics)
+    {
+        ALICEVISION_LOG_ERROR("Nothing to do.");
+    }
+    else
+    {
+        for (const auto& matchingViews: commonViewIds)
+        {
+            if(!sfmDataIn.isPoseAndIntrinsicDefined(matchingViews.first) &&
+                sfmDataInRef.isPoseAndIntrinsicDefined(matchingViews.second))
+            {
+                // Missing pose in sfmDataIn and valid pose in sfmDataInRef,
+                // so we can transfer the pose.
+
+                auto& viewA = sfmDataIn.getView(matchingViews.first);
+                const auto& viewB = sfmDataInRef.getView(matchingViews.second);
+                if (viewA.isPartOfRig() || viewB.isPartOfRig())
+                {
+                    ALICEVISION_LOG_DEBUG("Rig poses are not yet supported in SfMTransfer.");
+                    continue;
+                }
+
+                if (transferPoses)
+                {
+                    sfmDataIn.getPoses()[viewA.getPoseId()] = sfmDataInRef.getPoses().at(viewB.getPoseId());
+                }
+                if (transferIntrinsics)
+                {
+                    sfmDataIn.getIntrinsicPtr(viewA.getIntrinsicId())->assign(*sfmDataInRef.getIntrinsicPtr(viewB.getIntrinsicId()));
+                }
+            }
+        }
+    }
+
+    ALICEVISION_LOG_INFO("Save into '" << outSfMDataFilename << "'");
+    // Export the SfMData scene in the expected format
+    if (!sfmDataIO::Save(sfmDataIn, outSfMDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outSfMDataFilename << "'");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -77,6 +77,10 @@ inline std::istream& operator>>(std::istream& in, EMatchingMethod& alignment)
     return in;
 }
 
+inline std::ostream& operator<<(std::ostream& os, EMatchingMethod e)
+{
+    return os << EMatchingMethod_enumToString(e);
+}
 
 
 int main(int argc, char **argv)

--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -12,9 +12,6 @@
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <string>
 #include <sstream>
@@ -87,6 +84,12 @@ inline std::istream& operator>>(std::istream& in, EAlignmentMethod& alignment)
     return in;
 }
 
+inline std::ostream& operator<<(std::ostream& os, EAlignmentMethod e)
+{
+    return os << EAlignmentMethod_enumToString(e);
+}
+
+
 
 static bool parseAlignScale(const std::string& alignScale, double& S, Mat3& R, Vec3& t)
 {
@@ -110,28 +113,6 @@ static bool parseAlignScale(const std::string& alignScale, double& S, Mat3& R, V
   return true;
 }
 
-
-inline std::istream& operator>>(std::istream& in, sfm::MarkerWithCoord& marker)
-{
-    std::string token;
-    in >> token;
-    std::vector<std::string> markerCoord;
-    boost::split(markerCoord, token, boost::algorithm::is_any_of(":="));
-    if(markerCoord.size() != 2)
-        throw std::invalid_argument("Failed to parse MarkerWithCoord from: " + token);
-    marker.first = boost::lexical_cast<int>(markerCoord.front());
-
-    std::vector<std::string> coord;
-    boost::split(coord, markerCoord.back(), boost::algorithm::is_any_of(",;_"));
-    if (coord.size() != 3)
-        throw std::invalid_argument("Failed to parse Marker coordinates from: " + markerCoord.back());
-
-    for (int i = 0; i < 3; ++i)
-    {
-        marker.second(i) = boost::lexical_cast<double>(coord[i]);
-    }
-    return in;
-}
 
 int main(int argc, char **argv)
 {

--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -12,10 +12,14 @@
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <string>
 #include <sstream>
 #include <vector>
+
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
@@ -35,6 +39,7 @@ enum class EAlignmentMethod: unsigned char
   , AUTO_FROM_CAMERAS
   , AUTO_FROM_LANDMARKS
   , FROM_SINGLE_CAMERA
+  , FROM_MARKERS
 };
 
 /**
@@ -50,6 +55,7 @@ std::string EAlignmentMethod_enumToString(EAlignmentMethod alignmentMethod)
     case EAlignmentMethod::AUTO_FROM_CAMERAS:   return "auto_from_cameras";
     case EAlignmentMethod::AUTO_FROM_LANDMARKS: return "auto_from_landmarks";
     case EAlignmentMethod::FROM_SINGLE_CAMERA:  return "from_single_camera";
+    case EAlignmentMethod::FROM_MARKERS:        return "from_markers";
   }
   throw std::out_of_range("Invalid EAlignmentMethod enum");
 }
@@ -67,7 +73,8 @@ EAlignmentMethod EAlignmentMethod_stringToEnum(const std::string& alignmentMetho
   if(method == "transformation")      return EAlignmentMethod::TRANSFOMATION;
   if(method == "auto_from_cameras")   return EAlignmentMethod::AUTO_FROM_CAMERAS;
   if(method == "auto_from_landmarks") return EAlignmentMethod::AUTO_FROM_LANDMARKS;
-  if(method == "from_single_camera")   return EAlignmentMethod::FROM_SINGLE_CAMERA;
+  if(method == "from_single_camera")  return EAlignmentMethod::FROM_SINGLE_CAMERA;
+  if(method == "from_markers")        return EAlignmentMethod::FROM_MARKERS;
   throw std::out_of_range("Invalid SfM alignment method : " + alignmentMethod);
 }
 
@@ -93,6 +100,29 @@ static bool parseAlignScale(const std::string& alignScale, double& S, Mat3& R, V
   return true;
 }
 
+
+inline std::istream& operator>>(std::istream& in, sfm::MarkerWithCoord& marker)
+{
+    std::string token;
+    in >> token;
+    std::vector<std::string> markerCoord;
+    boost::split(markerCoord, token, boost::algorithm::is_any_of(":="));
+    if(markerCoord.size() != 2)
+        throw std::invalid_argument("Failed to parse MarkerWithCoord from: " + token);
+    marker.first = boost::lexical_cast<int>(markerCoord.front());
+
+    std::vector<std::string> coord;
+    boost::split(coord, markerCoord.back(), boost::algorithm::is_any_of(",;_"));
+    if (coord.size() != 3)
+        throw std::invalid_argument("Failed to parse Marker coordinates from: " + markerCoord.back());
+
+    for (int i = 0; i < 3; ++i)
+    {
+        marker.second(i) = boost::lexical_cast<double>(coord[i]);
+    }
+    return in;
+}
+
 int main(int argc, char **argv)
 {
   // command-line parameters
@@ -107,6 +137,10 @@ int main(int argc, char **argv)
   std::string transform;
   std::string landmarksDescriberTypesName;
   double userScale = 1;
+  bool applyScale = true;
+  bool applyRotation = true;
+  bool applyTranslation = true;
+  std::vector<sfm::MarkerWithCoord> markers;
 
   po::options_description allParams("AliceVision sfmTransform");
 
@@ -134,7 +168,16 @@ int main(int argc, char **argv)
       "Use all of them if empty\n"
       + feature::EImageDescriberType_informations()).c_str())
     ("scale", po::value<double>(&userScale)->default_value(userScale),
-      "Additional scale to apply.");
+      "Additional scale to apply.")
+    ("applyScale", po::value<bool>(&applyScale)->default_value(applyScale),
+        "Apply scale transformation.")
+    ("applyRotation", po::value<bool>(&applyRotation)->default_value(applyRotation),
+        "Apply rotation transformation.")
+    ("applyTranslation", po::value<bool>(&applyTranslation)->default_value(applyTranslation),
+        "Apply translation transformation.")
+    ("markers", po::value<std::vector<sfm::MarkerWithCoord>>(&markers)->multitoken(),
+        "Markers ID and target coordinates 'ID:x,y,z'.")
+    ;
 
   po::options_description logParams("Log parameters");
   logParams.add_options()
@@ -186,6 +229,12 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
+  if (alignmentMethod == EAlignmentMethod::FROM_MARKERS && markers.empty())
+  {
+      ALICEVISION_LOG_ERROR("Missing --markers option");
+      return EXIT_FAILURE;
+  }
+
   // Load input scene
   sfmData::SfMData sfmDataIn;
   if(!sfmDataIO::Load(sfmDataIn, sfmDataFilename, sfmDataIO::ESfMData::ALL))
@@ -219,22 +268,68 @@ int main(int argc, char **argv)
     break;
 
     case EAlignmentMethod::FROM_SINGLE_CAMERA:
-      sfm::computeNewCoordinateSystemFromSingleCamera(sfmDataIn,transform, S, R, t);
+      sfm::computeNewCoordinateSystemFromSingleCamera(sfmDataIn, transform, S, R, t);
     break;
-  }
 
-  {
-    std::stringstream ss;
-    ss << "Transformation:" << std::endl;
-    ss << "\t- Scale: " << S << std::endl;
-    ss << "\t- Rotation:\n" << R << std::endl;
-    ss << "\t- Translate: " << t.transpose() << std::endl;
-    ALICEVISION_LOG_INFO(ss.str());
+    case EAlignmentMethod::FROM_MARKERS:
+    {
+        std::vector<feature::EImageDescriberType> markersDescTypes = {
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
+            feature::EImageDescriberType::CCTAG3, feature::EImageDescriberType::CCTAG4
+#endif
+        };
+        std::set<feature::EImageDescriberType> usedDescTypes = sfmDataIn.getLandmarkDescTypes();
+
+        std::vector<feature::EImageDescriberType> usedMarkersDescTypes;
+        std::set_intersection(
+            usedDescTypes.begin(), usedDescTypes.end(),
+            markersDescTypes.begin(), markersDescTypes.end(),
+            std::back_inserter(usedMarkersDescTypes)
+        );
+        std::vector<feature::EImageDescriberType> inDescTypes = feature::EImageDescriberType_stringToEnums(landmarksDescriberTypesName);
+
+        std::vector<feature::EImageDescriberType> vDescTypes;
+        std::set_intersection(
+            usedMarkersDescTypes.begin(), usedMarkersDescTypes.end(),
+            inDescTypes.begin(), inDescTypes.end(),
+            std::back_inserter(vDescTypes)
+            );
+        if (vDescTypes.size() != 1)
+        {
+            ALICEVISION_LOG_ERROR("Alignment from markers: Invalid number of image describer types: " << vDescTypes.size());
+            for (auto d : vDescTypes)
+            {
+                ALICEVISION_LOG_ERROR(" - " << feature::EImageDescriberType_enumToString(d));
+            }
+            return EXIT_FAILURE;
+        }
+        const bool success = sfm::computeNewCoordinateSystemFromSpecificMarkers(sfmDataIn, vDescTypes.front(), markers, applyScale, S, R, t);
+        if (!success)
+        {
+            ALICEVISION_LOG_ERROR("Failed to find a valid transformation for these " << markers.size() << " markers.");
+            return EXIT_FAILURE;
+        }
+        break;
+    }
   }
 
   // apply user scale
   S *= userScale;
   t *= userScale;
+
+  if (!applyScale)
+      S = 1;
+  if (!applyRotation)
+      R = Mat3::Identity();
+  if (!applyTranslation)
+      t = Vec3::Zero();
+
+  {
+      ALICEVISION_LOG_INFO("Transformation:" << std::endl
+          << "\t- Scale: " << S << std::endl
+          << "\t- Rotation:\n" << R << std::endl
+          << "\t- Translate: " << t.transpose());
+  }
 
   sfm::applyTransform(sfmDataIn, S, R, t);
 


### PR DESCRIPTION
## Description

Use CCTag markers to define the coordinate system: the SfMTransform node provides new inputs to align specific markers to known 3D positions.

## Features list

- [X] StructureFromMotion node now computes ID for CCTags and store it in the landmark color (markers have no interesting color, so this field is re-used for the ID).
- [X] SfMTransform provides a list of markers/3D positions to redefine the coordinate system of the reconstruction.
- [x] SfMAlignment provides an option to align based on markers ID
- [x] SfMAlignment provides an option to align based on poseId
- [x] SfMAlignment provides an option to align views based on file pattern matching (regex)
- [x] SfMAlignment provides an option to align views based on metadata maching
- [x] New SfMTransfer software to retrieve poses and intrinsics from another reconstruction based on matching views

## Implementation remarks

Markers IDs are stored in the landmark color to avoid the creation of an additional field which would take space for nothing on all landmarks. Maybe in the future, we could consider to have multiple types of landmarks (with different data structure) but that would represent a complex change for a limited benefit for now.

- [X] minor warning fix in cctag
- [X] minor check added in Texturing
- [X] SfM: bug fix tracksPerView should have a key for each view
- [X] SfM fix: this is not an error if we have a calibration in input
