### PR TITLE
fix build error against Boost 1.71 or later

### DIFF
--- a/src/software/convert/main_convertLDRToHDR.cpp
+++ b/src/software/convert/main_convertLDRToHDR.cpp
@@ -288,7 +288,7 @@ void recoverSourceImage(const image::Image<image::RGBfColor>& hdrImage, hdr::rgb
     float offset[3];
     for(int i=0; i<3; ++i)
         offset[i] = std::abs(meanRecovered[i] - meanVal[i]);
-    ALICEVISION_LOG_INFO("Offset between target source image and recovered from hdr = " << offset);
+    ALICEVISION_LOG_INFO("Offset between target source image and recovered from hdr = " << offset[0] << ", " << offset[1] << ", " << offset[2]);
 }
 
 


### PR DESCRIPTION
## Description

I ran across the same build error described in #727; this PR corrects the ambiguity the compiler complains about.

## Implementation remarks

The original version tries to pass an array of floats to a logger function.  This breaks with newer versions of Boost.  This fix passes the array elements to the logger one at a time.
