### PR TITLE
[cmake] missing Boost::boost dependency

### DIFF
--- a/src/aliceVision/calibration/CMakeLists.txt
+++ b/src/aliceVision/calibration/CMakeLists.txt
@@ -24,6 +24,7 @@ alicevision_add_library(aliceVision_calibration
     aliceVision_dataio
     Boost::filesystem
     Boost::program_options
+    Boost::boost
 )
 
 if(ALICEVISION_HAVE_CCTAG)

--- a/src/aliceVision/dataio/CMakeLists.txt
+++ b/src/aliceVision/dataio/CMakeLists.txt
@@ -27,6 +27,7 @@ alicevision_add_library(aliceVision_dataio
     aliceVision_sfmDataIO
     aliceVision_system
     Boost::filesystem
+    Boost::boost
 )
 
 if(ALICEVISION_HAVE_OPENCV)

--- a/src/aliceVision/feature/CMakeLists.txt
+++ b/src/aliceVision/feature/CMakeLists.txt
@@ -72,6 +72,7 @@ alicevision_add_library(aliceVision_feature
     vlsift
   PRIVATE_LINKS
     Boost::filesystem
+    Boost::boost
 )
 
 # Link CCTAG library

--- a/src/aliceVision/fuseCut/CMakeLists.txt
+++ b/src/aliceVision/fuseCut/CMakeLists.txt
@@ -36,4 +36,5 @@ alicevision_add_library(aliceVision_fuseCut
     Boost::container
   PRIVATE_LINKS
     nanoflann
+    Boost::boost
 )

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -15,6 +15,7 @@
 #include <OpenEXR/half.h>
 
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <cstring>
 #include <stdexcept>

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -13,7 +13,6 @@
 #include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/imagebuf.h>
 
-#include <boost/algorithm/string.hpp>
 #include <string>
 
 namespace oiio = OIIO;

--- a/src/aliceVision/localization/CMakeLists.txt
+++ b/src/aliceVision/localization/CMakeLists.txt
@@ -37,6 +37,7 @@ alicevision_add_library(aliceVision_localization
     aliceVision_system
     aliceVision_matchingImageCollection
     Boost::filesystem
+    Boost::boost
 )
 
 if(ALICEVISION_HAVE_CCTAG)

--- a/src/aliceVision/matching/CMakeLists.txt
+++ b/src/aliceVision/matching/CMakeLists.txt
@@ -32,6 +32,7 @@ alicevision_add_library(aliceVision_matching
     aliceVision_system
   PRIVATE_LINKS
     Boost::filesystem
+    Boost::boost
     ${FLANN_LIBRARY}
 )
 

--- a/src/aliceVision/mesh/CMakeLists.txt
+++ b/src/aliceVision/mesh/CMakeLists.txt
@@ -32,4 +32,5 @@ alicevision_add_library(aliceVision_mesh
     Boost::filesystem
   PRIVATE_LINKS
     aliceVision_system
+    Boost::boost
 )

--- a/src/aliceVision/mvsData/CMakeLists.txt
+++ b/src/aliceVision/mvsData/CMakeLists.txt
@@ -42,6 +42,7 @@ alicevision_add_library(aliceVision_mvsData
     aliceVision_system
     ${ZLIB_LIBRARIES}
     Boost::filesystem
+    Boost::boost
     ${OPENIMAGEIO_LIBRARIES}
   PUBLIC_INCLUDE_DIRS
     ${ZLIB_INCLUDE_DIR}

--- a/src/aliceVision/mvsUtils/CMakeLists.txt
+++ b/src/aliceVision/mvsUtils/CMakeLists.txt
@@ -24,4 +24,5 @@ alicevision_add_library(aliceVision_mvsUtils
   PRIVATE_LINKS
     aliceVision_system
     Boost::filesystem
+    Boost::boost
 )

--- a/src/aliceVision/sensorDB/CMakeLists.txt
+++ b/src/aliceVision/sensorDB/CMakeLists.txt
@@ -17,6 +17,7 @@ alicevision_add_library(aliceVision_sensorDB
   PRIVATE_LINKS
     Boost::filesystem
     Boost::system
+    Boost::boost
 )
 
 # Install DB

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -73,6 +73,7 @@ alicevision_add_library(aliceVision_sfm
     aliceVision_sfmData
     aliceVision_sfmDataIO
     Boost::filesystem
+    Boost::boost
     ${CERES_LIBRARIES}
 )
 

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -27,6 +27,8 @@ alicevision_add_library(aliceVision_sfmData
     aliceVision_camera
     aliceVision_stl
     Boost::filesystem
+  PRIVATE_LINKS
+    Boost::boost
 )
 
 # Unit tests

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -36,6 +36,7 @@ alicevision_add_library(aliceVision_sfmDataIO
     Boost::filesystem
   PRIVATE_LINKS
     Boost::regex
+    Boost::boost
 )
 
 

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -27,6 +27,8 @@ alicevision_add_library(aliceVision_system
     Boost::date_time
     Boost::program_options
     ${ALICEVISION_NVTX_LIBRARY}
+  PRIVATE_LINKS
+    Boost::boost
 )
 
 alicevision_add_test(Logger_test.cpp NAME "system_Logger" LINKS aliceVision_system)

--- a/src/aliceVision/voctree/CMakeLists.txt
+++ b/src/aliceVision/voctree/CMakeLists.txt
@@ -25,6 +25,7 @@ alicevision_add_library(aliceVision_voctree
     aliceVision_feature
     aliceVision_sfmData
     aliceVision_system
+    Boost::boost
   PRIVATE_LINKS
     Boost::filesystem
 )


### PR DESCRIPTION
A quick fix for missing dependency from `Boost::boost` in some modules.
Because some header-only boost components are used we should also explicitly link with `Boost::boost`

