### PR TITLE
Dev/depth map folders

### DIFF
--- a/src/aliceVision/depthMap/DepthSimMap.cpp
+++ b/src/aliceVision/depthMap/DepthSimMap.cpp
@@ -401,8 +401,10 @@ void DepthSimMap::save(int rc, const StaticVector<int>& tcams)
 
     const int width = mp->getWidth(rc) / scale;
     const int height = mp->getHeight(rc) / scale;
+    const int nbDepthValues = std::count_if(depthMap->begin(), depthMap->end(), [](float v) { return v > 0.0f; });
 
     oiio::ParamValueList metadata = imageIO::getMetadataFromMap(mp->getMetadata(rc));
+    metadata.push_back(oiio::ParamValue("AliceVision:nbDepthValues", oiio::TypeDesc::INT32, 1, &nbDepthValues));
     metadata.push_back(oiio::ParamValue("AliceVision:downscale", mp->getDownscaleFactor(rc)));
     metadata.push_back(oiio::ParamValue("AliceVision:CArr", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::VEC3), 1, mp->CArr[rc].m));
     metadata.push_back(oiio::ParamValue("AliceVision:iCamArr", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::MATRIX33), 1, mp->iCamArr[rc].m));

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -889,9 +889,20 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
                 }
 
                 const std::string nmodMapFilepath = getFileNameFromIndex(mp, c, mvsUtils::EFileType::nmodMap, 0);
-                imageIO::readImage(nmodMapFilepath, wTmp, hTmp, numOfModalsMap, imageIO::EImageColorSpace::NO_CONVERSION);
-                if(wTmp != width || hTmp != height)
-                    throw std::runtime_error("Wrong nmod map dimensions: " + nmodMapFilepath);
+                // If we have an nModMap in input (from depthmapfilter) use it,
+                // else init with a constant value.
+                if(boost::filesystem::exists(nmodMapFilepath))
+                {
+                    imageIO::readImage(nmodMapFilepath, wTmp, hTmp, numOfModalsMap,
+                                       imageIO::EImageColorSpace::NO_CONVERSION);
+                    if(wTmp != width || hTmp != height)
+                        throw std::runtime_error("Wrong nmod map dimensions: " + nmodMapFilepath);
+                }
+                else
+                {
+                    ALICEVISION_LOG_WARNING("nModMap file can't be found.");
+                    numOfModalsMap.resize(width*height, 1);
+                }
             }
 
             int syMax = std::ceil(height/step);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -494,15 +494,15 @@ void DelaunayGraphCut::displayStatistics()
     // Display some statistics
 
     StaticVector<int>* ptsCamsHist = getPtsCamsHist();
-    ALICEVISION_LOG_INFO("Histogram of number of cams per point:");
+    ALICEVISION_LOG_TRACE("Histogram of number of cams per point:");
     for(int i = 0; i < ptsCamsHist->size(); ++i)
-        ALICEVISION_LOG_INFO("    " << i << ": " << mvsUtils::num2str((*ptsCamsHist)[i]));
+        ALICEVISION_LOG_TRACE("    " << i << ": " << mvsUtils::num2str((*ptsCamsHist)[i]));
     delete ptsCamsHist;
 
     StaticVector<int>* ptsNrcsHist = getPtsNrcHist();
-    ALICEVISION_LOG_INFO("Histogram of Nrc per point:");
+    ALICEVISION_LOG_TRACE("Histogram of Nrc per point:");
     for(int i = 0; i < ptsNrcsHist->size(); ++i)
-        ALICEVISION_LOG_INFO("    " << i << ": " << mvsUtils::num2str((*ptsNrcsHist)[i]));
+        ALICEVISION_LOG_TRACE("    " << i << ": " << mvsUtils::num2str((*ptsNrcsHist)[i]));
     delete ptsNrcsHist;
 }
 

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -302,7 +302,13 @@ bool Fuser::filterDepthMapsRC(int rc, int minNumOfModals, int minNumOfModalsWSP2
     metadata.push_back(oiio::ParamValue("AliceVision:downscale", mp->getDownscaleFactor(rc)));
     metadata.push_back(oiio::ParamValue("AliceVision:CArr", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::VEC3), 1, mp->CArr[rc].m));
     metadata.push_back(oiio::ParamValue("AliceVision:iCamArr", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::MATRIX33), 1, mp->iCamArr[rc].m));
