### PR TITLE
Add entry to cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3268,6 +3268,7 @@ Motorola;Motorola Moto Z Force;5.99;devicespecifications
 Motorola;Motorola Moto Z Play;6.06;devicespecifications
 Motorola;Motorola Moto Z2 Force Edition;4.96;devicespecifications
 Motorola;Motorola Moto Z2 Play;3.67;devicespecifications
+Motorola;Moto Z (2);6.29;usercontribution
 Motorola;Motorola Nexus 6;4.69;devicespecifications
 Motorola;Motorola P30;4.74;devicespecifications
 Motorola;XT1033;3.8;usercontribution

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3268,7 +3268,7 @@ Motorola;Motorola Moto Z Force;5.99;devicespecifications
 Motorola;Motorola Moto Z Play;6.06;devicespecifications
 Motorola;Motorola Moto Z2 Force Edition;4.96;devicespecifications
 Motorola;Motorola Moto Z2 Play;3.67;devicespecifications
-Motorola;Moto Z (2);6.29;usercontribution
+Motorola;Moto Z (2);4.98;usercontribution
 Motorola;Motorola Nexus 6;4.69;devicespecifications
 Motorola;Motorola P30;4.74;devicespecifications
 Motorola;XT1033;3.8;usercontribution


### PR DESCRIPTION
Add Moto Z (2) to camerasensors.db.

## Description
Added a missing entry to cameraSensors.db
This is my first time doing this.


## Implementation remarks

On each installation of meshroom I add this to the DB file so it functions with my phone, it would be nice if this were part of the standard program.

