### PR TITLE
[cameraInit] Support more extensions and add new viewId generation method

### DIFF
--- a/src/aliceVision/camera/PinholeBrown.hpp
+++ b/src/aliceVision/camera/PinholeBrown.hpp
@@ -34,7 +34,7 @@ class PinholeBrownT2 : public Pinhole
     PinholeBrownT2* clone() const override { return new PinholeBrownT2(*this); }
     void assign(const IntrinsicBase& other) override { *this = dynamic_cast<const PinholeBrownT2&>(other); }
   
-    EINTRINSIC getType() const override { return PINHOLE_CAMERA_BROWN; }
+    EINTRINSIC getType() const override { return EINTRINSIC::PINHOLE_CAMERA_BROWN; }
 
     virtual bool have_disto() const override { return true;}
 

--- a/src/aliceVision/camera/PinholeFisheye.hpp
+++ b/src/aliceVision/camera/PinholeFisheye.hpp
@@ -36,7 +36,7 @@ class PinholeFisheye : public Pinhole
   PinholeFisheye* clone() const override { return new PinholeFisheye(*this); }
   void assign(const IntrinsicBase& other) override { *this = dynamic_cast<const PinholeFisheye&>(other); }
 
-  EINTRINSIC getType() const override { return PINHOLE_CAMERA_FISHEYE; }
+  EINTRINSIC getType() const override { return EINTRINSIC::PINHOLE_CAMERA_FISHEYE; }
 
   virtual bool have_disto() const override { return true;}
 

--- a/src/aliceVision/camera/PinholeFisheye1.hpp
+++ b/src/aliceVision/camera/PinholeFisheye1.hpp
@@ -37,7 +37,7 @@ public:
   PinholeFisheye1* clone() const override { return new PinholeFisheye1(*this); }
   void assign(const IntrinsicBase& other) override { *this = dynamic_cast<const PinholeFisheye1&>(other); }
 
-  EINTRINSIC getType() const override { return PINHOLE_CAMERA_FISHEYE1; }
+  EINTRINSIC getType() const override { return EINTRINSIC::PINHOLE_CAMERA_FISHEYE1; }
 
   virtual bool have_disto() const override { return true;}
 

--- a/src/aliceVision/camera/PinholeRadial.hpp
+++ b/src/aliceVision/camera/PinholeRadial.hpp
@@ -63,7 +63,7 @@ class PinholeRadialK1 : public Pinhole
   PinholeRadialK1* clone() const override { return new PinholeRadialK1(*this); }
   void assign(const IntrinsicBase& other) override { *this = dynamic_cast<const PinholeRadialK1&>(other); }
 
-  EINTRINSIC getType() const override { return PINHOLE_CAMERA_RADIAL1; }
+  EINTRINSIC getType() const override { return EINTRINSIC::PINHOLE_CAMERA_RADIAL1; }
 
   virtual bool have_disto() const override {  return true; }
 
@@ -146,7 +146,7 @@ class PinholeRadialK3 : public Pinhole
   PinholeRadialK3* clone() const override { return new PinholeRadialK3(*this); }
   void assign(const IntrinsicBase& other) override { *this = dynamic_cast<const PinholeRadialK3&>(other); }
 
-  EINTRINSIC getType() const override { return PINHOLE_CAMERA_RADIAL3; }
+  EINTRINSIC getType() const override { return EINTRINSIC::PINHOLE_CAMERA_RADIAL3; }
 
   virtual bool have_disto() const override {  return true; }
 

--- a/src/aliceVision/camera/camera.hpp
+++ b/src/aliceVision/camera/camera.hpp
@@ -38,8 +38,8 @@ inline std::shared_ptr<Pinhole> createPinholeIntrinsic(EINTRINSIC intrinsicType,
       return std::make_shared<PinholeFisheye>(w, h, focal_length_pix, ppx, ppy);
     case EINTRINSIC::PINHOLE_CAMERA_FISHEYE1:
       return std::make_shared<PinholeFisheye1>(w, h, focal_length_pix, ppx, ppy);
-    case EINTRINSIC::PINHOLE_CAMERA_END:
-    case EINTRINSIC::PINHOLE_CAMERA_START:
+    case EINTRINSIC::UNKNOWN:
+    case EINTRINSIC::VALID_PINHOLE:
       break;
   }
   throw std::out_of_range("Unrecognized Intrinsic Enum");

