### PR TITLE
Update cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3974,6 +3974,7 @@ Olympus;Olympus OM-D E-M10 Mark III;17.3;dxomark
 Olympus;Olympus OM-D E-M5;17.3;dpreview,digicamdb,imaging-resource,dxomark
 Olympus;Olympus OM-D E-M5 II;17.3;dpreview,imaging-resource
 Olympus;Olympus OM-D E-M5 Mark II;17.3;digicamdb,dxomark
+Olympus;Olympus OM-D E-M5 Mark III;17.3;digicamdb,dxomark
 Olympus;Olympus PEN E-P1;17.3;dpreview,digicamdb,imaging-resource
 Olympus;Olympus PEN E-P2;17.3;dpreview,digicamdb,imaging-resource
 Olympus;Olympus PEN E-P3;17.3;dpreview,digicamdb,imaging-resource


### PR DESCRIPTION

## Description

Add Olympus OM-D E-M5 Mark III. This has an identical sensor size of the Mark II version of this camera
