### PR TITLE
update required CMake version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ Build instructions
 ------------------
 
 Required tools:
-* CMake >= 3.4
+* CMake >= 3.11
 * Git
 * C/C++ compiler (gcc or visual studio or clang) with C++11 support.
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
While building on my machine (Linux - Ubuntu 18.04) I ran into the prompt `CMake 3.11 or higher is required.` when running `cmake` for the first time. I have changed the required CMake version in the isntallation instructions to reflect the new tool version requirement.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->

- [x] updated CMake version

## Implementation remarks

Please let me know if I need to update anything else in the file to reflect my new change.

@flosincapite please review.