--- a/src/aliceVision/camera/cameraCommon.hpp
+++ b/src/aliceVision/camera/cameraCommon.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <boost/detail/bitmask.hpp>
+
 #include <string>
 #include <stdexcept>
 #include <algorithm>
@@ -16,28 +18,30 @@ namespace camera {
 
 enum EINTRINSIC
 {
-  PINHOLE_CAMERA_START = 0,
-  PINHOLE_CAMERA = 1,          // no distortion
-  PINHOLE_CAMERA_RADIAL1 = 2,  // radial distortion K1
-  PINHOLE_CAMERA_RADIAL3 = 3,  // radial distortion K1,K2,K3
-  PINHOLE_CAMERA_BROWN = 4,    // radial distortion K1,K2,K3, tangential distortion T1,T2
-  PINHOLE_CAMERA_FISHEYE = 5,  // a simple Fish-eye distortion model with 4 distortion coefficients
-  PINHOLE_CAMERA_FISHEYE1 = 6, // a simple Fish-eye distortion model with 1 distortion coefficient
-  PINHOLE_CAMERA_END
+  PINHOLE_CAMERA_START = (1u << 0),
+  PINHOLE_CAMERA = (1u << 1),  // no distortion
+  PINHOLE_CAMERA_RADIAL1 = (1u << 2), // radial distortion K1
+  PINHOLE_CAMERA_RADIAL3 = (1u << 3),  // radial distortion K1,K2,K3
+  PINHOLE_CAMERA_BROWN = (1u << 4),    // radial distortion K1,K2,K3, tangential distortion T1,T2
+  PINHOLE_CAMERA_FISHEYE = (1u << 5),  // a simple Fish-eye distortion model with 4 distortion coefficients
+  PINHOLE_CAMERA_FISHEYE1 = (1u << 6), // a simple Fish-eye distortion model with 1 distortion coefficient
+  PINHOLE_CAMERA_END = (1u << 7)
 };
+
+BOOST_BITMASK(EINTRINSIC)
 
 inline std::string EINTRINSIC_enumToString(EINTRINSIC intrinsic)
 {
   switch(intrinsic)
   {
-    case PINHOLE_CAMERA:          return "pinhole";
-    case PINHOLE_CAMERA_RADIAL1:  return "radial1";
-    case PINHOLE_CAMERA_RADIAL3:  return "radial3";
-    case PINHOLE_CAMERA_BROWN:    return "brown";
-    case PINHOLE_CAMERA_FISHEYE:  return "fisheye4";
-    case PINHOLE_CAMERA_FISHEYE1: return "fisheye1";
-    case PINHOLE_CAMERA_START:
-    case PINHOLE_CAMERA_END:
+      case EINTRINSIC::PINHOLE_CAMERA: return "pinhole";
+      case EINTRINSIC::PINHOLE_CAMERA_RADIAL1: return "radial1";
+      case EINTRINSIC::PINHOLE_CAMERA_RADIAL3: return "radial3";
+      case EINTRINSIC::PINHOLE_CAMERA_BROWN: return "brown";
+      case EINTRINSIC::PINHOLE_CAMERA_FISHEYE: return "fisheye4";
+      case EINTRINSIC::PINHOLE_CAMERA_FISHEYE1: return "fisheye1";
+      case EINTRINSIC::PINHOLE_CAMERA_START:
+      case EINTRINSIC::PINHOLE_CAMERA_END:
       break;
   }
   throw std::out_of_range("Invalid Intrinsic Enum");
@@ -48,25 +52,38 @@ inline EINTRINSIC EINTRINSIC_stringToEnum(const std::string& intrinsic)
   std::string type = intrinsic;
   std::transform(type.begin(), type.end(), type.begin(), ::tolower); //tolower
 
-  if(type == "pinhole")  return PINHOLE_CAMERA;
-  if(type == "radial1")  return PINHOLE_CAMERA_RADIAL1;
-  if(type == "radial3")  return PINHOLE_CAMERA_RADIAL3;
-  if(type == "brown")    return PINHOLE_CAMERA_BROWN;
-  if(type == "fisheye4") return PINHOLE_CAMERA_FISHEYE;
-  if(type == "fisheye1") return PINHOLE_CAMERA_FISHEYE1;
+  if(type == "pinhole") return EINTRINSIC::PINHOLE_CAMERA;
+  if(type == "radial1") return EINTRINSIC::PINHOLE_CAMERA_RADIAL1;
+  if(type == "radial3") return EINTRINSIC::PINHOLE_CAMERA_RADIAL3;
+  if(type == "brown") return EINTRINSIC::PINHOLE_CAMERA_BROWN;
+  if(type == "fisheye4") return EINTRINSIC::PINHOLE_CAMERA_FISHEYE;
+  if(type == "fisheye1") return EINTRINSIC::PINHOLE_CAMERA_FISHEYE1;
 
   throw std::out_of_range(intrinsic);
+}
+
+inline std::ostream& operator<<(std::ostream& os, EINTRINSIC e)
+{
+    return os << EINTRINSIC_enumToString(e);
+}
+
+inline std::istream& operator>>(std::istream& in, EINTRINSIC& e)
+{
+    std::string token;
+    in >> token;
+    e = EINTRINSIC_stringToEnum(token);
+    return in;
 }
 
 // Return if the camera type is a valid enum
 inline bool isValid(EINTRINSIC eintrinsic)
 {
-  return eintrinsic > PINHOLE_CAMERA_START && eintrinsic < PINHOLE_CAMERA_END;
+    return eintrinsic > EINTRINSIC::PINHOLE_CAMERA_START && eintrinsic < EINTRINSIC::PINHOLE_CAMERA_END;
 }
 
 inline bool isPinhole(EINTRINSIC eintrinsic)
 {
-  return eintrinsic > PINHOLE_CAMERA_START && eintrinsic < PINHOLE_CAMERA_END;
+    return eintrinsic > EINTRINSIC::PINHOLE_CAMERA_START && eintrinsic < EINTRINSIC::PINHOLE_CAMERA_END;
 }
 
 } // namespace camera

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -39,17 +39,17 @@ ceres::CostFunction* createCostFunctionFromIntrinsics(const IntrinsicBase* intri
 {
   switch(intrinsicPtr->getType())
   {
-    case PINHOLE_CAMERA:
+    case EINTRINSIC::PINHOLE_CAMERA:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_Pinhole, 2, 3, 6, 3>(new ResidualErrorFunctor_Pinhole(observation));
-    case PINHOLE_CAMERA_RADIAL1:
+    case EINTRINSIC::PINHOLE_CAMERA_RADIAL1:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK1, 2, 4, 6, 3>(new ResidualErrorFunctor_PinholeRadialK1(observation));
-    case PINHOLE_CAMERA_RADIAL3:
+    case EINTRINSIC::PINHOLE_CAMERA_RADIAL3:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK3, 2, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK3(observation));
-    case PINHOLE_CAMERA_BROWN:
+    case EINTRINSIC::PINHOLE_CAMERA_BROWN:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeBrownT2, 2, 8, 6, 3>(new ResidualErrorFunctor_PinholeBrownT2(observation));
-    case PINHOLE_CAMERA_FISHEYE:
+    case EINTRINSIC::PINHOLE_CAMERA_FISHEYE:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye, 2, 7, 6, 3>(new ResidualErrorFunctor_PinholeFisheye(observation));
-    case PINHOLE_CAMERA_FISHEYE1:
+    case EINTRINSIC::PINHOLE_CAMERA_FISHEYE1:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye1, 2, 4, 6, 3>(new ResidualErrorFunctor_PinholeFisheye1(observation));
     default:
       throw std::logic_error("Cannot create cost function, unrecognized intrinsic type in BA.");
@@ -66,17 +66,17 @@ ceres::CostFunction* createRigCostFunctionFromIntrinsics(const IntrinsicBase* in
 {
   switch(intrinsicPtr->getType())
   {
-    case PINHOLE_CAMERA:
+    case EINTRINSIC::PINHOLE_CAMERA:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_Pinhole, 2, 3, 6, 6, 3>(new ResidualErrorFunctor_Pinhole(observation));
-    case PINHOLE_CAMERA_RADIAL1:
+    case EINTRINSIC::PINHOLE_CAMERA_RADIAL1:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK1, 2, 4, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK1(observation));
-    case PINHOLE_CAMERA_RADIAL3:
+    case EINTRINSIC::PINHOLE_CAMERA_RADIAL3:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeRadialK3, 2, 6, 6, 6, 3>(new ResidualErrorFunctor_PinholeRadialK3(observation));
-    case PINHOLE_CAMERA_BROWN:
+    case EINTRINSIC::PINHOLE_CAMERA_BROWN:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeBrownT2, 2, 8, 6, 6, 3>(new ResidualErrorFunctor_PinholeBrownT2(observation));
-    case PINHOLE_CAMERA_FISHEYE:
+    case EINTRINSIC::PINHOLE_CAMERA_FISHEYE:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye, 2, 7, 6, 6, 3>(new ResidualErrorFunctor_PinholeFisheye(observation));
-    case PINHOLE_CAMERA_FISHEYE1:
+    case EINTRINSIC::PINHOLE_CAMERA_FISHEYE1:
       return new ceres::AutoDiffCostFunction<ResidualErrorFunctor_PinholeFisheye1, 2, 4, 6, 6, 3>(new ResidualErrorFunctor_PinholeFisheye1(observation));
     default:
       throw std::logic_error("Cannot create rig cost function, unrecognized intrinsic type in BA.");
@@ -93,13 +93,13 @@ ceres::CostFunction* createConstraintsCostFunctionFromIntrinsics(const Intrinsic
 {
   switch(intrinsicPtr->getType())
   {
-    case PINHOLE_CAMERA:
+    case EINTRINSIC::PINHOLE_CAMERA:
       return new ceres::AutoDiffCostFunction<ResidualErrorConstraintFunctor_Pinhole, 2, 3, 6, 6>(new ResidualErrorConstraintFunctor_Pinhole(observation_first.homogeneous(), observation_second.homogeneous()));
-    case PINHOLE_CAMERA_RADIAL1:
+    case EINTRINSIC::PINHOLE_CAMERA_RADIAL1:
       return new ceres::AutoDiffCostFunction<ResidualErrorConstraintFunctor_PinholeRadialK1, 2, 4, 6, 6>(new ResidualErrorConstraintFunctor_PinholeRadialK1(observation_first.homogeneous(), observation_second.homogeneous()));
-    case PINHOLE_CAMERA_RADIAL3:
+    case EINTRINSIC::PINHOLE_CAMERA_RADIAL3:
       return new ceres::AutoDiffCostFunction<ResidualErrorConstraintFunctor_PinholeRadialK3, 2, 6, 6, 6>(new ResidualErrorConstraintFunctor_PinholeRadialK3(observation_first.homogeneous(), observation_second.homogeneous()));
-    case PINHOLE_CAMERA_FISHEYE:
+    case EINTRINSIC::PINHOLE_CAMERA_FISHEYE:
       return new ceres::AutoDiffCostFunction<ResidualErrorConstraintFunctor_PinholeFisheye, 2, 7, 6, 6>(new ResidualErrorConstraintFunctor_PinholeFisheye(observation_first.homogeneous(), observation_second.homogeneous()));
     default:
       throw std::logic_error("Cannot create cost function, unrecognized intrinsic type in BA.");

--- a/src/aliceVision/sfm/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundleAdjustment_test.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(BUNDLE_ADJUSTMENT_EffectiveMinimization_Pinhole)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   const double dResidual_before = RMSE(sfmData);
 
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(BUNDLE_ADJUSTMENT_EffectiveMinimization_PinholeRadialK1)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA_RADIAL1);
+  SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA_RADIAL1);
 
   const double dResidual_before = RMSE(sfmData);
 
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(BUNDLE_ADJUSTMENT_EffectiveMinimization_PinholeRadialK3)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA_RADIAL3);
+  SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA_RADIAL3);
 
   const double dResidual_before = RMSE(sfmData);
 
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(BUNDLE_ADJUSTMENT_EffectiveMinimization_PinholeBrownT2)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA_BROWN);
+  SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA_BROWN);
 
   const double dResidual_before = RMSE(sfmData);
 
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(BUNDLE_ADJUSTMENT_EffectiveMinimization_PinholeFisheye)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA_FISHEYE);
+  SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA_FISHEYE);
 
   const double dResidual_before = RMSE(sfmData);
 
