### PR TITLE
Added sensor database entry for Samsung Galaxy Note9

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5296,6 +5296,7 @@ Samsung;Samsung Galaxy Note FE SD820;3.6;devicespecifications
 Samsung;Samsung Galaxy Note5;5.95;devicespecifications
 Samsung;Samsung Galaxy Note7 Exynos;3.6;devicespecifications
 Samsung;Samsung Galaxy Note7 SD820;3.6;devicespecifications
+Samsung;Samsung Galaxy Note9 SM-N960U;5.644;devicespecifications
 Samsung;Samsung Galaxy NX;23.5;dpreview,digicamdb
 Samsung;Samsung Galaxy Round;4.54;devicespecifications
 Samsung;Samsung Galaxy S2;4.54;devicespecifications

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5265,6 +5265,7 @@ Samsung;Samsung EX2F;7.44;dpreview,digicamdb,dxomark
 Samsung;Samsung Galaxy A5;4.69;devicespecifications
 Samsung;Samsung Galaxy A5 Duos;4.69;devicespecifications
 Samsung;Samsung Galaxy A8;5.3;devicespecifications
+Samsung;Samsung Galaxy A8 SM-A530W;5.3;devicespecifications
 Samsung;Samsung Galaxy A8 SM-A800F;5.3;devicespecifications
 Samsung;Samsung Galaxy A9;4.69;devicespecifications
 Samsung;Samsung Galaxy C5;4.74;devicespecifications


### PR DESCRIPTION
## Description
Added sensor database entry for Samsung Galaxy Note9, calculated from the vendor-provided specifications for the rear wide-angle camera.


## Features list
- [X] Added sensor database entry for Samsung Galaxy Note9


## Implementation remarks
Calculated based on the camera's maximum resolution of 4032px x 3024px and Samsung's stated sensor pixel size of 1.4µm.