### PR TITLE
Fix offset logging against boost 1.71

### DIFF
--- a/src/software/convert/main_convertLDRToHDR.cpp
+++ b/src/software/convert/main_convertLDRToHDR.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <string>
+#include <sstream>
 #include <regex>
 
 // These constants define the current software version.
@@ -285,10 +286,10 @@ void recoverSourceImage(const image::Image<image::RGBfColor>& hdrImage, hdr::rgb
       }
       meanRecovered[channel] /= hdrImage.size();
     }
-    float offset[3];
+    std::stringstream offsets;
     for(int i=0; i<3; ++i)
-        offset[i] = std::abs(meanRecovered[i] - meanVal[i]);
-    ALICEVISION_LOG_INFO("Offset between target source image and recovered from hdr = " << offset);
+        offsets << std::abs(meanRecovered[i] - meanVal[i]) << ' ';
+    ALICEVISION_LOG_INFO("Offset between target source image and recovered from hdr = " << offsets.str());
 }
 
 


### PR DESCRIPTION
Building against boost=1.71 (gcc=9.2) throws an error:
`operator <<` for `float[3]` is ambiguous.
