### PR TITLE
[fuseCut] added a parameter to filter points based on number of observations

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -871,12 +871,16 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
     verticesCoordsPrepare.resize(realMaxVertices);
     std::vector<double> pixSizePrepare(realMaxVertices);
     std::vector<float> simScorePrepare(realMaxVertices);
+    
+    // counter for points filtered based on the number of observations (minVis)
+    int minVisCounter = 0;
 
     ALICEVISION_LOG_INFO("simFactor: " << params.simFactor);
     ALICEVISION_LOG_INFO("nbPixels: " << nbPixels);
     ALICEVISION_LOG_INFO("maxVertices: " << params.maxPoints);
     ALICEVISION_LOG_INFO("step: " << step);
     ALICEVISION_LOG_INFO("realMaxVertices: " << realMaxVertices);
+    ALICEVISION_LOG_INFO("minVis: " << params.minVis);
 
     ALICEVISION_LOG_INFO("Load depth maps and add points.");
     {
@@ -1081,8 +1085,8 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
         // Filter points based on their number of observations
         if(visCams.size() < params.minVis)
         {
-            ALICEVISION_LOG_DEBUG("minVis value:" << params.minVis);
             pixSizePrepare[vIndex] = -1;
+            minVisCounter += 1;
             continue;
         }
 
@@ -1102,6 +1106,7 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
     ALICEVISION_LOG_INFO("Angle min: " << stat_minAngle << ", max: " << stat_maxAngle << ".");
     ALICEVISION_LOG_INFO("Angle score min: " << stat_minAngleScore << ", max: " << stat_maxAngleScore << ".");
 #endif
+    ALICEVISION_LOG_INFO((minVisCounter) << " points filtered based on the number of observations (minVis). ");
     removeInvalidPoints(verticesCoordsPrepare, pixSizePrepare, simScorePrepare, verticesAttrPrepare);
 
     ALICEVISION_LOG_INFO("Filter by angle score and sim score");

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1078,6 +1078,13 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
             pixSizePrepare[vIndex] = -1;
             continue;
         }
+        // Filter points based on their number of observations
+        if(visCams.size() < params.minVis)
+        {
+            ALICEVISION_LOG_DEBUG("minVis value:" << params.minVis);
+            pixSizePrepare[vIndex] = -1;
+            continue;
+        }
 
         const double angleScore = 1.0 + params.angleFactor / maxAngle;
         // Combine angleScore with simScore

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
@@ -42,6 +42,8 @@ struct FuseParams
     /// The step used to load depth values from depth maps is computed from maxInputPts. Here we define the minimal value for this step,
     /// so on small datasets we will not spend too much time at the beginning loading all depth values.
     int minStep = 2;
+    /// After fusion, filter points based on their number of observations
+    int minVis = 2;
 
     float simFactor = 15.0f;
     float angleFactor = 15.0f;

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -303,6 +303,8 @@ int aliceVision_main(int argc, char* argv[])
             "simFactor")
         ("angleFactor", po::value<float>(&fuseParams.angleFactor)->default_value(fuseParams.angleFactor),
             "angleFactor")
+        ("minVis", po::value<int>(&fuseParams.minVis)->default_value(fuseParams.minVis),
+            "Filter points based on their number of observations")
         ("partitioning", po::value<EPartitioningMode>(&partitioningMode)->default_value(partitioningMode),
             "Partitioning: 'singleBlock' or 'auto'.")
         ("repartition", po::value<ERepartitionMode>(&repartitionMode)->default_value(repartitionMode),


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Added a new parameter (minVis) in the graph cut step in order to filter out points with observation < minVis. 

## Features list

New parameter for the meshing node of the reconstruction pipe. 

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

I think the implementation is trivial however I am not sure the new parameter should have been referenced elsewhere in the code (I know it should be added to meshroom API). 

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

