### PR TITLE
[Docker] fix ubuntu dockerfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ ExternalProject_Add(${TBB_TARGET}
        BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tbb
        INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
        CONFIGURE_COMMAND ""
-       BUILD_COMMAND PREFIX=<INSTALL_DIR> make PREFIX=<INSTALL_DIR>
+       BUILD_COMMAND PREFIX=<INSTALL_DIR> make PREFIX=<INSTALL_DIR> -j$(nproc)
        INSTALL_COMMAND mkdir -p <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR} && echo "cp <BINARY_DIR>/build/linux_*_release/*.so* <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}" > tbb_so_files.sh && sh tbb_so_files.sh && cp -r "<BINARY_DIR>/include" "<INSTALL_DIR>"
        )
 set(TBB_CMAKE_FLAGS -DTBB_INCLUDE_DIRS:PATH=${CMAKE_INSTALL_PREFIX}/include -DTBB_LIBRARIES=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libtbb.so)
@@ -503,7 +503,7 @@ ExternalProject_Add(${OPENCV_TARGET}
     -DWITH_OPENCL=OFF
     -DBUILD_TESTS=OFF
     -DBUILD_LIST=core,improc,photo,objdetect,video,imgcodecs,videoio,features2d,xfeatures2d,version
-    ../${OPENCV_SRC_PATH}
+    <SOURCE_DIR>
 )
 # set(OPENCV_CMAKE_FLAGS -DOpenCV_DIR=${BUILD_DIR}/opencv_install -DCMAKE_PREFIX_PATH=${BUILD_DIR}/opencv_install)
 set(OPENCV_CMAKE_FLAGS -DOpenCV_DIR=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/opencv4 -DOPENCV_DIR=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/opencv4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,12 +592,12 @@ else()
 # Add sources
 add_subdirectory(src)
 
-endif()
-
 install(
-    FILES LICENSE-MPL2.md LICENSE-MIT-libmv.md COPYING.md CONTRIBUTORS.md
-    DESTINATION ${CMAKE_INSTALL_DATADIR}/aliceVision
-    )
+        FILES LICENSE-MPL2.md LICENSE-MIT-libmv.md COPYING.md CONTRIBUTORS.md
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/aliceVision
+)
+
+endif()
 
 # Bundle target (see src/cmake/MakeBundle.cmake)
 # Note: require that the install rule has been executed

--- a/Dockerfile_ubuntu
+++ b/Dockerfile_ubuntu
@@ -1,14 +1,14 @@
-ARG CUDA_TAG=9.2
+ARG CUDA_TAG=10.2
 ARG OS_TAG=18.04
 ARG NPROC=1
-FROM nvidia/cuda:${CUDA_TAG}-devel-ubuntu${OS_TAG}
+FROM alicevision/alicevision-deps:cuda${CUDA_TAG}-ubuntu${OS_TAG}
 LABEL maintainer="AliceVision Team alicevision-team@googlegroups.com"
 
 # use CUDA_TAG to select the image version to use
 # see https://hub.docker.com/r/nvidia/cuda/
 #
-# CUDA_TAG=8.0-devel
-# docker build --build-arg CUDA_TAG=$CUDA_TAG --tag alicevision:$CUDA_TAG .
+# CUDA_TAG=8.0
+# docker build --build-arg CUDA_TAG=$CUDA_TAG --tag alicevision/alicevision:cuda${CUDA_TAG}-ubuntu${OS_TAG} -f Dockerfile_ubuntu .
 #
 # then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
 # docker run -it --runtime=nvidia alicevision
@@ -17,49 +17,37 @@ LABEL maintainer="AliceVision Team alicevision-team@googlegroups.com"
 # OS/Version (FILE): cat /etc/issue.net
 # Cuda version (ENV): $CUDA_VERSION
 
-# Install all compilation tools
-RUN apt-get clean && \
-    apt-get update
-RUN apt-get install -y --no-install-recommends \
-        build-essential \
-        cmake \
-        git \
-        wget \
-        unzip \
-        yasm \
-        pkg-config \
-        libtool \
-        nasm \
-        automake \
-        gfortran
-
-# rm -rf /var/lib/apt/lists/*
-
 ENV AV_DEV=/opt/AliceVision_git \
     AV_BUILD=/tmp/AliceVision_build \
     AV_INSTALL=/opt/AliceVision_install \
     AV_BUNDLE=/opt/AliceVision_bundle \
-    PATH="${PATH}:${AV_BUNDLE}"
+    PATH="${PATH}:${AV_BUNDLE}" \
+    VERBOSE=1
 
 COPY . "${AV_DEV}"
 
-
-# Cannot get rig of this error on lapack build on Ubuntu, so use system libraries for lapack/suitesparse:
-#CMake Error at BLAS/SRC/cmake_install.cmake:53 (file):
-#  file INSTALL cannot find
-#  "/tmp/AliceVision_build/external/lapack_build/lib/libblas.so.3.8.0".
-#Call Stack (most recent call first):
-#  BLAS/cmake_install.cmake:46 (include)
-#  cmake_install.cmake:72 (include)
-RUN apt-get  install -y --no-install-recommends liblapack-dev libsuitesparse-dev
-
 WORKDIR "${AV_BUILD}"
-RUN cmake "${AV_DEV}" -DCMAKE_BUILD_TYPE=Release -DALICEVISION_BUILD_DEPENDENCIES:BOOL=ON -DAV_BUILD_LAPACK:BOOL=OFF -DAV_BUILD_SUITESPARSE:BOOL=OFF -DCMAKE_INSTALL_PREFIX="${AV_INSTALL}" -DALICEVISION_BUNDLE_PREFIX="${AV_BUNDLE}"
 
