### PR TITLE
Update cameraSensors.db - Added Samsung Note9 (SM-N960F - Wide Camera)

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5628,12 +5628,12 @@ Samsung;Samsung WB850F;6.17;dpreview,digicamdb
 Samsung;Samsung Wi-Fi;6.17;dpreview
 Samsung;Samsung WP10;6.08;dpreview,digicamdb
 Samsung;Samsung-SGH-I537;3.0;usercontribution
-samsung;SM-G920F;5.95;usercontribution
-samsung;SM-G930F;5.76;usercontribution
-samsung;SM-G970F;5.65;digicamdb
-samsung;SM-J111M;3.6;usercontribution
-SAMSUNG;SM-N9005;4.69;usercontribution
-samsung;SM-N960F;5.65;usercontribution
+Samsung;SM-G920F;5.95;usercontribution
+Samsung;SM-G930F;5.76;usercontribution
+Samsung;SM-G970F;5.65;digicamdb
+Samsung;SM-J111M;3.6;usercontribution
+Samsung;SM-N9005;4.69;usercontribution
+Samsung;SM-N960F;5.65;usercontribution
 Santin;Santin Max 4 Pro;4.74;devicespecifications
 Santin;Santin N1;4.71;devicespecifications
 Santin;Santin N1 Max;4.75;devicespecifications

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5633,6 +5633,7 @@ samsung;SM-G930F;5.76;usercontribution
 samsung;SM-G970F;5.65;digicamdb
 samsung;SM-J111M;3.6;usercontribution
 SAMSUNG;SM-N9005;4.69;usercontribution
+samsung;SM-N960F;5.65;usercontribution
 Santin;Santin Max 4 Pro;4.74;devicespecifications
 Santin;Santin N1;4.71;devicespecifications
 Santin;Santin N1 Max;4.75;devicespecifications


### PR DESCRIPTION
## Description
[Samsung Note9 (SM-N960F - Wide Camera)](https://www.phonemore.com/specs/samsung/galaxy-note-9/sm-n960fds-128gb/)

Resolution: 4032x3024 pixels
Sensor Size: 1/2.55"
Pixel Size: 1.4µm
Sensor Width: 4032 * 1.4µm = **5.6448mm**

## Implementation remarks
I'm not sure how to add the separate telephoto sensor.
