### PR TITLE
Replace deprecated basestring with str (Py3)

### DIFF
--- a/src/aliceVision/sensorDB/sensorDatabaseSort.py
+++ b/src/aliceVision/sensorDB/sensorDatabaseSort.py
@@ -8,6 +8,12 @@
 
 import argparse
 
+try:
+    _ = basestring
+except NameError:
+    # 'basestring' is undefined, so it must be Python 3
+    basestring = (str, bytes)
+
 # command line
 parser = argparse.ArgumentParser(description='Sort sensor width camera database by the brand / model name')
 parser.add_argument('-i', '--input', metavar='inputSensorDatabase.txt', required=True, type=str,
@@ -24,7 +30,7 @@ file.close()
 
 # process
 sensors = [entry.split(';')  for entry in database]
-sensors.sort(key=lambda t : tuple(s.lower() if isinstance(s, (str, bytes)) else s for s in t))
+sensors.sort(key=lambda t : tuple(s.lower() if isinstance(s, basestring) else s for s in t))
 outDatabase = ""
 for entry in sensors:
 	outDatabase += ';'.join(entry)

--- a/src/aliceVision/sensorDB/sensorDatabaseSort.py
+++ b/src/aliceVision/sensorDB/sensorDatabaseSort.py
@@ -24,7 +24,7 @@ file.close()
 
 # process
 sensors = [entry.split(';')  for entry in database]
-sensors.sort(key=lambda t : tuple(s.lower() if isinstance(s,str) else s for s in t))
+sensors.sort(key=lambda t : tuple(s.lower() if isinstance(s, (str, bytes)) else s for s in t))
 outDatabase = ""
 for entry in sensors:
 	outDatabase += ';'.join(entry)

--- a/src/aliceVision/sensorDB/sensorDatabaseSort.py
+++ b/src/aliceVision/sensorDB/sensorDatabaseSort.py
@@ -24,7 +24,7 @@ file.close()
 
 # process
 sensors = [entry.split(';')  for entry in database]
-sensors.sort(key=lambda t : tuple(s.lower() if isinstance(s,basestring) else s for s in t))
+sensors.sort(key=lambda t : tuple(s.lower() if isinstance(s,str) else s for s in t))
 outDatabase = ""
 for entry in sensors:
 	outDatabase += ';'.join(entry)


### PR DESCRIPTION
## Description
In Python3 `basestring` was removed and replaced with `str`. So I replaced them.