@@ -145,8 +145,8 @@ BOOST_AUTO_TEST_CASE(LOCAL_BUNDLE_ADJUSTMENT_EffectiveMinimization_Pinhole_Camer
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
-  SfMData sfmData_notRefined = getInputScene(d, config, PINHOLE_CAMERA); // used to compate which parameters are refined.
+  SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
+  SfMData sfmData_notRefined = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA); // used to compate which parameters are refined.
 
   // Transform the views scheme
   //          v0 - v3

--- a/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL1)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  const SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  const SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL1_TranslationAveragingL1)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  const SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  const SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL2_Chord
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  const SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  const SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingSoftL1)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  const SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  const SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;

--- a/src/aliceVision/sfm/pipeline/sequential/sequentialSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/sequentialSfM_test.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Intrinsics)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  const SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  const SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Partially_Known_Intrinsics)
   const NViewDataSet d = NRealisticCamerasRing(nviews, npoints, config);
 
   // Translate the input dataset to a SfMData scene
-  const SfMData sfmData = getInputScene(d, config, PINHOLE_CAMERA);
+  const SfMData sfmData = getInputScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(SEQUENTIAL_SFM_Known_Rig)
   const NViewDataSet d = NRealisticCamerasRing(nbPoses, nbPoints, config);
 
   // Translate the input dataset to a SfMData scene
