### PR TITLE
[HDR] Update the scale constraint

### DIFF
--- a/src/aliceVision/hdr/DebevecCalibrate.cpp
+++ b/src/aliceVision/hdr/DebevecCalibrate.cpp
@@ -130,7 +130,7 @@ bool DebevecCalibrate::process(const std::vector<std::vector<ImageSample>>& ldrS
         // Enforce f(0.5) = 0.0
         //
         const size_t pos_middle = std::floor(channelQuantization / 2);
-        A(channelQuantization - 1, channelQuantization - 1) += 1.0f;
+        A(pos_middle, pos_middle) += 1.0f;
 
         // M is
         //

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -380,6 +380,7 @@ int aliceVision_main(int argc, char** argv)
             }
 
             response.exponential();
+            response.scale();
             break;
         }
         case ECalibrationMethod::GROSSBERG:

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -739,8 +739,15 @@ int aliceVision_main(int argc, char** argv)
 
   if(method == EImageMatchingMethod::FRUSTUM_OR_VOCABULARYTREE)
   {
+      bool onlyPinhole = true;
+      for (auto & cam : sfmDataA.getIntrinsics()) {
+        if (!camera::isPinhole(cam.second->getType())) {
+          onlyPinhole = false;
+        }
+      }
+
       const std::size_t reconstructedViews = sfmDataA.getValidViews().size();
-      if(reconstructedViews == 0)
+      if(reconstructedViews == 0 || (onlyPinhole == false))
       {
           ALICEVISION_LOG_INFO("FRUSTUM_OR_VOCABULARYTREE: Use VOCABULARYTREE matching (no known pose).");
           method = EImageMatchingMethod::VOCABULARYTREE;

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -739,17 +739,24 @@ int aliceVision_main(int argc, char** argv)
 
   if(method == EImageMatchingMethod::FRUSTUM_OR_VOCABULARYTREE)
   {
+      // Frustum intersection is only implemented for pinhole cameras
       bool onlyPinhole = true;
       for (auto & cam : sfmDataA.getIntrinsics()) {
         if (!camera::isPinhole(cam.second->getType())) {
           onlyPinhole = false;
+          break;
         }
       }
 
       const std::size_t reconstructedViews = sfmDataA.getValidViews().size();
-      if(reconstructedViews == 0 || (onlyPinhole == false))
+      if(reconstructedViews == 0)
       {
-          ALICEVISION_LOG_INFO("FRUSTUM_OR_VOCABULARYTREE: Use VOCABULARYTREE matching (no known pose).");
+          ALICEVISION_LOG_INFO("FRUSTUM_OR_VOCABULARYTREE: Use VOCABULARYTREE matching, as there is no known pose.");
+          method = EImageMatchingMethod::VOCABULARYTREE;
+      }
+      else if(!onlyPinhole)
+      {
+          ALICEVISION_LOG_INFO("FRUSTUM_OR_VOCABULARYTREE: Use VOCABULARYTREE matching, as the scene contains non-pinhole cameras.");
           method = EImageMatchingMethod::VOCABULARYTREE;
       }
       else if(reconstructedViews == sfmDataA.getViews().size())


### PR DESCRIPTION
Debevec calibration needs an additional constraint to fix a degree of freedom.

We previously used that f(1) = 0 for all channels. But this caused problem on some dataset as the maximal value is different between channels.

This PR use f(0.5) = 0, which is the original constraint (as per the paper). We used f(1) = 0 for numerical stability in some tests.

This is a major update to the debevec update. All sequences should be tested.