### PR TITLE
[sensorDB] Add another LG G4 sensor description

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3014,7 +3014,6 @@ Lg;Lg X420EM;4.65;devicespecifications,usercontribution
 Lg;Lg X420EMW;4.65;devicespecifications,usercontribution
 Lg;Lg X6;4.65;devicespecifications,usercontribution
 Lg;Lg Zero;3.7;devicespecifications
-Lg;LG-H815;5.08;usercontribution
 LG Electronics;LM-G810EAW;5.64;devicespecifications,usercontribution
 LG Electronics;LM-G820N;5.64;devicespecifications,usercontribution
 LG Electronics;LM-G820QM;5.64;devicespecifications,usercontribution

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3022,6 +3022,7 @@ LG Electronics;LM-G820V;5.64;devicespecifications,usercontribution
 LG Electronics;LM-G850EM;5.64;devicespecifications,usercontribution
 LG Electronics;LM-G850UM;5.64;devicespecifications,usercontribution
 LG Electronics;LG-G900N;6.4;devicespecifications,usercontribution
+LG Electronics;LG-H815;5.95;devicespecifications,usercontribution
 LG Electronics;LG-H870;4.71;usercontribution
 LG Electronics;LG-H870;4.71;usercontribution
 LG Electronics;LG-H870DS;5.867;usercontribution


### PR DESCRIPTION
Multiple LG G4 were tested and for each of them the model and
manufacturer were named as in this commit. Since I don't know whether
the model and manufacturer names are version related, I keep the old
sensor description to avoid issues for other users.

See https://github.com/alicevision/AliceVision/issues/906

