### PR TITLE
HDR Panorama: Handle very high intensities

### DIFF
--- a/src/aliceVision/hdr/hdrMerge.cpp
+++ b/src/aliceVision/hdr/hdrMerge.cpp
@@ -199,7 +199,6 @@ void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfC
     image::Image<float> isPixelClamped_g(width, height);
     image::ImageGaussianFilter(isPixelClamped, 1.0f, isPixelClamped_g, 3, 3);
 
-    const float maxHalfFloat = 65504.0f;
 #pragma omp parallel for
     for (int y = 0; y < height; ++y)
     {
@@ -207,7 +206,7 @@ void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfC
         {
             image::RGBfColor& radianceColor = radiance(y, x);
 
-            double clampingCompensation = highlightCorrectionFactor * (isPixelClamped_g(y, x) / 3.0);
+            double clampingCompensation = highlightCorrectionFactor * isPixelClamped_g(y, x);
             double clampingCompensationInv = (1.0 - clampingCompensation);
             assert(clampingCompensation <= 1.0);
 
@@ -216,8 +215,6 @@ void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfC
                 if(highlightTarget > radianceColor(channel))
                 {
                     radianceColor(channel) = float(clampingCompensation * highlightTarget + clampingCompensationInv * radianceColor(channel));
-                    // Ensure that values can be stored in half float for openexr export
-                    radianceColor(channel) = std::min(maxHalfFloat, radianceColor(channel));
                 }
             }
         }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -368,8 +368,12 @@ void writeImage(const std::string& path,
   oiio::ImageBuf formatBuf;  // buffer for image format modification
   if(isEXR)
   {
-    formatBuf.copy(*outBuf, oiio::TypeDesc::HALF); // override format, use half instead of float
-    outBuf = &formatBuf;
+    int useFullFloat = imageSpec.get_int_attribute("AliceVision:useFullFloat", 0);
+
+    if (!useFullFloat) {
+      formatBuf.copy(*outBuf, oiio::TypeDesc::HALF); // override format, use half instead of float
+      outBuf = &formatBuf;
+    }
   }
 
   // write image

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -47,7 +47,7 @@ EImageFileType EImageFileType_stringToEnum(const std::string& imageFileType)
   if(type == "tif" || type == "tiff") return EImageFileType::TIFF;
   if(type == "exr")                   return EImageFileType::EXR;
 
-  throw std::out_of_range("Invalid image file type : " + imageFileType);
+  throw std::out_of_range("Invalid image file type: " + imageFileType);
 }
 
 std::string EImageFileType_enumToString(const EImageFileType imageFileType)
@@ -99,6 +99,53 @@ bool isSupported(const std::string& ext)
   const auto start = supportedExtensions.begin();
   const auto end = supportedExtensions.end();
   return (std::find(start, end, boost::to_lower_copy(ext)) != end);
+}
+
+
+std::string EStorageDataType_informations()
+{
+    return EStorageDataType_enumToString(EStorageDataType::Float) + ", " +
+        EStorageDataType_enumToString(EStorageDataType::Half) + ", " +
+        EStorageDataType_enumToString(EStorageDataType::HalfFinite) + ", " +
+        EStorageDataType_enumToString(EStorageDataType::Auto);
+}
+
+EStorageDataType EStorageDataType_stringToEnum(const std::string& dataType)
+{
+    std::string type = dataType;
+    std::transform(type.begin(), type.end(), type.begin(), ::tolower); //tolower
+
+    if (type == "float") return EStorageDataType::Float;
+    if (type == "half") return EStorageDataType::Half;
+    if (type == "halffinite") return EStorageDataType::HalfFinite;
+    if (type == "auto") return EStorageDataType::Auto;
+
+    throw std::out_of_range("Invalid EStorageDataType: " + dataType);
+}
+
+std::string EStorageDataType_enumToString(const EStorageDataType dataType)
+{
+    switch (dataType)
+    {
+    case EStorageDataType::Float:  return "Float";
+    case EStorageDataType::Half:   return "Half";
+    case EStorageDataType::HalfFinite:  return "HalfFinite";
+    case EStorageDataType::Auto:   return "Auto";
+    }
+    throw std::out_of_range("Invalid EStorageDataType enum");
+}
+
+std::ostream& operator<<(std::ostream& os, EStorageDataType dataType)
+{
+    return os << EStorageDataType_enumToString(dataType);
+}
+
+std::istream& operator>>(std::istream& in, EStorageDataType& dataType)
+{
+    std::string token;
+    in >> token;
+    dataType = EStorageDataType_stringToEnum(token);
+    return in;
 }
 
 // Warning: type conversion problems from string to param value, we may lose some metadata with string maps