-WORKDIR "${AV_BUILD}"
-RUN make -j${NPROC} install && make bundle
-# && cd /opt && rm -rf "${AV_BUILD}"
-
-WORKDIR "${AV_BUNDLE}/share/aliceVision"
-RUN wget https://gitlab.com/alicevision/trainedVocabularyTreeData/raw/master/vlfeat_K80L3.SIFT.tree
+RUN cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS:BOOL=ON \
+        -DTARGET_ARCHITECTURE=core \
+        -DALICEVISION_BUILD_DEPENDENCIES:BOOL=OFF \
+        -DCMAKE_PREFIX_PATH:PATH="${AV_INSTALL}" \
+        -DCMAKE_INSTALL_PREFIX:PATH="${AV_INSTALL}" \
+        -DALICEVISION_BUNDLE_PREFIX="${AV_BUNDLE}" \
+        -DALICEVISION_USE_ALEMBIC:BOOL=ON \
+        -DMINIGLOG:BOOL=ON \
+        -DALICEVISION_USE_CCTAG:BOOL=ON \
+        -DALICEVISION_USE_OPENCV:BOOL=ON \
+        -DALICEVISION_USE_OPENGV:BOOL=ON \
+        -DALICEVISION_USE_POPSIFT:BOOL=ON \
+        -DALICEVISION_USE_CUDA:BOOL=ON \
+        -DALICEVISION_BUILD_DOC:BOOL=OFF \
+        -DALICEVISION_BUILD_EXAMPLES:BOOL=OFF \
+        "${AV_DEV}" && \
+\
+   make install -j$(nproc) && \
+   make bundle && \
+   cd /opt && \
+   rm -rf "${AV_BUILD}"
 

--- a/Dockerfile_ubuntu_deps
+++ b/Dockerfile_ubuntu_deps
@@ -1,0 +1,79 @@
+ARG CUDA_TAG=10.2
+ARG OS_TAG=18.04
+ARG NPROC=1
+FROM nvidia/cuda:${CUDA_TAG}-devel-ubuntu${OS_TAG}
+LABEL maintainer="AliceVision Team alicevision-team@googlegroups.com"
+
+# use CUDA_TAG to select the image version to use
+# see https://hub.docker.com/r/nvidia/cuda/
+#
+# CUDA_TAG=8.0
+# docker build --build-arg CUDA_TAG=$CUDA_TAG --tag alicevision/alicevision-deps:cuda${CUDA_TAG}-ubuntu${OS_TAG} -f Dockerfile_ubuntu_deps .
+#
+# then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
+# docker run -it --runtime=nvidia alicevision
+
+
+# OS/Version (FILE): cat /etc/issue.net
+# Cuda version (ENV): $CUDA_VERSION
+
+# Install all compilation tools
+RUN apt-get clean && \
+    apt-get update
+RUN apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        wget \
+        unzip \
+        yasm \
+        pkg-config \
+        libtool \
+        libssl-dev \
+        nasm \
+        automake \
+        gfortran
+
+# rm -rf /var/lib/apt/lists/*
+
+ENV AV_DEV=/opt/AliceVision_git \
+    AV_BUILD=/tmp/AliceVision_build \
+    AV_INSTALL=/opt/AliceVision_install \
+    AV_BUNDLE=/opt/AliceVision_bundle \
+    PATH="${PATH}:${AV_BUNDLE}"
+
+# Manually install cmake
+WORKDIR /tmp/cmake
+ENV CMAKE_VERSION=3.17
+ENV CMAKE_VERSION_FULL=${CMAKE_VERSION}.2
+RUN wget https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION_FULL}.tar.gz && \
+    tar zxf cmake-${CMAKE_VERSION_FULL}.tar.gz && \
+    cd cmake-${CMAKE_VERSION_FULL} && \
+    ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
+    make -j$(nproc) install && \
+    cd /tmp && \
+    rm -rf cmake
+
+COPY CMakeLists.txt "${AV_DEV}/"
+
+
+# Cannot get rig of this error on lapack build on Ubuntu, so use system libraries for lapack/suitesparse:
+#CMake Error at BLAS/SRC/cmake_install.cmake:53 (file):
+#  file INSTALL cannot find
+#  "/tmp/AliceVision_build/external/lapack_build/lib/libblas.so.3.8.0".
+#Call Stack (most recent call first):
+#  BLAS/cmake_install.cmake:46 (include)
+#  cmake_install.cmake:72 (include)
+RUN apt-get  install -y --no-install-recommends liblapack-dev libsuitesparse-dev
+
+WORKDIR "${AV_BUILD}"
+RUN cmake "${AV_DEV}" \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DALICEVISION_BUILD_DEPENDENCIES:BOOL=ON \
+     -DAV_BUILD_ALICEVISION:BOOL=OFF \
+     -DAV_BUILD_LAPACK:BOOL=OFF \
+     -DAV_BUILD_SUITESPARSE:BOOL=OFF \
+     -DCMAKE_INSTALL_PREFIX="${AV_INSTALL}"
+
+WORKDIR "${AV_BUILD}"
+RUN make && cd /opt && rm -rf ${AV_BUILD}
+


### PR DESCRIPTION
fixes #718 

Update the dockerfile for ubuntu:

* split in deps and main like centos

* use latest cmake version

* some fixes in the cmake (dependency script)

  * use `<SOURCE_DIR>` for opencv

  * install license and other AV doc file only when installing AV

