### PR TITLE
Update cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5403,6 +5403,7 @@ Samsung;Samsung Galaxy S7 Edge SD820;3.2;devicespecifications
 Samsung;Samsung Galaxy S7 Exynos;3.2;devicespecifications
 Samsung;Samsung Galaxy S8;5.75;usercontribution
 Samsung;Samsung Galaxy S9;5.75;usercontribution
+Samsung;Samsung SM-M315F;7.42;devicespecifications
 Samsung;Samsung SM-G935F;3.2;devicespecifications
 Samsung;Samsung SM-G975U;5.66;devicespecifications
 Samsung;Samsung Galaxy S7 SD820;3.2;devicespecifications


### PR DESCRIPTION
Add samsung M31 (SM-M315F sensor with sensor length: 7.42)

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Add Samsung M31.

## Features list


