### PR TITLE
Add scale as parameter in functions for sfm

### DIFF
--- a/src/aliceVision/colorHarmonization/CommonDataByPair_matchedPoints.hpp
+++ b/src/aliceVision/colorHarmonization/CommonDataByPair_matchedPoints.hpp
@@ -10,6 +10,7 @@
 #include "aliceVision/colorHarmonization/CommonDataByPair.hpp"
 #include "aliceVision/matching/IndMatch.hpp"
 #include "aliceVision/feature/feature.hpp"
+#include "aliceVision/feature/RegionsPerView.hpp"
 
 #include <vector>
 
@@ -53,8 +54,8 @@ public:
 
       for(const matching::IndMatch& match : matchesPerDescIt.second) //< loop over matches
       {
-        const feature::SIOPointFeature& L = feature::getSIOPointFeatures(*_regionsL.at(descType)).at(match._i);
-        const feature::SIOPointFeature& R = feature::getSIOPointFeatures(*_regionsR.at(descType)).at(match._j);
+        const feature::PointFeature& L = _regionsL.at(descType)->Features().at(match._i);
+        const feature::PointFeature& R = _regionsR.at(descType)->Features().at(match._j);
 
         image::FilledCircle( L.x(), L.y(), ( int )_radius, ( unsigned char ) 255, &maskLeft );
         image::FilledCircle( R.x(), R.y(), ( int )_radius, ( unsigned char ) 255, &maskRight );

--- a/src/aliceVision/colorHarmonization/CommonDataByPair_vldSegment.hpp
+++ b/src/aliceVision/colorHarmonization/CommonDataByPair_vldSegment.hpp
@@ -20,8 +20,8 @@ class CommonDataByPair_vldSegment  : public CommonDataByPair
   CommonDataByPair_vldSegment( const std::string& sLeftImage,
                                const std::string& sRightImage,
                                const matching::IndMatches& matchesPerDesc,
-                               const std::vector<feature::SIOPointFeature>& featsL,
-                               const std::vector<feature::SIOPointFeature>& featsR)
+                               const std::vector<feature::PointFeature>& featsL,
+                               const std::vector<feature::PointFeature>& featsR)
            : CommonDataByPair( sLeftImage, sRightImage )
            , _matches( matchesPerDesc )
            , _featsL( featsL )
@@ -104,8 +104,8 @@ class CommonDataByPair_vldSegment  : public CommonDataByPair
 
 private:
   // Left and Right features
-  const std::vector<feature::SIOPointFeature>& _featsL;
-  const std::vector<feature::SIOPointFeature>& _featsR;
+  const std::vector<feature::PointFeature>& _featsL;
+  const std::vector<feature::PointFeature>& _featsR;
   // Left and Right corresponding index (putatives matches)
   matching::IndMatches _matches;
 };

