### PR TITLE
Move random generator to main(s) to control them

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,7 +247,7 @@ if(ALICEVISION_HAVE_OPENMP)
   if(NOT MSVC)
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       # for those using the clang with OpenMP support
-      list(APPEND ALICEVISION_LIBRARY_DEPENDENCIES iomp)
+      list(APPEND ALICEVISION_LIBRARY_DEPENDENCIES iomp5)
     else()
     list(APPEND ALICEVISION_LIBRARY_DEPENDENCIES gomp)
     endif()

--- a/src/aliceVision/geometry/rigidTransformation3D.cpp
+++ b/src/aliceVision/geometry/rigidTransformation3D.cpp
@@ -126,7 +126,8 @@ void Refine_RTS(const Mat &x1,
   }
 }
 
-bool ACRansac_FindRTS(const Mat &x1,
+bool ACRansac_FindRTS(std::mt19937 & generator, 
+                             const Mat &x1,
                              const Mat &x2,
                              double &S,
                              Vec3 &t,
@@ -151,8 +152,7 @@ bool ACRansac_FindRTS(const Mat &x1,
 
   KernelType kernel = KernelType(x1, x2);
   // Robust estimation of the Projection matrix and its precision
-  const std::pair<double, double> ACRansacOut =
-          robustEstimation::ACRANSAC(kernel, vec_inliers, numIterations, &RTS, dPrecision);
+  const std::pair<double, double> ACRansacOut = robustEstimation::ACRANSAC(generator, kernel, vec_inliers, numIterations, &RTS, dPrecision);
 
   const bool good = decomposeRTS(RTS, S, t, R);
 

--- a/src/aliceVision/geometry/rigidTransformation3D.hpp
+++ b/src/aliceVision/geometry/rigidTransformation3D.hpp
@@ -10,6 +10,8 @@
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/numeric/LMFunctor.hpp>
 
+#include <random>
+
 namespace aliceVision {
 namespace geometry {
 
@@ -267,6 +269,7 @@ private:
 /**
  * @brief Uses AC ransac to robustly estimate the similarity between two sets of points.
  * 
+ * @param[in] generator the random number generator
  * @param[in] x1 The first 3xN matrix of euclidean points.
  * @param[in] x2 The second 3xN matrix of euclidean points.
  * @param[out] S The scale factor.
@@ -277,7 +280,8 @@ private:
  * @return true if the found transformation is a similarity
  * @see FindRTS()
  */
-bool ACRansac_FindRTS(const Mat &x1,
+bool ACRansac_FindRTS(std::mt19937 & generator,
+                      const Mat &x1,
                       const Mat &x2,
                       double &S,
                       Vec3 &t,
@@ -288,6 +292,7 @@ bool ACRansac_FindRTS(const Mat &x1,
 /**
  * @brief Uses AC ransac to robustly estimate the similarity between two sets of 
  * points. Just a wrapper that output the similarity in matrix form
+ * @param[in] generator the random number generator
  * @param[in] x1 The first 3xN matrix of euclidean points.
  * @param[in] x2 The second 3xN matrix of euclidean points.
  * @param[out] RTS The 4x4 similarity matrix. 
@@ -297,7 +302,8 @@ bool ACRansac_FindRTS(const Mat &x1,
  * @see geometry::FindRTS()
  * @see geometry::ACRansac_FindRTS()
  */
-inline bool ACRansac_FindRTS(const Mat &x1,
+inline bool ACRansac_FindRTS(std::mt19937 & generator,
+                             const Mat &x1,
                              const Mat &x2, 
                              Mat4 &RTS, 
                              std::vector<std::size_t> &vec_inliers,
@@ -306,7 +312,7 @@ inline bool ACRansac_FindRTS(const Mat &x1,
   double S;
   Vec3 t; 
   Mat3 R; 
-  const bool good = ACRansac_FindRTS(x1, x2, S, t, R, vec_inliers, refine);
+  const bool good = ACRansac_FindRTS(generator, x1, x2, S, t, R, vec_inliers, refine);
   if(good)
     composeRTS(S, t, R, RTS);
   

--- a/src/aliceVision/geometry/rigidTransformation3D_test.cpp
+++ b/src/aliceVision/geometry/rigidTransformation3D_test.cpp
@@ -9,6 +9,7 @@
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 
 #include <iostream>
+#include <random>
 
 #define BOOST_TEST_MODULE rigidTransformation3D
 
@@ -146,8 +147,9 @@ BOOST_AUTO_TEST_CASE(SRT_precision_ACRANSAC_noNoise)
   Mat3 Rc;
   Vec3 tc;
 
+  std::mt19937 generator;
   std::vector<std::size_t> vec_inliers;
-  const bool result = ACRansac_FindRTS(x1, x2, Sc, tc, Rc, vec_inliers, true);
+  const bool result = ACRansac_FindRTS(generator, x1, x2, Sc, tc, Rc, vec_inliers, true);
 
   BOOST_CHECK(result);
   BOOST_CHECK(vec_inliers.size() == nbPoints);
@@ -202,8 +204,9 @@ BOOST_AUTO_TEST_CASE(SRT_precision_ACRANSAC_noiseByShuffling)
   Mat3 Rc;
   Vec3 tc;
 
+  std::mt19937 generator;
   std::vector<std::size_t> vec_inliers;
-  const bool result = ACRansac_FindRTS(x1, x2, Sc, tc, Rc, vec_inliers, true);
+  const bool result = ACRansac_FindRTS(generator, x1, x2, Sc, tc, Rc, vec_inliers, true);
 
   ALICEVISION_LOG_DEBUG(
           "Scale " << Sc << "\n" <<

--- a/src/aliceVision/linearProgramming/lInfinityCV/lInftyCV_resection_robust_test.cpp
+++ b/src/aliceVision/linearProgramming/lInfinityCV/lInftyCV_resection_robust_test.cpp
@@ -45,7 +45,8 @@ BOOST_AUTO_TEST_CASE(Resection_L_Infinity_Robust_OutlierFree) {
     const Mat & pt3D = d2._X;
     KernelType kernel(pt2D, pt3D);
     ScoreEvaluator<KernelType> scorer(2*Square(0.6));
-    Mat34 P = MaxConsensus(kernel, scorer, nullptr, 128);
+    std::mt19937 generator;
+    Mat34 P = MaxConsensus(generator, kernel, scorer, nullptr, 128);
 
     // Check that Projection matrix is near to the GT :
     Mat34 GT_ProjectionMatrix = d.P(nResectionCameraIndex).array()
@@ -98,7 +99,8 @@ BOOST_AUTO_TEST_CASE(Resection_L_Infinity_Robust_OneOutlier) {
     const Mat & pt3D = d2._X;
     KernelType kernel(pt2D, pt3D);
     ScoreEvaluator<KernelType> scorer(Square(0.1)); //Highly intolerant for the test
-    Mat34 P = MaxConsensus(kernel, scorer, nullptr, 128);
+    std::mt19937 generator;
+    Mat34 P = MaxConsensus(generator, kernel, scorer, nullptr, 128);
 
     // Check that Projection matrix is near to the GT :
     Mat34 GT_ProjectionMatrix = d.P(nResectionCameraIndex).array()

--- a/src/aliceVision/localization/ILocalizer.hpp
+++ b/src/aliceVision/localization/ILocalizer.hpp
@@ -60,7 +60,7 @@ using OccurenceMap = std::map<OccurenceKey, std::size_t>;
 class ILocalizer
 {
 public:
-    ILocalizer() : _isInit(false) { };
+    ILocalizer(std::mt19937 & generator) : _generator(generator), _isInit(false) { };
 
     // Only relevant for CCTagLocalizer
     virtual void setCudaPipe(int) { }
@@ -116,7 +116,7 @@ public:
 protected:
   bool _isInit;
   sfmData::SfMData _sfm_data;
-
+  std::mt19937 & _generator;
 };
 
 } //namespace aliceVision 

--- a/src/aliceVision/localization/VoctreeLocalizer.hpp
+++ b/src/aliceVision/localization/VoctreeLocalizer.hpp
@@ -82,6 +82,7 @@ public:
   /**
    * @brief Initialize a localizer based on a vocabulary tree
    * 
+   * @param[in] generator the random number generator object
    * @param[in] sfmData The sfmdata containing the scene
    * reconstruction.
    * @param[in] descriptorsFolder The path to the directory containing the features 
@@ -95,7 +96,8 @@ public:
    *
    * It enable the use of combined SIFT and CCTAG features.
    */
-  VoctreeLocalizer(const sfmData::SfMData &sfmData,
+  VoctreeLocalizer(std::mt19937 & generator,
+                   const sfmData::SfMData &sfmData,
                    const std::string &descriptorsFolder,
                    const std::string &vocTreeFilepath,
                    const std::string &weightsFilepath,

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <random>
+
 namespace aliceVision {
 
 
@@ -28,10 +30,11 @@ namespace matchingImageCollection {
 
 struct GeometricFilterMatrix
 {
-  GeometricFilterMatrix(double precision,
+  GeometricFilterMatrix(std::mt19937 & generator,
+                        double precision,
                         double precisionRobust,
                         std::size_t stIteration)
-    : m_dPrecision(precision)
+    : m_generator(generator), m_dPrecision(precision)
     , m_dPrecision_robust(precisionRobust)
     , m_stIteration(stIteration)
   {}
@@ -58,6 +61,7 @@ struct GeometricFilterMatrix
   double m_dPrecision;  //upper_bound precision used for robust estimation
   double m_dPrecision_robust;
   std::size_t m_stIteration; //maximal number of iteration for robust estimation
+  std::mt19937 & m_generator;
 };
 
 

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_E_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_E_AC.hpp
@@ -27,9 +27,10 @@ namespace matchingImageCollection {
 struct GeometricFilterMatrix_E_AC : public GeometricFilterMatrix
 {
   GeometricFilterMatrix_E_AC(
+    std::mt19937 & generator,
     double dPrecision = std::numeric_limits<double>::infinity(),
     size_t iteration = 1024)
-    : GeometricFilterMatrix(dPrecision, std::numeric_limits<double>::infinity(), iteration)
+    : GeometricFilterMatrix(generator, dPrecision, std::numeric_limits<double>::infinity(), iteration)
     , m_E(Mat3::Identity())
   {}
 
@@ -94,7 +95,7 @@ struct GeometricFilterMatrix_E_AC : public GeometricFilterMatrix
     const double upper_bound_precision = Square(m_dPrecision);
 
     std::vector<size_t> inliers;
-    const std::pair<double,double> ACRansacOut = ACRANSAC(kernel, inliers, m_stIteration, &m_E, upper_bound_precision);
+    const std::pair<double,double> ACRansacOut = ACRANSAC(m_generator, kernel, inliers, m_stIteration, &m_E, upper_bound_precision);
 
     if (inliers.empty())
       return EstimationStatus(false, false);

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp
@@ -29,10 +29,11 @@ namespace matchingImageCollection {
 struct GeometricFilterMatrix_F_AC: public GeometricFilterMatrix
 {
   GeometricFilterMatrix_F_AC(
+    std::mt19937 & generator,
     double dPrecision = std::numeric_limits<double>::infinity(),
     size_t iteration = 1024,
     robustEstimation::ERobustEstimator estimator = robustEstimation::ERobustEstimator::ACRANSAC)
-    : GeometricFilterMatrix(dPrecision, std::numeric_limits<double>::infinity(), iteration)
+    : GeometricFilterMatrix(generator, dPrecision, std::numeric_limits<double>::infinity(), iteration)
     , m_F(Mat3::Identity())
     , m_estimator(estimator)
   {}
@@ -172,7 +173,7 @@ struct GeometricFilterMatrix_F_AC: public GeometricFilterMatrix
         // Robustly estimate the Fundamental matrix with A Contrario ransac
         const double upper_bound_precision = Square(m_dPrecision);
         const std::pair<double,double> ACRansacOut =
-          ACRANSAC(kernel, out_inliers, m_stIteration, &m_F, upper_bound_precision);
+          ACRANSAC(m_generator, kernel, out_inliers, m_stIteration, &m_F, upper_bound_precision);
 
         if(out_inliers.empty())
           return std::make_pair(false, KernelType::MINIMUM_SAMPLES);
@@ -204,7 +205,7 @@ struct GeometricFilterMatrix_F_AC: public GeometricFilterMatrix
         const double normalizedThreshold = Square(m_dPrecision * kernel.normalizer2()(0, 0));
         ScoreEvaluator<KernelType> scorer(normalizedThreshold);
 
-        m_F = LO_RANSAC(kernel, scorer, &out_inliers);
+        m_F = LO_RANSAC(m_generator, kernel, scorer, &out_inliers);
 
         if(out_inliers.empty())
           return std::make_pair(false, KernelType::MINIMUM_SAMPLES);

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.cpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.cpp
@@ -111,7 +111,8 @@ bool growHomography(const std::vector<feature::PointFeature> &featuresI,
 
 
 
-void filterMatchesByHGrowing(const std::vector<feature::PointFeature>& siofeatures_I,
+void filterMatchesByHGrowing(std::mt19937 & generator, 
+                             const std::vector<feature::PointFeature>& siofeatures_I,
                              const std::vector<feature::PointFeature>& siofeatures_J,
                              const matching::IndMatches& putativeMatches,
                              std::vector<std::pair<Mat3, matching::IndMatches>>& homographiesAndMatches,
@@ -123,7 +124,7 @@ void filterMatchesByHGrowing(const std::vector<feature::PointFeature>& siofeatur
   using namespace aliceVision::matching;
 
   IndMatches remainingMatches = putativeMatches;
-  GeometricFilterMatrix_HGrowing dummy;
+  GeometricFilterMatrix_HGrowing dummy(generator);
 
   for(IndexT iH = 0; iH < param._maxNbHomographies; ++iH)
   {

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
@@ -117,7 +117,8 @@ struct HGrowingFilteringParam
  * @param[out] outGeometricInliers All the matches that supports one of the found homographies.
  * @param[in] param The parameters of the algorithm.
  */
-void filterMatchesByHGrowing(const std::vector<feature::PointFeature>& siofeatures_I,
+void filterMatchesByHGrowing(std::mt19937 & generator,
+                             const std::vector<feature::PointFeature>& siofeatures_I,
                              const std::vector<feature::PointFeature>& siofeatures_J,
                              const matching::IndMatches& putativeMatches,
                              std::vector<std::pair<Mat3,
@@ -148,9 +149,10 @@ void drawHomographyMatches(const sfmData::View &viewI,
 struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
 {
     explicit GeometricFilterMatrix_HGrowing(
+          std::mt19937 & generator,
           double dPrecision = std::numeric_limits<double>::infinity(),
           size_t iteration = 1024)
-              : GeometricFilterMatrix(dPrecision, std::numeric_limits<double>::infinity(), iteration)
+              : GeometricFilterMatrix(generator, dPrecision, std::numeric_limits<double>::infinity(), iteration)
   { }
   
   /**
@@ -225,7 +227,8 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
 
       std::vector<std::pair<Mat3, matching::IndMatches>> homographiesAndMatches;
       matching::IndMatches outGeometricInliers;
-      filterMatchesByHGrowing(regions_I.Features(),
+      filterMatchesByHGrowing(m_generator,
+                              regions_I.Features(),
                               regions_J.Features(),
                               putativeMatchesPerType.at(descType),
                               homographiesAndMatches,

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_H_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_H_AC.hpp
@@ -25,9 +25,10 @@ namespace matchingImageCollection {
 struct GeometricFilterMatrix_H_AC : public GeometricFilterMatrix
 {
   GeometricFilterMatrix_H_AC(
+    std::mt19937 &generator,
     double dPrecision = std::numeric_limits<double>::infinity(),
     size_t iteration = 1024)
-    : GeometricFilterMatrix(dPrecision, std::numeric_limits<double>::infinity(), iteration)
+    : GeometricFilterMatrix(generator, dPrecision, std::numeric_limits<double>::infinity(), iteration)
     , m_H(Mat3::Identity())
   {}
 
@@ -76,7 +77,7 @@ struct GeometricFilterMatrix_H_AC : public GeometricFilterMatrix
     const double upper_bound_precision = Square(m_dPrecision);
 
     std::vector<size_t> inliers;
-    const std::pair<double,double> ACRansacOut = ACRANSAC(kernel, inliers, m_stIteration, &m_H, upper_bound_precision);
+    const std::pair<double,double> ACRansacOut = ACRANSAC(m_generator, kernel, inliers, m_stIteration, &m_H, upper_bound_precision);
 
     if (inliers.empty())
       return EstimationStatus(false, false);

--- a/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
+++ b/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
@@ -201,12 +201,12 @@ BOOST_AUTO_TEST_CASE(P3P_Ransac_noisyFromImagePoints)
     Mat pts2Dnorm;
     ApplyTransformationToPoints(pts2D, Kgt.inverse(), &pts2Dnorm);
     KernelType kernel(pts2Dnorm, pts3D, Mat3::Identity());
-
+    
     std::vector<std::size_t> vec_inliers;
     const double threshold = 2*gaussianNoiseLevel;
     const double normalizedThreshold = Square(threshold / FOCAL);
     robustEstimation::ScoreEvaluator<KernelType> scorer(normalizedThreshold);
-    Mat34 Pest = robustEstimation::LO_RANSAC(kernel, scorer, &vec_inliers);
+    Mat34 Pest = robustEstimation::LO_RANSAC(gen, kernel, scorer, &vec_inliers);
     
     const std::size_t numInliersFound = vec_inliers.size();
     const std::size_t numInliersExpected = nbPoints-vec_outliers.size();

--- a/src/aliceVision/multiview/triangulation/Triangulation.cpp
+++ b/src/aliceVision/multiview/triangulation/Triangulation.cpp
@@ -56,7 +56,8 @@ void TriangulateNViewAlgebraic(const Mat2X &x,
   Nullspace(&design, X);
 }
 
-void TriangulateNViewLORANSAC(const Mat2X &x, 
+void TriangulateNViewLORANSAC(std::mt19937 & generator,
+                              const Mat2X &x, 
                               const std::vector< Mat34 > &Ps,
                               Vec4 *X, 
                               std::vector<std::size_t> *inliersIndex, 
@@ -65,7 +66,7 @@ void TriangulateNViewLORANSAC(const Mat2X &x,
   using TriangulationKernel = LORansacTriangulationKernel<>;
   TriangulationKernel kernel(x, Ps);
   robustEstimation::ScoreEvaluator<TriangulationKernel> scorer(thresholdError);
-  *X = robustEstimation::LO_RANSAC(kernel, scorer, inliersIndex);
+  *X = robustEstimation::LO_RANSAC(generator, kernel, scorer, inliersIndex);
 }
 
 double Triangulation::error(const Vec3 &X) const

--- a/src/aliceVision/multiview/triangulation/Triangulation.hpp
+++ b/src/aliceVision/multiview/triangulation/Triangulation.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <aliceVision/numeric/numeric.hpp>
-
+#include <random>
 #include <vector>
 
 namespace aliceVision {
@@ -54,13 +54,15 @@ void TriangulateNViewAlgebraic(const Mat2X &x,
  * Algorithm is Lo-RANSAC
  * It can return the the list of the cameras set as intlier by the Lo-RANSAC algorithm.
  * 
+ * @param[in] generator Random number generator initialized
  * @param[in] x are 2D coordinates (x,y,1) in each image
  * @param[in] Ps is the list of projective matrices for each camera
  * @param[out] X is the estimated 3D point
  * @param[out] inliersIndex (optional) store the index of the cameras (following Ps ordering, not the view_id) set as Inliers by Lo-RANSAC
  * @param[in] thresholdError (optional) set a threashold value to the Lo-RANSAC scorer
  */                               
-void TriangulateNViewLORANSAC(const Mat2X &x, 
+void TriangulateNViewLORANSAC(std::mt19937 & generator,
+                              const Mat2X &x, 
                               const std::vector< Mat34 > &Ps,
                               Vec4 *X,
                               std::vector<std::size_t> *inliersIndex = NULL,

--- a/src/aliceVision/multiview/triangulation/triangulation_test.cpp
+++ b/src/aliceVision/multiview/triangulation/triangulation_test.cpp
@@ -174,6 +174,7 @@ BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_FiveViews)
 //// is considered).
 BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_LORANSAC)
 {
+  std::mt19937 generator;
   const std::size_t numTrials = 100;
   for(std::size_t trial = 0; trial < numTrials; ++ trial)
   {
@@ -211,7 +212,7 @@ BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_LORANSAC)
     std::vector<std::size_t> vec_inliers;
     Vec4 X;
     double const threshold = 0.01; // modify the default value: 4 pixels is too much in this configuration.
-    TriangulateNViewLORANSAC(pt2d, Ps, &X, &vec_inliers, threshold);
+    TriangulateNViewLORANSAC(generator, pt2d, Ps, &X, &vec_inliers, threshold);
     
     // check inliers are correct
     BOOST_CHECK_EQUAL(vec_inliers.size(), inliers);

--- a/src/aliceVision/robustEstimation/ACRansac.hpp
+++ b/src/aliceVision/robustEstimation/ACRansac.hpp
@@ -148,6 +148,7 @@ inline ErrorIndex bestNFA(
 /**
  * @brief ACRANSAC routine (ErrorThreshold, NFA)
  *
+ * @param[in] generator Random number generator initialized
  * @param[in] kernel model and metric object
  * @param[out] vec_inliers points that fit the estimated model
  * @param[in] nIter maximum number of consecutive iterations
@@ -156,8 +157,8 @@ inline ErrorIndex bestNFA(
  *
  * @return (errorMax, minNFA)
  */
-template<typename Kernel>
-std::pair<double, double> ACRANSAC(const Kernel &kernel,
+template<typename RandomT, typename Kernel>
+std::pair<double, double> ACRANSAC(RandomT & generator, const Kernel &kernel,
   std::vector<size_t> & vec_inliers,
   size_t nIter = 1024,
   typename Kernel::Model * model = nullptr,
@@ -201,9 +202,9 @@ std::pair<double, double> ACRANSAC(const Kernel &kernel,
   {
     std::vector< std::size_t> vec_sample(sizeSample); // Sample indices
     if (bACRansacMode)
-      UniformSample(sizeSample, vec_index, vec_sample); // Get random sample
+      UniformSample(generator, sizeSample, vec_index, vec_sample); // Get random sample
     else
-      UniformSample(sizeSample, nData, vec_sample); // Get random sample
+      UniformSample(generator, sizeSample, nData, vec_sample); // Get random sample
 
     std::vector<typename Kernel::Model> vec_models; // Up to max_models solutions
     kernel.Fit(vec_sample, &vec_models);

--- a/src/aliceVision/robustEstimation/Ransac.hpp
+++ b/src/aliceVision/robustEstimation/Ransac.hpp
@@ -31,8 +31,9 @@ namespace robustEstimation{
 // 2. Kernel::MINIMUM_SAMPLES
 // 3. Kernel::Fit(vector<int>, vector<Kernel::Model> *)
 // 4. Kernel::Error(Model, int) -> error
-template<typename Kernel, typename Scorer>
+template<typename RandomT, typename Kernel, typename Scorer>
 typename Kernel::Model RANSAC(
+  RandomT & generator,
   const Kernel &kernel,
   const Scorer &scorer,
   std::vector<size_t> *best_inliers = nullptr,
@@ -72,7 +73,7 @@ typename Kernel::Model RANSAC(
     iteration < really_max_iterations; ++iteration) 
   {
       std::vector<size_t> sample;
-      UniformSample(min_samples, total_samples, sample);
+      UniformSample(generator, min_samples, total_samples, sample);
 
       std::vector<typename Kernel::Model> models;
       kernel.Fit(sample, &models);

--- a/src/aliceVision/robustEstimation/loRansac_test.cpp
+++ b/src/aliceVision/robustEstimation/loRansac_test.cpp
@@ -81,6 +81,7 @@ void lineFittingTest(std::size_t numPoints,
 {
   assert(outlierRatio >= 0 && outlierRatio < 1);
   assert(gaussianNoiseLevel >= 0);
+  std::mt19937 generator;
   
   Mat2X xy(2, numPoints);
   vector<std::size_t> vec_inliersGT;
@@ -91,7 +92,7 @@ void lineFittingTest(std::size_t numPoints,
   const double threshold = (withNoise) ? 3 * gaussianNoiseLevel : 0.3;
   LineKernelLoRansac kernel(xy);
 
-  estimatedModel = LO_RANSAC(kernel, ScoreEvaluator<LineKernel>(threshold), &vec_inliers);
+  estimatedModel = LO_RANSAC(generator, kernel, ScoreEvaluator<LineKernel>(threshold), &vec_inliers);
   ALICEVISION_LOG_DEBUG("#inliers found : " << vec_inliers.size()
           << " expected: " << numPoints - expectedInliers);
   ALICEVISION_LOG_DEBUG("model[0] found : " << estimatedModel[0]

--- a/src/aliceVision/robustEstimation/loRansac_test.cpp
+++ b/src/aliceVision/robustEstimation/loRansac_test.cpp
@@ -81,7 +81,6 @@ void lineFittingTest(std::size_t numPoints,
 {
   assert(outlierRatio >= 0 && outlierRatio < 1);
   assert(gaussianNoiseLevel >= 0);
-  std::mt19937 generator;
   
   Mat2X xy(2, numPoints);
   vector<std::size_t> vec_inliersGT;
@@ -92,7 +91,7 @@ void lineFittingTest(std::size_t numPoints,
   const double threshold = (withNoise) ? 3 * gaussianNoiseLevel : 0.3;
   LineKernelLoRansac kernel(xy);
 
-  estimatedModel = LO_RANSAC(generator, kernel, ScoreEvaluator<LineKernel>(threshold), &vec_inliers);
+  estimatedModel = LO_RANSAC(gen, kernel, ScoreEvaluator<LineKernel>(threshold), &vec_inliers);
   ALICEVISION_LOG_DEBUG("#inliers found : " << vec_inliers.size()
           << " expected: " << numPoints - expectedInliers);
   ALICEVISION_LOG_DEBUG("model[0] found : " << estimatedModel[0]

--- a/src/aliceVision/robustEstimation/maxConsensus.hpp
+++ b/src/aliceVision/robustEstimation/maxConsensus.hpp
@@ -29,8 +29,8 @@ namespace robustEstimation{
 /// 2. Kernel::MINIMUM_SAMPLES
 /// 3. Kernel::Fit(vector<int>, vector<Kernel::Model> *)
 /// 4. Kernel::Error(Model, int) -> error
-template<typename Kernel, typename Scorer>
-typename Kernel::Model MaxConsensus(const Kernel &kernel,
+template<typename RandomT, typename Kernel, typename Scorer>
+typename Kernel::Model MaxConsensus(RandomT generator, const Kernel &kernel,
   const Scorer &scorer,
   std::vector<std::size_t> *best_inliers = nullptr, std::size_t max_iteration = 1024) {
 
@@ -61,7 +61,7 @@ typename Kernel::Model MaxConsensus(const Kernel &kernel,
     for(std::size_t iteration = 0;  iteration < max_iteration; ++iteration) 
     {
       std::vector<std::size_t> sample;
-      UniformSample(min_samples, total_samples, sample);
+      UniformSample(generator, min_samples, total_samples, sample);
 
       std::vector<typename Kernel::Model> models;
       kernel.Fit(sample, &models);

--- a/src/aliceVision/robustEstimation/maxConsensus_test.cpp
+++ b/src/aliceVision/robustEstimation/maxConsensus_test.cpp
@@ -33,8 +33,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_OutlierFree) {
   // Check the best model that fit the most of the data
   //  in a robust framework (Max-consensus).
   std::vector<size_t> vec_inliers;
-  Vec2 model = MaxConsensus(kernel,
-    ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = MaxConsensus(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_SMALL(2.0-model[1], 1e-9);
   BOOST_CHECK_SMALL(1.0-model[0], 1e-9);
   BOOST_CHECK_EQUAL(5, vec_inliers.size());
@@ -50,8 +50,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_OutlierFree_DoNotGetBackModel) {
 
   LineKernel kernel(xy);
   std::vector<size_t> vec_inliers;
-  Vec2 model = MaxConsensus(kernel,
-    ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = MaxConsensus(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_EQUAL(5, vec_inliers.size());
 }
 
@@ -66,8 +66,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_OneOutlier) {
   LineKernel kernel(xy);
 
   std::vector<size_t> vec_inliers;
-  Vec2 model = MaxConsensus(kernel,
-    ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = MaxConsensus(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_SMALL(2.0-model[1], 1e-9);
   BOOST_CHECK_SMALL(1.0-model[0], 1e-9);
   BOOST_CHECK_EQUAL(5, vec_inliers.size());
@@ -83,8 +83,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_TooFewPoints) {
         3;   // y = 2x + 1 with x = 1
   LineKernel kernel(xy);
   std::vector<size_t> vec_inliers;
-  Vec2 model = MaxConsensus(kernel,
-    ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = MaxConsensus(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_EQUAL(0, vec_inliers.size());
 }
 
@@ -110,7 +110,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_RealisticCase) {
   //-- Add some noise (for the asked percentage amount)
   int nbPtToNoise = (int) numPoints * outlierRatio;
   vector<size_t> vec_samples; // Fit with unique random index
-  UniformSample(nbPtToNoise, numPoints, vec_samples);
+  std::mt19937 generator;
+  UniformSample(generator, nbPtToNoise, numPoints, vec_samples);
   for(size_t i = 0; i <vec_samples.size(); ++i)
   {
     const size_t randomIndex = vec_samples[i];
@@ -121,8 +122,7 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_RealisticCase) {
 
   LineKernel kernel(xy);
   std::vector<size_t> vec_inliers;
-  Vec2 model = MaxConsensus(kernel,
-    ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  Vec2 model = MaxConsensus(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_EQUAL(numPoints-nbPtToNoise, vec_inliers.size());
   BOOST_CHECK_SMALL((-2.0)-model[0], 1e-9);
   BOOST_CHECK_SMALL( 6.3-model[1], 1e-9);

--- a/src/aliceVision/robustEstimation/randSampling.hpp
+++ b/src/aliceVision/robustEstimation/randSampling.hpp
@@ -33,8 +33,9 @@ namespace robustEstimation{
  * @param[in] numSamples Number of unique samples to draw.
  * @return samples The vector containing the samples.
  */
-template<typename IntT>
-inline std::vector<IntT> randSample(IntT lowerBound,
+template<typename RandomT, typename IntT>
+inline std::vector<IntT> randSample(RandomT generator,
+                                    IntT lowerBound,
                                     IntT upperBound,
                                     IntT numSamples)
 {
@@ -43,10 +44,6 @@ inline std::vector<IntT> randSample(IntT lowerBound,
   assert(lowerBound < upperBound);
   assert(numSamples <= rangeSize);
   static_assert(std::is_integral<IntT>::value, "Only integer types are supported");
-
-  
-  std::random_device rd;
-  std::mt19937 generator(rd());
 
   if(numSamples * 1.5 > rangeSize)
   {
@@ -83,20 +80,22 @@ inline std::vector<IntT> randSample(IntT lowerBound,
 
 /**
 * @brief Pick a random subset of the integers in the range [0, upperBound).
-*
+* 
+* @param[in] generator Random number generator initialized
 * @param[in] numSamples The number of samples to produce.
 * @param[in] upperBound The upper bound of the range.
 * @param[out] samples The set containing the random numbers in the range [0, upperBound)
 */
-template<typename IntT>
-inline void UniformSample(std::size_t numSamples,
+template<typename RandomT, typename IntT>
+inline void UniformSample(RandomT & generator,
+                          std::size_t numSamples,
                           std::size_t upperBound,
                           std::set<IntT> &samples)
 {
   assert(numSamples <= upperBound);
   static_assert(std::is_integral<IntT>::value, "Only integer types are supported");
   
-  const auto vecSamples = randSample<IntT>(0, upperBound, numSamples);
+  const auto vecSamples = randSample<RandomT, IntT>(generator, 0, upperBound, numSamples);
   for(const auto& s : vecSamples)
   {
     samples.insert(s);
@@ -107,48 +106,55 @@ inline void UniformSample(std::size_t numSamples,
 /**
  * @brief Generate a unique random samples in the range [lowerBound upperBound).
  * 
+ * @param[in] generator Random number generator initialized
  * @param[in] lowerBound The lower bound of the range.
  * @param[in] upperBound The upper bound of the range (not included).
  * @param[in] numSamples Number of unique samples to draw.
  * @param[out] samples The vector containing the samples.
  */
-template<typename IntT>
-inline void UniformSample(std::size_t lowerBound,
+template<typename RandomT, typename IntT>
+inline void UniformSample(RandomT & generator,
+                          std::size_t lowerBound,
                           std::size_t upperBound,
                           std::size_t numSamples,
                           std::vector<IntT> &samples)
 {
-  samples = randSample<IntT>(lowerBound, upperBound, numSamples);
+  samples = randSample<RandomT, IntT>(generator, lowerBound, upperBound, numSamples);
 }
 
 /**
  * @brief Generate a unique random samples in the range [0 upperBound).
  * 
+ * @param[in] generator Random number generator initialized
  * @param[in] numSamples Number of unique samples to draw.
  * @param[in] upperBound The value at the end of the range (not included).
  * @param[out] samples The vector containing the samples.
  */
-template<typename IntT>
-inline void UniformSample(std::size_t numSamples,
+template<typename RandomT, typename IntT>
+inline void UniformSample(RandomT & generator,
+                          std::size_t numSamples,
                           std::size_t upperBound,
                           std::vector<IntT> &samples)
 {
-  UniformSample(0, upperBound, numSamples, samples);
+  UniformSample(generator, 0, upperBound, numSamples, samples);
 }
 
 /**
  * @brief Generate a random sequence containing a sampling without replacement of
  * of the elements of the input vector.
  * 
+ * @param[in] generator Random number generator initialized
  * @param[in] sampleSize The size of the sample to generate.
  * @param[in] elements The possible data indices.
  * @param[out] sample The random sample of sizeSample indices.
  */
-inline void UniformSample(std::size_t sampleSize,
+template<typename RandomT>
+inline void UniformSample(RandomT & generator,
+                          std::size_t sampleSize,
                           const std::vector<std::size_t>& elements,
                           std::vector<std::size_t>& sample)
 {
-  sample = randSample<std::size_t>(0, elements.size(), sampleSize);
+  sample = randSample<RandomT, std::size_t>(generator, 0, elements.size(), sampleSize);
   assert(sample.size() == sampleSize);
   for(auto& s : sample)
   {

--- a/src/aliceVision/robustEstimation/randSampling_test.cpp
+++ b/src/aliceVision/robustEstimation/randSampling_test.cpp
@@ -21,6 +21,8 @@ using namespace aliceVision::robustEstimation;
 // Assert that each time exactly N random number are picked (no repetition)
 BOOST_AUTO_TEST_CASE(UniformSampleTest_NoRepetions) {
 
+  std::mt19937 generator;
+
   for(std::size_t upperBound = 1; upperBound < 513; upperBound *= 2)
   { 
     //Size of the data set
@@ -29,7 +31,7 @@ BOOST_AUTO_TEST_CASE(UniformSampleTest_NoRepetions) {
       //Size of the consensus set
       std::vector<std::size_t> samples;
       std::cout << "Upper " << upperBound << " Lower " << 0 << " numSamples " << numSamples << "\n";
-      UniformSample(numSamples, upperBound, samples);
+      UniformSample(generator, numSamples, upperBound, samples);
       std::set<std::size_t> myset;
       for(const auto& s : samples) 
       {
@@ -44,6 +46,8 @@ BOOST_AUTO_TEST_CASE(UniformSampleTest_NoRepetions) {
 
 BOOST_AUTO_TEST_CASE(UniformSampleTest_UniformSampleSet) {
 
+  std::mt19937 generator;
+
   for(std::size_t upperBound = 1; upperBound < 513; upperBound *= 2)
   { 
     //Size of the data set
@@ -52,7 +56,7 @@ BOOST_AUTO_TEST_CASE(UniformSampleTest_UniformSampleSet) {
       //Size of the consensus set
       std::cout << "Upper " << upperBound << " Lower " << 0 << " numSamples " << numSample << "\n";
       std::set<std::size_t> samples;
-      UniformSample(numSample, upperBound, samples);
+      UniformSample(generator, numSample, upperBound, samples);
       BOOST_CHECK_EQUAL(numSample, samples.size());
       for(const auto& s : samples) 
       {
@@ -65,6 +69,7 @@ BOOST_AUTO_TEST_CASE(UniformSampleTest_UniformSampleSet) {
 
 BOOST_AUTO_TEST_CASE(UniformSampleTest_NoRepetionsBeginEnd) {
 
+  std::mt19937 generator;
   for(std::size_t upperBound = 1; upperBound < 513; upperBound *= 2)
   { 
     //Size of the data set
@@ -75,7 +80,7 @@ BOOST_AUTO_TEST_CASE(UniformSampleTest_NoRepetionsBeginEnd) {
       const std::size_t begin = upperBound-numSamples;
       std::cout << "Upper " << upperBound << " Lower " << begin << " numSamples " << numSamples << "\n";
       std::vector<std::size_t> samples;
-      UniformSample(begin, upperBound, numSamples, samples);
+      UniformSample(generator, begin, upperBound, numSamples, samples);
       std::set<std::size_t> myset;
       for(const auto& s : samples) 
       {
@@ -90,13 +95,15 @@ BOOST_AUTO_TEST_CASE(UniformSampleTest_NoRepetionsBeginEnd) {
 
 BOOST_AUTO_TEST_CASE(UniformSampleTest_randSample) {
   
+  std::mt19937 generator;
+
   for(std::size_t upperBound = 1; upperBound < 513; upperBound *= 2)
   { 
     for(std::size_t numSamples = 1; numSamples <= upperBound; numSamples *= 2)
     { 
       assert(upperBound >= numSamples);
       const std::size_t lowerBound = upperBound-numSamples;
-      const auto samples = randSample<std::size_t>(lowerBound, upperBound, numSamples);
+      const auto samples = randSample<std::mt19937, std::size_t>(generator, lowerBound, upperBound, numSamples);
       
       std::set<std::size_t> myset;
       std::cout << "Upper " << upperBound << " Lower " << lowerBound << " numSamples " << numSamples << "\n";

--- a/src/aliceVision/robustEstimation/ransac_test.cpp
+++ b/src/aliceVision/robustEstimation/ransac_test.cpp
@@ -35,7 +35,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_OutlierFree) {
   // Check the best model that fit the most of the data
   //  in a robust framework (Ransac).
   std::vector<size_t> vec_inliers;
-  Vec2 model = RANSAC(kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = RANSAC(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_SMALL(2.0-model[1], 1e-9);
   BOOST_CHECK_SMALL(1.0-model[0], 1e-9);
   BOOST_CHECK_EQUAL(5, vec_inliers.size());
@@ -52,7 +53,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_OneOutlier) {
   LineKernel kernel(xy);
 
   std::vector<size_t> vec_inliers;
-  Vec2 model = RANSAC(kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = RANSAC(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_SMALL(2.0-model[1], 1e-9);
   BOOST_CHECK_SMALL(1.0-model[0], 1e-9);
   BOOST_CHECK_EQUAL(5, vec_inliers.size());
@@ -68,7 +70,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_TooFewPoints) {
         3;   // y = 2x + 1 with x = 1
   LineKernel kernel(xy);
   std::vector<size_t> vec_inliers;
-  Vec2 model = RANSAC(kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = RANSAC(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_EQUAL(0, vec_inliers.size());
 }
 
@@ -94,7 +97,8 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_RealisticCase) {
 
   LineKernel kernel(xy);
   std::vector<size_t> vec_inliers;
-  Vec2 model = RANSAC(kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
+  std::mt19937 generator;
+  Vec2 model = RANSAC(generator, kernel, ScoreEvaluator<LineKernel>(0.3), &vec_inliers);
   BOOST_CHECK_EQUAL(NbPoints-nbPtToNoise, vec_inliers.size());
   BOOST_CHECK_SMALL((-2.0)-model[0], 1e-9);
   BOOST_CHECK_SMALL( 6.3-model[1], 1e-9);

--- a/src/aliceVision/sfm/pipeline/ReconstructionEngine.hpp
+++ b/src/aliceVision/sfm/pipeline/ReconstructionEngine.hpp
@@ -10,6 +10,7 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmData/colorize.hpp>
 
+#include <random>
 #include <string>
 
 namespace aliceVision {
@@ -31,9 +32,10 @@ public:
    * @param[in] sfmData The input SfMData of the scene
    * @param[in] outFolder The folder where outputs will be stored
    */
-  ReconstructionEngine(const sfmData::SfMData& sfmData, const std::string& outFolder)
-    : _outputFolder(outFolder)
-    , _sfmData(sfmData)
+  ReconstructionEngine(std::mt19937 & generator, const sfmData::SfMData& sfmData, const std::string& outFolder)
+    : _generator(generator),
+      _outputFolder(outFolder),
+      _sfmData(sfmData)
   {}
 
   virtual ~ReconstructionEngine() {}
@@ -81,6 +83,8 @@ protected:
   std::string _outputFolder;
   /// Internal SfMData
   sfmData::SfMData _sfmData;
+  /// Random generator
+  std::mt19937 & _generator;
 };
 
 

--- a/src/aliceVision/sfm/pipeline/RelativePoseInfo.cpp
+++ b/src/aliceVision/sfm/pipeline/RelativePoseInfo.cpp
@@ -77,6 +77,7 @@ bool estimate_Rt_fromE(const Mat3 & K1, const Mat3 & K2,
 using namespace aliceVision::robustEstimation;
 
 bool robustRelativePose(
+  std::mt19937 & generator,
   const Mat3 & K1, const Mat3 & K2,
   const Mat & x1, const Mat & x2,
   RelativePoseInfo & relativePose_info,
@@ -98,7 +99,7 @@ bool robustRelativePose(
                     x2, size_ima2.first, size_ima2.second, K1, K2);
 
   // Robustly estimation of the Essential matrix and its precision
-  const std::pair<double,double> acRansacOut = ACRANSAC(kernel, relativePose_info.vec_inliers,
+  const std::pair<double,double> acRansacOut = ACRANSAC(generator, kernel, relativePose_info.vec_inliers,
     max_iteration_count, &relativePose_info.essential_matrix, relativePose_info.initial_residual_tolerance);
   relativePose_info.found_residual_precision = acRansacOut.first;
 

--- a/src/aliceVision/sfm/pipeline/RelativePoseInfo.hpp
+++ b/src/aliceVision/sfm/pipeline/RelativePoseInfo.hpp
@@ -11,6 +11,7 @@
 #include <aliceVision/geometry/Pose3.hpp>
 
 #include <vector>
+#include <random>
 
 namespace aliceVision {
 namespace sfm {
@@ -54,6 +55,7 @@ struct RelativePoseInfo
  * @brief Estimate the Relative pose between two views from point matches and K matrices
  *  by using a robust essential matrix estimation.
  *
+ * @param[in] generator a reandom generator object
  * @param[in] K1 camera 1 intrinsics
  * @param[in] K2 camera 2 intrinsics
  * @param[in] x1 camera 1 image points
@@ -65,6 +67,7 @@ struct RelativePoseInfo
  */
 bool robustRelativePose
 (
+  std::mt19937 & generator,
   const Mat3 & K1, const Mat3 & K2,
   const Mat & x1, const Mat & x2,
   RelativePoseInfo & relativePose_info,

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.hpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.hpp
@@ -69,7 +69,8 @@ public:
   /**
    * @brief Use features in normalized camera frames
    */
-  bool Run(ETranslationAveragingMethod eTranslationAveragingMethod,
+  bool Run(std::mt19937 & generator,
+           ETranslationAveragingMethod eTranslationAveragingMethod,
            sfmData::SfMData& sfmData,
            const feature::FeaturesPerView& normalizedFeaturesPerView,
            const matching::PairwiseMatches& pairwiseMatches,
@@ -81,7 +82,9 @@ private:
            sfmData::SfMData& sfmData,
            const HashMap<IndexT, Mat3> & map_globalR);
 
-  void Compute_translations(const sfmData::SfMData& sfmData,
+  void Compute_translations(
+           std::mt19937 & generator,
+           const sfmData::SfMData& sfmData,
            const feature::FeaturesPerView& normalizedFeaturesPerView,
            const matching::PairwiseMatches& pairwiseMatches,
            const HashMap<IndexT, Mat3>& map_globalR,
@@ -93,7 +96,8 @@ private:
    * Use an edge coverage algorithm to reduce the graph covering complexity
    * Complexity: sub-linear in term of edges count.
    */
-  void ComputePutativeTranslation_EdgesCoverage(const sfmData::SfMData& sfmData,
+  void ComputePutativeTranslation_EdgesCoverage(std::mt19937 & generator,
+           const sfmData::SfMData& sfmData,
            const HashMap<IndexT, Mat3>& map_globalR,
            const feature::FeaturesPerView& normalizedFeaturesPerView,
            const matching::PairwiseMatches& pairwiseMatches,
@@ -103,7 +107,8 @@ private:
   /**
    * @brief Robust estimation and refinement of a translation and 3D points of an image triplets.
    */
-  bool Estimate_T_triplet(const sfmData::SfMData& sfmData,
+  bool Estimate_T_triplet(std::mt19937 & generator,
+           const sfmData::SfMData& sfmData,
            const HashMap<IndexT, Mat3>& map_globalR,
            const feature::FeaturesPerView& normalizedFeaturesPerView,
            const matching::PairwiseMatches& pairwiseMatches,

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -33,10 +33,11 @@ using namespace aliceVision::geometry;
 using namespace aliceVision::feature;
 using namespace aliceVision::sfmData;
 
-ReconstructionEngine_globalSfM::ReconstructionEngine_globalSfM(const SfMData& sfmData,
+ReconstructionEngine_globalSfM::ReconstructionEngine_globalSfM(std::mt19937 & generator,
+                                                               const SfMData& sfmData,
                                                                const std::string& outDirectory,
                                                                const std::string& loggingFile)
-  : ReconstructionEngine(sfmData, outDirectory)
+  : ReconstructionEngine(generator, sfmData, outDirectory)
   , _loggingFile(loggingFile)
   , _normalizedFeaturesPerView(nullptr)
 {
@@ -243,6 +244,7 @@ bool ReconstructionEngine_globalSfM::Compute_Global_Translations(const HashMap<I
   // Translation averaging (compute translations & update them to a global common coordinates system)
   GlobalSfMTranslationAveragingSolver translation_averaging_solver;
   const bool bTranslationAveraging = translation_averaging_solver.Run(
+    _generator,
     _eTranslationAveragingMethod,
     _sfmData,
     *_normalizedFeaturesPerView.get(),
@@ -521,7 +523,7 @@ void ReconstructionEngine_globalSfM::Compute_Relative_Rotations(rotationAveragin
       const std::pair<size_t, size_t> imageSize(1., 1.);
       const Mat3 K  = Mat3::Identity();
 
-      if(!robustRelativePose(K, K, x1, x2, relativePose_info, imageSize, imageSize, 256))
+      if(!robustRelativePose(_generator, K, K, x1, x2, relativePose_info, imageSize, imageSize, 256))
       {
         continue;
       }

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.hpp
@@ -22,7 +22,8 @@ class ReconstructionEngine_globalSfM : public ReconstructionEngine
 {
 public:
 
-  ReconstructionEngine_globalSfM(const sfmData::SfMData& sfmData,
+  ReconstructionEngine_globalSfM(std::mt19937 & generator,
+                                 const sfmData::SfMData& sfmData,
                                  const std::string& outDirectory,
                                  const std::string& loggingFile = "");
 

--- a/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
@@ -42,6 +42,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL1)
 {
   const int nviews = 6;
   const int npoints = 64;
+  std::mt19937 generator;
   const NViewDatasetConfigurator config;
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
@@ -54,6 +55,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL1)
   sfmData2.structure.clear();
 
   ReconstructionEngine_globalSfM sfmEngine(
+    generator,
     sfmData2,
     "./",
     "./Reconstruction_Report.html");
@@ -92,6 +94,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL1_TranslationAveragingL1)
 {
   const int nviews = 6;
   const int npoints = 64;
+  std::mt19937 generator;
   const NViewDatasetConfigurator config;
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
@@ -104,6 +107,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL1_TranslationAveragingL1)
   sfmData2.structure.clear();
 
   ReconstructionEngine_globalSfM sfmEngine(
+    generator,
     sfmData2,
     "./",
     "./Reconstruction_Report.html");
@@ -142,6 +146,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL2_Chord
 {
   const int nviews = 6;
   const int npoints = 64;
+  std::mt19937 generator;
   const NViewDatasetConfigurator config;
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
@@ -154,6 +159,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL2_Chord
   sfmData2.structure.clear();
 
   ReconstructionEngine_globalSfM sfmEngine(
+    generator,
     sfmData2,
     "./",
     "./Reconstruction_Report.html");
@@ -197,13 +203,14 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingSoftL1)
 
   // Translate the input dataset to a SfMData scene
   const SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  std::mt19937 generator;
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;
   sfmData2.getPoses().clear();
   sfmData2.structure.clear();
 
-  ReconstructionEngine_globalSfM sfmEngine(
+  ReconstructionEngine_globalSfM sfmEngine(generator,
     sfmData2,
     "./",
     "./Reconstruction_Report.html");

--- a/src/aliceVision/sfm/pipeline/localization/SfMLocalizationSingle3DTrackObservationDatabase.cpp
+++ b/src/aliceVision/sfm/pipeline/localization/SfMLocalizationSingle3DTrackObservationDatabase.cpp
@@ -69,7 +69,9 @@ namespace sfm {
     return true;
   }
 
-  bool SfMLocalizationSingle3DTrackObservationDatabase::Localize(const Pair& imageSize,
+  bool SfMLocalizationSingle3DTrackObservationDatabase::Localize(
+                               std::mt19937 & generator,
+                               const Pair& imageSize,
                                const camera::IntrinsicBase* optionalIntrinsics,
                                const feature::Regions& queryRegions,
                                geometry::Pose3& pose,
@@ -99,7 +101,7 @@ namespace sfm {
       resectionData.pt2D.col(i) = queryRegions.GetRegionPosition(putativeMatches[i]._j);
     }
 
-    const bool resection =  SfMLocalizer::Localize(imageSize, optionalIntrinsics, resectionData, pose);
+    const bool resection =  SfMLocalizer::Localize(generator, imageSize, optionalIntrinsics, resectionData, pose);
 
     if(resectionDataPtr != nullptr)
       (*resectionDataPtr) = std::move(resectionData);

--- a/src/aliceVision/sfm/pipeline/localization/SfMLocalizationSingle3DTrackObservationDatabase.hpp
+++ b/src/aliceVision/sfm/pipeline/localization/SfMLocalizationSingle3DTrackObservationDatabase.hpp
@@ -38,7 +38,7 @@ public:
 
   /**
   * @brief Try to localize an image in the database
-  *
+  * @param[in] generator the random number generator to use in ransac
   * @param[in] imageSize the w,h image size
   * @param[in] optionalIntrinsics camera intrinsic if known (else nullptr)
   * @param[in] queryRegions the image regions (type must be the same as the database)
@@ -46,7 +46,7 @@ public:
   * @param[out] resectionData matching data (2D-3D and inliers; optional)
   * @return True if a putative pose has been estimated
   */
-  bool Localize(const Pair& imageSize,
+  bool Localize(std::mt19937 & generator, const Pair& imageSize,
                 const camera::IntrinsicBase* optionalIntrinsics,
                 const feature::Regions& queryRegions,
                 geometry::Pose3& pose,

--- a/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
+++ b/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
@@ -30,7 +30,7 @@ struct ResectionSquaredResidualError
   }
 };
 
-bool SfMLocalizer::Localize(const Pair& imageSize,
+bool SfMLocalizer::Localize(std::mt19937 & generator, const Pair& imageSize,
                             const camera::IntrinsicBase* optionalIntrinsics,
                             ImageLocalizerMatchData& resectionData,
                             geometry::Pose3& pose,
@@ -65,7 +65,7 @@ bool SfMLocalizer::Localize(const Pair& imageSize,
     KernelType kernel(resectionData.pt2D, imageSize.first, imageSize.second, resectionData.pt3D);
     // Robust estimation of the Projection matrix and its precision
     const std::pair<double,double> ACRansacOut =
-      aliceVision::robustEstimation::ACRANSAC(kernel, resectionData.vec_inliers, resectionData.max_iteration, &P, precision);
+      aliceVision::robustEstimation::ACRANSAC(generator, kernel, resectionData.vec_inliers, resectionData.max_iteration, &P, precision);
     // Update the upper bound precision of the model found by AC-RANSAC
     resectionData.error_max = ACRansacOut.first;
   }
@@ -102,7 +102,7 @@ bool SfMLocalizer::Localize(const Pair& imageSize,
 
         // Robust estimation of the Projection matrix and its precision
         const std::pair<double, double> ACRansacOut =
-                aliceVision::robustEstimation::ACRANSAC(kernel, resectionData.vec_inliers, resectionData.max_iteration, &P, precision);
+                aliceVision::robustEstimation::ACRANSAC(generator, kernel, resectionData.vec_inliers, resectionData.max_iteration, &P, precision);
         // Update the upper bound precision of the model found by AC-RANSAC
         resectionData.error_max = ACRansacOut.first;
         break;
@@ -141,7 +141,7 @@ bool SfMLocalizer::Localize(const Pair& imageSize,
         // @todo refactor, maybe move scorer directly inside the kernel
         const double threshold = resectionData.error_max * resectionData.error_max * (kernel.normalizer2()(0, 0) * kernel.normalizer2()(0, 0));
         robustEstimation::ScoreEvaluator<KernelType> scorer(threshold);
-        P = robustEstimation::LO_RANSAC(kernel, scorer, &resectionData.vec_inliers);
+        P = robustEstimation::LO_RANSAC(generator, kernel, scorer, &resectionData.vec_inliers);
         break;
       }
 

--- a/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.hpp
+++ b/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.hpp
@@ -12,6 +12,7 @@
 #include <aliceVision/feature/RegionsPerView.hpp>
 #include <aliceVision/robustEstimation/estimators.hpp>
 
+#include <random>
 #include <cstddef>
 #include <limits>
 
@@ -61,6 +62,7 @@ public:
   /**
   * @brief Try to localize an image in the database
   *
+  * @param[in] generator the random number generator to use in ransac
   * @param[in] imageSize the w,h image size
   * @param[in] optionalIntrinsics camera intrinsic if known (else nullptr)
   * @param[in] queryRegions the image regions (type must be the same as the database)
@@ -68,7 +70,7 @@ public:
   * @param[out] resectionData matching data (2D-3D and inliers; optional)
   * @return True if a putative pose has been estimated
   */
-  virtual bool Localize(const Pair& imageSize,
+  virtual bool Localize(std::mt19937 & generator, const Pair& imageSize,
                         const camera::IntrinsicBase* optionalIntrinsics,
                         const feature::Regions& queryRegions,
                         geometry::Pose3& pose,
@@ -79,6 +81,7 @@ public:
   /**
   * @brief Try to localize an image from known 2D-3D matches
   *
+  * @param[in] generator the random number generator to use in ransac
   * @param[in] imageSize the w,h image size
   * @param[in] optionalIntrinsics camera intrinsic if known (else nullptr)
   * @param[in,out] resectionData matching data (with filled 2D-3D correspondences).
@@ -88,7 +91,7 @@ public:
    * frameworks are ERobustEstimator::ACRANSAC and ERobustEstimator::LORANSAC.
   * @return True if a putative pose has been estimated
   */
-  static bool Localize(const Pair& imageSize,
+  static bool Localize(std::mt19937 & generator, const Pair& imageSize,
                        const camera::IntrinsicBase* optionalIntrinsics,
                        ImageLocalizerMatchData& resectionData,
                        geometry::Pose3& pose,

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.hpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.hpp
@@ -84,6 +84,7 @@ struct RelativeRotationInfo
 
 /**
  * @brief Estimate the relative pose between two views.
+ * @param[in] generator the random number generator
  * @param[in] K1 3x3 calibration matrix of the first view.
  * @param[in] K2 3x3 calibration matrix of the second view.
  * @param[in] x1 The points on the first image.
@@ -94,7 +95,8 @@ struct RelativeRotationInfo
  * @param[in] maxIterationCount Max number of iteration for the ransac process.
  * @return true if a homography has been estimated.
  */
-bool robustRelativeRotation_fromE(const Mat3 & K1, const Mat3 & K2,
+bool robustRelativeRotation_fromE(std::mt19937 & generator, 
+                                  const Mat3 & K1, const Mat3 & K2,
                                   const Mat & x1, const Mat & x2,
                                   const std::pair<size_t, size_t> & size_ima1,
                                   const std::pair<size_t, size_t> & size_ima2,
@@ -103,6 +105,7 @@ bool robustRelativeRotation_fromE(const Mat3 & K1, const Mat3 & K2,
 
 /**
  * @brief Estimate the relative rotation between two views related by a pure rotation.
+ * @param[in] generator the random number generator
  * @param[in] K1 3x3 calibration matrix of the first view.
  * @param[in] K2 3x3 calibration matrix of the second view.
  * @param[in] x1 The points on the first image.
@@ -113,7 +116,8 @@ bool robustRelativeRotation_fromE(const Mat3 & K1, const Mat3 & K2,
  * @param[in] maxIterationCount Max number of iteration for the ransac process.
  * @return true if a homography has been estimated.
  */
-bool robustRelativeRotation_fromH(const Mat3 &K1, const Mat3 &K2,
+bool robustRelativeRotation_fromH(std::mt19937 & generator, 
+                                  const Mat3 &K1, const Mat3 &K2,
                                   const Mat2X &x1, const Mat2X &x2,
                                   const std::pair<size_t, size_t> &imgSize1,
                                   const std::pair<size_t, size_t> &imgSize2,
@@ -127,7 +131,8 @@ class ReconstructionEngine_panorama : public ReconstructionEngine
 {
 public:
 
-  ReconstructionEngine_panorama(const sfmData::SfMData& sfmData,
+  ReconstructionEngine_panorama(std::mt19937 & generator,
+                                 const sfmData::SfMData& sfmData,
                                  const std::string& outDirectory,
                                  const std::string& loggingFile = "");
 

--- a/src/aliceVision/sfm/pipeline/panorama/panoramaSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/panoramaSfM_test.cpp
@@ -32,7 +32,9 @@ using namespace aliceVision::sfmData;
 
 
 BOOST_AUTO_TEST_CASE(PANORAMA_SFM)
-{
+{   
+    std::mt19937 generator;
+
     // rotation between the two views
     const Mat3 rotation = aliceVision::rotationXYZ(0.01, -0.001, -0.2);
     ALICEVISION_LOG_INFO("Ground truth rotation:\n" << rotation);
@@ -69,7 +71,7 @@ BOOST_AUTO_TEST_CASE(PANORAMA_SFM)
     {
         RelativeRotationInfo rotationInfo{};
     ALICEVISION_LOG_INFO("\n\n###########################################\nUncalibrated from H");
-        robustRelativeRotation_fromH(K1, K2, pts1, pts2,
+        robustRelativeRotation_fromH(generator, K1, K2, pts1, pts2,
                               std::make_pair<std::size_t, std::size_t>(1920, 1080),
                               std::make_pair<std::size_t, std::size_t>(1920, 1080),
                               rotationInfo);
@@ -80,7 +82,7 @@ BOOST_AUTO_TEST_CASE(PANORAMA_SFM)
 
         // test the calibrated version, compute normalized points for each view (by multiplying by the inverse of K) and estimate H and R
     ALICEVISION_LOG_INFO("\n\n###########################################\nCalibrated from H");
-        robustRelativeRotation_fromH(Mat3::Identity(), Mat3::Identity(),
+        robustRelativeRotation_fromH(generator, Mat3::Identity(), Mat3::Identity(),
                               (K1.inverse()*pts1.colwise().homogeneous()).colwise().hnormalized(),
                               (K2.inverse()*pts2.colwise().homogeneous()).colwise().hnormalized(),
                               std::make_pair<std::size_t, std::size_t>(1920, 1080),

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -88,7 +88,8 @@ public:
 
 public:
 
-  ReconstructionEngine_sequentialSfM(const sfmData::SfMData& sfmData,
+  ReconstructionEngine_sequentialSfM(std::mt19937 & generator,
+                                     const sfmData::SfMData& sfmData,
                                      const Params& params,
                                      const std::string& outputFolder,
                                      const std::string& loggingFile = "");

--- a/src/aliceVision/sfm/pipeline/sequential/sequentialSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/sequentialSfM_test.cpp
@@ -37,6 +37,7 @@ using namespace aliceVision::sfmData;
 // Test a scene where all the camera intrinsics are known
 BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Intrinsics)
 {
+  std::mt19937 generator;
   const int nviews = 6;
   const int npoints = 128;
   const NViewDatasetConfigurator config;
@@ -55,6 +56,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Intrinsics)
   sfmParams.lockAllIntrinsics = true;
 
   ReconstructionEngine_sequentialSfM sfmEngine(
+    generator,
     sfmData2,
     sfmParams,
     "./",
@@ -86,6 +88,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Intrinsics)
 // Test a scene where only the two first camera have known intrinsics
 BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Partially_Known_Intrinsics)
 {
+  std::mt19937 generator;
   const int nviews = 6;
   const int npoints = 256;
   const NViewDatasetConfigurator config;
@@ -114,6 +117,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Partially_Known_Intrinsics)
   sfmParams.lockAllIntrinsics = true;
 
   ReconstructionEngine_sequentialSfM sfmEngine(
+    generator,
     sfmData2,
     sfmParams,
     "./",
@@ -149,6 +153,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Rig)
 {
   const int nbPoses = 10;
   const int nbPoints = 128;
+  std::mt19937 generator;
 
   const NViewDatasetConfigurator config;
   const NViewDataSet d = NRealisticCamerasRing(nbPoses, nbPoints, config);
@@ -166,6 +171,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Rig)
   sfmParams.lockAllIntrinsics = true;
 
   ReconstructionEngine_sequentialSfM sfmEngine(
+    generator,
     sfmData2,
     sfmParams,
     "./",

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -280,7 +280,7 @@ void StructureEstimationFromKnownPoses::triangulate(
   }
 
   // Triangulate them using a robust triangulation scheme
-  StructureComputation_robust structure_estimator(true);
+  StructureComputation_robust structure_estimator(_generator, true);
   structure_estimator.triangulate(sfmData);
 }
 

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.hpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.hpp
@@ -10,6 +10,7 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/feature/RegionsPerView.hpp>
 #include <aliceVision/matching/IndMatch.hpp>
+#include <random>
 
 namespace aliceVision {
 namespace sfm {
@@ -17,6 +18,7 @@ namespace sfm {
 class StructureEstimationFromKnownPoses
 {
 public:
+  StructureEstimationFromKnownPoses(std::mt19937 & generator) : _generator(generator) {}
 
   /// Use geometry of the views to compute a putative structure from features and descriptors.
   void run(sfmData::SfMData& sfmData,
@@ -51,6 +53,7 @@ private:
   //--
   matching::PairwiseMatches _putativeMatches;
   matching::PairwiseMatches _tripletMatches;
+  std::mt19937 & _generator;
 };
 
 } // namespace sfm

--- a/src/aliceVision/sfm/sfmTriangulation.cpp
+++ b/src/aliceVision/sfm/sfmTriangulation.cpp
@@ -97,8 +97,8 @@ void StructureComputation_blind::triangulate(sfmData::SfMData& sfmData) const
   }
 }
 
-StructureComputation_robust::StructureComputation_robust(bool verbose)
-  : StructureComputation_basis(verbose)
+StructureComputation_robust::StructureComputation_robust(std::mt19937 & generator, bool verbose)
+  : StructureComputation_basis(verbose), _generator(generator)
 {}
 
 void StructureComputation_robust::triangulate(sfmData::SfMData& sfmData) const
@@ -177,7 +177,7 @@ bool StructureComputation_robust::robust_triangulation(const sfmData::SfMData& s
   for(IndexT i = 0; i < nbIter; ++i)
   {
     std::set<IndexT> samples;
-    robustEstimation::UniformSample(std::min(std::size_t(min_sample_index), observations.size()), observations.size(), samples);
+    robustEstimation::UniformSample(_generator, std::min(std::size_t(min_sample_index), observations.size()), observations.size(), samples);
 
     // Hypothesis generation.
     const Vec3 current_model = track_sample_triangulation(sfmData, observations, samples);

--- a/src/aliceVision/sfm/sfmTriangulation.hpp
+++ b/src/aliceVision/sfm/sfmTriangulation.hpp
@@ -9,6 +9,7 @@
 
 #include <aliceVision/types.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <random>
 
 namespace aliceVision {
 namespace sfm {
@@ -42,7 +43,7 @@ struct StructureComputation_blind: public StructureComputation_basis
 // - Check cheirality and a pixel residual error (TODO: make it a parameter)
 struct StructureComputation_robust: public StructureComputation_basis
 {
-  StructureComputation_robust(bool verbose = false);
+  StructureComputation_robust(std::mt19937 & generator, bool verbose = false);
 
   virtual void triangulate(sfmData::SfMData& sfmData) const;
 
@@ -64,6 +65,9 @@ private:
   Vec3 track_sample_triangulation(const sfmData::SfMData& sfmData,
                                   const sfmData::Observations& observations,
                                   const std::set<IndexT>& samples) const;
+                            
+private:
+  std::mt19937 & _generator;
 };
 
 } // namespace sfm

--- a/src/aliceVision/sfm/utils/alignment.cpp
+++ b/src/aliceVision/sfm/utils/alignment.cpp
@@ -56,7 +56,8 @@ std::ostream& operator<<(std::ostream& os, const MarkerWithCoord& marker)
     return os;
 }
 
-bool computeSimilarityFromCommonViews(const sfmData::SfMData& sfmDataA,
+bool computeSimilarityFromCommonViews(std::mt19937 & generator,
+    const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     const std::vector<std::pair<IndexT, IndexT>>& commonViewIds,
     double* out_S,
@@ -106,7 +107,7 @@ bool computeSimilarityFromCommonViews(const sfmData::SfMData& sfmDataA,
     Mat3 R;
     std::vector<std::size_t> inliers;
 
-    if (!aliceVision::geometry::ACRansac_FindRTS(xA, xB, S, t, R, inliers, true))
+    if (!aliceVision::geometry::ACRansac_FindRTS(generator, xA, xB, S, t, R, inliers, true))
         return false;
 
     ALICEVISION_LOG_DEBUG("There are " << reconstructedCommonViewIds.size() << " common cameras and " << inliers.size() << " were used to compute the similarity transform.");
@@ -118,7 +119,8 @@ bool computeSimilarityFromCommonViews(const sfmData::SfMData& sfmDataA,
     return true;
 }
 
-bool computeSimilarityFromCommonCameras_viewId(const sfmData::SfMData& sfmDataA,
+bool computeSimilarityFromCommonCameras_viewId(std::mt19937 & generator,
+                       const sfmData::SfMData& sfmDataA,
                        const sfmData::SfMData& sfmDataB,
                        double* out_S,
                        Mat3* out_R,
@@ -137,10 +139,11 @@ bool computeSimilarityFromCommonCameras_viewId(const sfmData::SfMData& sfmDataA,
   {
       commonViewIds_pairs.push_back(std::make_pair(id, id));
   }
-  return computeSimilarityFromCommonViews(sfmDataA, sfmDataB, commonViewIds_pairs, out_S, out_R, out_t);
+  return computeSimilarityFromCommonViews(generator, sfmDataA, sfmDataB, commonViewIds_pairs, out_S, out_R, out_t);
 }
 
 bool computeSimilarityFromCommonCameras_poseId(
+        std::mt19937 & generator,
         const sfmData::SfMData& sfmDataA,
         const sfmData::SfMData& sfmDataB,
         double* out_S,
@@ -183,7 +186,7 @@ bool computeSimilarityFromCommonCameras_poseId(
     Mat3 R;
     std::vector<std::size_t> inliers;
 
-    if (!aliceVision::geometry::ACRansac_FindRTS(xA, xB, S, t, R, inliers, true))
+    if (!aliceVision::geometry::ACRansac_FindRTS(generator, xA, xB, S, t, R, inliers, true))
         return false;
 
     ALICEVISION_LOG_DEBUG("There are " << commonPoseIds.size() << " common camera poses and " << inliers.size() << " were used to compute the similarity transform.");
@@ -270,6 +273,7 @@ void matchViewsByFilePattern(
 
 
 bool computeSimilarityFromCommonCameras_imageFileMatching(
+    std::mt19937 & generator,
     const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     const std::string& filePatternMatching,
@@ -286,7 +290,7 @@ bool computeSimilarityFromCommonCameras_imageFileMatching(
 
     ALICEVISION_LOG_DEBUG("Found " << commonViewIds.size() << " common views.");
 
-    return computeSimilarityFromCommonViews(sfmDataA, sfmDataB, commonViewIds, out_S, out_R, out_t);
+    return computeSimilarityFromCommonViews(generator, sfmDataA, sfmDataB, commonViewIds, out_S, out_R, out_t);
 }
 
 
@@ -352,6 +356,7 @@ void matchViewsByMetadataMatching(
 }
 
 bool computeSimilarityFromCommonCameras_metadataMatching(
+    std::mt19937 & generator,
     const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     const std::vector<std::string>& metadataList,
@@ -368,7 +373,7 @@ bool computeSimilarityFromCommonCameras_metadataMatching(
 
     ALICEVISION_LOG_DEBUG("Found " << commonViewIds.size() << " common views.");
 
-    return computeSimilarityFromCommonViews(sfmDataA, sfmDataB, commonViewIds, out_S, out_R, out_t);
+    return computeSimilarityFromCommonViews(generator, sfmDataA, sfmDataB, commonViewIds, out_S, out_R, out_t);
 }
 
 
@@ -404,6 +409,7 @@ std::map<std::pair<feature::EImageDescriberType, int>, IndexT> getUniqueMarkers(
 
 
 bool computeSimilarityFromCommonMarkers(
+    std::mt19937 & generator,
     const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     double* out_S,
@@ -468,7 +474,7 @@ bool computeSimilarityFromCommonMarkers(
     Mat3 R;
     std::vector<std::size_t> inliers;
 
-    if (!aliceVision::geometry::ACRansac_FindRTS(xA, xB, S, t, R, inliers, true))
+    if (!aliceVision::geometry::ACRansac_FindRTS(generator, xA, xB, S, t, R, inliers, true))
         return false;
 
     ALICEVISION_LOG_DEBUG("There are " << commonLandmarks.size() << " common markers and " << inliers.size() << " were used to compute the similarity transform.");

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -10,6 +10,8 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/geometry/Pose3.hpp>
 
+#include <random>
+
 namespace aliceVision {
 namespace sfm {
 
@@ -75,7 +77,7 @@ void matchViewsByMetadataMatching(
 
 /**
  * @brief Compute a 5DOF rigid transform between the two set of cameras based on common viewIds.
- *
+ * @param[in] generator the random generator object
  * @param[in] sfmDataA
  * @param[in] sfmDataB
  * @param[out] out_S output scale factor
@@ -83,7 +85,8 @@ void matchViewsByMetadataMatching(
  * @param[out] out_t output translation vector
  * @return true if it finds a similarity transformation
  */
-bool computeSimilarityFromCommonCameras_viewId(const sfmData::SfMData& sfmDataA,
+bool computeSimilarityFromCommonCameras_viewId(std::mt19937 & generator,
+                       const sfmData::SfMData& sfmDataA,
                        const sfmData::SfMData& sfmDataB,
                        double* out_S,
                        Mat3* out_R,
@@ -92,6 +95,7 @@ bool computeSimilarityFromCommonCameras_viewId(const sfmData::SfMData& sfmDataA,
 /**
 * @brief Compute a 5DOF rigid transform between the two set of cameras based on common poseIds.
 *
+* @param[in] generator the random generator object
 * @param[in] sfmDataA
 * @param[in] sfmDataB
 * @param[out] out_S output scale factor
@@ -100,6 +104,7 @@ bool computeSimilarityFromCommonCameras_viewId(const sfmData::SfMData& sfmDataA,
 * @return true if it finds a similarity transformation
 */
 bool computeSimilarityFromCommonCameras_poseId(
+    std::mt19937 & generator,
     const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     double* out_S,
@@ -107,6 +112,7 @@ bool computeSimilarityFromCommonCameras_poseId(
     Vec3* out_t);
 
 bool computeSimilarityFromCommonCameras_imageFileMatching(
+    std::mt19937 & generator,
     const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     const std::string& filePatternMatching,
@@ -115,6 +121,7 @@ bool computeSimilarityFromCommonCameras_imageFileMatching(
     Vec3* out_t);
 
 bool computeSimilarityFromCommonCameras_metadataMatching(
+    std::mt19937 & generator,
     const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     const std::vector<std::string>& metadataList,
@@ -124,6 +131,7 @@ bool computeSimilarityFromCommonCameras_metadataMatching(
 
 
 bool computeSimilarityFromCommonMarkers(
+    std::mt19937 & generator,
     const sfmData::SfMData& sfmDataA,
     const sfmData::SfMData& sfmDataB,
     double* out_S,

--- a/src/samples/robustEssential/main_robustEssential.cpp
+++ b/src/samples/robustEssential/main_robustEssential.cpp
@@ -45,6 +45,8 @@ bool exportToPly(const std::vector<Vec3> & vec_points,
 
 int main() {
 
+  std::mt19937 generator;
+
   const std::string sInputDir = string("../") + string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
   const string jpg_filenameL = sInputDir + "100_7101.jpg";
   const string jpg_filenameR = sInputDir + "100_7102.jpg";
@@ -156,7 +158,7 @@ int main() {
     std::pair<size_t, size_t> size_imaL(imageL.Width(), imageL.Height());
     std::pair<size_t, size_t> size_imaR(imageR.Width(), imageR.Height());
     sfm::RelativePoseInfo relativePose_info;
-    if (!sfm::robustRelativePose(K, K, xL, xR, relativePose_info, size_imaL, size_imaR, 256))
+    if (!sfm::robustRelativePose(generator, K, K, xL, xR, relativePose_info, size_imaL, size_imaR, 256))
     {
       std::cerr << " /!\\ Robust relative pose estimation failure."
         << std::endl;

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -53,6 +53,8 @@ bool readIntrinsic(const std::string & fileName, Mat3 & K);
 ///   way 2: independent cameras motion [R|t], shared focal [f] and structure
 int main() {
 
+  std::mt19937 generator;
+
   const std::string sInputDir = string("../") + string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
   Image<RGBColor> image;
   const string jpg_filenameL = sInputDir + "100_7101.jpg";
@@ -165,7 +167,7 @@ int main() {
     std::pair<size_t, size_t> size_imaL(imageL.Width(), imageL.Height());
     std::pair<size_t, size_t> size_imaR(imageR.Width(), imageR.Height());
     RelativePoseInfo relativePose_info;
-    if (!robustRelativePose(K, K, xL, xR, relativePose_info, size_imaL, size_imaR, 256))
+    if (!robustRelativePose(generator, K, K, xL, xR, relativePose_info, size_imaL, size_imaR, 256))
     {
       std::cerr << " /!\\ Robust relative pose estimation failure."
         << std::endl;

--- a/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
+++ b/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <iostream>
+#include <random>
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
@@ -40,6 +41,7 @@ int main() {
   std::cout << "Compute the relative pose between two spherical image."
    << "\nUse an Acontrario robust estimation based on angular errors." << std::endl;
 
+  std::mt19937 generator;
   const std::string sInputDir = std::string(THIS_SOURCE_DIR);
   const string jpg_filenameL = sInputDir + "/SponzaLion000.jpg";
 
@@ -164,8 +166,7 @@ int main() {
       // Robust estimation of the Essential matrix and it's precision
       Mat3 E;
       const double precision = std::numeric_limits<double>::infinity();
-      const std::pair<double,double> ACRansacOut =
-        ACRANSAC(kernel, vec_inliers, 1024, &E, precision);
+      const std::pair<double,double> ACRansacOut = ACRANSAC(generator, kernel, vec_inliers, 1024, &E, precision);
       const double & threshold = ACRansacOut.first;
       const double & NFA = ACRansacOut.second;
 

--- a/src/samples/robustFundamental/main_robustFundamental.cpp
+++ b/src/samples/robustFundamental/main_robustFundamental.cpp
@@ -76,6 +76,8 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
+  std::mt19937 generator;
+
   Image<unsigned char> imageL, imageR;
   readImage(jpgFilenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
   readImage(jpgFilenameR, imageR, image::EImageColorSpace::NO_CONVERSION);
@@ -185,7 +187,7 @@ int main(int argc, char **argv)
       true); // configure as point to line error model.
 
     Mat3 F;
-    const std::pair<double,double> ACRansacOut = ACRANSAC(kernel, vec_inliers, 1024, &F,
+    const std::pair<double,double> ACRansacOut = ACRANSAC(generator, kernel, vec_inliers, 1024, &F,
       Square(4.0)); // Upper bound of authorized threshold
     
     const double & thresholdF = ACRansacOut.first;

--- a/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
+++ b/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
@@ -34,6 +34,7 @@ using namespace std;
 
 int main() {
 
+  std::mt19937 generator;
   const std::string sInputDir = string("../") + string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
   Image<RGBColor> image;
   const string jpg_filenameL = sInputDir + "100_7101.jpg";
@@ -141,7 +142,7 @@ int main() {
       true); // configure as point to line error model.
 
     Mat3 F;
-    const std::pair<double,double> ACRansacOut = ACRANSAC(kernel, vec_inliers, 1024, &F,
+    const std::pair<double,double> ACRansacOut = ACRANSAC(generator, kernel, vec_inliers, 1024, &F,
       Square(4.0)); // Upper bound of authorized threshold
     const double & thresholdF = ACRansacOut.first;
 

--- a/src/samples/robustHomography/main_robustHomography.cpp
+++ b/src/samples/robustHomography/main_robustHomography.cpp
@@ -33,6 +33,7 @@ using namespace svg;
 using namespace std;
 
 int main() {
+  std::mt19937 generator;
 
   Image<RGBColor> image;
   const string jpg_filenameL = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
@@ -140,7 +141,7 @@ int main() {
       false); // configure as point to point error model.
 
     Mat3 H;
-    const std::pair<double,double> ACRansacOut = ACRANSAC(kernel, vec_inliers, 1024, &H,
+    const std::pair<double,double> ACRansacOut = ACRANSAC(generator, kernel, vec_inliers, 1024, &H,
       std::numeric_limits<double>::infinity());
     const double & thresholdH = ACRansacOut.first;
 

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -169,6 +169,7 @@ int main(int argc, char **argv)
   ALICEVISION_COUT(vm);
 
   Image<RGBColor> image;
+  std::mt19937 generator;
 
   Image<float> imageLeft, imageRight;
   readImage(filenameLeft, imageLeft, image::EImageColorSpace::NO_CONVERSION);
@@ -276,7 +277,7 @@ int main(int argc, char **argv)
   // First sort the putative matches by increasing distance ratio value
   sortMatches_byDistanceRatio(vec_PutativeMatches);
 
-  matchingImageCollection::filterMatchesByHGrowing(regions_perImage.at(0).get()->Features(),
+  matchingImageCollection::filterMatchesByHGrowing(generator, regions_perImage.at(0).get()->Features(),
                                                    regions_perImage.at(1).get()->Features(),
                                                    vec_PutativeMatches,
                                                    homographiesAndMatches,

--- a/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
+++ b/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
@@ -33,7 +33,7 @@ using namespace svg;
 using namespace std;
 
 int main() {
-
+  std::mt19937 generator;
   Image<RGBColor> image;
   const string jpg_filenameL = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
   const string jpg_filenameR = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
@@ -140,7 +140,7 @@ int main() {
       false); // configure as point to point error model.
 
     Mat3 H;
-    const std::pair<double,double> ACRansacOut = ACRANSAC(kernel, vec_inliers, 1024, &H,
+    const std::pair<double,double> ACRansacOut = ACRANSAC(generator, kernel, vec_inliers, 1024, &H,
       std::numeric_limits<double>::infinity());
     const double & thresholdH = ACRansacOut.first;
 

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -264,6 +264,8 @@ int main(int argc, char** argv)
     return EXIT_FAILURE;
   }
 
+  std::mt19937 generator;
+
   const double defaultLoRansacMatchingError = 4.0;
   const double defaultLoRansacResectionError = 4.0;
   if(!robustEstimation::adjustRobustEstimatorThreshold(matchingEstimator, matchingErrorMax, defaultLoRansacMatchingError) ||
@@ -337,7 +339,8 @@ int main(int argc, char** argv)
 #endif
   {
 
-    localization::VoctreeLocalizer* tmpLoc = new localization::VoctreeLocalizer(sfmData,
+    localization::VoctreeLocalizer* tmpLoc = new localization::VoctreeLocalizer(generator, 
+                                                   sfmData,
                                                    descriptorsFolder,
                                                    vocTreeFilepath,
                                                    weightsFilepath,

--- a/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
+++ b/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
@@ -102,6 +102,8 @@ int main(int argc, char **argv)
   // set verbose level
   system::Logger::get()->setLogLevel(verboseLevel);
   
+  std::mt19937 generator;
+
   // load input SfMData scene
   sfmData::SfMData sfmData;
   if(!sfmDataIO::Load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS|sfmDataIO::EXTRINSICS)))
@@ -154,7 +156,8 @@ int main(int argc, char **argv)
   sfmData.structure.clear();
 
   // compute Structure from known camera poses
-  sfm::StructureEstimationFromKnownPoses structureEstimator;
+  
+  sfm::StructureEstimationFromKnownPoses structureEstimator(generator);
   structureEstimator.match(sfmData, pairs, regionsPerView, geometricErrorMax);
 
   // unload descriptors before triangulation

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -250,6 +250,8 @@ int main(int argc, char **argv)
 
   // a. Load SfMData (image view & intrinsics data)
 
+  std::mt19937 generator;
+
   SfMData sfmData;
   if(!sfmDataIO::Load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS|sfmDataIO::EXTRINSICS)))
   {
@@ -344,7 +346,7 @@ int main(int argc, char **argv)
     // compute matches from known camera poses when you have an initialization on the camera poses
     ALICEVISION_LOG_INFO("Putative matches from known poses: " << pairsPoseKnown.size() << " image pairs.");
 
-    sfm::StructureEstimationFromKnownPoses structureEstimator;
+    sfm::StructureEstimationFromKnownPoses structureEstimator(generator);
     structureEstimator.match(sfmData, pairsPoseKnown, regionPerView, knownPosesGeometricErrorMax);
     mapPutativesMatches = structureEstimator.getPutativesMatches();
   }
@@ -459,7 +461,7 @@ int main(int argc, char **argv)
       matchingImageCollection::robustModelEstimation(geometricMatches,
         &sfmData,
         regionPerView,
-        GeometricFilterMatrix_F_AC(geometricErrorMax, maxIteration, geometricEstimator),
+        GeometricFilterMatrix_F_AC(generator, geometricErrorMax, maxIteration, geometricEstimator),
         mapPutativesMatches,
         guidedMatching);
     }
@@ -470,7 +472,7 @@ int main(int argc, char **argv)
       matchingImageCollection::robustModelEstimation(geometricMatches,
         &sfmData,
         regionPerView,
-        GeometricFilterMatrix_E_AC(std::numeric_limits<double>::infinity(), maxIteration),
+        GeometricFilterMatrix_E_AC(generator, std::numeric_limits<double>::infinity(), maxIteration),
         mapPutativesMatches,
         guidedMatching);
 
@@ -499,7 +501,7 @@ int main(int argc, char **argv)
       matchingImageCollection::robustModelEstimation(geometricMatches,
         &sfmData,
         regionPerView,
-        GeometricFilterMatrix_H_AC(std::numeric_limits<double>::infinity(), maxIteration),
+        GeometricFilterMatrix_H_AC(generator, std::numeric_limits<double>::infinity(), maxIteration),
         mapPutativesMatches, guidedMatching,
         onlyGuidedMatching ? -1.0 : 0.6);
     }
@@ -510,7 +512,7 @@ int main(int argc, char **argv)
       matchingImageCollection::robustModelEstimation(geometricMatches,
         &sfmData,
         regionPerView,
-        GeometricFilterMatrix_HGrowing(std::numeric_limits<double>::infinity(), maxIteration),
+        GeometricFilterMatrix_HGrowing(generator, std::numeric_limits<double>::infinity(), maxIteration),
         mapPutativesMatches,
         guidedMatching);
     }

--- a/src/software/pipeline/main_globalSfM.cpp
+++ b/src/software/pipeline/main_globalSfM.cpp
@@ -132,6 +132,8 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
+  std::mt19937 generator;
+
   // load input SfMData scene
   sfmData::SfMData sfmData;
   if(!sfmDataIO::Load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS)))
@@ -183,7 +185,7 @@ int main(int argc, char **argv)
 
   // global SfM reconstruction process
   aliceVision::system::Timer timer;
-  sfm::ReconstructionEngine_globalSfM sfmEngine(
+  sfm::ReconstructionEngine_globalSfM sfmEngine(generator,
     sfmData,
     outDirectory,
     (fs::path(outDirectory) / "sfm_log.html").string());

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -296,7 +296,9 @@ int main(int argc, char **argv)
     }
   }
 
-  sfm::ReconstructionEngine_sequentialSfM sfmEngine(
+  std::mt19937 generator;
+
+  sfm::ReconstructionEngine_sequentialSfM sfmEngine(generator,
     sfmData,
     sfmParams,
     extraInfoFolder,

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -154,6 +154,8 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
+  std::mt19937 generator;
+
   // load input SfMData scene
   sfmData::SfMData inputSfmData;
   if(!sfmDataIO::Load(inputSfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS|sfmDataIO::EXTRINSICS)))
@@ -213,6 +215,7 @@ int main(int argc, char **argv)
   // Panorama reconstruction process
   aliceVision::system::Timer timer;
   sfm::ReconstructionEngine_panorama sfmEngine(
+    generator,
     inputSfmData,
     outDirectory,
     (fs::path(outDirectory) / "sfm_log.html").string());

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -256,6 +256,8 @@ int main(int argc, char** argv)
   
   std::unique_ptr<localization::ILocalizer> localizer;
 
+  std::mt19937 generator;
+
   // load SfMData
   sfmData::SfMData sfmData;
   if(!sfmDataIO::Load(sfmData, sfmFilePath, sfmDataIO::ESfMData::ALL))
@@ -268,7 +270,7 @@ int main(int argc, char** argv)
   if(useVoctreeLocalizer)
   {
     ALICEVISION_COUT("Calibrating sequence using the voctree localizer");
-    localization::VoctreeLocalizer* tmpLoc = new localization::VoctreeLocalizer(sfmData,
+    localization::VoctreeLocalizer* tmpLoc = new localization::VoctreeLocalizer(generator, sfmData,
                                                             descriptorsFolder,
                                                             vocTreeFilepath,
                                                             weightsFilepath,

--- a/src/software/pipeline/main_rigLocalization.cpp
+++ b/src/software/pipeline/main_rigLocalization.cpp
@@ -254,8 +254,9 @@ int main(int argc, char** argv)
   ALICEVISION_COUT("Program called with the following parameters:");
   ALICEVISION_COUT(vm);
 
+  std::mt19937 generator;
+
   std::unique_ptr<localization::LocalizerParameters> param;
-  
   std::unique_ptr<localization::ILocalizer> localizer;
 
   // load SfMData
@@ -270,7 +271,8 @@ int main(int argc, char** argv)
   if(useVoctreeLocalizer)
   {
     ALICEVISION_COUT("Localizing sequence using the voctree localizer");
-    localization::VoctreeLocalizer* tmpLoc = new localization::VoctreeLocalizer(sfmData,
+    localization::VoctreeLocalizer* tmpLoc = new localization::VoctreeLocalizer(generator, 
+                                                            sfmData,
                                                             descriptorsFolder,
                                                             vocTreeFilepath,
                                                             weightsFilepath,

--- a/src/software/utils/main_qualityEvaluation.cpp
+++ b/src/software/utils/main_qualityEvaluation.cpp
@@ -100,6 +100,8 @@ int main(int argc, char **argv)
   if (!fs::exists(outputFolder))
     fs::create_directory(outputFolder);
 
+  std::mt19937 generator;
+
   // load GT camera rotations & positions [R|C]:
   sfmData::SfMData sfmData_gt;
 
@@ -156,7 +158,7 @@ int main(int argc, char **argv)
 
   // evaluation
   htmlDocument::htmlDocumentStream _htmlDocStream("aliceVision Quality evaluation.");
-  EvaluteToGT(vec_camPosGT, vec_C, vec_camRotGT, vec_camRot, outputFolder, &_htmlDocStream);
+  EvaluteToGT(generator, vec_camPosGT, vec_C, vec_camRotGT, vec_camRot, outputFolder, &_htmlDocStream);
 
   std::ofstream htmlFileStream((fs::path(outputFolder) / "ExternalCalib_Report.html").string());
   htmlFileStream << _htmlDocStream.getDoc();

--- a/src/software/utils/main_sfmAlignment.cpp
+++ b/src/software/utils/main_sfmAlignment.cpp
@@ -174,6 +174,8 @@ int main(int argc, char **argv)
   // set verbose level
   system::Logger::get()->setLogLevel(verboseLevel);
 
+  std::mt19937 generator;
+
   // Load input scene
   sfmData::SfMData sfmDataIn;
   if(!sfmDataIO::Load(sfmDataIn, sfmDataFilename, sfmDataIO::ESfMData::ALL))
@@ -201,27 +203,27 @@ int main(int argc, char **argv)
   {
     case EAlignmentMethod::FROM_CAMERAS_VIEWID:
     {
-      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_viewId(sfmDataIn, sfmDataInRef, &S, &R, &t);
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_viewId(generator, sfmDataIn, sfmDataInRef, &S, &R, &t);
       break;
     }
     case EAlignmentMethod::FROM_CAMERAS_POSEID:
     {
-      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_poseId(sfmDataIn, sfmDataInRef, &S, &R, &t);
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_poseId(generator, sfmDataIn, sfmDataInRef, &S, &R, &t);
       break;
     }
     case EAlignmentMethod::FROM_CAMERAS_FILEPATH:
     {
-      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_imageFileMatching(sfmDataIn, sfmDataInRef, fileMatchingPattern, &S, &R, &t);
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_imageFileMatching(generator, sfmDataIn, sfmDataInRef, fileMatchingPattern, &S, &R, &t);
       break;
     }
     case EAlignmentMethod::FROM_CAMERAS_METADATA:
     {
-      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_metadataMatching(sfmDataIn, sfmDataInRef, metadataMatchingList, &S, &R, &t);
+      hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_metadataMatching(generator, sfmDataIn, sfmDataInRef, metadataMatchingList, &S, &R, &t);
       break;
     }
     case EAlignmentMethod::FROM_MARKERS:
     {
-      hasValidSimilarity = sfm::computeSimilarityFromCommonMarkers(sfmDataIn, sfmDataInRef, &S, &R, &t);
+      hasValidSimilarity = sfm::computeSimilarityFromCommonMarkers(generator, sfmDataIn, sfmDataInRef, &S, &R, &t);
       break;
     }
   }

--- a/src/software/utils/main_sfmLocalization.cpp
+++ b/src/software/utils/main_sfmLocalization.cpp
@@ -110,6 +110,8 @@ int main(int argc, char **argv)
   // set verbose level
   system::Logger::get()->setLogLevel(verboseLevel);
 
+  std::mt19937 generator;
+
   // Load input SfM_Data scene
   sfmData::SfMData sfmData;
   if(!sfmDataIO::Load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
@@ -190,7 +192,7 @@ int main(int argc, char **argv)
   matching_data.error_max = maxResidualError;
 
   // Try to localize the image in the database thanks to its regions
-  if (!localizer.Localize(
+  if (!localizer.Localize(generator,
     Pair(imageGray.Width(), imageGray.Height()),
     optional_intrinsic.get(),
     *(query_regions.get()),

--- a/src/software/utils/precisionEvaluationToGt.hpp
+++ b/src/software/utils/precisionEvaluationToGt.hpp
@@ -26,6 +26,7 @@ namespace aliceVision
 
 /// Compute a 5DOF rigid transform between the two camera trajectories
 inline bool computeSimilarity(
+  std::mt19937 & generator,
   const std::vector<Vec3> & vec_camPosGT,
   const std::vector<Vec3> & vec_camPosComputed,
   std::vector<Vec3> & vec_camPosComputed_T,
@@ -49,7 +50,7 @@ inline bool computeSimilarity(
   Vec3 t;
   Mat3 R;
   std::vector<std::size_t> inliers;
-  if(!aliceVision::geometry::ACRansac_FindRTS(x1, x2, S, t, R, inliers, true))
+  if(!aliceVision::geometry::ACRansac_FindRTS(generator, x1, x2, S, t, R, inliers, true))
     return false;
 
   vec_camPosComputed_T.resize(vec_camPosGT.size());
@@ -105,6 +106,7 @@ inline bool exportToPly(const std::vector<Vec3> & vec_camPosGT,
 /// Compare two camera path (translation and rotation residual after a 5DOF rigid registration)
 /// Export computed statistics to a HTLM stream
 inline void EvaluteToGT(
+  std::mt19937 & generator,
   const std::vector<Vec3> & vec_camCenterGT,
   const std::vector<Vec3> & vec_camCenterComputed,
   const std::vector<Mat3> & vec_camRotGT,
@@ -125,7 +127,7 @@ inline void EvaluteToGT(
   Vec3 t;
   double scale;
   
-  computeSimilarity(vec_camCenterGT, vec_camCenterComputed, vec_camPosComputed_T, &scale, &R, &t);
+  computeSimilarity(generator, vec_camCenterGT, vec_camCenterComputed, vec_camPosComputed_T, &scale, &R, &t);
   
   std::cout << "\nEstimated similarity transformation between the sequences\n";
   std::cout << "R\n" << R << std::endl;


### PR DESCRIPTION
## Description

Currently, random objects (ransac mostly) use random generators which are created using time as seed. We want to be able to repeat a run : control the seed. As the seed is fixed, we need to make sure the generator object is globally defined and not reset each time we call a function which use it.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

