### PR TITLE
Add an alias for Asus ZE500KL to sensor database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -245,6 +245,7 @@ Asus;Asus ZenFone Zoom;4.7;devicespecifications
 Asus;Asus ZenFone Zoom ZX551ML;4.7;devicespecifications
 Asus;Asus ZenPad S 8.0 Z580CA;3.6;devicespecifications
 Asus;Asus ZenPad S 8.0 Z580CA 16GB;3.6;devicespecifications
+Asus;ASUS_Z00ED;4.69;devicespecifications
 Axgio;Axgio N3;4.69;devicespecifications
 BenQ;BenQ AC100;6.16;digicamdb
 BenQ;BenQ AE100;6.16;digicamdb


### PR DESCRIPTION
## Description
Asus ZenFone 2 Laser ZE500KL images are tagged with the ASUS_Z00ED camera model.