### PR TITLE
[SfM] Major bug fix on BlockOrder in BACeres

### DIFF
--- a/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
@@ -49,7 +49,6 @@ public:
     ceres::LinearSolverType linearSolverType;
     ceres::PreconditionerType preconditionerType;
     ceres::SparseLinearAlgebraLibraryType sparseLinearAlgebraLibraryType;
-    ceres::ParameterBlockOrdering linearSolverOrdering;
     std::shared_ptr<ceres::LossFunction> lossFunction;
     unsigned int nbThreads;
     bool useParametersOrdering = true;
@@ -171,16 +170,7 @@ private:
   /**
    * @brief Clear structures for a new problem
    */
-  inline void resetProblem()
-  {
-    _statistics = Statistics();
-
-    _allParametersBlocks.clear();
-    _posesBlocks.clear();
-    _intrinsicsBlocks.clear();
-    _landmarksBlocks.clear();
-    _rigBlocks.clear();
-  }
+  void resetProblem();
 
   /**
    * @brief Set user Ceres options to the solver
@@ -305,6 +295,10 @@ private:
   /// rig sub-poses blocks wrapper
   /// block: ceres angleAxis(3) + translation(3)
   HashMap<IndexT, HashMap<IndexT, std::array<double,6>>> _rigBlocks;
+
+  /// hinted order for ceres to eliminate blocks when solving.
+  /// note: this ceres parameter is built internally and must be reset on each call to the solver.
+  ceres::ParameterBlockOrdering _linearSolverOrdering;
 
 };
 

--- a/src/aliceVision/sfm/ResidualErrorFunctor.hpp
+++ b/src/aliceVision/sfm/ResidualErrorFunctor.hpp
@@ -408,13 +408,14 @@ struct ResidualErrorFunctor_PinholeRadialK3
     {
       const T * cam_R = subpose_Rt;
       const T * cam_t = &subpose_Rt[3];
-      // Rotate the point according to the camera rotation
-      ceres::AngleAxisRotatePoint(cam_R, pos_proj, pos_proj);
+      // Rotate the point according to the camera rotation. In-place rotation not supported by Ceres
+      T pos_proj_tmp[3];
+      ceres::AngleAxisRotatePoint(cam_R, pos_proj, pos_proj_tmp);
 
       // Apply the camera translation
-      pos_proj[0] += cam_t[0];
-      pos_proj[1] += cam_t[1];
-      pos_proj[2] += cam_t[2];
+      pos_proj[0] = pos_proj_tmp[0] + cam_t[0];
+      pos_proj[1] = pos_proj_tmp[1] + cam_t[1];
+      pos_proj[2] = pos_proj_tmp[2] + cam_t[2];
     }
 
     // Transform the point from homogeneous to euclidean (undistorted point)


### PR DESCRIPTION
Ceres accepts a ParameterBlockOrdering hint which must assign
every parameter block to exactly one group.

BundleAdjustmentCeres can be called multiple times, and on each
call resetProblem() is called internally to clear the parameter blocks.

However, resetProblem() did not clear the ParameterBlockOrdering.
If the BundleAdjustmentCeres object was used more than once,
Ceres would fail with an error.

In practice, the BundleAdjustmentCeres object is used in a loop that
repeatedly calls adjust() while removing outliers on each iteration.

If the first iteration succeeded with no outliers, the loop would
correctly exit. However, if any outliers are present, the entire
bundle adjustment routine fails leading to the warning:

  "Bundle Adjustment failed, the solution is not usable."

This incorrect Ceres usage seems to have been the main cause
of bundle adjustment failures. The error given by Ceres was:

FAILURE (The program has 3855 parameter blocks, but the parameter block
  ordering has 7621 parameter blocks.)

Includes fix for rig error functor which was previously unreachable due
to bug. Without fix, rigs cause SfM to crash.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

