### PR TITLE
Update compensation of aperture and ISO change in HDR fusion

### DIFF
--- a/src/aliceVision/sfmData/View.cpp
+++ b/src/aliceVision/sfmData/View.cpp
@@ -43,7 +43,7 @@ float View::getCameraExposureSetting(const float referenceISO, const float refer
     aperture2² = iso2 / iso1 * 1
     aperture2 = sqrt(iso2 / iso1)
     */
-    float iso_2_aperture = sqrt(iso / lReferenceIso);
+    float iso_2_aperture = (iso < 1e-6f)?1.0f:sqrt(iso / lReferenceIso);
   
     /*
     aperture = f / diameter

--- a/src/aliceVision/sfmData/View.cpp
+++ b/src/aliceVision/sfmData/View.cpp
@@ -21,39 +21,37 @@ float View::getCameraExposureSetting(const float referenceISO, const float refer
 {
     const float shutter = getMetadataShutter();
     const float fnumber = getMetadataFNumber();
-    const float iso = getMetadataISO();
-    
-    if(shutter < 0 || fnumber < 0)
+    if(shutter <= 0.0f || fnumber <= 0.0f)
         return -1.f;
 
-    float lReferenceIso = referenceISO;
-    if (lReferenceIso < 0.0f) {
-        lReferenceIso = iso;
-    }
-
     float lReferenceFNumber = referenceFNumber;
-    if (lReferenceFNumber < 0.0f) {
+    if (lReferenceFNumber <= 0.0f)
+    {
         lReferenceFNumber = fnumber;
     }
-    
-    /* 
+
+    const float iso = getMetadataISO();
+    /*
     iso = qLt / aperture^2
-    isoratio = iso2 / iso1 = qLt / aperture1² / (qLt / aperture2²) 
-    isoratio = aperture2² / aperture1²
-    aperture2² = iso2 / iso1 * 1
+    isoratio = iso2 / iso1 = (qLt / aperture1^2) / (qLt / aperture2^2)
+    isoratio = aperture2^2 / aperture1^2
+    aperture2^2 = iso2 / iso1 * 1
     aperture2 = sqrt(iso2 / iso1)
     */
-    float iso_2_aperture = (iso < 1e-6f)?1.0f:sqrt(iso / lReferenceIso);
-  
+    float iso_2_aperture = 1.0f;
+    if(iso > 1e-6f && referenceISO > 1e-6f)
+    {
+        // Need to have both iso and reference iso to use it
+        iso_2_aperture = std::sqrt(iso / referenceISO);
+    }
+
     /*
     aperture = f / diameter
     aperture2 / aperture1 = diameter2 / diameter1
-    (aperture2 / aperture1)² = (area2 / pi) / (area1 / pi)
+    (aperture2 / aperture1)^2 = (area2 / pi) / (area1 / pi)
     */
-
     float new_fnumber = fnumber * iso_2_aperture;
     float exp_increase = (new_fnumber / lReferenceFNumber) * (new_fnumber / lReferenceFNumber);
-
 
     return shutter * exp_increase;
 }

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -207,7 +207,7 @@ public:
    * For the same scene, this value is linearly proportional to the amount of light captured by the camera according to
    * the shooting parameters (shutter speed, f-number, iso).
    */
-  float getCameraExposureSetting() const;
+  float getCameraExposureSetting(const float referenceISO = -1.0f, const float referenceFNumber = -1.0f) const;
 
   /**
    * @brief Get the Exposure Value. EV is a number that represents a combination of a camera's shutter speed and

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -207,7 +207,7 @@ public:
    * For the same scene, this value is linearly proportional to the amount of light captured by the camera according to
    * the shooting parameters (shutter speed, f-number, iso).
    */
-  float getCameraExposureSetting(const float referenceISO = -1.0f, const float referenceFNumber = -1.0f) const;
+  float getCameraExposureSetting(const float referenceISO = 100.0f, const float referenceFNumber = 8.0f) const;
 
   /**
    * @brief Get the Exposure Value. EV is a number that represents a combination of a camera's shutter speed and

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -355,7 +355,7 @@ int aliceVision_main(int argc, char** argv)
         for(int j = 0; j < group.size(); ++j)
         {   
             
-            float etime = group[j]->getCameraExposureSetting(group[0]->getMetadataISO(), group[0]->getMetadataFNumber());
+            float etime = group[j]->getCameraExposureSetting(/*group[0]->getMetadataISO(), group[0]->getMetadataFNumber()*/);
             exposures.push_back(etime);
         }
         groupedExposures.push_back(exposures);

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -353,8 +353,9 @@ int aliceVision_main(int argc, char** argv)
         std::vector<float> exposures;
 
         for(int j = 0; j < group.size(); ++j)
-        {
-            float etime = group[j]->getCameraExposureSetting();
+        {   
+            
+            float etime = group[j]->getCameraExposureSetting(group[0]->getMetadataISO(), group[0]->getMetadataFNumber());
             exposures.push_back(etime);
         }
         groupedExposures.push_back(exposures);

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -261,7 +261,7 @@ int aliceVision_main(int argc, char** argv)
             ALICEVISION_LOG_INFO("Load " << filepath);
             image::readImage(filepath, images[i], image::EImageColorSpace::SRGB);
 
-            exposures[i] = group[i]->getCameraExposureSetting(targetView->getMetadataISO(), targetView->getMetadataFNumber());
+            exposures[i] = group[i]->getCameraExposureSetting(/*targetView->getMetadataISO(), targetView->getMetadataFNumber()*/);
         }
 
         // Merge HDR images

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -261,7 +261,7 @@ int aliceVision_main(int argc, char** argv)
             ALICEVISION_LOG_INFO("Load " << filepath);
             image::readImage(filepath, images[i], image::EImageColorSpace::SRGB);
 
-            exposures[i] = group[i]->getCameraExposureSetting();
+            exposures[i] = group[i]->getCameraExposureSetting(targetView->getMetadataISO(), targetView->getMetadataFNumber());
         }
 
         // Merge HDR images


### PR DESCRIPTION
HDR fusion did not work when using multiple brackets with variable ISO and/or Aperture.
This PR updates the equations used.
