### PR TITLE
More generic metadata support

### DIFF
--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -38,3 +38,7 @@ alicevision_add_test(sfmData_test.cpp
   LINKS aliceVision_sfmData
         aliceVision_system
 )
+alicevision_add_test(view_test.cpp
+  NAME "view"
+  LINKS aliceVision_sfmData
+)

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -13,6 +13,7 @@ set(sfmData_files_headers
 set(sfmData_files_sources
   SfMData.cpp
   uid.cpp
+  View.cpp
   colorize.cpp
 )
 

--- a/src/aliceVision/sfmData/View.cpp
+++ b/src/aliceVision/sfmData/View.cpp
@@ -1,0 +1,165 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// Copyright (c) 2012 openMVG contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "View.hpp"
+
+#include <boost/algorithm/string.hpp>
+
+#include <string>
+#include <utility>
+#include <regex>
+
+
+namespace aliceVision {
+namespace sfmData {
+
+float View::getCameraExposureSetting() const
+{
+    const float shutter = getMetadataShutter();
+    const float fnumber = getMetadataFNumber();
+    if(shutter < 0 || fnumber < 0)
+        return -1.f;
+
+    const float iso = getMetadataISO();
+    const float isoRatio = (iso < 0.f) ? 1.0 : (iso / 100.f);
+
+    float cameraExposure = (shutter * isoRatio) / (fnumber * fnumber);
+    return cameraExposure;
+}
+
+float View::getEv() const
+{
+    return std::log2(1.f / getCameraExposureSetting());
+}
+
+std::map<std::string, std::string>::const_iterator View::findMetadataIterator(const std::string& name) const
+{
+    auto it = _metadata.find(name);
+    if(it != _metadata.end())
+        return it;
+    std::string nameLower = name;
+    boost::algorithm::to_lower(nameLower);
+    for(auto mIt = _metadata.begin(); mIt != _metadata.end(); ++mIt)
+    {
+        std::string key = mIt->first;
+        boost::algorithm::to_lower(key);
+        if(key.size() > name.size())
+        {
+            auto delimiterIt = key.find_last_of("/:");
+            if(delimiterIt != std::string::npos)
+                key = key.substr(delimiterIt + 1);
+        }
+        if(key == nameLower)
+        {
+            return mIt;
+        }
+    }
+    return _metadata.end();
+}
+
+bool View::hasMetadata(const std::vector<std::string>& names) const
+{
+    for(const std::string& name : names)
+    {
+        const auto it = findMetadataIterator(name);
+        if(it != _metadata.end())
+            return true;
+    }
+    return false;
+}
+
+bool View::hasDigitMetadata(const std::vector<std::string>& names, bool isPositive) const
+{
+    bool hasDigitMetadata = false;
+    double value = -1.0;
+
+    for(const std::string& name : names)
+    {
+        const auto it = findMetadataIterator(name);
+
+        if(it == _metadata.end() || it->second.empty())
+        {
+            continue;
+        }
+
+        try
+        {
+            value = std::stod(it->second);
+            hasDigitMetadata = true;
+            break;
+        }
+        catch(std::exception&)
+        {
+            value = -1.0;
+        }
+    }
+    return hasDigitMetadata && (!isPositive || (value > 0));
+}
+
+const std::string& View::getMetadata(const std::vector<std::string>& names) const
+{
+    static const std::string emptyString;
+    for(const std::string& name : names)
+    {
+        const auto it = findMetadataIterator(name);
+        if(it != _metadata.end())
+            return it->second;
+    }
+    return emptyString;
+}
+
+double View::readRealNumber(const std::string& str) const
+{
+    try
+    {
+        std::smatch m;
+        std::regex pattern_frac("([0-9]+)\\/([0-9]+)");
+
+        if(!std::regex_search(str, m, pattern_frac))
+        {
+            return std::stod(str);
+        }
+
+        const int num = std::stoi(m[1].str());
+        const int denum = std::stoi(m[2].str());
+
+        if(denum != 0)
+            return double(num) / double(denum);
+        else
+            return 0.0;
+    }
+    catch(std::exception&)
+    {
+        return -1.0;
+    }
+}
+
+double View::getDoubleMetadata(const std::vector<std::string>& names) const
+{
+    const std::string value = getMetadata(names);
+    if(value.empty())
+        return -1.0;
+    return readRealNumber(value);
+}
+
+int View::getIntMetadata(const std::vector<std::string>& names) const
+{
+    const std::string value = getMetadata(names);
+    if(value.empty())
+        return -1;
+    try
+    {
+        return std::stoi(value);
+    }
+    catch(std::exception&)
+    {
+        return -1;
+    }
+}
+
+} // namespace sfmData
+} // namespace aliceVision

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -183,8 +183,10 @@ public:
   }
 
   /**
-   * @brief xxx
-   * @return true if the view is xxx
+   * @brief If the view is part of a camera rig, the camera can be a sub-pose of the rig pose but can also be temporarily solved independently.
+   * @return true if the view is not part of a rig.
+   *         true if the view is part of a rig and the camera is solved separately.
+   *         false if the view is part of a rig and the camera is solved as a sub-pose of the rig pose.
    */
   bool isPoseIndependant() const
   {
@@ -192,35 +194,65 @@ public:
   }
 
   /**
-   * 
-  */
+   * @brief Get the Camera Exposure Setting value.
+   * For the same scene, this value is linearly proportional to the amount of light captured by the camera according to
+   * the shooting parameters (shutter speed, f-number, iso).
+   */
   float getCameraExposureSetting() const;
 
