### PR TITLE
Added working infos in LG G6 camera sensors

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -2939,6 +2939,7 @@ Lg;Lg G4;5.95;devicespecifications
 Lg;Lg G5;5.95;devicespecifications
 Lg;Lg G5 SE;5.95;devicespecifications
 Lg;Lg G6;4.71;devicespecifications
+LG Electronics;LG-H870;4.71
 Lg;Lg G6+;4.71;devicespecifications
 Lg;Lg Google Nexus 5;4.54;devicespecifications
 Lg;Lg K8;4.6;devicespecifications


### PR DESCRIPTION
The previous infos for LG G6's camera sensors didn't work for me. I searched my camera sensors info and I noticed that the phone saves photos with this format in metadata, and when tested it worked, so I added them.

