### PR TITLE
Minor Changes in the docker build command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -390,15 +390,11 @@ docker build --tag alicevision:ubuntu18.04-cuda9.2 -f Dockerfile_ubuntu .
 
 Parameters `OS_TAG` and `CUDA_TAG` can be passed to build the image with a specific OS and CUDA version.
 Use NPROC=8 to select the number of cores to use, 1 by default.
-For example, in order to create a CentOS 7 with Cuda 9.2, use:
+For example, the first line of below's commands shows the example to create docker for a CentOS 7 with Cuda 9.2 and second line for Ubuntu 16.04 with Cuda 8.0:
 
 ```
-docker build --build-arg OS_TAG=7 CUDA_TAG=9.2 --tag alicevision:centos7-cuda9.2 .
-docker build --build-arg OS_TAG=16.04 CUDA_TAG=8.0 NPROC=8 --tag alicevision:ubuntu16.04-cuda8.0 -f Dockerfile_ubuntu .
-```
-In the latest version of docker (e.g 19.03.8) the `--build-arg` should be specified for each parameters seperetly, like this: 
-```
-sudo docker build --build-arg OS_TAG=18.04 --build-arg CUDA_TAG=10.2 --build-arg NPROC=4 --tag alicevision:ubuntu18.04-cuda10.2 -f Dockerfile_ubuntu .
+docker build --build-arg OS_TAG=7 --build-arg CUDA_TAG=9.2 --tag alicevision:centos7-cuda9.2 .
+docker build --build-arg OS_TAG=16.04 --build-arg CUDA_TAG=8.0 --build-arg NPROC=8 --tag alicevision:ubuntu16.04-cuda8.0 -f Dockerfile_ubuntu .
 ```
 
 In order to run the image [nvidia docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) is needed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -396,6 +396,10 @@ For example, in order to create a CentOS 7 with Cuda 9.2, use:
 docker build --build-arg OS_TAG=7 CUDA_TAG=9.2 --tag alicevision:centos7-cuda9.2 .
 docker build --build-arg OS_TAG=16.04 CUDA_TAG=8.0 NPROC=8 --tag alicevision:ubuntu16.04-cuda8.0 -f Dockerfile_ubuntu .
 ```
+In the latest version of docker (e.g 19.03.8) the `--build-arg` should be specified for each parameters seperetly, like this: 
+```
+sudo docker build --build-arg OS_TAG=18.04 --build-arg CUDA_TAG=10.2 --build-arg NPROC=4 --tag alicevision:ubuntu18.04-cuda10.2 -f Dockerfile_ubuntu .
+```
 
 In order to run the image [nvidia docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) is needed.
 


### PR DESCRIPTION
Looks like the docker build command that was provided earlier should have been for the earlier version of Dockers, I'm using Docker version 19.03.8 and copying the above command doesn't work. Since in the newer version of docker, the --build-arg needs to be added separately for each param.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

