### PR TITLE
[bug] fix popsift static release

### DIFF
--- a/src/aliceVision/feature/ImageDescriber.hpp
+++ b/src/aliceVision/feature/ImageDescriber.hpp
@@ -69,7 +69,7 @@ class ImageDescriber
 public:
   ImageDescriber() = default;
 
-  virtual ~ImageDescriber() {}
+  virtual ~ImageDescriber() = default;
 
   /**
    * @brief Check if the image describer use CUDA

--- a/src/aliceVision/feature/ImageDescriber.hpp
+++ b/src/aliceVision/feature/ImageDescriber.hpp
@@ -67,7 +67,7 @@ std::istream& operator>>(std::istream& in, EImageDescriberPreset& p);
 class ImageDescriber
 {
 public:
-  ImageDescriber() {}
+  ImageDescriber() = default;
 
   virtual ~ImageDescriber() {}
 

--- a/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp
+++ b/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp
@@ -41,7 +41,7 @@ struct AKAZEParams
 class ImageDescriber_AKAZE : public ImageDescriber
 {
 public:
-  ImageDescriber_AKAZE(const AKAZEParams& params = AKAZEParams(), bool isOriented = true)
+  explicit ImageDescriber_AKAZE(const AKAZEParams& params = AKAZEParams(), bool isOriented = true)
     : ImageDescriber()
     , _params(params)
     , _isOriented(isOriented)
@@ -175,6 +175,8 @@ public:
       case AKAZE_MLDB:  regions.reset(new AKAZE_BinaryRegions); break;
     }
   }
+
+  ~ImageDescriber_AKAZE() override = default;
 
 private:
   AKAZEParams _params;

--- a/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
+++ b/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
@@ -29,10 +29,6 @@ ImageDescriber_CCTAG::CCTagParameters::CCTagParameters(size_t nRings)
 #endif
 }
 
-ImageDescriber_CCTAG::CCTagParameters::~CCTagParameters()
-{
-}
-
 bool ImageDescriber_CCTAG::CCTagParameters::setPreset(EImageDescriberPreset preset)
 {
   switch(preset)
@@ -60,9 +56,6 @@ ImageDescriber_CCTAG::ImageDescriber_CCTAG(const std::size_t nRings)
   , _params(nRings)
   {}
 
-ImageDescriber_CCTAG::~ImageDescriber_CCTAG()
-{
-}
 
 bool ImageDescriber_CCTAG::useCuda() const
 {

--- a/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.hpp
+++ b/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.hpp
@@ -28,8 +28,9 @@ namespace feature {
 class ImageDescriber_CCTAG : public ImageDescriber
 {
 public:
-  ImageDescriber_CCTAG(const std::size_t nRings = 3);
-  ~ImageDescriber_CCTAG();
+  explicit ImageDescriber_CCTAG(const std::size_t nRings = 3);
+
+  ~ImageDescriber_CCTAG() override = default;
 
   /**
    * @brief Check if the image describer use CUDA
@@ -106,8 +107,9 @@ public:
 
   struct CCTagParameters
   {
-    CCTagParameters(size_t nRings);
-    ~CCTagParameters();
+    explicit CCTagParameters(size_t nRings);
+
+    ~CCTagParameters() = default;
 
     bool setPreset(EImageDescriberPreset preset);
 

--- a/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.hpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.hpp
@@ -32,6 +32,8 @@ class ImageDescriber_AKAZE_OCV : public ImageDescriber
 {
 public:
 
+    ImageDescriber_AKAZE_OCV() = default;
+
   /**
    * @brief Check if the image describer use CUDA
    * @return True if the image describer use CUDA
@@ -102,6 +104,8 @@ public:
   {
     regions.reset( new AKAZE_Float_Regions );
   }
+
+  ~ImageDescriber_AKAZE_OCV() override = default;
 
 };
 

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT.hpp
@@ -27,7 +27,7 @@ namespace feature {
 class ImageDescriber_SIFT : public ImageDescriber
 {
 public:
-  ImageDescriber_SIFT(const SiftParams& params = SiftParams(), bool isOriented = true)
+  explicit ImageDescriber_SIFT(const SiftParams& params = SiftParams(), bool isOriented = true)
     : _params(params)
     , _isOriented(isOriented)
   {
@@ -165,6 +165,8 @@ public:
   {
     _imageDescriberImpl->allocate(regions);
   }
+
+  ~ImageDescriber_SIFT() override = default;
 
 private:
   SiftParams _params;

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
@@ -14,10 +14,13 @@
 #include <popsift/sift_octave.h>
 #include <popsift/common/device_prop.h>
 
+#include <atomic>
+
 namespace aliceVision {
 namespace feature {
 
 std::unique_ptr<PopSift> ImageDescriber_SIFT_popSIFT::_popSift = nullptr;
+std::atomic<int> ImageDescriber_SIFT_popSIFT::_instanceCounter{0};
 
 void ImageDescriber_SIFT_popSIFT::setConfigurationPreset(EImageDescriberPreset preset)
 {
@@ -93,6 +96,24 @@ void ImageDescriber_SIFT_popSIFT::resetConfiguration()
   config.setFilterSorting(popsift::Config::LargestScaleFirst);
 
   _popSift.reset(new PopSift(config, popsift::Config::ExtractingMode, PopSift::FloatImages));
+}
+
+ImageDescriber_SIFT_popSIFT::ImageDescriber_SIFT_popSIFT(const SiftParams& params, bool isOriented)
+    : ImageDescriber()
+    , _params(params)
+    , _isOriented(isOriented)
+{
+    _instanceCounter++;
+}
+
+ImageDescriber_SIFT_popSIFT::~ImageDescriber_SIFT_popSIFT()
+{
+    _instanceCounter--;
+
+    if(_instanceCounter.load() == 0)
+    {
+        _popSift.reset(nullptr);
+    }
 }
 
 } // namespace feature

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
@@ -81,7 +81,7 @@ void ImageDescriber_SIFT_popSIFT::resetConfiguration()
   cudaDeviceReset();
 
   popsift::cuda::device_prop_t deviceInfo;
-  deviceInfo.set(0, true); // use only the first device & print informations
+  deviceInfo.set(0, true); // use only the first device & print information
 
   // reset configuration
   popsift::Config config;

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.hpp
@@ -94,7 +94,7 @@ public:
    */
   bool describe(const image::Image<float>& image,
                 std::unique_ptr<Regions>& regions,
-                const image::Image<unsigned char>* mask = NULL) override;
+                const image::Image<unsigned char>* mask = nullptr) override;
 
   /**
    * @brief Allocate Regions type depending of the ImageDescriber

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.hpp
@@ -26,11 +26,7 @@ namespace feature {
 class ImageDescriber_SIFT_popSIFT : public ImageDescriber
 {
 public:
-  ImageDescriber_SIFT_popSIFT(const SiftParams& params = SiftParams(), bool isOriented = true)
-    : ImageDescriber()
-    , _params(params)
-    , _isOriented(isOriented)
-  {}
+  explicit ImageDescriber_SIFT_popSIFT(const SiftParams& params = SiftParams(), bool isOriented = true);
 
   /**
    * @brief Check if the image describer use CUDA
@@ -109,6 +105,11 @@ public:
     regions.reset(new SIFT_Regions);
   }
 
+  /**
+   * @brief Destructor
+   */
+  ~ImageDescriber_SIFT_popSIFT() override;
+
 private:
 
   void resetConfiguration();
