### PR TITLE
[sfmDataIO] throw if we try to load an abc file and AliceVision is built without Alembic support

### DIFF
--- a/src/aliceVision/sfmDataIO/sfmDataIO.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIO.cpp
@@ -101,13 +101,15 @@ bool Load(sfmData::SfMData& sfmData, const std::string& filename, ESfMData partF
   {
     status = loadJSON(sfmData, filename, partFlag);
   }
-#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_ALEMBIC)
-  else if(extension == ".abc") // Alembic
+  else if (extension == ".abc") // Alembic
   {
-    AlembicImporter(filename).populateSfM(sfmData, partFlag);
-    status = true;
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_ALEMBIC)
+      AlembicImporter(filename).populateSfM(sfmData, partFlag);
+      status = true;
+#else
+      ALICEVISION_THROW_ERROR("Cannot load the ABC file: \"" << filename << "\", AliceVision is built without Alembic support.");
+#endif
   }
-#endif // ALICEVISION_HAVE_ALEMBIC
   else if(fs::is_directory(filename))
   {
     status = readGt(filename, sfmData);


### PR DESCRIPTION
fix https://github.com/alicevision/meshroom/issues/890