@@ -280,7 +327,7 @@ void readImage(const std::string& path,
 
     // compute luminance via a weighted sum of R,G,B
     // (assuming Rec709 primaries and a linear scale)
-    const float weights[3] = {.2126, .7152, .0722};
+    const float weights[3] = {.2126f, .7152f, .0722f};
     oiio::ImageBuf grayscaleBuf;
     oiio::ImageBufAlgo::channel_sum(grayscaleBuf, inBuf, weights, convertionROI);
     inBuf.copy(grayscaleBuf);
@@ -322,6 +369,24 @@ void readImage(const std::string& path,
 
     inBuf.get_pixels(exportROI, format, image.data());
   }
+}
+
+bool containsHalfFloatOverflow(const oiio::ImageBuf& image)
+{
+    oiio::ImageBufAlgo::PixelStats stats;
+    oiio::ImageBufAlgo::computePixelStats(stats, image);
+
+    for(auto maxValue: stats.max)
+    {
+        if(maxValue > HALF_MAX)
+            return true;
+    }
+    for (auto minValue: stats.min)
+    {
+        if (minValue < -HALF_MAX)
+            return true;
+    }
+    return false;
 }
 
 template<typename T>
@@ -368,11 +433,33 @@ void writeImage(const std::string& path,
   oiio::ImageBuf formatBuf;  // buffer for image format modification
   if(isEXR)
   {
-    int useFullFloat = imageSpec.get_int_attribute("AliceVision:useFullFloat", 0);
+    const std::string storageDataTypeStr = imageSpec.get_string_attribute("AliceVision:storageDataType", EStorageDataType_enumToString(EStorageDataType::HalfFinite));
+    EStorageDataType storageDataType  = EStorageDataType_stringToEnum(storageDataTypeStr);
 
-    if (!useFullFloat) {
-      formatBuf.copy(*outBuf, oiio::TypeDesc::HALF); // override format, use half instead of float
-      outBuf = &formatBuf;
+    if (storageDataType == EStorageDataType::Auto)
+    {
+        if (containsHalfFloatOverflow(*outBuf))
+        {
+            storageDataType = EStorageDataType::Float;
+        }
+        else
+        {
+            storageDataType = EStorageDataType::Half;
+        }
+        ALICEVISION_LOG_DEBUG("writeImage storageDataTypeStr: " << storageDataType);
+    }
+
+    if (storageDataType == EStorageDataType::HalfFinite)
+    {
+        oiio::ImageBufAlgo::clamp(colorspaceBuf, *outBuf, -HALF_MAX, HALF_MAX);
+        outBuf = &colorspaceBuf;
+    }
+
+    if (storageDataType == EStorageDataType::Half ||
+        storageDataType == EStorageDataType::HalfFinite)
+    {
+        formatBuf.copy(*outBuf, oiio::TypeDesc::HALF); // override format, use half instead of float
+        outBuf = &formatBuf;
     }
   }
 

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -42,6 +42,7 @@ enum class EImageFileType
   EXR
 };
 
+
 /**
  * @brief get informations about each image file type
  * @return String
@@ -90,6 +91,25 @@ std::vector<std::string> getSupportedExtensions();
  * @return true if valid extension
  */
 bool isSupported(const std::string& ext);
+
+
+/**
+* @brief Data type use to write the image
+*/
+enum class EStorageDataType
+{
+    Float, //< Use full floating point precision to store
+    Half, //< Use half (values our of range could become inf or nan)
+    HalfFinite, //< Use half, but ensures out-of-range pixels are clamps to keep finite pixel values
+    Auto //< Use half if all pixels can be stored in half without clamp, else use full float
+};
+
+std::string EStorageDataType_informations();
+EStorageDataType EStorageDataType_stringToEnum(const std::string& dataType);
+std::string EStorageDataType_enumToString(const EStorageDataType dataType);
+std::ostream& operator<<(std::ostream& os, EStorageDataType dataType);
+std::istream& operator>>(std::istream& in, EStorageDataType& dataType);
+
 
 /**
  * @brief convert a metadata string map into an oiio::ParamValueList

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -44,6 +44,11 @@ std::string getHdrImagePath(const std::string& outputPath, std::size_t g)
     return hdrImagePath;
 }
 
+bool isOverflow(const image::Image<image::RGBfColor> & input) {
+    const float maxHalfFloat = 65504.0f;
+    return (input.maxCoeff() > maxHalfFloat);
+}
+
 int aliceVision_main(int argc, char** argv)
 {
     std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
@@ -287,6 +292,12 @@ int aliceVision_main(int argc, char** argv)
 
         // Write an image with parameters from the target view
         oiio::ParamValueList targetMetadata = image::readImageMetadata(targetView->getImagePath());
+
+        if (isOverflow(HDRimage)) 
+        {
+            targetMetadata.push_back(oiio::ParamValue("AliceVision:useFullFloat", int(1)));
+        }
+
         image::writeImage(hdrImagePath, HDRimage, image::EImageColorSpace::AUTO, targetMetadata);
     }
 

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -44,10 +44,6 @@ std::string getHdrImagePath(const std::string& outputPath, std::size_t g)
     return hdrImagePath;
 }
 
-bool isOverflow(const image::Image<image::RGBfColor> & input) {
-    const float maxHalfFloat = 65504.0f;
-    return (input.maxCoeff() > maxHalfFloat);
-}
 
 int aliceVision_main(int argc, char** argv)
 {
@@ -63,6 +59,8 @@ int aliceVision_main(int argc, char** argv)
     hdr::EFunctionType fusionWeightFunction = hdr::EFunctionType::GAUSSIAN;
     float highlightCorrectionFactor = 1.0f;
     float highlightTargetLux = 120000.0f;
+
+    image::EStorageDataType storageDataType = image::EStorageDataType::Float;
 
     int rangeStart = -1;
     int rangeSize = 1;
@@ -97,6 +95,8 @@ int aliceVision_main(int argc, char** argv)
         ("highlightCorrectionFactor", po::value<float>(&highlightCorrectionFactor)->default_value(highlightCorrectionFactor),
          "float value between 0 and 1 to correct clamped highlights in dynamic range: use 0 for no correction, 1 for "
          "full correction to maxLuminance.")
+        ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
+         ("Storage data type: " + image::EStorageDataType_informations()).c_str())
         ("rangeStart", po::value<int>(&rangeStart)->default_value(rangeStart),
           "Range image index start.")
         ("rangeSize", po::value<int>(&rangeSize)->default_value(rangeSize),
@@ -292,11 +292,7 @@ int aliceVision_main(int argc, char** argv)
 
         // Write an image with parameters from the target view
         oiio::ParamValueList targetMetadata = image::readImageMetadata(targetView->getImagePath());
-
-        if (isOverflow(HDRimage)) 
-        {
-            targetMetadata.push_back(oiio::ParamValue("AliceVision:useFullFloat", int(1)));
-        }
+        targetMetadata.push_back(oiio::ParamValue("AliceVision:storageDataType", image::EStorageDataType_enumToString(storageDataType)));
 
         image::writeImage(hdrImagePath, HDRimage, image::EImageColorSpace::AUTO, targetMetadata);
     }


### PR DESCRIPTION
- [x] Handle very high intensities in HDR. Previously caused infinite values in 16-bits exr. If overflow, save as 32bits exr.
- [x] Also clamp values for graphcut seams.
- [x] Expose image storageDataType on some nodes