### PR TITLE
Add Oneplus 5T sensor width to the database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4149,6 +4149,7 @@ Oneplus;Oneplus 5T;5.22;devicespecifications
 OnePlus;Oneplus 6;5.5;devicespecifications
 OnePlus;Oneplus 6T;5.5;devicespecifications
 OnePlus;Oneplus A5000;5.22;devicespecifications
+OnePlus;Oneplus A5010;5.22;devicespecifications
 OnePlus;Oneplus A6000;5.5;devicespecifications
 OnePlus;Oneplus A6003;5.5;devicespecifications
 OnePlus;Oneplus A6010;5.5;devicespecifications


### PR DESCRIPTION
My OnePlus 5T write the model data as A5010 in the `EXIF` metadata. Add this missing entry to the database.