-  const SfMData sfmData = getInputRigScene(d, config, PINHOLE_CAMERA);
+  const SfMData sfmData = getInputRigScene(d, config, EINTRINSIC::PINHOLE_CAMERA);
 
   // Remove poses and structure
   SfMData sfmData2 = sfmData;

--- a/src/aliceVision/sfm/utils/syntheticScene.cpp
+++ b/src/aliceVision/sfm/utils/syntheticScene.cpp
@@ -78,15 +78,15 @@ sfmData::SfMData getInputScene(const NViewDataSet& d,
     const unsigned int h = config._cy *2;
     switch (eintrinsic)
     {
-      case camera::PINHOLE_CAMERA:
+        case camera::EINTRINSIC::PINHOLE_CAMERA:
         sfmData.intrinsics[0] = std::make_shared<camera::Pinhole>
           (w, h, config._fx, config._cx, config._cy);
       break;
-      case camera::PINHOLE_CAMERA_RADIAL1:
+        case camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL1:
         sfmData.intrinsics[0] = std::make_shared<camera::PinholeRadialK1>
           (w, h, config._fx, config._cx, config._cy, 0.0);
       break;
-      case camera::PINHOLE_CAMERA_RADIAL3:
+        case camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3:
         sfmData.intrinsics[0] = std::make_shared<camera::PinholeRadialK3>
           (w, h, config._fx, config._cx, config._cy, 0., 0., 0.);
       break;
@@ -164,13 +164,13 @@ sfmData::SfMData getInputRigScene(const NViewDataSet& d,
     const unsigned int h = config._cy * 2;
     switch (eintrinsic)
     {
-      case camera::PINHOLE_CAMERA:
+      case camera::EINTRINSIC::PINHOLE_CAMERA:
         sfmData.intrinsics[0] = std::make_shared<camera::Pinhole>(w, h, config._fx, config._cx, config._cy);
       break;
-      case camera::PINHOLE_CAMERA_RADIAL1:
+      case camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL1:
         sfmData.intrinsics[0] = std::make_shared<camera::PinholeRadialK1>(w, h, config._fx, config._cx, config._cy, 0.0);
       break;
-      case camera::PINHOLE_CAMERA_RADIAL3:
+      case camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3:
         sfmData.intrinsics[0] = std::make_shared<camera::PinholeRadialK3>(w, h, config._fx, config._cx, config._cy, 0., 0., 0.);
       break;
       default:

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -318,7 +318,7 @@ bool readCamera(const ICamera& camera, const M44d& mat, sfmData::SfMData& sfmDat
   ICompoundProperty userProps = getAbcUserProperties(cs);
   std::string imagePath;
   std::vector<unsigned int> sensorSize_pix = {0, 0};
-  std::string mvg_intrinsicType = EINTRINSIC_enumToString(PINHOLE_CAMERA);
+  std::string mvg_intrinsicType = EINTRINSIC_enumToString(EINTRINSIC::PINHOLE_CAMERA);
   std::string mvg_intrinsicInitializationMode = EIntrinsicInitMode_enumToString(EIntrinsicInitMode::CALIBRATED);
   std::vector<double> mvg_intrinsicParams;
   double initialFocalLengthPix = -1;

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -411,7 +411,8 @@ bool saveJSON(const sfmData::SfMData& sfmData, const std::string& filename, ESfM
   return true;
 }
 
-bool loadJSON(sfmData::SfMData& sfmData, const std::string& filename, ESfMData partFlag, bool incompleteViews)
+bool loadJSON(sfmData::SfMData& sfmData, const std::string& filename, ESfMData partFlag, bool incompleteViews,
+              EViewIdMethod viewIdMethod, const std::string& viewIdRegex)
 {
   Vec3 version;
 
@@ -498,6 +499,7 @@ bool loadJSON(sfmData::SfMData& sfmData, const std::string& filename, ESfMData p
           v.setHeight(intrinsics->h());
         }
         updateIncompleteView(incompleteViews.at(i));
+        updateIncompleteView(incompleteViews.at(i), viewIdMethod, viewIdRegex);
       }
 
       // copy complete views in the SfMData views map

--- a/src/aliceVision/sfmDataIO/jsonIO.hpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfmDataIO/viewIO.hpp>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -218,9 +219,12 @@ bool saveJSON(const sfmData::SfMData& sfmData, const std::string& filename, ESfM
  * @param[in] filename The filename
  * @param[in] partFlag The ESfMData load flag
  * @param[in] incompleteViews If true, try to load incomplete views
+ * @param[in] viewIdMethod ViewId generation method to use if incompleteViews is true
+ * @param[in] viewIdRegex Optional regex used when viewIdMethod is FILENAME
  * @return true if completed
  */
-bool loadJSON(sfmData::SfMData& sfmData, const std::string& filename, ESfMData partFlag, bool incompleteViews = false);
+bool loadJSON(sfmData::SfMData& sfmData, const std::string& filename, ESfMData partFlag, bool incompleteViews = false,
+              EViewIdMethod viewIdMethod = EViewIdMethod::METADATA, const std::string& viewIdRegex = "");
 
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -163,13 +163,13 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& vie
   else if((focalLengthIn35mm > 0.0 && focalLengthIn35mm < 18.0) || (defaultFieldOfView > 100.0))
   {
     // if the focal lens is short, the fisheye model should fit better.
-    intrinsicType = camera::PINHOLE_CAMERA_FISHEYE;
+      intrinsicType = camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE;
   }
-  else if(intrinsicType == camera::PINHOLE_CAMERA_START)
+  else if(intrinsicType == camera::EINTRINSIC::PINHOLE_CAMERA_START)
   {
     // choose a default camera model if no default type
     // use standard lens with radial distortion by default
-    intrinsicType = camera::PINHOLE_CAMERA_RADIAL3;
+      intrinsicType = camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3;
   }
 
   // create the desired intrinsic
@@ -180,13 +180,13 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& vie
   // initialize distortion parameters
   switch(intrinsicType)
   {
-    case camera::PINHOLE_CAMERA_FISHEYE:
+      case camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE:
     {
       if(cameraBrand == "GoPro")
         intrinsic->updateFromParams({pxFocalLength, ppx, ppy, 0.0524, 0.0094, -0.0037, -0.0004});
       break;
     }
-    case camera::PINHOLE_CAMERA_FISHEYE1:
+      case camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE1:
     {
       if(cameraBrand == "GoPro")
         intrinsic->updateFromParams({pxFocalLength, ppx, ppy, 1.04});

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -40,7 +40,7 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& vie
                                                 double sensorWidth = -1,
                                                 double defaultFocalLengthPx = -1,
                                                 double defaultFieldOfView = -1,
-                                                camera::EINTRINSIC defaultIntrinsicType = camera::PINHOLE_CAMERA_START,
+                                                camera::EINTRINSIC defaultIntrinsicType = camera::EINTRINSIC::PINHOLE_CAMERA_START,
                                                 double defaultPPx = -1,
                                                 double defaultPPy = -1);
 

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -17,11 +17,50 @@
 namespace aliceVision {
 namespace sfmDataIO {
 
+enum class EViewIdMethod
+{
+    METADATA,
+    FILENAME
+};
+
+inline std::string EViewIdMethod_enumToString(EViewIdMethod viewIdMethod)
+{
+    switch(viewIdMethod)
+    {
+        case EViewIdMethod::METADATA: return "metadata";
+        case EViewIdMethod::FILENAME: return "filename";
+    }
+    throw std::out_of_range("Invalid ViewIdMethod type Enum: " + std::to_string(int(viewIdMethod)));
+}
+
+inline EViewIdMethod EViewIdMethod_stringToEnum(const std::string& viewIdMethod)
+{
+    if(viewIdMethod == "metadata") return EViewIdMethod::METADATA;
+    if(viewIdMethod == "filename") return EViewIdMethod::FILENAME;
+
+    throw std::out_of_range("Invalid ViewIdMethod type string " + viewIdMethod);
+}
+
+inline std::ostream& operator<<(std::ostream& os, EViewIdMethod s)
+{
+    return os << EViewIdMethod_enumToString(s);
+}
+
+inline std::istream& operator>>(std::istream& in, EViewIdMethod& s)
+{
+    std::string token;
+    in >> token;
+    s = EViewIdMethod_stringToEnum(token);
+    return in;
+}
+
 /**
  * @brief update an incomplete view (at least only the image path)
  * @param view The given incomplete view
+ * @param[in] viewIdMethod ViewId generation method to use
+ * @param[in] viewIdRegex Optional regex used when viewIdMethod is FILENAME
  */
-void updateIncompleteView(sfmData::View& view);
+void updateIncompleteView(sfmData::View& view, EViewIdMethod viewIdMethod = EViewIdMethod::METADATA, const std::string& viewIdRegex = "");
 
 /**
  * @brief create an intrinsic for the given View

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -30,19 +30,18 @@ void updateIncompleteView(sfmData::View& view);
  * @param[in] sensorWidth (-1 if unknown)
  * @param[in] defaultFocalLengthPx (-1 if unknown)
  * @param[in] defaultFieldOfView (-1 if unknown)
- * @param[in] defaultIntrinsicType (PINHOLE_CAMERA_START if unknown)
+ * @param[in] defaultIntrinsicType (unknown by default)
  * @param[in] defaultPPx (-1 if unknown)
  * @param[in] defaultPPy (-1 if unknown)
+ * @param[in] allowedEintrinsics The intrinsics values that can be attributed
  * @return shared_ptr IntrinsicBase
  */
-std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& view,
-                                                double mmFocalLength = -1.0,
-                                                double sensorWidth = -1,
-                                                double defaultFocalLengthPx = -1,
-                                                double defaultFieldOfView = -1,
-                                                camera::EINTRINSIC defaultIntrinsicType = camera::EINTRINSIC::PINHOLE_CAMERA_START,
-                                                double defaultPPx = -1,
-                                                double defaultPPy = -1);
+std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(
+					const sfmData::View& view, double mmFocalLength = -1.0, double sensorWidth = -1,
+					double defaultFocalLengthPx = -1, double defaultFieldOfView = -1,
+					camera::EINTRINSIC defaultIntrinsicType = camera::EINTRINSIC::UNKNOWN,
+					camera::EINTRINSIC allowedEintrinsics = camera::EINTRINSIC::VALID_CAMERA_MODEL,
+					double defaultPPx = -1, double defaultPPy = -1);
 
 /**
     * @brief Allows you to retrieve the image file path corresponding to a view by searching through a list of folders.

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -31,6 +31,7 @@
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;
+using namespace aliceVision::sfmDataIO;
 
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
@@ -372,7 +373,7 @@ int aliceVision_main(int argc, char **argv)
   if(imageFolder.empty())
   {
     // fill SfMData from the JSON file
-    sfmDataIO::loadJSON(sfmData, sfmFilePath, sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS|sfmDataIO::EXTRINSICS), true);
+    loadJSON(sfmData, sfmFilePath, ESfMData(VIEWS|INTRINSICS|EXTRINSICS), true);
   }
   else
   {
@@ -389,7 +390,7 @@ int aliceVision_main(int argc, char **argv)
       {
         sfmData::View& view = incompleteViews.at(i);
         view.setImagePath(imagePaths.at(i));
-        sfmDataIO::updateIncompleteView(view);
+        updateIncompleteView(view);
       }
 
       for(const auto& view : incompleteViews)
@@ -556,7 +557,7 @@ int aliceVision_main(int argc, char **argv)
     }
 
     // build intrinsic
-    std::shared_ptr<camera::IntrinsicBase> intrinsicBase = sfmDataIO::getViewIntrinsic(view, focalLengthmm, sensorWidth, defaultFocalLengthPixel, defaultFieldOfView, defaultCameraModel, defaultPPx, defaultPPy);
+    std::shared_ptr<camera::IntrinsicBase> intrinsicBase = getViewIntrinsic(view, focalLengthmm, sensorWidth, defaultFocalLengthPixel, defaultFieldOfView, defaultCameraModel, defaultPPx, defaultPPy);
     camera::Pinhole* intrinsic = dynamic_cast<camera::Pinhole*>(intrinsicBase.get());
 
     // set initialization mode
@@ -742,7 +743,7 @@ int aliceVision_main(int argc, char **argv)
   }
 
   // store SfMData views & intrinsic data
-  if(!sfmDataIO::Save(sfmData, outputFilePath, sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS|sfmDataIO::EXTRINSICS)))
+  if(!Save(sfmData, outputFilePath, ESfMData(VIEWS|INTRINSICS|EXTRINSICS)))
   {
     return EXIT_FAILURE;
   }

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/image/io.cpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
@@ -385,7 +386,7 @@ int aliceVision_main(int argc, char **argv)
     sfmData::Views& views = sfmData.getViews();
     std::vector<std::string> imagePaths;
 
-    if(listFiles(imageFolder, {".jpg", ".jpeg", ".tif", ".tiff", ".exr"},  imagePaths))
+    if(listFiles(imageFolder, image::getSupportedExtensions(), imagePaths))
     {
       std::vector<sfmData::View> incompleteViews(imagePaths.size());
 


### PR DESCRIPTION
## Features list

- [x] Support more extensions, using available extensions with OpenImageIO (https://github.com/alicevision/meshroom/pull/965)
- [x] Add a method to define viewId from filename (via regex) instead of generating a UID from metadata to enable evaluation tests on datasets with ground truth.
- [x] Allow to choose the intrinsics permitted in the init camera