### PR TITLE
[sw] convertSfMFormat: remove pose only if it exists

### DIFF
--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -178,7 +178,8 @@ int aliceVision_main(int argc, char **argv)
       if(toRemove)
       {
         viewsToRemove.push_back(view.getViewId());
-        if(view.isPoseIndependant())
+        // remove pose only if it exists and it is independent
+        if(view.isPoseIndependant() && sfmData.existsPose(view))
           posesToRemove.push_back(view.getPoseId());
       }
     }


### PR DESCRIPTION
If a whitelist of views is provided to convertSfMFormat, it removes all the other views
Currently, if the pose does not exist it is added to the list of poses that are to be removed. 
This makes the application crash.

This fixes the issue by first checking the pose exists.