+  /**
+   * @brief Get the Exposure Value. EV is a number that represents a combination of a camera's shutter speed and
+   * f-number, such that all combinations that yield the same exposure have the same EV.
+   * It progresses in a linear sequence as camera exposure is changed in power-of-2 steps.
+   */
   float getEv() const;
 
+  /**
+   * @brief Get an iterator on the map of metadata from a given name.
+   */
   std::map<std::string, std::string>::const_iterator findMetadataIterator(const std::string& name) const;
 
   /**
    * @brief Return true if the given metadata name exists
-   * @param[in] name The metadata name
+   * @param[in] names List of possible names for the metadata
    * @return true if the corresponding metadata value exists
    */
   bool hasMetadata(const std::vector<std::string>& names) const;
 
   /**
    * @brief Return true if the given metadata name exists and is a digit
-   * @param[in] name The metadata name
+   * @param[in] names List of possible names for the metadata
    * @param[in] isPositive true if the metadata must be positive
    * @return true if the corresponding metadata value exists
    */
   bool hasDigitMetadata(const std::vector<std::string>& names, bool isPositive = true) const;
 
+  /**
+   * @brief Get the metadata value as a string
+   * @param[in] names List of possible names for the metadata
+   * @return the metadata value as a string or an empty string if it does not exist
+   */
   const std::string& getMetadata(const std::vector<std::string>& names) const;
 
+  /**
+   * @brief Read a floating point value from a string. It support an integer, a floating point value or a fraction.
+   * @param[in] str string with the number to evaluate
+   * @return the extracted floating point value or -1.0 if it fails to convert the string
+   */
   double readRealNumber(const std::string& str) const;
 
+  /**
+   * @brief Get the metadata value as a double
+   * @param[in] names List of possible names for the metadata
+   * @return the metadata value as a double or -1.0 if it does not exist
+   */
   double getDoubleMetadata(const std::vector<std::string>& names) const;
 
