### PR TITLE
Fix CameraInit: missing escape character

### DIFF
--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -190,7 +190,7 @@ int aliceVision_main(int argc, char **argv)
   double defaultFieldOfView = -1.0;
   EGroupCameraFallback groupCameraFallback = EGroupCameraFallback::FOLDER;
   EViewIdMethod viewIdMethod = EViewIdMethod::METADATA;
-  std::string viewIdRegex = ".*?(\d+)";
+  std::string viewIdRegex = ".*?(\\d+)";
 
   bool allowSingleView = false;
 


### PR DESCRIPTION
## Description

Fix missing escape character in cameraInit regex .

