### PR TITLE
Dev/white balance

### DIFF
--- a/src/aliceVision/hdr/sampling.cpp
+++ b/src/aliceVision/hdr/sampling.cpp
@@ -145,7 +145,7 @@ void square(image::Image<image::RGBfColor> & dest, const Eigen::Matrix<image::RG
     }
 }
 
-bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<float>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const EImageColorSpace & colorspace, const Sampling::Params params)
+bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<float>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const EImageColorSpace & colorspace, bool applyWhiteBalance, const Sampling::Params params)
 {
     const int radiusp1 = params.radius + 1;
     const int diameter = (params.radius * 2) + 1;
@@ -169,8 +169,12 @@ bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, c
     {
         const float exposure = times[idBracket];
 
+        image::ImageReadOptions options;
+        options.outputColorSpace = colorspace;
+        options.applyWhiteBalance = applyWhiteBalance;
+
         // Load image
-        readImage(imagePaths[idBracket], img, colorspace);
+        readImage(imagePaths[idBracket], img, options);
 
         if(img.Width() != imageWidth || img.Height() != imageHeight)
         {

--- a/src/aliceVision/hdr/sampling.hpp
+++ b/src/aliceVision/hdr/sampling.hpp
@@ -66,7 +66,7 @@ public:
     void filter(size_t maxTotalPoints);
     void extractUsefulSamples(std::vector<ImageSample> & out_samples, const std::vector<ImageSample> & samples, int imageIndex) const;
     
-    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<float>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::EImageColorSpace & colorspace, const Params params);
+    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<float>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::EImageColorSpace & colorspace, bool applyWhiteBalance, const Params params);
 
 private:
     MapSampleRefList _positions;

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -42,6 +42,20 @@ enum class EImageFileType
   EXR
 };
 
+/**
+ * @brief aggregate for multiple image reading options
+ */
+struct ImageReadOptions
+{  
+  ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO, bool useWhiteBalance = true) :
+  outputColorSpace(colorSpace), applyWhiteBalance(useWhiteBalance)
+  {
+  }
+
+  EImageColorSpace outputColorSpace;
+  bool applyWhiteBalance;
+};
+
 
 /**
  * @brief get informations about each image file type
@@ -161,12 +175,12 @@ void getBufferFromImage(Image<RGBColor>& image, oiio::ImageBuf& buffer);
  * @param[out] image The output image buffer
  * @param[in] image color space
  */
-void readImage(const std::string& path, Image<float>& image, EImageColorSpace imageColorSpace);
-void readImage(const std::string& path, Image<unsigned char>& image, EImageColorSpace imageColorSpace);
-void readImage(const std::string& path, Image<RGBAfColor>& image, EImageColorSpace imageColorSpace);
-void readImage(const std::string& path, Image<RGBAColor>& image, EImageColorSpace imageColorSpace);
-void readImage(const std::string& path, Image<RGBfColor>& image, EImageColorSpace imageColorSpace);
-void readImage(const std::string& path, Image<RGBColor>& image, EImageColorSpace imageColorSpace);
+void readImage(const std::string& path, Image<float>& image, const ImageReadOptions & imageReadOptions);
+void readImage(const std::string& path, Image<unsigned char>& image, const ImageReadOptions & imageReadOptions);
+void readImage(const std::string& path, Image<RGBAfColor>& image, const ImageReadOptions & imageReadOptions);
+void readImage(const std::string& path, Image<RGBAColor>& image, const ImageReadOptions & imageReadOptions);
+void readImage(const std::string& path, Image<RGBfColor>& image, const ImageReadOptions & imageReadOptions);
+void readImage(const std::string& path, Image<RGBColor>& image, const ImageReadOptions & imageReadOptions);
 
 /**
  * @brief write an image with a given path and buffer

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -359,6 +359,16 @@ public:
     return static_cast<EEXIFOrientation>(orientation);
   }
 
+  const bool getApplyWhiteBalance() const 
+  {
+    if (getIntMetadata({"AliceVision:useWhiteBalance"}) == 0)
+    {
+      return false;
+    }
+    
+    return true;
+  }
+
   const bool hasMetadataDateTimeOriginal() const
   {
       return hasMetadata(
@@ -509,7 +519,7 @@ public:
    */
   void addMetadata(const std::string& key, const std::string& value)
   {
-    _metadata.emplace(key, value);
+    _metadata[key] = value;
   }
 
 private:

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -277,7 +277,11 @@ int aliceVision_main(int argc, char** argv)
         {
             const std::string filepath = group[i]->getImagePath();
             ALICEVISION_LOG_INFO("Load " << filepath);
-            image::readImage(filepath, images[i], image::EImageColorSpace::SRGB);
+
+            image::ImageReadOptions options;
+            options.outputColorSpace = image::EImageColorSpace::SRGB;
+            options.applyWhiteBalance = group[i]->getApplyWhiteBalance();
+            image::readImage(filepath, images[i], options);
 
             exposures[i] = group[i]->getCameraExposureSetting(/*targetView->getMetadataISO(), targetView->getMetadataFNumber()*/);
         }

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -206,15 +206,19 @@ int aliceVision_main(int argc, char** argv)
         std::vector<std::string> paths;
         std::vector<float> exposures;
 
+        bool applyWhiteBalance = true;
+
         for (auto & v : group)
         {
             paths.push_back(v->getImagePath());
             exposures.push_back(v->getCameraExposureSetting());
+
+            applyWhiteBalance = applyWhiteBalance && v->getApplyWhiteBalance();
         }
 
         ALICEVISION_LOG_INFO("Extracting samples from group " << groupIdx);
         std::vector<hdr::ImageSample> out_samples;
-        const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, exposures, width, height, channelQuantization, image::EImageColorSpace::SRGB, params);
+        const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, exposures, width, height, channelQuantization, image::EImageColorSpace::SRGB, applyWhiteBalance, params);
         if (!res)
         {
             ALICEVISION_LOG_ERROR("Error while extracting samples from group " << groupIdx);

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -284,7 +284,13 @@ int aliceVision_main(int argc, char* argv[])
 
         // Read input file
         image::Image<image::RGBfColor> originalImage;
-        image::readImage(v.second->getImagePath(), originalImage, image::EImageColorSpace::LINEAR);
+
+        image::ImageReadOptions options;
+        options.outputColorSpace = image::EImageColorSpace::LINEAR;
+        options.applyWhiteBalance = v.second->getApplyWhiteBalance();
+        
+
+        image::readImage(v.second->getImagePath(), originalImage, options);
         oiio::ImageBuf bufInput(
             oiio::ImageSpec(originalImage.Width(), originalImage.Height(), 3, oiio::TypeDesc::FLOAT),
             originalImage.data());

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -750,9 +750,14 @@ int aliceVision_main(int argc, char * argv[])
 
             ALICEVISION_LOG_INFO(++i << "/" << size << " - Process view '" << viewId << "'.");
 
+
+            image::ImageReadOptions options;
+            options.outputColorSpace = image::EImageColorSpace::LINEAR;
+            options.applyWhiteBalance = view.getApplyWhiteBalance();
+
             // Read original image
             image::Image<image::RGBAfColor> image;
-            image::readImage(viewPath, image, image::EImageColorSpace::LINEAR);
+            image::readImage(viewPath, image, options);
 
             // If exposureCompensation is needed for sfmData files
             if (pParams.exposureCompensation)


### PR DESCRIPTION
Add an option to ignore the white balance post processing in LibRaw. 

CameraInit will set this parameter in the SfmData::Views given command line parameters

Option is passed to image reading function.

For the moment, only using this option in panorama related nodes