@@ -116,6 +117,7 @@ private:
   SiftParams _params;
   bool _isOriented = true;
   static std::unique_ptr<PopSift> _popSift;
+  static std::atomic<int> _instanceCounter;
 };
 
 } // namespace feature

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeat.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeat.hpp
@@ -28,7 +28,7 @@ namespace feature {
 class ImageDescriber_SIFT_vlfeat : public ImageDescriber
 {
 public:
-  ImageDescriber_SIFT_vlfeat(const SiftParams& params = SiftParams(), bool isOriented = true)
+  explicit ImageDescriber_SIFT_vlfeat(const SiftParams& params = SiftParams(), bool isOriented = true)
     : ImageDescriber()
     , _params(params)
     , _isOriented(isOriented)
@@ -37,7 +37,7 @@ public:
     VLFeatInstance::initialize();
   }
 
-  ~ImageDescriber_SIFT_vlfeat()
+  ~ImageDescriber_SIFT_vlfeat() override
   {
     VLFeatInstance::destroy();
   }

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeatFloat.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeatFloat.hpp
@@ -28,7 +28,7 @@ namespace feature {
 class ImageDescriber_SIFT_vlfeatFloat : public ImageDescriber
 {
 public:
-  ImageDescriber_SIFT_vlfeatFloat(const SiftParams& params = SiftParams(), bool isOriented = true)
+  explicit ImageDescriber_SIFT_vlfeatFloat(const SiftParams& params = SiftParams(), bool isOriented = true)
     : ImageDescriber()
     , _params(params)
     , _isOriented(isOriented)
@@ -37,7 +37,7 @@ public:
     VLFeatInstance::initialize();
   }
 
-  ~ImageDescriber_SIFT_vlfeatFloat()
+  ~ImageDescriber_SIFT_vlfeatFloat() override
   {
     VLFeatInstance::destroy();
   }

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -215,7 +215,7 @@ private:
 
     const auto imageDescriberIndexes = useGPU ? job.gpuImageDescriberIndexes : job.cpuImageDescriberIndexes;
 
-    for(auto& imageDescriberIndex : imageDescriberIndexes)
+    for(const auto & imageDescriberIndex : imageDescriberIndexes)
     {
       const auto& imageDescriber = _imageDescribers.at(imageDescriberIndex);
       const feature::EImageDescriberType imageDescriberType = imageDescriber->getDescriberType();

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -61,6 +61,8 @@ class FeatureExtractor
       , outputBasename(fs::path(fs::path(outputFolder) / fs::path(std::to_string(view.getViewId()))).string())
     {}
 
+    ~ViewJob() = default;
+
     bool useGPU() const
     {
       return !gpuImageDescriberIndexes.empty();
@@ -203,6 +205,8 @@ public:
         computeViewJob(job, true);
     }
   }
+
+  ~FeatureExtractor() = default;
 
 private:
 


### PR DESCRIPTION
Since alicevision/popsift/pull/71, popsift is now always releasing the resources with the destructor.

In our implementation of `ImageDescriber_SIFT_popSIFT` popsift is a static member of the class to avoid multiple instances of the Cuda run-time.
Since static object are destroyed last, it happens in `alicevision_extractFeatures` that the popsift destructor tries to release resource when the Cuda runtime is already shut down.
This causes an error on exit from the program:
```
~/dev/alicevision/sandbox/popsift/src/popsift/s_image.cu:259
    Could not destroy texture object: driver shutting down
```

In order to fix the problem, a static counter in the class `ImageDescriber_SIFT_popSIFT` has been added to count how many instances of the class there are and when the last one is destroyed, also the static popsift is destroyed (the old good "the last one shut the door" principle :-) )

This is a mitigating solution in that it is efficient in managing multiple instances of `ImageDescriber_SIFT_popSIFT` running at the same time, but obviously it has the drawback that it introduces overheads for allocating/deallocating cuda stuff when several `ImageDescriber_SIFT_popSIFT` instances are created and destroyed in sequence.

In alicevision `ImageDescriber_SIFT_popSIFT` at the moment is only used with a single instance so there are no issues.

Incidentally, it cleans up a little the constructors/destructors of the other feature classes with missing `explicit`, `default` and `override`. Sorry, the OCD kicked in. :-)