### PR TITLE
[cmake] all-in-one: update geogram to 1.7.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ elseif(UNIX)
 endif()
 set(GEOGRAM_TARGET geogram)
 ExternalProject_Add(${GEOGRAM_TARGET}
-       URL https://github.com/alicevision/geogram/archive/v1.6.6.tar.gz
+       URL https://github.com/alicevision/geogram/archive/v1.7.3.tar.gz
        PREFIX ${BUILD_DIR}
        BUILD_IN_SOURCE 0
        BUILD_ALWAYS 0


### PR DESCRIPTION
## Description

Include a fix for the installation of geogram_num_3rdparty.
Replace #691 