+  /**
+   * @brief Get the metadata value as an integer
+   * @param[in] names List of possible names for the metadata
+   * @return the metadata value as an integer or -1 if it does not exist
+   */
   int getIntMetadata(const std::vector<std::string>& names) const;
 
   /**
@@ -269,9 +301,9 @@ public:
   }
 
   /**
-     * @brief Get the corresponding "ExposureTime" (shutter) metadata value
-     * @return the metadata value float or -1 if no corresponding value
-     */
+   * @brief Get the corresponding "ExposureTime" (shutter) metadata value
+   * @return the metadata value float or -1 if no corresponding value
+   */
   double getMetadataShutter() const
   {
       return getDoubleMetadata({"ExposureTime"});

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -271,23 +271,32 @@ public:
    * @param[in] isPositive true if the metadata must be positive
    * @return true if the corresponding metadata value exists
    */
-  bool hasDigitMetadata(const std::string& name, bool isPositive = true) const
+  bool hasDigitMetadata(const std::vector<std::string>& names, bool isPositive = true) const
   {
+    bool hasDigitMetadata = false;
     double value = -1.0;
-    const auto it = findMetadataIterator(name);
 
-    if(it == _metadata.end() || it->second.empty())
-      return false;
+    for(const std::string& name : names)
+    {
+        const auto it = findMetadataIterator(name);
 
-    try
-    {
-      value = std::stod(it->second);
+        if(it == _metadata.end() || it->second.empty())
+        {
+            continue;
+        }
+
+        try
+        {
+            value = std::stod(it->second);
+            hasDigitMetadata = true;
+            break;
+        }
+        catch(std::exception &)
+        {
+            value = -1.0;
+        }
     }
-    catch(std::exception &)
-    {
-      return false;
-    }
-    return (!isPositive || (value > 0));
+    return hasDigitMetadata && (!isPositive || (value > 0));
   }
 
   const std::string& getMetadata(const std::vector<std::string>& names) const
@@ -392,11 +401,11 @@ public:
    */
   double getMetadataFNumber() const
   {
-      if(hasDigitMetadata("FNumber"))
+      if(hasDigitMetadata({"FNumber"}))
       {
           return getDoubleMetadata({"FNumber"});
       }
-      if (hasDigitMetadata("ApertureValue"))
+      if (hasDigitMetadata({"ApertureValue"}))
       {
           const double aperture = getDoubleMetadata({"ApertureValue"});
           // fnumber = 2^(aperture/2)

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -9,8 +9,6 @@
 
 #include <aliceVision/types.hpp>
 
-#include <boost/algorithm/string.hpp>
-
 #include <string>
 #include <utility>
 
@@ -196,65 +194,18 @@ public:
   /**
    * 
   */
-  float getCameraExposureSetting() const
-  {
-    const float shutter = getMetadataShutter();
-    const float fnumber = getMetadataFNumber();
-    if (shutter < 0 || fnumber < 0)
-        return -1.f;
+  float getCameraExposureSetting() const;
 
-    const float iso = getMetadataISO();
-    const float isoRatio = (iso < 0.f) ? 1.0 : (iso / 100.f);
+  float getEv() const;
 
-    float cameraExposure = (shutter * isoRatio) / (fnumber * fnumber);
-    return cameraExposure;
-  }
-
-  float getEv() const
-  {
-    return std::log2(1.f/getCameraExposureSetting());
-  }
-
-  std::map<std::string, std::string>::const_iterator findMetadataIterator(const std::string& name) const
-  {
-    auto it = _metadata.find(name);
-    if(it != _metadata.end())
-      return it;
-    std::string nameLower = name;
-    boost::algorithm::to_lower(nameLower);
-    for(auto mIt = _metadata.begin(); mIt != _metadata.end(); ++mIt)
-    {
-      std::string key = mIt->first;
-      boost::algorithm::to_lower(key);
-      if(key.size() > name.size())
-      {
-        auto delimiterIt = key.find_last_of("/:");
-        if(delimiterIt != std::string::npos)
-          key = key.substr(delimiterIt + 1);
-      }
-      if(key == nameLower)
-      {
-        return mIt;
-      }
-    }
-    return _metadata.end();
-  }
+  std::map<std::string, std::string>::const_iterator findMetadataIterator(const std::string& name) const;
 
   /**
    * @brief Return true if the given metadata name exists
    * @param[in] name The metadata name
    * @return true if the corresponding metadata value exists
    */
-  bool hasMetadata(const std::vector<std::string>& names) const
-  {
-    for(const std::string& name: names)
-    {
-      const auto it = findMetadataIterator(name);
-      if(it != _metadata.end())
-        return true;
-    }
-    return false;
-  }
+  bool hasMetadata(const std::vector<std::string>& names) const;
 
   /**
    * @brief Return true if the given metadata name exists and is a digit
@@ -262,75 +213,15 @@ public:
    * @param[in] isPositive true if the metadata must be positive
    * @return true if the corresponding metadata value exists
    */
-  bool hasDigitMetadata(const std::vector<std::string>& names, bool isPositive = true) const
-  {
-    bool hasDigitMetadata = false;
-    double value = -1.0;
+  bool hasDigitMetadata(const std::vector<std::string>& names, bool isPositive = true) const;
 
-    for(const std::string& name : names)
-    {
-        const auto it = findMetadataIterator(name);
+  const std::string& getMetadata(const std::vector<std::string>& names) const;
 
-        if(it == _metadata.end() || it->second.empty())
-        {
-            continue;
-        }
+  double readRealNumber(const std::string& str) const;
 
-        try
-        {
-            value = std::stod(it->second);
-            hasDigitMetadata = true;
-            break;
-        }
-        catch(std::exception &)
-        {
-            value = -1.0;
-        }
-    }
-    return hasDigitMetadata && (!isPositive || (value > 0));
-  }
+  double getDoubleMetadata(const std::vector<std::string>& names) const;
 
-  const std::string& getMetadata(const std::vector<std::string>& names) const
-  {
-    static const std::string emptyString;
-    for(const std::string& name: names)
-    {
-      const auto it = findMetadataIterator(name);
-      if(it != _metadata.end())
-        return it->second;
-    }
-    return emptyString;
-  }
-
-  double getDoubleMetadata(const std::vector<std::string>& names) const
-  {
-    const std::string value = getMetadata(names);
-    if(value.empty())
-      return -1.0;
-    try
-    {
-      return std::stod(value);
-    }
-    catch(std::exception&)
-    {
-      return -1.0;
-    }
-  }
-
-  int getIntMetadata(const std::vector<std::string>& names) const
-  {
-    const std::string value = getMetadata(names);
-    if(value.empty())
-      return -1;
-    try
-    {
-      return std::stoi(value);
-    }
-    catch(std::exception&)
-    {
-      return -1;
-    }
-  }
+  int getIntMetadata(const std::vector<std::string>& names) const;
 
   /**
    * @brief Get the corresponding "Make" metadata value

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -234,19 +234,10 @@ public:
       }
       if(key == nameLower)
       {
-        if(it == _metadata.end())
-        {
-          // we found one candidate match
-          it = mIt;
-        }
-        else
-        {
-          // multiple entries match the input
-          return _metadata.end();
-        }
+        return mIt;
       }
     }
-    return it;
+    return _metadata.end();
   }
 
   /**

--- a/src/aliceVision/sfmData/uid.cpp
+++ b/src/aliceVision/sfmData/uid.cpp
@@ -23,11 +23,11 @@ std::size_t computeViewUID(const View& view)
   const std::string& bodySerialNumber = view.getMetadataBodySerialNumber();
   const std::string& lensSerialNumber = view.getMetadataLensSerialNumber();
 
-  if(view.hasMetadata("Exif:ImageUniqueID") ||
+  if(view.hasMetadata({"Exif:ImageUniqueID", "ImageUniqueID"}) ||
      !bodySerialNumber.empty() ||
      !lensSerialNumber.empty())
   {
-    stl::hash_combine(uid, view.getMetadataOrEmpty("Exif:ImageUniqueID"));
+    stl::hash_combine(uid, view.getMetadata({"Exif:ImageUniqueID", "ImageUniqueID"}));
     stl::hash_combine(uid, bodySerialNumber);
     stl::hash_combine(uid, lensSerialNumber);
   }
@@ -38,31 +38,31 @@ std::size_t computeViewUID(const View& view)
     stl::hash_combine(uid, imagePath.stem().string() + imagePath.extension().string());
   }
 
-  if(view.hasMetadata("Exif:DateTimeOriginal"))
+  if(view.hasMetadata({"Exif:DateTimeOriginal", "DateTimeOriginal"}))
   {
-    stl::hash_combine(uid, view.getMetadataOrEmpty("Exif:DateTimeOriginal"));
-    stl::hash_combine(uid, view.getMetadataOrEmpty("Exif:SubsecTimeOriginal"));
+    stl::hash_combine(uid, view.getMetadata({"Exif:DateTimeOriginal", "DateTimeOriginal"}));
+    stl::hash_combine(uid, view.getMetadata({"Exif:SubsecTimeOriginal", "SubsecTimeOriginal"}));
   }
-  else if(view.hasMetadata("imageCounter"))
+  else if(view.hasMetadata({"imageCounter"}))
   {
     // if the view is from a video camera
-    stl::hash_combine(uid, view.getMetadataOrEmpty("imageCounter"));
+    stl::hash_combine(uid, view.getMetadata({"imageCounter"}));
   }
   else
   {
     // if no original date/time, fallback to the file date/time
-    stl::hash_combine(uid, view.getMetadataOrEmpty("DateTime"));
+    stl::hash_combine(uid, view.getMetadata({"DateTime"}));
   }
 
   // can't use view.getWidth() and view.getHeight() directly
   // because ground truth tests and previous version datasets
   // view UID use EXIF width and height (or 0)
 
-  if(view.hasMetadata("Exif:PixelXDimension"))
-    stl::hash_combine(uid, std::stoi(view.getMetadata("Exif:PixelXDimension")));
+  if(view.hasMetadata({"Exif:PixelXDimension", "PixelXDimension"}))
+    stl::hash_combine(uid, std::stoi(view.getMetadata({"Exif:PixelXDimension", "PixelXDimension"})));
 
-  if(view.hasMetadata("Exif:PixelYDimension"))
-    stl::hash_combine(uid, std::stoi(view.getMetadata("Exif:PixelYDimension")));
+  if(view.hasMetadata({"Exif:PixelYDimension", "PixelYDimension"}))
+    stl::hash_combine(uid, std::stoi(view.getMetadata({"Exif:PixelYDimension", "PixelYDimension"})));
 
   // limit to integer to maximize compatibility (like Alembic in Maya)
   uid = std::abs((int) uid);

--- a/src/aliceVision/sfmData/view_test.cpp
+++ b/src/aliceVision/sfmData/view_test.cpp
@@ -1,0 +1,42 @@
+
+#include <boost/filesystem.hpp>
+#include <aliceVision/sfmData/View.hpp>
+
+#define BOOST_TEST_MODULE view
+
+#include <boost/test/unit_test.hpp>
+
+using namespace aliceVision;
+namespace fs = boost::filesystem;
+
+BOOST_AUTO_TEST_CASE(View_Metadata)
+{
+  {
+    sfmData::View view;
+
+    view.addMetadata("key", "value");
+    view.addMetadata("exif/2/FocalLength", "50");
+
+    BOOST_CHECK(view.hasMetadata({"key"}));
+    BOOST_CHECK_EQUAL(view.getMetadata({"key"}), "value");
+
+    BOOST_CHECK(view.hasMetadata({"FocalLength"}));
+    BOOST_CHECK_EQUAL(view.getMetadata({"FocalLength"}), "50");
+
+    BOOST_CHECK(!view.hasMetadata({"DoesNotExist"}));
+    BOOST_CHECK_EQUAL(view.getMetadata({"DoesNotExist"}), "");
+
+    BOOST_CHECK_EQUAL(view.getMetadataFocalLength(), 50.0);
+  }
+  {
+    sfmData::View view;
+
+    view.addMetadata("Exif:FocalLength", "50");
+
+    BOOST_CHECK(view.hasMetadata({"FocalLength"}));
+    BOOST_CHECK_EQUAL(view.getMetadata({"focalLength"}), "50");
+
+    BOOST_CHECK_EQUAL(view.getMetadataFocalLength(), 50.0);
+  }
+}
+

--- a/src/aliceVision/sfmData/view_test.cpp
+++ b/src/aliceVision/sfmData/view_test.cpp
@@ -28,6 +28,7 @@ BOOST_AUTO_TEST_CASE(View_Metadata)
 
     BOOST_CHECK_EQUAL(view.getMetadataFocalLength(), 50.0);
   }
+
   {
     sfmData::View view;
 
@@ -37,6 +38,17 @@ BOOST_AUTO_TEST_CASE(View_Metadata)
     BOOST_CHECK_EQUAL(view.getMetadata({"focalLength"}), "50");
 
     BOOST_CHECK_EQUAL(view.getMetadataFocalLength(), 50.0);
+  }
+
+  {
+      sfmData::View view;
+
+      view.addMetadata("test:FOCALLENGTH", "50/10");
+
+      BOOST_CHECK(view.hasMetadata({"FocalLength"}));
+      BOOST_CHECK_EQUAL(view.getMetadata({"focalLength"}), "50/10");
+
+      BOOST_CHECK_EQUAL(view.getMetadataFocalLength(), 5.0);
   }
 }
 

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -191,8 +191,8 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
     // We chose a full frame 24x36 camera
     float sensorWidthMM = 36.0;
 
-    if(view.hasMetadata("AliceVision:SensorWidth"))
-      sensorWidthMM = std::stof(view.getMetadata("AliceVision:SensorWidth"));
+    if(view.hasMetadata({"AliceVision:SensorWidth"}))
+      sensorWidthMM = view.getDoubleMetadata({"AliceVision:SensorWidth"});
 
     // Take the max of the image size to handle the case where the image is in portrait mode
     const float imgWidth = pinhole->w();

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -104,11 +104,11 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& vie
 
   bool isResized = false;
 
-  if(view.hasMetadata("Exif:PixelXDimension") && view.hasMetadata("Exif:PixelYDimension")) // has dimension metadata
+  if(view.hasMetadata({"Exif:PixelXDimension", "PixelXDimension"}) && view.hasMetadata({"Exif:PixelYDimension", "PixelYDimension"})) // has dimension metadata
   {
     // check if the image is resized
-    int exifWidth = std::stoi(view.getMetadata("Exif:PixelXDimension"));
-    int exifHeight = std::stoi(view.getMetadata("Exif:PixelYDimension"));
+    int exifWidth = std::stoi(view.getMetadata({"Exif:PixelXDimension", "PixelXDimension"}));
+    int exifHeight = std::stoi(view.getMetadata({"Exif:PixelYDimension", "PixelXDimension"}));
 
     // if metadata is rotated
     if(exifWidth == view.getHeight() && exifHeight == view.getWidth())

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -214,7 +214,7 @@ int aliceVision_main(int argc, char** argv)
        isSequence = true;
     }
 
-    std::string dateTimeMetadata = view.getMetadataOrEmpty("Exif:DateTimeOriginal");
+    std::string dateTimeMetadata = view.getMetadata({"Exif:DateTimeOriginal", "DateTimeOriginal"});
 
     if(!dateTimeMetadata.empty()) // picture
     {

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -446,8 +446,8 @@ int aliceVision_main(int argc, char **argv)
     const std::string& make = view.getMetadataMake();
     const std::string& model = view.getMetadataModel();
     const bool hasCameraMetadata = (!make.empty() || !model.empty());
-    const bool hasFocalIn35mmMetadata = view.hasDigitMetadata("Exif:FocalLengthIn35mmFilm");
-    const double focalIn35mm = hasFocalIn35mmMetadata ? std::stod(view.getMetadata("Exif:FocalLengthIn35mmFilm")) : -1.0;
+    const bool hasFocalIn35mmMetadata = view.hasDigitMetadata({"Exif:FocalLengthIn35mmFilm", "FocalLengthIn35mmFilm"});
+    const double focalIn35mm = hasFocalIn35mmMetadata ? view.getDoubleMetadata({"Exif:FocalLengthIn35mmFilm", "FocalLengthIn35mmFilm"}) : -1.0;
     const double imageRatio = static_cast<double>(view.getWidth()) / static_cast<double>(view.getHeight());
     const double diag24x36 = std::sqrt(36.0 * 36.0 + 24.0 * 24.0);
     camera::EIntrinsicInitMode intrinsicInitMode = camera::EIntrinsicInitMode::UNKNOWN;


### PR DESCRIPTION
Recognize images with non standard metadata as exported by Nuke on EXR images.

- [x] Support metadata with a group defined by "/" instead of ":". Can contain multiple "/".
- [x] Case insensitive search for metadata.

Replace https://github.com/alicevision/AliceVision/pull/777