--- a/src/aliceVision/feature/KeypointSet.hpp
+++ b/src/aliceVision/feature/KeypointSet.hpp
@@ -18,7 +18,7 @@ namespace feature {
 /// Association storage of associated feature and descriptor for a given image.
 /// Load, save, R/W accessor operation.
 ///
-/// typedef vector<SIOPointFeature> featsT;
+/// typedef vector<PointFeature> featsT;
 /// typedef vector<Descriptor<uchar,128> > descsT;
 /// KeypointSet< featsT, descsT > kpSet;
 template<typename FeaturesT, typename DescriptorsT>

--- a/src/aliceVision/feature/PointFeature.hpp
+++ b/src/aliceVision/feature/PointFeature.hpp
@@ -27,55 +27,26 @@ class PointFeature {
   friend std::istream& operator>>(std::istream& in, PointFeature& obj);
 
 public:
-  PointFeature(float x=0.0f, float y=0.0f)
-   : _coords(x, y) {}
+  PointFeature() {}
+  PointFeature(float x, float y, float scale, float orient)
+   : _coords(x, y),
+     _scale(scale),
+     _orientation(orient)
+  {}
 
   float x() const { return _coords(0); }
   float y() const { return _coords(1); }
   const Vec2f & coords() const { return _coords;}
+  float scale() const { return _scale; }
+  float& scale() { return _scale; }
 
   float& x() { return _coords(0); }
   float& y() { return _coords(1); }
   Vec2f& coords() { return _coords;}
 
-protected:
-  Vec2f _coords;  // (x, y)
-};
-
-typedef std::vector<PointFeature> PointFeatures;
-
-//with overloaded operators:
-inline std::ostream& operator<<(std::ostream& out, const PointFeature& obj)
-{
-  return out << obj._coords(0) << " " << obj._coords(1);
-}
-
-inline std::istream& operator>>(std::istream& in, PointFeature& obj)
-{
-  return in >> obj._coords(0) >> obj._coords(1);
-}
-
-/**
- * Base class for ScaleInvariant Oriented Point features.
- * Add scale and orientation description to basis PointFeature.
- */
-class SIOPointFeature : public PointFeature {
-
-  friend std::ostream& operator<<(std::ostream& out, const SIOPointFeature& obj);
-  friend std::istream& operator>>(std::istream& in, SIOPointFeature& obj);
-
-public:
-  SIOPointFeature(float x=0.0f, float y=0.0f,
-                  float scale=0.0f, float orient=0.0f)
-    : PointFeature(x,y)
-    , _scale(scale)
-    , _orientation(orient) {}
-
-  float scale() const { return _scale; }
-  float& scale() { return _scale; }
   float orientation() const { return _orientation; }
   float& orientation() { return _orientation; }
-  
+
   /**
     * @brief Return the orientation of the feature as an unit vector.
     * @return a unit vector corresponding to the orientation of the feature.
@@ -93,33 +64,34 @@ public:
   {
     return scale()*getOrientationVector();
   }
-  
-  bool operator ==(const SIOPointFeature& b) const {
+
+  bool operator ==(const PointFeature& b) const {
     return (_scale == b.scale()) &&
            (_orientation == b.orientation()) &&
            (x() == b.x()) && (y() == b.y()) ;
   }
 
-  bool operator !=(const SIOPointFeature& b) const {
+  bool operator !=(const PointFeature& b) const {
     return !((*this)==b);
   }
 
 protected:
-  float _scale;        // In pixels.
-  float _orientation;  // In radians.
+  Vec2f _coords = {0.0f, 0.0f};  // (x, y)
+  float _scale = 0.0f; // In pixels.
+  float _orientation = 0.0f;  // In radians.
 };
 
-//
-inline std::ostream& operator<<(std::ostream& out, const SIOPointFeature& obj)
+typedef std::vector<PointFeature> PointFeatures;
+
+//with overloaded operators:
+inline std::ostream& operator<<(std::ostream& out, const PointFeature& obj)
 {
-  const PointFeature *pf = static_cast<const PointFeature*>(&obj);
-  return out << *pf << " " << obj._scale << " " << obj._orientation;
+  return out << obj._coords(0) << " " << obj._coords(1) << " " << obj._scale << " " << obj._orientation;
 }
 
-inline std::istream& operator>>(std::istream& in, SIOPointFeature& obj)
+inline std::istream& operator>>(std::istream& in, PointFeature& obj)
 {
-  PointFeature *pf = static_cast<PointFeature*>(&obj);
-  return in >> *pf >> obj._scale >> obj._orientation;
+  return in >> obj._coords(0) >> obj._coords(1) >> obj._scale >> obj._orientation;
 }
 
 /// Read feats from file

--- a/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.cpp
+++ b/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.cpp
@@ -63,7 +63,7 @@ bool ImageDescriber_AKAZE::describe(const image::Image<float>& image,
           point.angle = 0.0f;
 
         regionsCasted->Features()[i] =
-          SIOPointFeature(point.x, point.y, point.size, point.angle);
+          PointFeature(point.x, point.y, point.size, point.angle);
 
         ComputeMSURFDescriptor(cur_slice.Lx, cur_slice.Ly, point.octave,
           regionsCasted->Features()[i],
@@ -102,12 +102,12 @@ bool ImageDescriber_AKAZE::describe(const image::Image<float>& image,
           point.angle = 0.0f;
 
         regionsCasted->Features()[i] =
-          SIOPointFeature(point.x, point.y, point.size, point.angle);
+          PointFeature(point.x, point.y, point.size, point.angle);
 
         // compute LIOP descriptor (do not need rotation computation, since
         // LIOP descriptor is rotation invariant).
         // rescale for LIOP patch extraction
-        const SIOPointFeature fp = SIOPointFeature(point.x, point.y, point.size/2.0, point.angle);
+        const PointFeature fp = PointFeature(point.x, point.y, point.size/2.0, point.angle);
 
         float desc[144];
         liop_extractor.extract(image, fp, desc);
@@ -143,7 +143,7 @@ bool ImageDescriber_AKAZE::describe(const image::Image<float>& image,
         else
           point.angle = 0.0f;
 
-        regionsCasted->Features()[i] = SIOPointFeature(point.x, point.y, point.size, point.angle);
+        regionsCasted->Features()[i] = PointFeature(point.x, point.y, point.size, point.angle);
 
         // compute MLDB descriptor
         Descriptor<bool,486> desc;

--- a/src/aliceVision/feature/akaze/descriptorLIOP.cpp
+++ b/src/aliceVision/feature/akaze/descriptorLIOP.cpp
@@ -287,7 +287,7 @@ void DescriptorExtractor_LIOP::CreateLIOP_GOrder(
 
 void DescriptorExtractor_LIOP::extract(
   const image::Image<float>& I,
-  const SIOPointFeature& feat,
+  const PointFeature& feat,
   float desc[144])
 {
   memset(desc, 0, sizeof(float)*144);

--- a/src/aliceVision/feature/akaze/descriptorLIOP.hpp
+++ b/src/aliceVision/feature/akaze/descriptorLIOP.hpp
@@ -45,7 +45,7 @@ public:
 
   void extract(
     const image::Image<float> & I,
-    const SIOPointFeature & feat,
+    const PointFeature & feat,
     float desc[144]);
 
   void CreateLIOP_GOrder(

--- a/src/aliceVision/feature/akaze/descriptorMLDB.hpp
+++ b/src/aliceVision/feature/akaze/descriptorMLDB.hpp
@@ -145,7 +145,7 @@ namespace feature {
     const image::Image<Real> &Lx,
     const image::Image<Real> &Ly,
     const int id_octave ,
-    const SIOPointFeature & ipt ,
+    const PointFeature & ipt ,
     Descriptor<bool, 486> & desc )
   {
     // // Note : in KAZE description we compute descriptor of previous slice and never the current one

--- a/src/aliceVision/feature/akaze/descriptorMSURF.hpp
+++ b/src/aliceVision/feature/akaze/descriptorMSURF.hpp
@@ -42,7 +42,7 @@ namespace feature {
     const ImageT & Lx ,
     const ImageT & Ly ,
     const int id_octave ,
-    const SIOPointFeature & ipt ,
+    const PointFeature & ipt ,
     Descriptor< Real , 64 > & desc )
   {
 
@@ -144,7 +144,7 @@ namespace feature {
     const ImageT & Lx ,
     const ImageT & Ly ,
     const int id_octave ,
-    const SIOPointFeature & ipt ,
+    const PointFeature & ipt ,
     Descriptor< unsigned char , 64 > & desc )
   {
     Descriptor< float , 64 > descFloat;

--- a/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
+++ b/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
@@ -143,7 +143,8 @@ bool ImageDescriber_CCTAG::describe(const image::Image<unsigned char>& image,
       }
       desc[cctag.id()] = (unsigned char) 255;
       regionsCasted->Descriptors().push_back(desc);
-      regionsCasted->Features().push_back(PointFeature(cctag.x(), cctag.y(), cctag.scale(), orientation)); // TODO: scale factor
+      const float scale = std::max(cctag.outerEllipse().a(), cctag.outerEllipse().b());
+      regionsCasted->Features().push_back(PointFeature(cctag.x(), cctag.y(), scale, orientation));
     }
   }
 

--- a/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
+++ b/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
@@ -122,10 +122,12 @@ bool ImageDescriber_CCTAG::describe(const image::Image<unsigned char>& image,
 #else //todo: #ifdef depreciated
   cctag::MemoryPool::instance().updateMemoryAuthorizedWithRAM();
   cctag::View cctagView((const unsigned char *) image.data(), image.Width(), image.Height(), image.Depth()*image.Width());
-  boost::ptr_list<cctag::ICCTag> cctags;
   cctag::cctagDetection(cctags, _cudaPipe, 1 ,cctagView._grayView ,*_params._internalParams, durations );
 #endif
   durations->print( std::cerr );
+
+  // There is no notion of orientation in CCTag
+  const float orientation = 0.0f;
 
   for (const auto & cctag : cctags)
   {
@@ -141,7 +143,7 @@ bool ImageDescriber_CCTAG::describe(const image::Image<unsigned char>& image,
       }
       desc[cctag.id()] = (unsigned char) 255;
       regionsCasted->Descriptors().push_back(desc);
-      regionsCasted->Features().push_back(SIOPointFeature(cctag.x(), cctag.y()));
+      regionsCasted->Features().push_back(PointFeature(cctag.x(), cctag.y(), cctag.scale(), orientation)); // TODO: scale factor
     }
   }
 

--- a/src/aliceVision/feature/features_test.cpp
+++ b/src/aliceVision/feature/features_test.cpp
@@ -22,7 +22,7 @@ using namespace aliceVision;
 using namespace aliceVision::feature;
 
 // Define a feature and a container of features
-typedef SIOPointFeature Feature_T;
+typedef PointFeature Feature_T;
 typedef std::vector<Feature_T> Feats_T;
 
 // Define a descriptor and a container of descriptors

--- a/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.cpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.cpp
@@ -48,7 +48,7 @@ bool ImageDescriber_AKAZE_OCV::describe(const image::Image<unsigned char>& image
 
   for(const auto& i_keypoint : vec_keypoints)
   {
-    SIOPointFeature feat(i_keypoint.pt.x, i_keypoint.pt.y, i_keypoint.size, i_keypoint.angle);
+    PointFeature feat(i_keypoint.pt.x, i_keypoint.pt.y, i_keypoint.size, i_keypoint.angle);
     regionsCasted->Features().push_back(feat);
 
     memcpy(descriptor.getData(),

--- a/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp
@@ -161,7 +161,7 @@ bool ImageDescriber_SIFT_openCV::describe(const image::Image<unsigned char>& ima
   int cpt = 0;
   for(const auto& i_kp : v_keypoints)
   {
-    SIOPointFeature feat(i_kp.pt.x, i_kp.pt.y, i_kp.size, i_kp.angle);
+    PointFeature feat(i_kp.pt.x, i_kp.pt.y, i_kp.size, i_kp.angle);
     regionsCasted->Features().push_back(feat);
 
     Descriptor<unsigned char, 128> desc;

--- a/src/aliceVision/feature/regionsFactory.hpp
+++ b/src/aliceVision/feature/regionsFactory.hpp
@@ -14,18 +14,18 @@ namespace aliceVision {
 namespace feature {
 
 /// Define the classic SIFT Keypoint
-typedef ScalarRegions<SIOPointFeature,unsigned char,128> SIFT_Regions;
+using SIFT_Regions = ScalarRegions<unsigned char,128>;
 /// Define the classic SIFT features using float representation
-typedef ScalarRegions<SIOPointFeature,float,128> SIFT_Float_Regions;
+using SIFT_Float_Regions = ScalarRegions<float,128>;
 /// Define the classic CCTag Keypoint
-typedef ScalarRegions<SIOPointFeature,unsigned char,128> CCTAG_Regions;
+using CCTAG_Regions = ScalarRegions<unsigned char,128>;
 /// Define the AKAZE Keypoint (with a float descriptor)
-typedef ScalarRegions<SIOPointFeature,float,64> AKAZE_Float_Regions;
+using AKAZE_Float_Regions = ScalarRegions<float,64>;
 /// Define the AKAZE Keypoint (with a LIOP descriptor)
-typedef ScalarRegions<SIOPointFeature,unsigned char,144> AKAZE_Liop_Regions;
+using AKAZE_Liop_Regions = ScalarRegions<unsigned char,144>;
 
 /// Define the AKAZE Keypoint (with a binary descriptor saved in an uchar array)
-typedef BinaryRegions<SIOPointFeature,64> AKAZE_BinaryRegions;
+using AKAZE_BinaryRegions = BinaryRegions<64>;
 
 } // namespace feature
 } // namespace aliceVision

--- a/src/aliceVision/feature/selection.cpp
+++ b/src/aliceVision/feature/selection.cpp
@@ -23,12 +23,12 @@ const size_t gridSize = 3;
 */
 void sortMatches_byFeaturesScale(
 	const aliceVision::matching::IndMatches& inputMatches,
-	const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& regionsI,
-	const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& regionsJ,
+    const aliceVision::feature::Regions& regionsI,
+    const aliceVision::feature::Regions& regionsJ,
 	aliceVision::matching::IndMatches& outputMatches)
 {
-	const std::vector<aliceVision::feature::SIOPointFeature>& vecFeatureI = regionsI.Features();
-	const std::vector<aliceVision::feature::SIOPointFeature>& vecFeatureJ = regionsJ.Features();
+    const std::vector<aliceVision::feature::PointFeature>& vecFeatureI = regionsI.Features();
+    const std::vector<aliceVision::feature::PointFeature>& vecFeatureJ = regionsJ.Features();
 
 	//outputMatches will contain the sorted matches if inputMatches.
 	outputMatches.reserve(inputMatches.size());
@@ -38,17 +38,17 @@ void sortMatches_byFeaturesScale(
 	std::vector<std::pair<float, size_t>> vecFeatureScale;
 
 	for (size_t i = 0; i < inputMatches.size(); i++)
-  {
+    {
 		float scale1 = vecFeatureI[inputMatches[i]._i].scale();
 		float scale2 = vecFeatureJ[inputMatches[i]._j].scale();
 		vecFeatureScale.emplace_back((scale1 + scale2) / 2.0, i);
-	}
+    }
 
 	std::sort(vecFeatureScale.begin(), vecFeatureScale.end(), matchCompare);
 
 	//The sorted match vector is filled according to the result of the sorting above.
 	for (size_t i = 0; i < vecFeatureScale.size(); i++)
-  {
+    {
 		outputMatches.push_back(inputMatches[vecFeatureScale[i].second]);
 	}
 }
@@ -96,8 +96,8 @@ void thresholdMatches(aliceVision::matching::IndMatches& outputMatches, const st
  * @param[in] sfm_data The sfm data file
  * @param[out] outMatches The remaining matches
  */
-void matchesGridFiltering(const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& lRegions, 
-        const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& rRegions, 
+void matchesGridFiltering(const aliceVision::feature::Regions& lRegions,
+        const aliceVision::feature::Regions& rRegions,
         const aliceVision::Pair& indexImagePair,
         const aliceVision::sfmData::SfMData sfm_data, 
         aliceVision::matching::IndMatches& outMatches)
@@ -121,8 +121,8 @@ void matchesGridFiltering(const aliceVision::feature::FeatRegions<aliceVision::f
   // Split matches in grid cells
   for(const auto& match: outMatches)
   {
-    const aliceVision::feature::SIOPointFeature& leftPoint = lRegions.Features()[match._i];
-    const aliceVision::feature::SIOPointFeature& rightPoint = rRegions.Features()[match._j];
+    const aliceVision::feature::PointFeature& leftPoint = lRegions.Features()[match._i];
+    const aliceVision::feature::PointFeature& rightPoint = rRegions.Features()[match._j];
     
     const float leftGridIndex_f = std::floor(leftPoint.x() / (float)leftCellWidth) + std::floor(leftPoint.y() / (float)leftCellHeight) * gridSize;
     const float rightGridIndex_f = std::floor(rightPoint.x() / (float)rightCellWidth) + std::floor(rightPoint.y() / (float)rightCellHeight) * gridSize;

--- a/src/aliceVision/feature/selection.hpp
+++ b/src/aliceVision/feature/selection.hpp
@@ -29,8 +29,8 @@ namespace feature {
 */
 void sortMatches_byFeaturesScale(
 	const aliceVision::matching::IndMatches& inputMatches,
-	const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& regionsI,
-	const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& regionsJ,
+    const aliceVision::feature::Regions& regionsI,
+    const aliceVision::feature::Regions& regionsJ,
 	aliceVision::matching::IndMatches& outputMatches);
 
 /** 
@@ -62,8 +62,8 @@ void thresholdMatches(aliceVision::matching::IndMatches& outputMatches, const st
  * @param[in] sfm_data The sfm data file
  * @param[out] outMatches The remaining matches
  */
-void matchesGridFiltering(const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& lRegions, 
-        const aliceVision::feature::FeatRegions<aliceVision::feature::SIOPointFeature>& rRegions, 
+void matchesGridFiltering(const aliceVision::feature::Regions& lRegions,
+        const aliceVision::feature::Regions& rRegions,
         const aliceVision::Pair& indexImagePair,
         const aliceVision::sfmData::SfMData sfm_data, 
         aliceVision::matching::IndMatches& outMatches);

--- a/src/aliceVision/feature/sift/SIFT.hpp
+++ b/src/aliceVision/feature/sift/SIFT.hpp
@@ -10,7 +10,7 @@
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/feature/ImageDescriber.hpp>
 #include <aliceVision/feature/regionsFactory.hpp>
-// #include <aliceVision/config.hpp> // TO CHECK
+#include <aliceVision/config.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 extern "C" {

--- a/src/aliceVision/feature/svgVisualization.cpp
+++ b/src/aliceVision/feature/svgVisualization.cpp
@@ -62,10 +62,10 @@ float getStrokeEstimate(const std::pair<size_t,size_t> & imgSize)
 
 void drawMatchesSideBySide(const std::string& imagePathLeft,
                            const std::pair<size_t,size_t>& imageSizeLeft,
-                           const std::vector<feature::SIOPointFeature>& keypointsLeft,
+                           const std::vector<feature::PointFeature>& keypointsLeft,
                            const std::string& imagePathRight,
                            const std::pair<size_t,size_t>& imageSizeRight,
-                           const std::vector<feature::SIOPointFeature>& keypointsRight,
+                           const std::vector<feature::PointFeature>& keypointsRight,
                            const matching::IndMatches& matches,
                            const std::string &outputSVGPath)
 {
@@ -115,10 +115,10 @@ void drawMatchesSideBySide(const std::string& imagePathLeft,
 
 void drawHomographyMatches(const std::string& imagePathLeft,
                            const std::pair<size_t,size_t>& imageSizeLeft,
-                           const std::vector<feature::SIOPointFeature>& siofeatures_I,
+                           const std::vector<feature::PointFeature>& siofeatures_I,
                            const std::string& imagePathRight,
                            const std::pair<size_t,size_t>& imageSizeRight,
-                           const std::vector<feature::SIOPointFeature>& siofeatures_J,
+                           const std::vector<feature::PointFeature>& siofeatures_J,
                            const std::vector<std::pair<Mat3, matching::IndMatches>>& homographiesAndMatches,
                            const matching::IndMatches& putativeMatches,
                            const std::string& outFilename)
@@ -137,8 +137,8 @@ void drawHomographyMatches(const std::string& imagePathLeft,
   {
     const float radius{1.f};
     const float strokeSize{2.f};
-    const feature::SIOPointFeature &fI = siofeatures_I.at(match._i);
-    const feature::SIOPointFeature &fJ = siofeatures_J.at(match._j);
+    const feature::PointFeature &fI = siofeatures_I.at(match._i);
+    const feature::PointFeature &fJ = siofeatures_J.at(match._j);
     const svg::svgStyle style = svg::svgStyle().stroke("white", strokeSize);
 
     svgStream.drawCircle(fI.x(), fI.y(), radius, style);
@@ -158,8 +158,8 @@ void drawHomographyMatches(const std::string& imagePathLeft,
 
       for (const auto &match : bestMatchesId)
       {
-        const feature::SIOPointFeature &fI = siofeatures_I.at(match._i);
-        const feature::SIOPointFeature &fJ = siofeatures_J.at(match._j);
+        const feature::PointFeature &fI = siofeatures_I.at(match._i);
+        const feature::PointFeature &fJ = siofeatures_J.at(match._j);
 
         const svg::svgStyle style = svg::svgStyle().stroke(color, strokeSize);
 
@@ -232,7 +232,7 @@ void saveMatches2SVG(const std::string &imagePathLeft,
 
 void saveKeypoints2SVG(const std::string &inputImagePath,
                        const std::pair<size_t,size_t> & imageSize,
-                       const std::vector<feature::SIOPointFeature> &keypoints,
+                       const std::vector<feature::PointFeature> &keypoints,
                        const std::string &outputSVGPath,
                        bool richKeypoint /*= true*/)
 {
@@ -245,7 +245,7 @@ void saveKeypoints2SVG(const std::string &inputImagePath,
   const float radius = getRadiusEstimate(imageSize);
   const float strokeWidth = getStrokeEstimate(imageSize);
   
-  for(const feature::SIOPointFeature &kpt : keypoints) 
+  for(const feature::PointFeature &kpt : keypoints)
   {
     svgStream.drawCircle(kpt.x(), kpt.y(), (richKeypoint) ? kpt.scale()*radius : radius, svg::svgStyle().stroke("yellow", strokeWidth));
     if(richKeypoint)
@@ -280,10 +280,10 @@ void saveKeypoints2SVG(const std::string &inputImagePath,
  */
 void drawKeypointsSideBySide(const std::string&imagePathLeft,
                              const std::pair<size_t,size_t>& imageSizeLeft,
-                             const std::vector<feature::SIOPointFeature>& keypointsLeft,
+                             const std::vector<feature::PointFeature>& keypointsLeft,
                              const std::string &imagePathRight,
                              const std::pair<size_t,size_t>& imageSizeRight,
-                             const std::vector<feature::SIOPointFeature>& keypointsRight,
+                             const std::vector<feature::PointFeature>& keypointsRight,
                              const std::string &outputSVGPath,
                              bool richKeypoint)
 {
@@ -557,8 +557,8 @@ void saveEpipolarGeometry2SVG(const std::string &imagePath,
 
 void saveMatchesAsMotion(const std::string &imagePath,
                          const std::pair<size_t, size_t> & imageSize,
-                         const std::vector<feature::SIOPointFeature> &keypoints,
-                         const std::vector<feature::SIOPointFeature> &otherKeypoints,
+                         const std::vector<feature::PointFeature> &keypoints,
+                         const std::vector<feature::PointFeature> &otherKeypoints,
                          const matching::IndMatches &matches,
                          const std::string &outputSVGPath,
                          bool left,
@@ -595,8 +595,8 @@ void saveMatchesAsMotion(const std::string &imagePath,
 
 void saveMatchesAsMotion(const std::string &imagePath,
                          const std::pair<size_t, size_t> & imageSize,
-                         const std::vector<feature::SIOPointFeature> &keypoints,
-                         const std::vector<feature::SIOPointFeature> &otherKeypoints,
+                         const std::vector<feature::PointFeature> &keypoints,
+                         const std::vector<feature::PointFeature> &otherKeypoints,
                          const std::vector<std::pair<Mat3, matching::IndMatches>>& homographiesAndMatches,
                          const std::string &outputSVGPath,
                          bool left,

--- a/src/aliceVision/feature/svgVisualization.hpp
+++ b/src/aliceVision/feature/svgVisualization.hpp
@@ -54,10 +54,10 @@ std::string describerTypeColor(feature::EImageDescriberType descType);
  */
 void drawMatchesSideBySide(const std::string& imagePathLeft,
                            const std::pair<size_t,size_t>& imageSizeLeft,
-                           const std::vector<feature::SIOPointFeature>& keypointsLeft,
+                           const std::vector<feature::PointFeature>& keypointsLeft,
                            const std::string& imagePathRight,
                            const std::pair<size_t,size_t>& imageSizeRight,
-                           const std::vector<feature::SIOPointFeature>& keypointsRight,
+                           const std::vector<feature::PointFeature>& keypointsRight,
                            const matching::IndMatches& matches,
                            const std::string &outputSVGPath);
 
@@ -81,10 +81,10 @@ void drawMatchesSideBySide(const std::string& imagePathLeft,
  */
 void drawHomographyMatches(const std::string& imagePathLeft,
                            const std::pair<size_t,size_t>& imageSizeLeft,
-                           const std::vector<feature::SIOPointFeature>& siofeatures_I,
+                           const std::vector<feature::PointFeature>& siofeatures_I,
                            const std::string& imagePathRight,
                            const std::pair<size_t,size_t>& imageSizeRight,
-                           const std::vector<feature::SIOPointFeature>& siofeatures_J,
+                           const std::vector<feature::PointFeature>& siofeatures_J,
                            const std::vector<std::pair<Mat3, matching::IndMatches>>& homographiesAndMatches,
                            const matching::IndMatches& putativeMatches,
                            const std::string& outFilename);
@@ -158,10 +158,10 @@ void saveMatches2SVG(const std::string &imagePathLeft,
  */
 void drawKeypointsSideBySide(const std::string&imagePathLeft,
                              const std::pair<size_t,size_t>& imageSizeLeft,
-                             const std::vector<feature::SIOPointFeature>& keypointsLeft,
+                             const std::vector<feature::PointFeature>& keypointsLeft,
                              const std::string &imagePathRight,
                              const std::pair<size_t,size_t>& imageSizeRight,
-                             const std::vector<feature::SIOPointFeature>& keypointsRight,
+                             const std::vector<feature::PointFeature>& keypointsRight,
                              const std::string &outputSVGPath,
                              bool richKeypoint = true);
 
@@ -179,7 +179,7 @@ void drawKeypointsSideBySide(const std::string&imagePathLeft,
  */
 void saveKeypoints2SVG(const std::string &inputImagePath,
                        const std::pair<size_t,size_t> & imageSize,
-                       const std::vector<feature::SIOPointFeature> &keypoints,
+                       const std::vector<feature::PointFeature> &keypoints,
                        const std::string &outputSVGPath,
                        bool richKeypoint = true);
 /**
@@ -259,8 +259,8 @@ void saveEpipolarGeometry2SVG(const std::string &imagePath,
  */
 void saveMatchesAsMotion(const std::string &imagePath,
                          const std::pair<size_t, size_t> & imageSize,
-                         const std::vector<feature::SIOPointFeature> &keypoints,
-                         const std::vector<feature::SIOPointFeature> &otherKeypoints,
+                         const std::vector<feature::PointFeature> &keypoints,
+                         const std::vector<feature::PointFeature> &otherKeypoints,
                          const matching::IndMatches &matches,
                          const std::string &outputSVGPath,
                          bool left,
@@ -268,8 +268,8 @@ void saveMatchesAsMotion(const std::string &imagePath,
 
 void saveMatchesAsMotion(const std::string &imagePath,
                          const std::pair<size_t, size_t> & imageSize,
-                         const std::vector<feature::SIOPointFeature> &keypoints,
-                         const std::vector<feature::SIOPointFeature> &otherKeypoints,
+                         const std::vector<feature::PointFeature> &keypoints,
+                         const std::vector<feature::PointFeature> &otherKeypoints,
                          const std::vector<std::pair<Mat3, matching::IndMatches>>& homographiesAndMatches,
                          const std::string &outputSVGPath,
                          bool left,

--- a/src/aliceVision/localization/optimization.cpp
+++ b/src/aliceVision/localization/optimization.cpp
@@ -100,6 +100,7 @@ bool refineSequence(std::vector<LocalizationResult> & vec_localizationResult,
     }
   }
   
+  const double unknownScale = 0.0;
   for(size_t viewID = 0; viewID < numViews; ++viewID)
   {
     LocalizationResult &currResult = vec_localizationResult[viewID];
@@ -165,7 +166,7 @@ bool refineSequence(std::vector<LocalizationResult> & vec_localizationResult,
         }
 
         // the 3D point exists already, add the observation
-        landmark.observations[viewID] =  sfmData::Observation(feature, match.featId);
+        landmark.observations[viewID] =  sfmData::Observation(feature, match.featId, unknownScale);
       }
       else
       {
@@ -173,7 +174,7 @@ bool refineSequence(std::vector<LocalizationResult> & vec_localizationResult,
         sfmData::Landmark newLandmark;
         newLandmark.descType = match.descType;
         newLandmark.X = currResult.getPt3D().col(idx);
-        newLandmark.observations[viewID] = sfmData::Observation(feature, match.featId);
+        newLandmark.observations[viewID] = sfmData::Observation(feature, match.featId, unknownScale);
         tinyScene.structure[match.landmarkId] = std::move(newLandmark);
       }
     }

--- a/src/aliceVision/matching/IndMatchDecorator.hpp
+++ b/src/aliceVision/matching/IndMatchDecorator.hpp
@@ -59,20 +59,6 @@ class IndMatchDecorator
 public:
 
   IndMatchDecorator(const std::vector<IndMatch> & vec_matches,
-    const std::vector<feature::SIOPointFeature> & leftFeat,
-    const std::vector<feature::SIOPointFeature> & rightFeat)
-    :_vec_matches(vec_matches)
-  {
-    for (size_t i = 0; i < vec_matches.size(); ++i) {
-      const size_t I = vec_matches[i]._i;
-      const size_t J = vec_matches[i]._j;
-      _vecDecoredMatches.push_back(
-        IndMatchDecoratorStruct(leftFeat[I].x(),leftFeat[I].y(),
-        rightFeat[J].x(), rightFeat[J].y(), vec_matches[i]));
-    }
-  }
-
-  IndMatchDecorator(const std::vector<IndMatch> & vec_matches,
     const std::vector<feature::PointFeature> & leftFeat,
     const std::vector<feature::PointFeature> & rightFeat)
     :_vec_matches(vec_matches)

--- a/src/aliceVision/matching/kvld/algorithm.cpp
+++ b/src/aliceVision/matching/kvld/algorithm.cpp
@@ -38,7 +38,7 @@ float getRange(
 
 //=============================IO interface======================//
 
-std::ofstream& writeDetector( std::ofstream& out, const aliceVision::feature::SIOPointFeature& feature )
+std::ofstream& writeDetector( std::ofstream& out, const aliceVision::feature::PointFeature& feature )
 {
   out << feature.x() << " "
     << feature.y() << " "
@@ -47,7 +47,7 @@ std::ofstream& writeDetector( std::ofstream& out, const aliceVision::feature::SI
   return out;
 }
 
-std::ifstream& readDetector( std::ifstream& in, aliceVision::feature::SIOPointFeature& point )
+std::ifstream& readDetector( std::ifstream& in, aliceVision::feature::PointFeature& point )
 {
   in >> point.x()
     >> point.y()

--- a/src/aliceVision/matching/kvld/algorithm.h
+++ b/src/aliceVision/matching/kvld/algorithm.h
@@ -86,8 +86,8 @@ private :
 
 //=============================IO interface ======================//
 
-std::ofstream& writeDetector( std::ofstream& out, const aliceVision::feature::SIOPointFeature& vect );
-std::ifstream& readDetector( std::ifstream& in, aliceVision::feature::SIOPointFeature& point );
+std::ofstream& writeDetector( std::ofstream& out, const aliceVision::feature::PointFeature& vect );
+std::ifstream& readDetector( std::ifstream& in, aliceVision::feature::PointFeature& point );
 //======================================elemetuary operations================================//
 template < typename T >
 inline T point_distance( const T x1, const T y1, const T x2, const T y2 )

--- a/src/aliceVision/matching/kvld/kvld.cpp
+++ b/src/aliceVision/matching/kvld/kvld.cpp
@@ -200,8 +200,8 @@ VLD::VLD( const ImageScale& series, T const& P1, T const& P2 ) : contrast( 0.0 )
 
 float KVLD( const Image< float >& I1,
             const Image< float >& I2,
-            const std::vector<feature::SIOPointFeature> & F1,
-            const std::vector<feature::SIOPointFeature> & F2,
+            const std::vector<feature::PointFeature> & F1,
+            const std::vector<feature::PointFeature> & F2,
             const vector< Pair >& matches,
             vector< Pair >& matchesFiltered,
             vector< double >& score,

--- a/src/aliceVision/matching/kvld/kvld.h
+++ b/src/aliceVision/matching/kvld/kvld.h
@@ -165,8 +165,8 @@ public:
 
 float KVLD(const aliceVision::image::Image< float >& I1,
   const aliceVision::image::Image< float >& I2,
-  const std::vector<aliceVision::feature::SIOPointFeature> & F1,
-  const std::vector<aliceVision::feature::SIOPointFeature> & F2,
+  const std::vector<aliceVision::feature::PointFeature> & F1,
+  const std::vector<aliceVision::feature::PointFeature> & F2,
   const std::vector< aliceVision::Pair >& matches,
   std::vector< aliceVision::Pair >& matchesFiltered,
   std::vector< double >& score,

--- a/src/aliceVision/matching/kvld/kvld_draw.h
+++ b/src/aliceVision/matching/kvld/kvld_draw.h
@@ -17,8 +17,8 @@ namespace aliceVision {
 void getKVLDMask(
   image::Image< unsigned char > *maskL,
   image::Image< unsigned char > *maskR,
-  const std::vector< feature::SIOPointFeature > &vec_F1,
-  const std::vector< feature::SIOPointFeature > &vec_F2,
+  const std::vector< feature::PointFeature > &vec_F1,
+  const std::vector< feature::PointFeature > &vec_F2,
   const std::vector< Pair >& vec_matches,
   const std::vector< bool >& vec_valide,
   const aliceVision::Mat& mat_E)
@@ -29,15 +29,15 @@ void getKVLDMask(
     {
       if( vec_valide[ it1 ] && vec_valide[ it2 ] && mat_E( it1, it2 ) >= 0 )
       {
-        const feature::SIOPointFeature & l1 = vec_F1[ vec_matches[ it1 ].first ];
-        const feature::SIOPointFeature & l2 = vec_F1[ vec_matches[ it2 ].first ];
+        const feature::PointFeature & l1 = vec_F1[ vec_matches[ it1 ].first ];
+        const feature::PointFeature & l2 = vec_F1[ vec_matches[ it2 ].first ];
         float l = ( l1.coords() - l2.coords() ).norm();
         int widthL = std::max( 1.f, l / ( dimension + 1.f ) );
 
         image::DrawLineThickness(l1.x(), l1.y(), l2.x(), l2.y(), 255, widthL, maskL);
 
-        const feature::SIOPointFeature & r1 = vec_F2[ vec_matches[ it1 ].second ];
-        const feature::SIOPointFeature & r2 = vec_F2[ vec_matches[ it2 ].second ];
+        const feature::PointFeature & r1 = vec_F2[ vec_matches[ it1 ].second ];
+        const feature::PointFeature & r2 = vec_F2[ vec_matches[ it2 ].second ];
         float r = ( r1.coords() - r2.coords() ).norm();
         int widthR = std::max( 1.f, r / ( dimension + 1.f ) );
 

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.cpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.cpp
@@ -61,8 +61,8 @@ std::size_t GeometricFilterMatrix_HGrowing::getNbAllVerifiedMatches() const
 
 
 
-bool growHomography(const std::vector<feature::SIOPointFeature> &featuresI,
-                    const std::vector<feature::SIOPointFeature> &featuresJ,
+bool growHomography(const std::vector<feature::PointFeature> &featuresI,
+                    const std::vector<feature::PointFeature> &featuresJ,
                     const matching::IndMatches &matches,
                     const IndexT &seedMatchId,
                     std::set<IndexT> &planarMatchesIndices, Mat3 &transformation,
@@ -74,8 +74,8 @@ bool growHomography(const std::vector<feature::SIOPointFeature> &featuresI,
   transformation = Mat3::Identity();
 
   const matching::IndMatch & seedMatch = matches.at(seedMatchId);
-  const feature::SIOPointFeature & seedFeatureI = featuresI.at(seedMatch._i);
-  const feature::SIOPointFeature & seedFeatureJ = featuresJ.at(seedMatch._j);
+  const feature::PointFeature & seedFeatureI = featuresI.at(seedMatch._i);
+  const feature::PointFeature & seedFeatureJ = featuresJ.at(seedMatch._j);
 
   double currTolerance;
 
@@ -111,8 +111,8 @@ bool growHomography(const std::vector<feature::SIOPointFeature> &featuresI,
 
 
 
-void filterMatchesByHGrowing(const std::vector<feature::SIOPointFeature>& siofeatures_I,
-                             const std::vector<feature::SIOPointFeature>& siofeatures_J,
+void filterMatchesByHGrowing(const std::vector<feature::PointFeature>& siofeatures_I,
+                             const std::vector<feature::PointFeature>& siofeatures_J,
                              const matching::IndMatches& putativeMatches,
                              std::vector<std::pair<Mat3, matching::IndMatches>>& homographiesAndMatches,
                              matching::IndMatches& outGeometricInliers,
@@ -210,8 +210,8 @@ void filterMatchesByHGrowing(const std::vector<feature::SIOPointFeature>& siofea
 
 void drawHomographyMatches(const sfmData::View &viewI,
                            const sfmData::View &viewJ,
-                           const std::vector<feature::SIOPointFeature> &siofeatures_I,
-                           const std::vector<feature::SIOPointFeature> &siofeatures_J,
+                           const std::vector<feature::PointFeature> &siofeatures_I,
+                           const std::vector<feature::PointFeature> &siofeatures_J,
                            const std::vector<std::pair<Mat3, matching::IndMatches>> &homographiesAndMatches,
                            const matching::IndMatches &putativeMatches,
                            const std::string &outFilename)

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
@@ -82,8 +82,8 @@ struct GrowParameters
  * @param[in] param The parameters of the algorihm.
  * @return true if the \c transformation is different than the identity matrix.
  */
-bool growHomography(const std::vector<feature::SIOPointFeature> &featuresI,
-                    const std::vector<feature::SIOPointFeature> &featuresJ,
+bool growHomography(const std::vector<feature::PointFeature> &featuresI,
+                    const std::vector<feature::PointFeature> &featuresJ,
                     const matching::IndMatches &matches,
                     const IndexT &seedMatchId,
                     std::set<IndexT> &planarMatchesIndices,
@@ -118,8 +118,8 @@ struct HGrowingFilteringParam
  * @param[out] outGeometricInliers All the matches that supports one of the found homographies.
  * @param[in] param The parameters of the algorithm.
  */
-void filterMatchesByHGrowing(const std::vector<feature::SIOPointFeature>& siofeatures_I,
-                             const std::vector<feature::SIOPointFeature>& siofeatures_J,
+void filterMatchesByHGrowing(const std::vector<feature::PointFeature>& siofeatures_I,
+                             const std::vector<feature::PointFeature>& siofeatures_J,
                              const matching::IndMatches& putativeMatches,
                              std::vector<std::pair<Mat3,
                              matching::IndMatches>>& homographiesAndMatches,
@@ -139,8 +139,8 @@ void filterMatchesByHGrowing(const std::vector<feature::SIOPointFeature>& siofea
  */
 void drawHomographyMatches(const sfmData::View &viewI,
                            const sfmData::View &viewJ,
-                           const std::vector<feature::SIOPointFeature> &siofeatures_I,
-                           const std::vector<feature::SIOPointFeature> &siofeatures_J,
+                           const std::vector<feature::PointFeature> &siofeatures_I,
+                           const std::vector<feature::PointFeature> &siofeatures_J,
                            const std::vector<std::pair<Mat3, matching::IndMatches>> &homographiesAndMatches,
                            const matching::IndMatches &putativeMatches,
                            const std::string &outFilename);
@@ -223,13 +223,11 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
 
       const Regions & regions_I = regionsPerView.getRegions(viewId_I, descType);
       const Regions & regions_J = regionsPerView.getRegions(viewId_J, descType);
-      const std::vector<SIOPointFeature>& siofeatures_I = getSIOPointFeatures(regions_I);
-      const std::vector<SIOPointFeature>& siofeatures_J = getSIOPointFeatures(regions_J);
 
       std::vector<std::pair<Mat3, matching::IndMatches>> homographiesAndMatches;
       matching::IndMatches outGeometricInliers;
-      filterMatchesByHGrowing(siofeatures_I,
-                              siofeatures_J,
+      filterMatchesByHGrowing(regions_I.Features(),
+                              regions_J.Features(),
                               putativeMatchesPerType.at(descType),
                               homographiesAndMatches,
                               outGeometricInliers,
@@ -243,7 +241,6 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
         continue;
       }
 
-
       if (boost::filesystem::exists(outputSvgDir))
       {
         const std::size_t nbMatches = outGeometricInliers.size();
@@ -254,8 +251,8 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
         const std::string outFilename = (boost::filesystem::path(outputSvgDir) / boost::filesystem::path(name)).string();
         drawHomographyMatches(viewI,
                               viewJ,
-                              siofeatures_I,
-                              siofeatures_J,
+                              regions_I.Features(),
+                              regions_J.Features(),
                               homographiesAndMatches,
                               putativeMatchesPerType.at(descType),
                               outFilename);

--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils.cpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils.cpp
@@ -56,8 +56,8 @@ void centerMatrix(const Eigen::Matrix2Xf & points2d, Mat3 & t)
 }
 
 
-void centeringMatrices(const std::vector<feature::SIOPointFeature> & featuresI,
-                       const std::vector<feature::SIOPointFeature> & featuresJ,
+void centeringMatrices(const std::vector<feature::PointFeature> & featuresI,
+                       const std::vector<feature::PointFeature> & featuresJ,
                        const matching::IndMatches & matches,
                        Mat3 & cI,
                        Mat3 & cJ,
@@ -94,8 +94,8 @@ void centeringMatrices(const std::vector<feature::SIOPointFeature> & featuresI,
   centerMatrix(ptsJ, cJ);
 }
 
-void computeSimilarity(const feature::SIOPointFeature & feat1,
-                       const feature::SIOPointFeature & feat2,
+void computeSimilarity(const feature::PointFeature & feat1,
+                       const feature::PointFeature & feat2,
                        Mat3 & S)
 {
   S = Mat3::Identity();
@@ -125,8 +125,8 @@ void computeSimilarity(const feature::SIOPointFeature & feat1,
   S = A2 * A1.inverse();
 }
 
-void estimateAffinity(const std::vector<feature::SIOPointFeature> & featuresI,
-                      const std::vector<feature::SIOPointFeature> & featuresJ,
+void estimateAffinity(const std::vector<feature::PointFeature> & featuresI,
+                      const std::vector<feature::PointFeature> & featuresJ,
                       const matching::IndMatches & matches,
                       Mat3 & affineTransformation,
                       const std::set<IndexT> & usefulMatchesId)
@@ -155,8 +155,8 @@ void estimateAffinity(const std::vector<feature::SIOPointFeature> & featuresI,
   int iMatch = 0;
   for (IndexT matchId : matchesId)
   {
-    const feature::SIOPointFeature & featI = featuresI.at(matches.at(matchId)._i);
-    const feature::SIOPointFeature & featJ = featuresJ.at(matches.at(matchId)._j);
+    const feature::PointFeature & featI = featuresI.at(matches.at(matchId)._i);
+    const feature::PointFeature & featJ = featuresJ.at(matches.at(matchId)._j);
     const Vec2 featICoords (featI.x(), featI.y());
 
     M.block(iMatch,0,1,3) = featICoords.homogeneous().transpose();
@@ -175,8 +175,8 @@ void estimateAffinity(const std::vector<feature::SIOPointFeature> & featuresI,
   affineTransformation(2,2) = 1.;
 }
 
-void estimateHomography(const std::vector<feature::SIOPointFeature> &featuresI,
-                        const std::vector<feature::SIOPointFeature> &featuresJ,
+void estimateHomography(const std::vector<feature::PointFeature> &featuresI,
+                        const std::vector<feature::PointFeature> &featuresJ,
                         const matching::IndMatches &matches,
                         Mat3 &H,
                         const std::set<IndexT> &usefulMatchesId)
@@ -208,8 +208,8 @@ void estimateHomography(const std::vector<feature::SIOPointFeature> &featuresI,
   IndexT iMatch = 0;
   for(IndexT matchId : matchesId)
   {
-    const feature::SIOPointFeature & featI = featuresI.at(matches.at(matchId)._i);
-    const feature::SIOPointFeature & featJ = featuresJ.at(matches.at(matchId)._j);
+    const feature::PointFeature & featI = featuresI.at(matches.at(matchId)._i);
+    const feature::PointFeature & featJ = featuresJ.at(matches.at(matchId)._j);
     Vec2 fI(featI.x(), featI.y());
     Vec2 fJ(featJ.x(), featJ.y());
     Vec3 ptI = CI * fI.homogeneous();
@@ -234,8 +234,8 @@ void estimateHomography(const std::vector<feature::SIOPointFeature> &featuresI,
     H /= H(2,2);
 }
 
-void findTransformationInliers(const std::vector<feature::SIOPointFeature> &featuresI,
-                               const std::vector<feature::SIOPointFeature> &featuresJ,
+void findTransformationInliers(const std::vector<feature::PointFeature> &featuresI,
+                               const std::vector<feature::PointFeature> &featuresJ,
                                const matching::IndMatches &matches,
                                const Mat3 &transformation,
                                double tolerance,
@@ -247,8 +247,8 @@ void findTransformationInliers(const std::vector<feature::SIOPointFeature> &feat
 #pragma omp parallel for
   for (int iMatch = 0; iMatch < matches.size(); ++iMatch)
   {
-    const feature::SIOPointFeature & featI = featuresI.at(matches.at(iMatch)._i);
-    const feature::SIOPointFeature & featJ = featuresJ.at(matches.at(iMatch)._j);
+    const feature::PointFeature & featI = featuresI.at(matches.at(iMatch)._i);
+    const feature::PointFeature & featJ = featuresJ.at(matches.at(iMatch)._j);
 
     const Vec2 ptI(featI.x(), featI.y());
     const Vec2 ptJ(featJ.x(), featJ.y());
@@ -354,8 +354,8 @@ public:
     double _softThresh;
 };
 
-bool refineHomography(const std::vector<feature::SIOPointFeature> &featuresI,
-                      const std::vector<feature::SIOPointFeature> &featuresJ,
+bool refineHomography(const std::vector<feature::PointFeature> &featuresI,
+                      const std::vector<feature::PointFeature> &featuresJ,
                       const matching::IndMatches& remainingMatches,
                       Mat3& homography,
                       std::set<IndexT>& bestMatchesId,

--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils.hpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils.hpp
@@ -191,8 +191,8 @@ void centerMatrix(const Eigen::Matrix2Xf & points2d, Mat3 & t);
  * @param[out] cJ The standardizing matrix to apply to (the subpart of) \c featuresJ
  * @param[in] usefulMatchesId To consider a subpart of \c matches only.
  */
-void centeringMatrices(const std::vector<feature::SIOPointFeature> & featuresI,
-                       const std::vector<feature::SIOPointFeature> & featuresJ,
+void centeringMatrices(const std::vector<feature::PointFeature> & featuresI,
+                       const std::vector<feature::PointFeature> & featuresJ,
                        const matching::IndMatches & matches,
                        Mat3 & cI,
                        Mat3 & cJ,
@@ -204,8 +204,8 @@ void centeringMatrices(const std::vector<feature::SIOPointFeature> & featuresI,
  * @param[in] feat2 The second feature with known scale & orientation.
  * @param[out] S The similarity transformation between f1 et f2 so that f2 = S * f1.
  */
-void computeSimilarity(const feature::SIOPointFeature & feat1,
-                       const feature::SIOPointFeature & feat2,
+void computeSimilarity(const feature::PointFeature & feat1,
+                       const feature::PointFeature & feat2,
                        Mat3 & S);
 
 /**
@@ -217,8 +217,8 @@ void computeSimilarity(const feature::SIOPointFeature & feat1,
  * @param[out] affineTransformation The estimated Affine transformation.
  * @param[in] usefulMatchesId To consider a subpart of \c matches only.
  */
-void estimateAffinity(const std::vector<feature::SIOPointFeature> & featuresI,
-                      const std::vector<feature::SIOPointFeature> & featuresJ,
+void estimateAffinity(const std::vector<feature::PointFeature> & featuresI,
+                      const std::vector<feature::PointFeature> & featuresJ,
                       const matching::IndMatches & matches,
                       Mat3 & affineTransformation,
                       const std::set<IndexT> & usefulMatchesId = std::set<IndexT>());
@@ -232,8 +232,8 @@ void estimateAffinity(const std::vector<feature::SIOPointFeature> & featuresI,
  * @param[out] H The estimated Homography transformation.
  * @param[in] usefulMatchesId To consider a subpart of \c matches only.
  */
-void estimateHomography(const std::vector<feature::SIOPointFeature> & featuresI,
-                        const std::vector<feature::SIOPointFeature> & featuresJ,
+void estimateHomography(const std::vector<feature::PointFeature> & featuresI,
+                        const std::vector<feature::PointFeature> & featuresJ,
                         const matching::IndMatches & matches,
                         Mat3 &H,
                         const std::set<IndexT> & usefulMatchesId = std::set<IndexT>());
@@ -247,8 +247,8 @@ void estimateHomography(const std::vector<feature::SIOPointFeature> & featuresI,
  * @param[in] tolerance The tolerated pixel error.
  * @param[in] inliersId The index in the \c matches vector.
  */
-void findTransformationInliers(const std::vector<feature::SIOPointFeature> & featuresI,
-                               const std::vector<feature::SIOPointFeature> & featuresJ, 
+void findTransformationInliers(const std::vector<feature::PointFeature> & featuresI,
+                               const std::vector<feature::PointFeature> & featuresJ,
                                const matching::IndMatches & matches,
                                const Mat3 & transformation,
                                double tolerance,
@@ -270,8 +270,8 @@ void findTransformationInliers(const Mat2X& featuresI,
                                std::set<IndexT> &inliersId);
 
 
-bool refineHomography(const std::vector<feature::SIOPointFeature> &featuresI,
-                      const std::vector<feature::SIOPointFeature> &featuresJ,
+bool refineHomography(const std::vector<feature::PointFeature> &featuresI,
+                      const std::vector<feature::PointFeature> &featuresJ,
                       const matching::IndMatches& remainingMatches,
                       Mat3& homography,
                       std::set<IndexT>& bestMatchesId,

--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(matchingImageCollection_centerMatrix)
 BOOST_AUTO_TEST_CASE(matchingImageCollection_similarityEstimation)
 {
   // same point should give the identity matrix
-  const feature::SIOPointFeature feat1 {1.0f, 5.0f, 1.0f, 0.1f};
+  const feature::PointFeature feat1 {1.0f, 5.0f, 1.0f, 0.1f};
   Mat3 S;
   matchingImageCollection::computeSimilarity(feat1, feat1, S);
 
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(matchingImageCollection_similarityEstimation)
     // generate a random point with a random scale and orientation
     const Vec2f point = Vec2f::Random();
     const Vec2f param = Vec2f::Random();
-    const feature::SIOPointFeature feat2 {point(0), point(1), param(0), param(1)};
+    const feature::PointFeature feat2 {point(0), point(1), param(0), param(1)};
 
     // estimate the similarity
     matchingImageCollection::computeSimilarity(feat1, feat2, S);

--- a/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
+++ b/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
@@ -63,12 +63,13 @@ bool refinePoseAsItShouldbe(const Mat & pt3D,
   {
   });
   // structure data (2D-3D correspondences)
+  const double unknownScale = 0.0;
   for(size_t i = 0; i < vec_inliers.size(); ++i)
   {
     const size_t idx = vec_inliers[i];
     Landmark landmark;
     landmark.X = pt3D.col(idx);
-    landmark.observations[0] = Observation(pt2D.col(idx), UndefinedIndexT);
+    landmark.observations[0] = Observation(pt2D.col(idx), UndefinedIndexT, unknownScale);
     sfm_data.structure[i] = std::move(landmark);
   }
 

--- a/src/aliceVision/robustEstimation/estimators.hpp
+++ b/src/aliceVision/robustEstimation/estimators.hpp
@@ -66,7 +66,7 @@ inline std::ostream& operator<<(std::ostream& os, ERobustEstimator e)
     return os << ERobustEstimator_enumToString(e);
 }
 
-inline std::istream& operator>>(std::istream& in, robustEstimation::ERobustEstimator& estimatorType)
+inline std::istream& operator>>(std::istream& in, ERobustEstimator& estimatorType)
 {
     std::string token;
     in >> token;

--- a/src/aliceVision/sfm/BundleAdjustment.hpp
+++ b/src/aliceVision/sfm/BundleAdjustment.hpp
@@ -8,6 +8,9 @@
 #pragma once
 
 #include <boost/detail/bitmask.hpp>
+#include <string>
+#include <algorithm>
+#include <stdexcept>
 
 namespace aliceVision {
 
@@ -16,6 +19,58 @@ class SfMData;
 } // namespace sfmData
 
 namespace sfm {
+
+/**
+ * @brief Defines basic, scale and covariance options for features that can be used in a bundle adjustment.
+ */
+enum class EFeatureConstraint
+{
+  BASIC = 0,
+  SCALE = 1
+};
+
+/**
+*@brief convert an enum ESfMobservationConstraint to its corresponding string
+*
+*/
+inline std::string ESfMobservationConstraint_enumToString(EFeatureConstraint m)
+{
+  switch(m)
+  {
+    case EFeatureConstraint::BASIC: return "Basic";
+    case EFeatureConstraint::SCALE: return "Scale";
+  }
+  throw std::out_of_range("Invalid ESfMobservationConstraint enum: " + std::to_string(int(m)));
+}
+
+/**
+* @brief convert a string featureConstraint to its corresponding enum featureConstraint
+* @param String
+* @return ESfMobservationConstraint
+*/
+inline EFeatureConstraint ESfMobservationConstraint_stringToEnum(const std::string& m)
+{
+  std::string featureConstraint = m;
+  std::transform(featureConstraint.begin(), featureConstraint.end(), featureConstraint.begin(), ::tolower);
+
+  if(featureConstraint == "basic") return EFeatureConstraint::BASIC;
+  if(featureConstraint == "scale") return EFeatureConstraint::SCALE;
+
+  throw std::out_of_range("Invalid ESfMobservationConstraint: " + m);
+}
+
+inline std::ostream& operator<<(std::ostream& os, EFeatureConstraint m)
+{
+    return os << ESfMobservationConstraint_enumToString(m);
+}
+
+inline std::istream& operator>>(std::istream& in, EFeatureConstraint& m)
+{
+    std::string token;
+    in >> token;
+    m = ESfMobservationConstraint_stringToEnum(token);
+    return in;
+}
 
 class BundleAdjustment
 {

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -35,22 +35,22 @@ using namespace aliceVision::geometry;
  * @param[in] observation The corresponding observation
  * @return cost functor
  */
-ceres::CostFunction* createCostFunctionFromIntrinsics(const IntrinsicBase* intrinsicPtr, const Vec2& observation)
+ceres::CostFunction* createCostFunctionFromIntrinsics(const IntrinsicBase* intrinsicPtr, const sfmData::Observation& observation)
 {
   switch(intrinsicPtr->getType())
   {
     case PINHOLE_CAMERA:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_Pinhole, 2, 3, 6, 3>(new ResidualErrorFunctor_Pinhole(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_Pinhole, 2, 3, 6, 3>(new ResidualErrorFunctor_Pinhole(observation));
     case PINHOLE_CAMERA_RADIAL1:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK1, 2, 4, 6, 3>(new ResidualErrorFunctor_PinholeRadialK1(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK1, 2, 4, 6, 3>(new ResidualErrorFunctor_PinholeRadialK1(observation));
     case PINHOLE_CAMERA_RADIAL3:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK3, 2, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK3(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK3, 2, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK3(observation));
     case PINHOLE_CAMERA_BROWN:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeBrownT2, 2, 8, 6, 3>(new ResidualErrorFunctor_PinholeBrownT2(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeBrownT2, 2, 8, 6, 3>(new ResidualErrorFunctor_PinholeBrownT2(observation));
     case PINHOLE_CAMERA_FISHEYE:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye, 2, 7, 6, 3>(new ResidualErrorFunctor_PinholeFisheye(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye, 2, 7, 6, 3>(new ResidualErrorFunctor_PinholeFisheye(observation));
     case PINHOLE_CAMERA_FISHEYE1:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye1, 2, 4, 6, 3>(new ResidualErrorFunctor_PinholeFisheye1(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye1, 2, 4, 6, 3>(new ResidualErrorFunctor_PinholeFisheye1(observation));
     default:
       throw std::logic_error("Cannot create cost function, unrecognized intrinsic type in BA.");
   }
@@ -62,22 +62,22 @@ ceres::CostFunction* createCostFunctionFromIntrinsics(const IntrinsicBase* intri
  * @param[in] observation The corresponding observation
  * @return cost functor
  */
-ceres::CostFunction* createRigCostFunctionFromIntrinsics(const IntrinsicBase* intrinsicPtr, const Vec2& observation)
+ceres::CostFunction* createRigCostFunctionFromIntrinsics(const IntrinsicBase* intrinsicPtr, const sfmData::Observation& observation)
 {
   switch(intrinsicPtr->getType())
   {
     case PINHOLE_CAMERA:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_Pinhole, 2, 3, 6, 6, 3>(new ResidualErrorFunctor_Pinhole(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_Pinhole, 2, 3, 6, 6, 3>(new ResidualErrorFunctor_Pinhole(observation));
     case PINHOLE_CAMERA_RADIAL1:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK1, 2, 4, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK1(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK1, 2, 4, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK1(observation));
     case PINHOLE_CAMERA_RADIAL3:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK3, 2, 6, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK3(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK3, 2, 6, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK3(observation));
     case PINHOLE_CAMERA_BROWN:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeBrownT2, 2, 8, 6, 6, 3>(new ResidualErrorFunctor_PinholeBrownT2(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeBrownT2, 2, 8, 6, 6, 3>(new ResidualErrorFunctor_PinholeBrownT2(observation));
     case PINHOLE_CAMERA_FISHEYE:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye, 2, 7, 6, 6, 3>(new ResidualErrorFunctor_PinholeFisheye(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye, 2, 7, 6, 6, 3>(new ResidualErrorFunctor_PinholeFisheye(observation));
     case PINHOLE_CAMERA_FISHEYE1:
-      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye1, 2, 4, 6, 6, 3>(new ResidualErrorFunctor_PinholeFisheye1(observation.data()));
+      return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye1, 2, 4, 6, 6, 3>(new ResidualErrorFunctor_PinholeFisheye1(observation));
     default:
       throw std::logic_error("Cannot create rig cost function, unrecognized intrinsic type in BA.");
   }
@@ -573,7 +573,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
 
       if(view.isPartOfRig() && !view.isPoseIndependant())
       {
-        ceres::CostFunction* costFunction = createRigCostFunctionFromIntrinsics(sfmData.getIntrinsicPtr(view.getIntrinsicId()), observation.x);
+        ceres::CostFunction* costFunction = createRigCostFunctionFromIntrinsics(sfmData.getIntrinsicPtr(view.getIntrinsicId()), observation);
 
         problem.AddResidualBlock(costFunction,
             lossFunction,
@@ -584,7 +584,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
       }
       else
       {
-        ceres::CostFunction* costFunction = createCostFunctionFromIntrinsics(sfmData.getIntrinsicPtr(view.getIntrinsicId()), observation.x);
+        ceres::CostFunction* costFunction = createCostFunctionFromIntrinsics(sfmData.getIntrinsicPtr(view.getIntrinsicId()), observation);
 
         problem.AddResidualBlock(costFunction,
             lossFunction,

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
@@ -277,6 +277,9 @@ private:
   /// user Ceres options to use in the solver
   CeresOptions _ceresOptions;
 
+  /// user FeatureConstraint options to use
+  EFeatureConstraint _featureConstraint;
+
   /// last adjustment iteration statisics
   Statistics _statistics;
 

--- a/src/aliceVision/sfm/ResidualErrorFunctor.hpp
+++ b/src/aliceVision/sfm/ResidualErrorFunctor.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <aliceVision/camera/camera.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
 
 #include <ceres/rotation.h>
 
@@ -29,10 +30,9 @@ namespace sfm {
  */
 struct ResidualErrorFunctor_Pinhole
 {
-  ResidualErrorFunctor_Pinhole(const double* const pos_2dpoint)
+  explicit ResidualErrorFunctor_Pinhole(const sfmData::Observation& obs)
+      : _obs(obs)
   {
-    m_pos_2dpoint[0] = pos_2dpoint[0];
-    m_pos_2dpoint[1] = pos_2dpoint[1];
   }
 
   // Enum to map intrinsics parameters between aliceVision & ceres camera data parameter block.
@@ -58,8 +58,9 @@ struct ResidualErrorFunctor_Pinhole
 
     // Compute and return the error is the difference between the predicted
     //  and observed position
-    out_residuals[0] = projected_x - T(m_pos_2dpoint[0]);
-    out_residuals[1] = projected_y - T(m_pos_2dpoint[1]);
+    const T scale(_obs.scale > 0.0 ? _obs.scale : 1.0);
+    out_residuals[0] = (projected_x - T(_obs.x[0])) / scale;
+    out_residuals[1] = (projected_y - T(_obs.x[1])) / scale;
   }
 
   template <typename T>
@@ -162,7 +163,7 @@ struct ResidualErrorFunctor_Pinhole
     return true;
   }
 
-  double m_pos_2dpoint[2]; // The 2D observation
+  const sfmData::Observation& _obs; // The 2D observation
 };
 
 /**
@@ -178,10 +179,9 @@ struct ResidualErrorFunctor_Pinhole
  */
 struct ResidualErrorFunctor_PinholeRadialK1
 {
-  ResidualErrorFunctor_PinholeRadialK1(const double* const pos_2dpoint)
+  explicit ResidualErrorFunctor_PinholeRadialK1(const sfmData::Observation& obs)
+      : _obs(obs)
   {
-    m_pos_2dpoint[0] = pos_2dpoint[0];
-    m_pos_2dpoint[1] = pos_2dpoint[1];
   }
 
   // Enum to map intrinsics parameters between aliceVision & ceres camera data parameter block.
@@ -216,8 +216,9 @@ struct ResidualErrorFunctor_PinholeRadialK1
 
     // Compute and return the error is the difference between the predicted
     //  and observed position
-    out_residuals[0] = projected_x - T(m_pos_2dpoint[0]);
-    out_residuals[1] = projected_y - T(m_pos_2dpoint[1]);
+    const T scale(_obs.scale > 0.0 ? _obs.scale : 1.0);
+    out_residuals[0] = (projected_x - T(_obs.x[0])) / scale;
+    out_residuals[1] = (projected_y - T(_obs.x[1])) / scale;
   }
 
   template <typename T>
@@ -316,7 +317,7 @@ struct ResidualErrorFunctor_PinholeRadialK1
     return true;
   }
 
-  double m_pos_2dpoint[2]; // The 2D observation
+  const sfmData::Observation& _obs; // The 2D observation
 };
 
 /**
@@ -332,10 +333,9 @@ struct ResidualErrorFunctor_PinholeRadialK1
  */
 struct ResidualErrorFunctor_PinholeRadialK3
 {
-  ResidualErrorFunctor_PinholeRadialK3(const double* const pos_2dpoint)
+  explicit ResidualErrorFunctor_PinholeRadialK3(const sfmData::Observation& obs)
+      : _obs(obs)
   {
-    m_pos_2dpoint[0] = pos_2dpoint[0];
-    m_pos_2dpoint[1] = pos_2dpoint[1];
   }
 
   // Enum to map intrinsics parameters between aliceVision & ceres camera data parameter block.
@@ -375,8 +375,9 @@ struct ResidualErrorFunctor_PinholeRadialK3
 
     // Compute and return the error is the difference between the predicted
     //  and observed position
-    out_residuals[0] = projected_x - T(m_pos_2dpoint[0]);
-    out_residuals[1] = projected_y - T(m_pos_2dpoint[1]);
+    const T scale(_obs.scale > 0.0 ? _obs.scale : 1.0);
+    out_residuals[0] = (projected_x - T(_obs.x[0])) / scale;
+    out_residuals[1] = (projected_y - T(_obs.x[1])) / scale;
   }
 
   template <typename T>
@@ -469,7 +470,7 @@ struct ResidualErrorFunctor_PinholeRadialK3
     return true;
   }
 
-  double m_pos_2dpoint[2]; // The 2D observation
+  const sfmData::Observation& _obs; // The 2D observation
 };
 
 /**
@@ -485,10 +486,9 @@ struct ResidualErrorFunctor_PinholeRadialK3
  */
 struct ResidualErrorFunctor_PinholeBrownT2
 {
-  ResidualErrorFunctor_PinholeBrownT2(const double* const pos_2dpoint)
+  explicit ResidualErrorFunctor_PinholeBrownT2(const sfmData::Observation& obs)
+      : _obs(obs)
   {
-    m_pos_2dpoint[0] = pos_2dpoint[0];
-    m_pos_2dpoint[1] = pos_2dpoint[1];
   }
 
   // Enum to map intrinsics parameters between aliceVision & ceres camera data parameter block.
@@ -534,8 +534,9 @@ struct ResidualErrorFunctor_PinholeBrownT2
 
     // Compute and return the error is the difference between the predicted
     //  and observed position
-    out_residuals[0] = projected_x - T(m_pos_2dpoint[0]);
-    out_residuals[1] = projected_y - T(m_pos_2dpoint[1]);
+    const T scale(_obs.scale > 0.0 ? _obs.scale : 1.0);
+    out_residuals[0] = (projected_x - T(_obs.x[0])) / scale;
+    out_residuals[1] = (projected_y - T(_obs.x[1])) / scale;
   }
 
   template <typename T>
@@ -635,7 +636,7 @@ struct ResidualErrorFunctor_PinholeBrownT2
     return true;
   }
 
-  double m_pos_2dpoint[2]; // The 2D observation
+  const sfmData::Observation& _obs; // The 2D observation
 };
 
 
@@ -652,10 +653,9 @@ struct ResidualErrorFunctor_PinholeBrownT2
  */
 struct ResidualErrorFunctor_PinholeFisheye
 {
-  ResidualErrorFunctor_PinholeFisheye(const double* const pos_2dpoint)
+  explicit ResidualErrorFunctor_PinholeFisheye(const sfmData::Observation& obs)
+      : _obs(obs)
   {
-    m_pos_2dpoint[0] = pos_2dpoint[0];
-    m_pos_2dpoint[1] = pos_2dpoint[1];
   }
 
   // Enum to map intrinsics parameters between aliceVision & ceres camera data parameter block.
@@ -702,8 +702,9 @@ struct ResidualErrorFunctor_PinholeFisheye
 
     // Compute and return the error is the difference between the predicted
     //  and observed position
-    out_residuals[0] = projected_x - T(m_pos_2dpoint[0]);
-    out_residuals[1] = projected_y - T(m_pos_2dpoint[1]);
+    const T scale(_obs.scale > 0.0 ? _obs.scale : 1.0);
+    out_residuals[0] = (projected_x - T(_obs.x[0])) / scale;
+    out_residuals[1] = (projected_y - T(_obs.x[1])) / scale;
 
   }
 
@@ -803,7 +804,7 @@ struct ResidualErrorFunctor_PinholeFisheye
     return true;
   }
 
-  double m_pos_2dpoint[2]; // The 2D observation
+  const sfmData::Observation& _obs; // The 2D observation
 };
 
 /**
@@ -819,10 +820,9 @@ struct ResidualErrorFunctor_PinholeFisheye
  */
 struct ResidualErrorFunctor_PinholeFisheye1
 {
-  ResidualErrorFunctor_PinholeFisheye1(const double* const pos_2dpoint)
+  explicit ResidualErrorFunctor_PinholeFisheye1(const sfmData::Observation& obs)
+      : _obs(obs)
   {
-    m_pos_2dpoint[0] = pos_2dpoint[0];
-    m_pos_2dpoint[1] = pos_2dpoint[1];
   }
 
   // Enum to map intrinsics parameters between aliceVision & ceres camera data parameter block.
@@ -857,8 +857,9 @@ struct ResidualErrorFunctor_PinholeFisheye1
 
     // Compute and return the error is the difference between the predicted
     //  and observed position
-    out_residuals[0] = projected_x - T(m_pos_2dpoint[0]);
-    out_residuals[1] = projected_y - T(m_pos_2dpoint[1]);
+    const T scale(_obs.scale > 0.0 ? _obs.scale : 1.0);
+    out_residuals[0] = (projected_x - T(_obs.x[0])) / scale;
+    out_residuals[1] = (projected_y - T(_obs.x[1])) / scale;
   }
 
   template <typename T>
@@ -957,7 +958,7 @@ struct ResidualErrorFunctor_PinholeFisheye1
     return true;
   }
 
-  double m_pos_2dpoint[2]; // The 2D observation
+  const sfmData::Observation& _obs; // The 2D observation
 };
 
 

--- a/src/aliceVision/sfm/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundleAdjustment_test.cpp
@@ -305,6 +305,7 @@ SfMData getInputScene(const NViewDataSet & d, const NViewDatasetConfigurator & c
   }
 
   // 4. Landmarks
+  const double unknownScale = 0.0;
   for (int i = 0; i < npoints; ++i) {
 
     // Collect the image of point i in each frame.
@@ -316,7 +317,7 @@ SfMData getInputScene(const NViewDataSet & d, const NViewDatasetConfigurator & c
       pt(0) += rand()/RAND_MAX - .5;
       pt(1) += rand()/RAND_MAX - .5;
 
-      landmark.observations[j] = Observation(pt, i);
+      landmark.observations[j] = Observation(pt, i, unknownScale);
     }
     sfm_data.structure[i] = landmark;
   }

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -361,7 +361,7 @@ bool ReconstructionEngine_globalSfM::Compute_Initial_Structure(matching::Pairwis
 bool ReconstructionEngine_globalSfM::Adjust()
 {
   // refine sfm  scene (in a 3 iteration process (free the parameters regarding their incertainty order)):
-  BundleAdjustmentCeres::CeresOptions options;
+  BundleAdjustmentCeres::CeresOptions options; 
   options.useParametersOrdering = false; // disable parameters ordering
 
   BundleAdjustmentCeres BA(options);
@@ -389,7 +389,7 @@ bool ReconstructionEngine_globalSfM::Adjust()
 
   // Remove outliers (max_angle, residual error)
   const size_t pointcount_initial = _sfmData.structure.size();
-  RemoveOutliers_PixelResidualError(_sfmData, 4.0);
+  RemoveOutliers_PixelResidualError(_sfmData, _featureConstraint, 4.0);
   const size_t pointcount_pixelresidual_filter = _sfmData.structure.size();
   RemoveOutliers_AngleError(_sfmData, 2.0);
   const size_t pointcount_angular_filter = _sfmData.structure.size();

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.hpp
@@ -65,6 +65,7 @@ private:
   ERotationAveragingMethod _eRotationAveragingMethod;
   ETranslationAveragingMethod _eTranslationAveragingMethod;
   bool _lockAllIntrinsics = false;
+  EFeatureConstraint _featureConstraint = EFeatureConstraint::BASIC;
 
   // Data provider
   feature::FeaturesPerView* _featuresPerView;

--- a/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
+++ b/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
@@ -197,13 +197,14 @@ bool SfMLocalizer::RefinePose(camera::IntrinsicBase* intrinsics,
   std::shared_ptr<camera::IntrinsicBase> localIntrinsics(intrinsics->clone());
   tinyScene.intrinsics[0] = localIntrinsics;
 
+  const double unknownScale = 0.0;
   // structure data (2D-3D correspondences)
   for(std::size_t i = 0; i < matchingData.vec_inliers.size(); ++i)
   {
     const std::size_t idx = matchingData.vec_inliers[i];
     sfmData::Landmark landmark;
     landmark.X = matchingData.pt3D.col(idx);
-    landmark.observations[0] = sfmData::Observation(matchingData.pt2D.col(idx), UndefinedIndexT);
+    landmark.observations[0] = sfmData::Observation(matchingData.pt2D.col(idx), UndefinedIndexT, unknownScale); // TODO-SCALE
     tinyScene.structure[i] = std::move(landmark);
   }
 

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
@@ -658,7 +658,10 @@ void ReconstructionEngine_panorama::Compute_Relative_Rotations(rotationAveraging
               Vec2 pt1 = _featuresPerView->getFeatures(I, descType)[match._i].coords().cast<double>();
               Vec2 pt2 = _featuresPerView->getFeatures(J, descType)[match._j].coords().cast<double>();
 
-              sfm::Constraint2D constraint(I, sfm::Observation(pt1, 0), J, sfm::Observation(pt2, 0));
+              const PointFeature& pI = _featuresPerView->getFeatures(I, descType)[match._i];
+              const PointFeature& pJ = _featuresPerView->getFeatures(J, descType)[match._j];
+
+              sfm::Constraint2D constraint(I, sfm::Observation(pt1, 0, pI.scale()), J, sfm::Observation(pt2, 0, pJ.scale()));
               constraints2d.push_back(constraint);
 
               index_inlier++;

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1657,12 +1657,14 @@ void ReconstructionEngine_sequentialSfM::updateScene(const IndexT viewIndex, con
   {
     const Vec3 X = resectionData.pt3D.col(i);
     const Vec2 x = resectionData.pt2D.col(i);
+    Landmark& landmark = _sfmData.structure[*iterTrackId];
+    double scale = _featuresPerView->getFeatures(viewIndex, landmark.descType)[i].scale(); // TODO: check i index, TODO: replace x() with scale()
     const Vec2 residual = resectionData.optionalIntrinsic->residual(resectionData.pose, X, x);
     if (residual.norm() < resectionData.error_max &&
         resectionData.pose.depth(X) > 0)
     {
       // Inlier, add the point to the reconstructed track
-      _sfmData.structure[*iterTrackId].observations[viewIndex] = Observation(x, resectionData.featuresId[i].second);
+      landmark.observations[viewIndex] = Observation(x, resectionData.featuresId[i].second, scale);
     }
   }
 }

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -689,7 +689,7 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
       statistics.show();
     }
 
-    nbOutliers = removeOutliers(_params.maxReprojectionError);
+    nbOutliers = removeOutliers();
 
     std::set<IndexT> removedViewsIdIteration;
     eraseUnstablePosesAndObservations(this->_sfmData, _params.minPointsPerPose, _params.minTrackLength, &removedViewsIdIteration);
@@ -2054,9 +2054,9 @@ void ReconstructionEngine_sequentialSfM::triangulate_2Views(SfMData& scene, cons
   }
 }
 
-std::size_t ReconstructionEngine_sequentialSfM::removeOutliers(double precision)
+std::size_t ReconstructionEngine_sequentialSfM::removeOutliers()
 {
-  const std::size_t nbOutliersResidualErr = RemoveOutliers_PixelResidualError(_sfmData, precision, 2);
+  const std::size_t nbOutliersResidualErr = RemoveOutliers_PixelResidualError(_sfmData, _params.featureConstraint, _params.maxReprojectionError, 2);
   const std::size_t nbOutliersAngleErr = RemoveOutliers_AngleError(_sfmData, _params.minAngleForLandmark);
 
   ALICEVISION_LOG_INFO("Remove outliers: " << std::endl

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1656,14 +1656,15 @@ void ReconstructionEngine_sequentialSfM::updateScene(const IndexT viewIndex, con
   {
     const Vec3 X = resectionData.pt3D.col(i);
     const Vec2 x = resectionData.pt2D.col(i);
-    Landmark& landmark = _sfmData.structure[*iterTrackId];
-    double scale = _featuresPerView->getFeatures(viewIndex, landmark.descType)[i].scale(); // TODO: check i index, TODO: replace x() with scale()
     const Vec2 residual = resectionData.optionalIntrinsic->residual(resectionData.pose, X, x);
     if (residual.norm() < resectionData.error_max &&
         resectionData.pose.depth(X) > 0)
     {
+      Landmark& landmark = _sfmData.structure[*iterTrackId];
+      const IndexT idFeat = resectionData.featuresId[i].second;
+      const double scale = _featuresPerView->getFeatures(viewIndex, landmark.descType)[idFeat].scale();
       // Inlier, add the point to the reconstructed track
-      landmark.observations[viewIndex] = Observation(x, resectionData.featuresId[i].second, scale);
+      landmark.observations[viewIndex] = Observation(x, idFeat, scale);
     }
   }
 }

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -55,6 +55,7 @@ public:
     double minAngleForTriangulation = 3.0;
     double minAngleForLandmark = 2.0;
     double maxReprojectionError = 4.0;
+    EFeatureConstraint featureConstraint = EFeatureConstraint::BASIC;
     float minAngleInitialPair = 5.0f;
     float maxAngleInitialPair = 40.0f;
     bool filterTrackForks = true;
@@ -355,7 +356,7 @@ private:
    * @param[in] precision
    * @return number of removed outliers
    */
-  std::size_t removeOutliers(double precision);
+  std::size_t removeOutliers();
 
 private:
 

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -272,8 +272,10 @@ void StructureEstimationFromKnownPoses::triangulate(
     {
       const size_t imaIndex = it->first;
       const size_t featIndex = it->second;
-      const Vec2 pt = regionsPerView.getRegions(imaIndex, track.descType).GetRegionPosition(featIndex);
-      observations[imaIndex] = Observation(pt, featIndex);
+      const feature::Regions& regions = regionsPerView.getRegions(imaIndex, track.descType);
+      const feature::PointFeature& feat = regions.Features()[featIndex];
+
+      observations[imaIndex] = Observation(feat.coords().cast<double>(), featIndex, feat.scale());
     }
   }
 

--- a/src/aliceVision/sfm/sfmFilters.cpp
+++ b/src/aliceVision/sfm/sfmFilters.cpp
@@ -32,7 +32,14 @@ IndexT RemoveOutliers_PixelResidualError(sfmData::SfMData& sfmData,
       const sfmData::View * view = sfmData.views.at(itObs->first).get();
       const geometry::Pose3 pose = sfmData.getPose(*view).getTransform();
       const camera::IntrinsicBase * intrinsic = sfmData.intrinsics.at(view->getIntrinsicId()).get();
-      const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x);
+
+      Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x);
+      if(itObs->second.scale > 0) // TODO-SCALE: add an option to use the scale optionally
+      {
+          // Apply the scale of the feature to get a residual value
+          // relative to the feature precision.
+          residual /= itObs->second.scale;
+      }
 
       if((pose.depth(iterTracks->second.X) < 0) || (residual.norm() > dThresholdPixel))
       {

--- a/src/aliceVision/sfm/sfmFilters.cpp
+++ b/src/aliceVision/sfm/sfmFilters.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/stl/stl.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/sfm/BundleAdjustment.hpp>
 
 #include <iterator>
 
@@ -16,11 +17,13 @@ namespace aliceVision {
 namespace sfm {
 
 IndexT RemoveOutliers_PixelResidualError(sfmData::SfMData& sfmData,
+                                         EFeatureConstraint featureConstraint,
                                          const double dThresholdPixel,
                                          const unsigned int minTrackLength)
 {
   IndexT outlier_count = 0;
   sfmData::Landmarks::iterator iterTracks = sfmData.structure.begin();
+
 
   while(iterTracks != sfmData.structure.end())
   {
@@ -34,7 +37,7 @@ IndexT RemoveOutliers_PixelResidualError(sfmData::SfMData& sfmData,
       const camera::IntrinsicBase * intrinsic = sfmData.intrinsics.at(view->getIntrinsicId()).get();
 
       Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x);
-      if(itObs->second.scale > 0) // TODO-SCALE: add an option to use the scale optionally
+      if(featureConstraint == EFeatureConstraint::SCALE)
       {
           // Apply the scale of the feature to get a residual value
           // relative to the feature precision.

--- a/src/aliceVision/sfm/sfmFilters.cpp
+++ b/src/aliceVision/sfm/sfmFilters.cpp
@@ -37,7 +37,7 @@ IndexT RemoveOutliers_PixelResidualError(sfmData::SfMData& sfmData,
       const camera::IntrinsicBase * intrinsic = sfmData.intrinsics.at(view->getIntrinsicId()).get();
 
       Vec2 residual = intrinsic->residual(pose, iterTracks->second.X, itObs->second.x);
-      if(featureConstraint == EFeatureConstraint::SCALE)
+      if(featureConstraint == EFeatureConstraint::SCALE && itObs->second.scale > 0.0)
       {
           // Apply the scale of the feature to get a residual value
           // relative to the feature precision.

--- a/src/aliceVision/sfm/sfmFilters.hpp
+++ b/src/aliceVision/sfm/sfmFilters.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <aliceVision/types.hpp>
+#include <aliceVision/sfm/BundleAdjustment.hpp>
 
 namespace aliceVision {
 
@@ -33,6 +34,7 @@ inline PairSet Pair_filter(const IterablePairs& pairs, const IterableIndex& inde
 /// Remove observations with too large reprojection error.
 /// Return the number of removed tracks.
 IndexT RemoveOutliers_PixelResidualError(sfmData::SfMData& sfmData,
+                                         EFeatureConstraint featureConstraint,
                                          const double dThresholdPixel,
                                          const unsigned int minTrackLength = 2);
 

--- a/src/aliceVision/sfm/utils/syntheticScene.cpp
+++ b/src/aliceVision/sfm/utils/syntheticScene.cpp
@@ -96,6 +96,7 @@ sfmData::SfMData getInputScene(const NViewDataSet& d,
   }
 
   // 4. Landmarks
+  const double unknownScale = 0.0;
   for(int i = 0; i < npoints; ++i)
   {
     // Collect the image of point i in each frame.
@@ -103,7 +104,7 @@ sfmData::SfMData getInputScene(const NViewDataSet& d,
     landmark.X = d._X.col(i);
     for (int j = 0; j < nviews; ++j) {
       const Vec2 pt = d._x[j].col(i);
-      landmark.observations[j] = sfmData::Observation(pt, i);
+      landmark.observations[j] = sfmData::Observation(pt, i, unknownScale);
     }
     sfmData.structure[i] = landmark;
   }
@@ -178,6 +179,7 @@ sfmData::SfMData getInputRigScene(const NViewDataSet& d,
   }
 
   // 5. Landmarks
+  const double unknownScale = 0.0;
   for(int landmarkId = 0; landmarkId < nbPoints; ++landmarkId)
   {
     // Collect the image of point i in each frame.
@@ -188,7 +190,7 @@ sfmData::SfMData getInputRigScene(const NViewDataSet& d,
       const sfmData::View& view = *sfmData.views.at(viewId);
       const geometry::Pose3 camPose = sfmData.getPose(view).getTransform();
       const Vec2 pt = Project(sfmData.intrinsics.at(0)->get_projective_equivalent(camPose), landmark.X);
-      landmark.observations[viewId] = sfmData::Observation(pt, landmarkId);
+      landmark.observations[viewId] = sfmData::Observation(pt, landmarkId, unknownScale);
     }
     sfmData.structure[landmarkId] = landmark;
   }

--- a/src/aliceVision/sfm/utils/syntheticScene.hpp
+++ b/src/aliceVision/sfm/utils/syntheticScene.hpp
@@ -56,6 +56,10 @@ void generateSyntheticFeatures(feature::FeaturesPerView& out_featuresPerView,
       out_featuresPerView.addFeatures(it.first, descType, pointFeatures);
     }
   }
+  // Use arbitrary values for feature scale and orientation
+  const float scale = 0.0f;
+  const float orientation = 0.0f;
+
   // Fill with the observation values
   for(const auto& it: sfmData.getLandmarks())
   {
@@ -66,7 +70,7 @@ void generateSyntheticFeatures(feature::FeaturesPerView& out_featuresPerView,
       const IndexT viewId = obsIt.first;
       const sfmData::Observation& obs = obsIt.second;
 
-      out_featuresPerView.getFeaturesPerDesc(viewId)[descType][obs.id_feat] = feature::PointFeature(obs.x(0) + noise(generator), obs.x(1) + noise(generator));
+      out_featuresPerView.getFeaturesPerDesc(viewId)[descType][obs.id_feat] = feature::PointFeature(obs.x(0) + noise(generator), obs.x(1) + noise(generator), scale, orientation);
     }
   }
 }

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -22,13 +22,15 @@ namespace sfmData {
 struct Observation
 {
   Observation(): id_feat(UndefinedIndexT) {}
-  Observation(const Vec2 & p, IndexT idFeat)
+  Observation(const Vec2 & p, IndexT idFeat, double scale_ = 1.0) // TODO: remove default value to scale
     : x(p)
     , id_feat(idFeat)
+    , scale(scale_)
   {}
 
   Vec2 x;
   IndexT id_feat;
+  double scale = 1.0;
 
   bool operator==(const Observation& other) const
   {

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -22,7 +22,7 @@ namespace sfmData {
 struct Observation
 {
   Observation(): id_feat(UndefinedIndexT) {}
-  Observation(const Vec2 & p, IndexT idFeat, double scale_ = 1.0) // TODO: remove default value to scale
+  Observation(const Vec2 & p, IndexT idFeat, double scale_)
     : x(p)
     , id_feat(idFeat)
     , scale(scale_)

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -21,7 +21,7 @@ namespace sfmData {
  */
 struct Observation
 {
-  Observation(): id_feat(UndefinedIndexT) {}
+  Observation() {}
   Observation(const Vec2 & p, IndexT idFeat, double scale_)
     : x(p)
     , id_feat(idFeat)
@@ -29,8 +29,8 @@ struct Observation
   {}
 
   Vec2 x;
-  IndexT id_feat;
-  double scale = 1.0;
+  IndexT id_feat = UndefinedIndexT;
+  double scale = 0.0;
 
   bool operator==(const Observation& other) const
   {

--- a/src/aliceVision/sfmDataIO/alembicIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/alembicIO_test.cpp
@@ -117,13 +117,14 @@ SfMData createTestScene(IndexT singleViewsCount,
     nbIntrinsics += subPoseCount;
   }
 
+  const double unknownScale = 0.0;
   // Fill with not meaningful tracks
   for(IndexT i = 0; i < pointCount; ++i)
   {
     // Add structure
     Observations observations;
-    observations[0] = Observation( Vec2(std::rand() % 10000, std::rand() % 10000), 0);
-    observations[1] = Observation( Vec2(std::rand() % 10000, std::rand() % 10000), 1);
+    observations[0] = Observation( Vec2(std::rand() % 10000, std::rand() % 10000), 0, unknownScale);
+    observations[1] = Observation( Vec2(std::rand() % 10000, std::rand() % 10000), 1, unknownScale);
     sfm_data.structure[i].observations = observations;
     sfm_data.structure[i].X = Vec3(std::rand() % 10000, std::rand() % 10000, std::rand() % 10000);
     sfm_data.structure[i].rgb = image::RGBColor((std::rand() % 1000) / 1000.0, (std::rand() % 1000) / 1000.0, (std::rand() % 1000) / 1000.0);

--- a/src/aliceVision/sfmDataIO/sfmDataIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIO_test.cpp
@@ -60,9 +60,10 @@ sfmData::SfMData createTestScene(std::size_t viewsCount = 2, std::size_t observa
 
   // Fill with not meaningful tracks
   sfmData::Observations observations;
+  const double unknownScale = 0.0;
   for(std::size_t i = 0; i < observationCount; ++i)
   {
-    observations[i] = sfmData::Observation( Vec2(i,i), i);
+    observations[i] = sfmData::Observation( Vec2(i,i), i, unknownScale);
   }
 
   sfmData.structure[0].observations = observations;

--- a/src/samples/kvldFilter/main_kvldFilter.cpp
+++ b/src/samples/kvldFilter/main_kvldFilter.cpp
@@ -134,11 +134,11 @@ int main(int argc, char **argv)
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "01_features.jpg";
@@ -161,8 +161,8 @@ int main(int argc, char **argv)
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));

--- a/src/samples/robustEssential/main_robustEssential.cpp
+++ b/src/samples/robustEssential/main_robustEssential.cpp
@@ -84,11 +84,11 @@ int main() {
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "02_features.jpg";
@@ -120,8 +120,8 @@ int main() {
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
@@ -174,8 +174,8 @@ int main() {
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < relativePose_info.vec_inliers.size(); ++i)  {
-      const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
-      const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
+      const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
+      const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
       const Vec2f L = LL.coords();
       const Vec2f R = RR.coords();
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
@@ -203,8 +203,8 @@ int main() {
     std::vector<double> vec_residuals;
     vec_residuals.reserve(relativePose_info.vec_inliers.size() * 4);
     for (size_t i = 0; i < relativePose_info.vec_inliers.size(); ++i)  {
-      const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
-      const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
+      const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
+      const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
       // Point triangulation
       Vec3 X;
       TriangulateDLT(P1, LL.coords().cast<double>(), P2, RR.coords().cast<double>(), &X);

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -255,9 +255,9 @@ int main() {
       // Reject point that is behind the camera
       if (pose0.depth(X) < 0 && pose1.depth(X) < 0)
           continue;
-      // Add a new landmark (3D point with it's 2d observations)
-      landmarks[i].observations[tinyScene.views[0]->getViewId()] = sfmData::Observation(LL.coords().cast<double>(), vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i);
-      landmarks[i].observations[tinyScene.views[1]->getViewId()] = sfmData::Observation(RR.coords().cast<double>(), vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j);
+      // Add a new landmark (3D point with its 2d observations)
+      landmarks[i].observations[tinyScene.views[0]->getViewId()] = sfmData::Observation(LL.coords().cast<double>(), vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i, LL.scale());
+      landmarks[i].observations[tinyScene.views[1]->getViewId()] = sfmData::Observation(RR.coords().cast<double>(), vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j, RR.scale());
       landmarks[i].X = X;
     }
     sfmDataIO::Save(tinyScene, "EssentialGeometry_start.ply", sfmDataIO::ESfMData::ALL);

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -93,11 +93,11 @@ int main() {
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "02_features.jpg";
@@ -129,8 +129,8 @@ int main() {
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
@@ -183,8 +183,8 @@ int main() {
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < relativePose_info.vec_inliers.size(); ++i)  {
-      const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
-      const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
+      const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
+      const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
       const Vec2f L = LL.coords();
       const Vec2f R = RR.coords();
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
@@ -247,8 +247,8 @@ int main() {
     const Mat34 P2 = tinyScene.intrinsics[tinyScene.views[1]->getIntrinsicId()]->get_projective_equivalent(pose1);
     sfmData::Landmarks & landmarks = tinyScene.structure;
     for (size_t i = 0; i < relativePose_info.vec_inliers.size(); ++i)  {
-      const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
-      const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
+      const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._i];
+      const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[relativePose_info.vec_inliers[i]]._j];
       // Point triangulation
       Vec3 X;
       TriangulateDLT(P1, LL.coords().cast<double>(), P2, RR.coords().cast<double>(), &X);

--- a/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
+++ b/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
@@ -85,11 +85,11 @@ int main() {
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "02_features.jpg";
@@ -115,8 +115,8 @@ int main() {
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));

--- a/src/samples/robustFundamental/main_robustFundamental.cpp
+++ b/src/samples/robustFundamental/main_robustFundamental.cpp
@@ -116,11 +116,11 @@ int main(int argc, char **argv)
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "02_features.jpg";
@@ -144,8 +144,8 @@ int main(int argc, char **argv)
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) 
     {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
@@ -206,8 +206,8 @@ int main(int argc, char **argv)
       svgStream.drawImage(jpgFilenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  
       {
-        const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
-        const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
+        const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
+        const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
         const Vec2f L = LL.coords();
         const Vec2f R = RR.coords();
         svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));

--- a/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
+++ b/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
@@ -74,11 +74,11 @@ int main() {
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "02_features.jpg";
@@ -101,8 +101,8 @@ int main() {
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
@@ -160,8 +160,8 @@ int main() {
       svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
       svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  {
-        const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
-        const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
+        const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
+        const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
         const Vec2f L = LL.coords();
         const Vec2f R = RR.coords();
         svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
@@ -230,8 +230,8 @@ int main() {
         svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
         for ( size_t i = 0; i < vec_corresponding_index.size(); ++i)  {
 
-          const SIOPointFeature & LL = regionsL->Features()[vec_corresponding_index[i]._i];
-          const SIOPointFeature & RR = regionsR->Features()[vec_corresponding_index[i]._j];
+          const PointFeature & LL = regionsL->Features()[vec_corresponding_index[i]._i];
+          const PointFeature & RR = regionsR->Features()[vec_corresponding_index[i]._j];
           const Vec2f L = LL.coords();
           const Vec2f R = RR.coords();
           svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));

--- a/src/samples/robustHomography/main_robustHomography.cpp
+++ b/src/samples/robustHomography/main_robustHomography.cpp
@@ -73,11 +73,11 @@ int main() {
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "02_features.jpg";
@@ -100,8 +100,8 @@ int main() {
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
@@ -159,8 +159,8 @@ int main() {
       svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
       svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  {
-        const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
-        const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
+        const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
+        const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
         const Vec2f L = LL.coords();
         const Vec2f R = RR.coords();
         svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -203,12 +203,6 @@ int main(int argc, char **argv)
   extract(imageDescriber, imageLeft, regions_perImage[0]);
   extract(imageDescriber, imageRight, regions_perImage[1]);
 
-  const std::vector<PointFeature>& pointsLeft = regions_perImage.at(0)->GetRegionsPositions();
-  const std::vector<PointFeature>& pointsRight = regions_perImage.at(1)->GetRegionsPositions();
-  // get the SIOPointFeature
-  const feature::FeatRegions<feature::SIOPointFeature>* siofeatures_I = dynamic_cast<const feature::FeatRegions<feature::SIOPointFeature>*>(regions_perImage.at(0).get());
-  const feature::FeatRegions<feature::SIOPointFeature>* siofeatures_J = dynamic_cast<const feature::FeatRegions<feature::SIOPointFeature>*>(regions_perImage.at(1).get());
-
 
   //--
   // Display images sides by side with extracted features
@@ -218,10 +212,10 @@ int main(int argc, char **argv)
     const string out_filename = "01.features."+describerTypesName+".svg";
     drawKeypointsSideBySide(filenameLeft,
                             imageLeftSize,
-                            feature::getSIOPointFeatures(*regions_perImage.at(0)),
+                            regions_perImage.at(0).get()->Features(),
                             filenameRight,
                             imageRightSize,
-                            feature::getSIOPointFeatures(*regions_perImage.at(1)),
+                            fregions_perImage.at(1).get()->Features(),
                             out_filename);
   }
 
@@ -234,8 +228,8 @@ int main(int argc, char **argv)
 
   matching::DistanceRatioMatch(ratioThreshold,
                                matching::BRUTE_FORCE_L2,
-                               *regions_perImage[0].get(),
-                               *regions_perImage[1].get(),
+                               *regions_perImage[0],
+                               *regions_perImage[1],
                                vec_PutativeMatches);
 
   // two ways to show the matches
@@ -243,10 +237,10 @@ int main(int argc, char **argv)
     // side by side
     drawMatchesSideBySide(filenameLeft,
                           imageLeftSize,
-                          feature::getSIOPointFeatures(*regions_perImage.at(0)),
+                          regions_perImage.at(0).get()->Features(),
                           filenameRight,
                           imageRightSize,
-                          feature::getSIOPointFeatures(*regions_perImage.at(1)),
+                          regions_perImage.at(1).get()->Features(),
                           vec_PutativeMatches,
                           "02.putativeMatchesSideBySide." + describerTypesName + ".svg");
   }
@@ -257,8 +251,8 @@ int main(int argc, char **argv)
     const bool richKpts = false;
     saveMatchesAsMotion(filenameLeft,
                         imageLeftSize,
-                        feature::getSIOPointFeatures(*regions_perImage.at(0)),
-                        feature::getSIOPointFeatures(*regions_perImage.at(1)),
+                        regions_perImage.at(0).get()->Features(),
+                        regions_perImage.at(1).get()->Features(),
                         vec_PutativeMatches,
                         "03.putativeMatchesMotion."+describerTypesName+".svg",
                         isLeft, richKpts);
@@ -282,8 +276,8 @@ int main(int argc, char **argv)
   // First sort the putative matches by increasing distance ratio value
   sortMatches_byDistanceRatio(vec_PutativeMatches);
 
-  matchingImageCollection::filterMatchesByHGrowing(siofeatures_I->Features(),
-                                                   siofeatures_J->Features(),
+  matchingImageCollection::filterMatchesByHGrowing(regions_perImage.at(0).get()->Features(),
+                                                   regions_perImage.at(1).get()->Features(),
                                                    vec_PutativeMatches,
                                                    homographiesAndMatches,
                                                    outGeometricInliers,
@@ -308,8 +302,8 @@ int main(int argc, char **argv)
     // first visualize all the filtered matched together, without distinction of which homography they belong to
     saveMatchesAsMotion(filenameLeft,
                         imageLeftSize,
-                        feature::getSIOPointFeatures(*regions_perImage.at(0)),
-                        feature::getSIOPointFeatures(*regions_perImage.at(1)),
+                        regions_perImage.at(0).get()->Features(),
+                        regions_perImage.at(1).get()->Features(),
                         outGeometricInliers,
                         "04.allGrownMatchesMotion."+describerTypesName+".svg",
                         isLeft, richKpts);
@@ -317,8 +311,8 @@ int main(int argc, char **argv)
     // now visualize the matches grouped by homography with different colors
     saveMatchesAsMotion(filenameLeft,
                         imageLeftSize,
-                        feature::getSIOPointFeatures(*regions_perImage.at(0)),
-                        feature::getSIOPointFeatures(*regions_perImage.at(1)),
+                        regions_perImage.at(0).get()->Features(),
+                        regions_perImage.at(1).get()->Features(),
                         homographiesAndMatches,
                         "05.allGrownMatchesByHomographyMotion."+describerTypesName+".svg",
                         isLeft, richKpts);
@@ -326,10 +320,10 @@ int main(int argc, char **argv)
     // finally we can visualize the pair of images size by size with the matches grouped by color
     drawHomographyMatches(filenameLeft,
                           imageLeftSize,
-                          feature::getSIOPointFeatures(*regions_perImage.at(0)),
+                          regions_perImage.at(0).get()->Features(),
                           filenameRight,
                           imageRightSize,
-                          feature::getSIOPointFeatures(*regions_perImage.at(1)),
+                          regions_perImage.at(1).get()->Features(),
                           homographiesAndMatches,
                           vec_PutativeMatches,
                           "06.allGrownMatchesByHomography."+describerTypesName+".svg");

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
                             regions_perImage.at(0).get()->Features(),
                             filenameRight,
                             imageRightSize,
-                            fregions_perImage.at(1).get()->Features(),
+                            regions_perImage.at(1).get()->Features(),
                             out_filename);
   }
 

--- a/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
+++ b/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
@@ -73,11 +73,11 @@ int main() {
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     string out_filename = "02_features.jpg";
@@ -100,8 +100,8 @@ int main() {
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
@@ -159,8 +159,8 @@ int main() {
       svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
       svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  {
-        const SIOPointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
-        const SIOPointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
+        const PointFeature & LL = regionsL->Features()[vec_PutativeMatches[vec_inliers[i]]._i];
+        const PointFeature & RR = regionsR->Features()[vec_PutativeMatches[vec_inliers[i]]._j];
         const Vec2f L = LL.coords();
         const Vec2f R = RR.coords();
         svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
@@ -229,8 +229,8 @@ int main() {
         svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
         for ( size_t i = 0; i < vec_corresponding_index.size(); ++i)  {
 
-          const SIOPointFeature & LL = regionsL->Features()[vec_corresponding_index[i]._i];
-          const SIOPointFeature & RR = regionsR->Features()[vec_corresponding_index[i]._j];
+          const PointFeature & LL = regionsL->Features()[vec_corresponding_index[i]._i];
+          const PointFeature & RR = regionsR->Features()[vec_corresponding_index[i]._j];
           const Vec2f L = LL.coords();
           const Vec2f R = RR.coords();
           svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));

--- a/src/samples/siftPutativeMatches/main_siftMatching.cpp
+++ b/src/samples/siftPutativeMatches/main_siftMatching.cpp
@@ -67,11 +67,11 @@ int main() {
 
     //-- Draw features :
     for (size_t i=0; i < featsL.size(); ++i )  {
-      const SIOPointFeature point = regionsL->Features()[i];
+      const PointFeature point = regionsL->Features()[i];
       DrawCircle(point.x(), point.y(), point.scale(), 255, &concat);
     }
     for (size_t i=0; i < featsR.size(); ++i )  {
-      const SIOPointFeature point = regionsR->Features()[i];
+      const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
     const std::string out_filename = "01_features.jpg";
@@ -94,8 +94,8 @@ int main() {
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
       //Get back linked feature, draw a circle and link them by a line
-      const SIOPointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
-      const SIOPointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
+      const PointFeature L = regionsL->Features()[vec_PutativeMatches[i]._i];
+      const PointFeature R = regionsR->Features()[vec_PutativeMatches[i]._j];
       svgStream.drawLine(L.x(), L.y(), R.x()+imageL.Width(), R.y(), svgStyle().stroke("green", 2.0));
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -39,6 +39,7 @@ bool exportToMatlab(
   const std::string & outDirectory
   )
 {
+  const double unknownScale = 0.0;
   // WARNING: Observation::id_feat is used to put the ID of the 3D landmark.
   std::map<IndexT, std::vector<Observation> > observationsPerView;
   
@@ -54,7 +55,7 @@ bool exportToMatlab(
       for(const auto& obs: landmark.observations)
       {
         const IndexT obsView = obs.first; // The ID of the view that provides this 2D observation.
-        observationsPerView[obsView].push_back(Observation(obs.second.x, landmarkId));
+        observationsPerView[obsView].push_back(Observation(obs.second.x, landmarkId, unknownScale));
       }
     }
     landmarksFile.close();

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -539,8 +539,8 @@ int main(int argc, char **argv)
         assert(descType != feature::EImageDescriberType::UNINITIALIZED);
         const aliceVision::matching::IndMatches& inputMatches = match.second;
 
-        const feature::FeatRegions<feature::SIOPointFeature>* rRegions = dynamic_cast<const feature::FeatRegions<feature::SIOPointFeature>*>(&regionPerView.getRegions(indexImagePair.second, descType));
-        const feature::FeatRegions<feature::SIOPointFeature>* lRegions = dynamic_cast<const feature::FeatRegions<feature::SIOPointFeature>*>(&regionPerView.getRegions(indexImagePair.first, descType));
+        const feature::Regions* rRegions = &regionPerView.getRegions(indexImagePair.second, descType);
+        const feature::Regions* lRegions = &regionPerView.getRegions(indexImagePair.first, descType);
 
         // get the regions for the current view pair:
         if(rRegions && lRegions)

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -686,7 +686,8 @@ int main(int argc, char** argv)
   // load SfMData
   sfmData::SfMData sfmDataA, sfmDataB;
 
-  if(!sfmDataIO::Load(sfmDataA, sfmDataFilenameA, sfmDataIO::ESfMData::ALL))
+  using namespace sfmDataIO;
+  if(!sfmDataIO::Load(sfmDataA, sfmDataFilenameA, ESfMData(ESfMData::VIEWS|ESfMData::EXTRINSICS|ESfMData::INTRINSICS)))
   {
     ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilenameA + "' cannot be read.");
     return EXIT_FAILURE;
@@ -694,7 +695,7 @@ int main(int argc, char** argv)
 
   if(useMultiSfM)
   {
-    if(!sfmDataIO::Load(sfmDataB, sfmDataFilenameB, sfmDataIO::ESfMData::ALL))
+    if(!sfmDataIO::Load(sfmDataB, sfmDataFilenameB, ESfMData(ESfMData::VIEWS|ESfMData::EXTRINSICS|ESfMData::INTRINSICS)))
     {
       ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilenameB + "' cannot be read.");
       return EXIT_FAILURE;

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -16,6 +16,7 @@
 #include <aliceVision/types.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/track/Track.hpp>
+#include <aliceVision/sfm/BundleAdjustment.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
@@ -32,6 +33,8 @@ using namespace aliceVision;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 using namespace aliceVision::track;
+using namespace aliceVision::sfm;
+
 
 /**
  * @brief Retrieve the view id in the sfmData from the image filename.
@@ -78,7 +81,7 @@ int main(int argc, char **argv)
   std::string outputSfM;
 
   // user optional parameters
-
+  // user optional parameters
   std::string outputSfMViewsAndPoses;
   std::string extraInfoFolder;
   std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
@@ -164,7 +167,9 @@ int main(int argc, char **argv)
     ("useRigConstraint", po::value<bool>(&sfmParams.useRigConstraint)->default_value(sfmParams.useRigConstraint),
       "Enable/Disable rig constraint.\n")
     ("lockScenePreviouslyReconstructed", po::value<bool>(&lockScenePreviouslyReconstructed)->default_value(lockScenePreviouslyReconstructed),
-      "Lock/Unlock scene previously reconstructed.\n");
+      "Lock/Unlock scene previously reconstructed.\n")
+    ("observationConstraint", po::value<EFeatureConstraint>(&sfmParams.featureConstraint)->default_value(sfmParams.featureConstraint),
+      "Use of an observation constraint : basic, scale the observation or use of the covariance.\n");
 
   po::options_description logParams("Log parameters");
   logParams.add_options()

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -81,7 +81,6 @@ int main(int argc, char **argv)
   std::string outputSfM;
 
   // user optional parameters
-  // user optional parameters
   std::string outputSfMViewsAndPoses;
   std::string extraInfoFolder;
   std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -94,6 +94,7 @@ void createDenseSfMData(const sfmData::SfMData& sfmData,
   outSfmData = sfmData;
   outSfmData.getLandmarks().clear();
 
+  const double unknownScale = 0.0;
   for(std::size_t i = 0; i < vertices.size(); ++i)
   {
     const Point3d& point = vertices.at(i);
@@ -106,7 +107,7 @@ void createDenseSfMData(const sfmData::SfMData& sfmData,
       {
         const sfmData::View& view = sfmData.getView(mp.getViewId(cam));
         const camera::IntrinsicBase* intrinsicPtr = sfmData.getIntrinsicPtr(view.getIntrinsicId());
-        const sfmData::Observation observation(intrinsicPtr->project(sfmData.getPose(view).getTransform(), pt3D, true), UndefinedIndexT); // apply distortion
+        const sfmData::Observation observation(intrinsicPtr->project(sfmData.getPose(view).getTransform(), pt3D, true), UndefinedIndexT, unknownScale); // apply distortion
         landmark.observations[view.getViewId()] = observation;
       }
     }

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -199,14 +199,14 @@ alicevision_add_software(aliceVision_utils_split360Images
 
 
 # Project 180° fisheye images into equirectangular
-alicevision_add_software(aliceVision_utils_fisheyeProjection
-  SOURCE main_fisheyeProjection.cpp
-  FOLDER ${FOLDER_SOFTWARE_UTILS}
-  LINKS aliceVision_system
-        aliceVision_numeric
-        aliceVision_image
-        ${OPENIMAGEIO_LIBRARIES}
-        ${Boost_LIBRARIES}
-)
+#alicevision_add_software(aliceVision_utils_fisheyeProjection
+#  SOURCE main_fisheyeProjection.cpp
+#  FOLDER ${FOLDER_SOFTWARE_UTILS}
+#  LINKS aliceVision_system
+#        aliceVision_numeric
+#        aliceVision_image
+#        ${OPENIMAGEIO_LIBRARIES}
+#        ${Boost_LIBRARIES}
+#)
 
 endif() # ALICEVISION_BUILD_SFM

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -199,14 +199,14 @@ alicevision_add_software(aliceVision_utils_split360Images
 
 
 # Project 180° fisheye images into equirectangular
-#alicevision_add_software(aliceVision_utils_fisheyeProjection
-#  SOURCE main_fisheyeProjection.cpp
-#  FOLDER ${FOLDER_SOFTWARE_UTILS}
-#  LINKS aliceVision_system
-#        aliceVision_numeric
-#        aliceVision_image
-#        ${OPENIMAGEIO_LIBRARIES}
-#        ${Boost_LIBRARIES}
-#)
+alicevision_add_software(aliceVision_utils_fisheyeProjection
+  SOURCE main_fisheyeProjection.cpp
+  FOLDER ${FOLDER_SOFTWARE_UTILS}
+  LINKS aliceVision_system
+        aliceVision_numeric
+        aliceVision_image
+        ${OPENIMAGEIO_LIBRARIES}
+        ${Boost_LIBRARIES}
+)
 
 endif() # ALICEVISION_BUILD_SFM

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -50,7 +50,7 @@ using namespace aliceVision::lInfinity;
 using namespace aliceVision::sfm;
 using namespace aliceVision::sfmData;
 
-typedef feature::SIOPointFeature FeatureT;
+typedef feature::PointFeature FeatureT;
 typedef vector<FeatureT> featsT;
 
 ColorHarmonizationEngineGlobal::ColorHarmonizationEngineGlobal(
@@ -254,8 +254,8 @@ bool ColorHarmonizationEngineGlobal::Process()
             p_imaNames.first,
             p_imaNames.second,
             matches,
-            feature::getSIOPointFeatures(_regionsPerView.getRegions(viewI, descType)),
-            feature::getSIOPointFeatures(_regionsPerView.getRegions(viewJ, descType)));
+            _regionsPerView.getRegions(viewI, descType).Features(),
+            _regionsPerView.getRegions(viewJ, descType).Features());
 
           dataSelector.computeMask( maskI, maskJ );
         }


### PR DESCRIPTION
## Description
Add scale as parameter in functions for sfm.
Single PointFeature class with scale and orientation.

## Features list
[X] SfM: Add `observationConstraint` param to choose between:
- **Basic**: use standard reprojection error in pixel coordinates
- **Scale**: use reprojection in pixel coordinates relative to the features scale
