### PR TITLE
[appveyor] build alicevision snapshot binaries (win)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,11 +63,8 @@ build:
 cache:
   c:\tools\vcpkg\installed\
 
-# zip Win64 build
-
+# zip Win64 build and push build to artifacts
 7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*.*
-
-# push build to artifacts
 
 artifacts:
   - path: alicevisionWin64snapshot.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,8 +63,9 @@ build:
 cache:
   c:\tools\vcpkg\installed\
 
+after_build:
 # zip Win64 build and push build to artifacts
-7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*.*
+  - 7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*.*
 
 artifacts:
   - path: alicevisionWin64snapshot.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,8 +67,7 @@ cache:
 
 after_build:
   - 7z a %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
-  - cd %APPVEYOR_BUILD_FOLDER%\build\
-  - dir
+  - appveyor PushArtifact alicevisionWin64snapshot.zip
   
 artifacts:
   - path: build\alicevisionWin64snapshot.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,11 +63,11 @@ build:
 cache:
   c:\tools\vcpkg\installed\
 
-# zip Win64 build and push build to artifacts
+# zip Win64 build and push build to artifacts 
 
 after_build:
-  - 7z a %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
- 
+  - set BUILD_ARCHIVE=%APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot-%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%.zip
+  - 7z a %BUILD_ARCHIVE% %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
+
 artifacts:
-  - path: build\alicevisionWin64snapshot.zip
-    name: alicevisionWin64snapshot
+  - path: 'build\*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,8 +66,9 @@ cache:
 # zip Win64 build and push build to artifacts
 
 after_build:
-  - 7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
+  - 7z a %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
   - cd %APPVEYOR_BUILD_FOLDER%\build\
+  - dir
   
 artifacts:
   - path: alicevisionWin64snapshot.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,8 +63,9 @@ build:
 cache:
   c:\tools\vcpkg\installed\
 
-after_build:
 # zip Win64 build and push build to artifacts
+
+after_build:
   - 7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*.*
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,8 +66,9 @@ cache:
 # zip Win64 build and push build to artifacts
 
 after_build:
-  - 7z a %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
-
+  - 7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
+  - cd %APPVEYOR_BUILD_FOLDER%\build\
+  
 artifacts:
-  - path: %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip
+  - path: alicevisionWin64snapshot.zip
     name: alicevisionWin64snapshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ build:
 cache:
   c:\tools\vcpkg\installed\
 
-# zip Win64 build and push build to artifacts, include Licenses and Copyright information
+# 7zip Win64 build and push build to artifacts, include Licenses and Copyright information
 
 after_build:
   - COPY "%APPVEYOR_BUILD_FOLDER%\COPYING.md" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,8 +67,7 @@ cache:
 
 after_build:
   - 7z a %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
-  - appveyor PushArtifact alicevisionWin64snapshot.zip
-  
+ 
 artifacts:
   - path: build\alicevisionWin64snapshot.zip
     name: alicevisionWin64snapshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,10 +66,8 @@ cache:
 # 7zip Win64 build and push build to artifacts, include Licenses and Copyright information
 
 after_build:
-#  - COPY "%APPVEYOR_BUILD_FOLDER%\COPYING.md" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
-#  - COPY "%APPVEYOR_BUILD_FOLDER%\LICENSE*" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
   - set BUILD_ARCHIVE=%APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot-%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%.zip
-  - 7z a %BUILD_ARCHIVE% %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
+  - 7z a %BUILD_ARCHIVE% %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\* %APPVEYOR_BUILD_FOLDER%\LICENSE* %APPVEYOR_BUILD_FOLDER%\COPYING.md
 
 artifacts:
   - path: 'build\*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,3 +62,13 @@ build:
 
 cache:
   c:\tools\vcpkg\installed\
+
+# zip Win64 build
+
+7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*.*
+
+# push build to artifacts
+
+artifacts:
+  - path: alicevisionWin64snapshot.zip
+    name: alicevisionWin64snapshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,8 +66,8 @@ cache:
 # zip Win64 build and push build to artifacts
 
 after_build:
-  - 7z a alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*.*
+  - 7z a %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
 
 artifacts:
-  - path: alicevisionWin64snapshot.zip
+  - path: %APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot.zip
     name: alicevisionWin64snapshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,8 +66,8 @@ cache:
 # 7zip Win64 build and push build to artifacts, include Licenses and Copyright information
 
 after_build:
-  - COPY "%APPVEYOR_BUILD_FOLDER%\COPYING.md" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
-  - COPY "%APPVEYOR_BUILD_FOLDER%\LICENSE*" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
+#  - COPY "%APPVEYOR_BUILD_FOLDER%\COPYING.md" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
+#  - COPY "%APPVEYOR_BUILD_FOLDER%\LICENSE*" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
   - set BUILD_ARCHIVE=%APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot-%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%.zip
   - 7z a %BUILD_ARCHIVE% %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,9 +63,11 @@ build:
 cache:
   c:\tools\vcpkg\installed\
 
-# zip Win64 build and push build to artifacts 
+# zip Win64 build and push build to artifacts, include Licenses and Copyright information
 
 after_build:
+  - COPY "%APPVEYOR_BUILD_FOLDER%\COPYING.md" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
+  - COPY "%APPVEYOR_BUILD_FOLDER%\LICENSE*" "%APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\"
   - set BUILD_ARCHIVE=%APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot-%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%.zip
   - 7z a %BUILD_ARCHIVE% %APPVEYOR_BUILD_FOLDER%\build\Windows-AMD64\Release\*
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,5 +71,5 @@ after_build:
   - dir
   
 artifacts:
-  - path: alicevisionWin64snapshot.zip
+  - path: C:\projects\alicevision\build\alicevisionWin64snapshot.zip
     name: alicevisionWin64snapshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ build:
 cache:
   c:\tools\vcpkg\installed\
 
-# 7zip Win64 build and push build to artifacts, include Licenses and Copyright information
+# 7z Win64 build and push build to artifacts, include Licenses and Copyright information
 
 after_build:
   - set BUILD_ARCHIVE=%APPVEYOR_BUILD_FOLDER%\build\alicevisionWin64snapshot-%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,5 +71,5 @@ after_build:
   - dir
   
 artifacts:
-  - path: C:\projects\alicevision\build\alicevisionWin64snapshot.zip
+  - path: build\alicevisionWin64snapshot.zip
     name: alicevisionWin64snapshot


### PR DESCRIPTION
> [setup appveyor to release windows binaries from the develop branch](https://github.com/alicevision/AliceVision/issues/392#issuecomment-392254832)

For every commit, a snapshot build for windows can be downloaded from the [appveyor build artifacts tab](https://ci.appveyor.com/project/AliceVision/alicevision/build/artifacts).

Details: https://www.appveyor.com/docs/packaging-artifacts/

**Note**: (_to be added to the wiki_)
Do not use snapshots if you need a stable version.
Snapshot builds are for developers and testers and should be considered unstable.

With snapshots, users can test and report back on a bugfix/feature without waiting for the official release or needing to build alicevision on their own.