-
+    {
+        float minDepth, maxDepth, midDepth;
+        size_t nbDepths;
+        mp->getMinMaxMidNbDepth(rc, minDepth, maxDepth, midDepth, nbDepths);
+        metadata.push_back(oiio::ParamValue("AliceVision:maxDepth", maxDepth));
+        metadata.push_back(oiio::ParamValue("AliceVision:minDepth", minDepth));
+    }
     {
       std::vector<double> matrixP = mp->getOriginalP(rc);
       metadata.push_back(oiio::ParamValue("AliceVision:P", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::MATRIX44), 1, matrixP.data()));

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -65,7 +65,10 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
 
           if(readFromDepthMaps)
           {
-            path = getFileNameFromViewId(this, view.getViewId(), mvsUtils::EFileType::depthMap, 1);
+              // use output of DepthMapFilter if scale==0
+              // use output of DepthMap if scale==1
+              const int scale = (depthMapsFolder.empty() ? 0 : 1);
+              path = getFileNameFromViewId(this, view.getViewId(), mvsUtils::EFileType::depthMap, scale);
           }
           else if(_imagesFolder != "/" && !_imagesFolder.empty() && fs::is_directory(_imagesFolder) && !fs::is_empty(_imagesFolder))
           {

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -139,7 +139,6 @@ int aliceVision_main(int argc, char* argv[])
     std::string outputMesh;
     std::string outputDensePointCloud;
     std::string depthMapsFolder;
-    std::string depthMapsFilterFolder;
     EPartitioningMode partitioningMode = ePartitioningSingleBlock;
     ERepartitionMode repartitionMode = eRepartitionMultiResolution;
     std::size_t estimateSpaceMinObservations = 3;
@@ -168,8 +167,6 @@ int aliceVision_main(int argc, char* argv[])
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
         ("depthMapsFolder", po::value<std::string>(&depthMapsFolder),
-            "Input depth maps folder.")
-        ("depthMapsFilterFolder", po::value<std::string>(&depthMapsFilterFolder),
             "Input filtered depth maps folder.")
         ("maxInputPoints", po::value<int>(&fuseParams.maxInputPoints)->default_value(fuseParams.maxInputPoints),
             "Max input points loaded from images.")
@@ -262,10 +259,9 @@ int aliceVision_main(int argc, char* argv[])
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
-    if(depthMapsFolder.empty() || depthMapsFilterFolder.empty())
+    if(depthMapsFolder.empty())
     {
       if(depthMapsFolder.empty() &&
-         depthMapsFilterFolder.empty() &&
          repartitionMode == eRepartitionMultiResolution &&
          partitioningMode == ePartitioningSingleBlock)
       {
@@ -275,7 +271,7 @@ int aliceVision_main(int argc, char* argv[])
       else
       {
         ALICEVISION_LOG_ERROR("Invalid input options:\n"
-                              "- Meshing from depth maps require --depthMapsFolder and --depthMapsFilterFolder options.\n"
+                              "- Meshing from depth maps require --depthMapsFolder option.\n"
                               "- Meshing from SfM require option --partitioning set to 'singleBlock' and option --repartition set to 'multiResolution'.");
         return EXIT_FAILURE;
       }
@@ -290,7 +286,7 @@ int aliceVision_main(int argc, char* argv[])
     }
 
     // initialization
-    mvsUtils::MultiViewParams mp(sfmData, "", depthMapsFolder, depthMapsFilterFolder, meshingFromDepthMaps);
+    mvsUtils::MultiViewParams mp(sfmData, "", "", depthMapsFolder, meshingFromDepthMaps);
 
     mp.userParams.put("LargeScale.universePercentile", universePercentile);
 

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -27,7 +27,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 4
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;


### PR DESCRIPTION
## Description

Meshing simplification by using only one input folder for depthMaps files.

Thanks to @fabiencastan  for his help.

## Features list

- [X] Fix missing metadata for depthMap and depthMapFilter.
- [X] Use only one depthMaps input folder.
- [X] Clean histogram LOG_INFO. (use LOG_TRACE intead)  [fuseCut]