### PR TITLE
[feature] sift: update default values, add new filtering and add dsp-sift variation

### DIFF
--- a/src/aliceVision/feature/CMakeLists.txt
+++ b/src/aliceVision/feature/CMakeLists.txt
@@ -18,6 +18,7 @@ set(features_files_headers
   Hamming.hpp
   ImageDescriber.hpp
   imageDescriberCommon.hpp
+  imageStats.hpp
   KeypointSet.hpp
   metric.hpp
   PointFeature.hpp
@@ -36,6 +37,7 @@ set(features_files_sources
   FeaturesPerView.cpp
   ImageDescriber.cpp
   imageDescriberCommon.cpp
+  imageStats.cpp
 )
 
 # CCTAG ImageDescriber

--- a/src/aliceVision/feature/CMakeLists.txt
+++ b/src/aliceVision/feature/CMakeLists.txt
@@ -10,6 +10,7 @@ set(features_files_headers
   sift/ImageDescriber_SIFT.hpp
   sift/ImageDescriber_SIFT_vlfeat.hpp
   sift/ImageDescriber_SIFT_vlfeatFloat.hpp
+  sift/ImageDescriber_DSPSIFT_vlfeat.hpp
   sift/SIFT.hpp
   Descriptor.hpp
   feature.hpp
@@ -31,6 +32,7 @@ set(features_files_sources
   akaze/descriptorLIOP.cpp
   akaze/ImageDescriber_AKAZE.cpp
   sift/SIFT.cpp
+  sift/ImageDescriber_DSPSIFT_vlfeat.cpp
   FeaturesPerView.cpp
   ImageDescriber.cpp
   imageDescriberCommon.cpp

--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -55,7 +55,7 @@ std::string EImageDescriberPreset_enumToString(const EImageDescriberPreset image
   if(imageDescriberPreset == EImageDescriberPreset::HIGH)   return "high";
   if(imageDescriberPreset == EImageDescriberPreset::ULTRA)  return "ultra";
 
-  throw std::invalid_argument("Unrecognized EImageDescriberPreset");
+  throw std::invalid_argument("Unrecognized EImageDescriberPreset: " + std::to_string(int(imageDescriberPreset)));
 }
 
 std::ostream& operator<<(std::ostream& os, EImageDescriberPreset p)
@@ -69,6 +69,113 @@ std::istream& operator>>(std::istream& in, EImageDescriberPreset& p)
   in >> token;
   p = EImageDescriberPreset_stringToEnum(token);
   return in;
+}
+
+
+EFeatureQuality EFeatureQuality_stringToEnum(const std::string& imageDescriberPreset)
+{
+    std::string preset = imageDescriberPreset;
+    std::transform(preset.begin(), preset.end(), preset.begin(), ::tolower); // tolower
+
+    if(preset == "low")
+        return EFeatureQuality::LOW;
+    if(preset == "medium")
+        return EFeatureQuality::MEDIUM;
+    if(preset == "normal")
+        return EFeatureQuality::NORMAL;
+    if(preset == "high")
+        return EFeatureQuality::HIGH;
+    if(preset == "ultra")
+        return EFeatureQuality::ULTRA;
+
+    throw std::invalid_argument("Invalid descriptor preset: " + preset);
+}
+
+std::string EFeatureQuality_enumToString(const EFeatureQuality imageDescriberPreset)
+{
+    if(imageDescriberPreset == EFeatureQuality::LOW)
+        return "low";
+    if(imageDescriberPreset == EFeatureQuality::MEDIUM)
+        return "medium";
+    if(imageDescriberPreset == EFeatureQuality::NORMAL)
+        return "normal";
+    if(imageDescriberPreset == EFeatureQuality::HIGH)
+        return "high";
+    if(imageDescriberPreset == EFeatureQuality::ULTRA)
+        return "ultra";
+
+    throw std::invalid_argument("Unrecognized EFeatureQuality: " + std::to_string(int(imageDescriberPreset)));
+}
+
+std::ostream& operator<<(std::ostream& os, EFeatureQuality p)
+{
+    return os << EFeatureQuality_enumToString(p);
+}
+
+std::istream& operator>>(std::istream& in, EFeatureQuality& p)
+{
+    std::string token;
+    in >> token;
+    p = EFeatureQuality_stringToEnum(token);
+    return in;
+}
+
+
+EFeatureConstrastFiltering EFeatureConstrastFiltering_stringToEnum(const std::string& v)
+{
+    std::string value = v;
+    std::transform(value.begin(), value.end(), value.begin(), ::tolower); // tolower
+
+    if(value == "static")
+        return EFeatureConstrastFiltering::Static;
+    if(value == "adaptivetomedianvariance")
+        return EFeatureConstrastFiltering::AdaptiveToMedianVariance;
+    if(value == "nofiltering")
+        return EFeatureConstrastFiltering::NoFiltering;
+    if(value == "gridsortoctaves")
+        return EFeatureConstrastFiltering::GridSortOctaves;
+    if(value == "gridsort")
+        return EFeatureConstrastFiltering::GridSort;
+    if(value == "gridsortscalesteps")
+        return EFeatureConstrastFiltering::GridSortScaleSteps;
+    if(value == "gridsortoctavesteps")
+        return EFeatureConstrastFiltering::GridSortOctaveSteps;
+    throw std::invalid_argument("Invalid EFeatureConstrastFiltering: " + v);
+}
+
+std::string EFeatureConstrastFiltering_enumToString(const EFeatureConstrastFiltering v)
+{
+    switch(v)
+    {
+        case EFeatureConstrastFiltering::Static:
+            return "Static";
+        case EFeatureConstrastFiltering::AdaptiveToMedianVariance:
+            return "AdaptiveToMedianVariance";
+        case EFeatureConstrastFiltering::NoFiltering:
+            return "NoFiltering";
+        case EFeatureConstrastFiltering::GridSortOctaves:
+            return "GridSortOctaves";
+        case EFeatureConstrastFiltering::GridSort:
+            return "GridSort";
+        case EFeatureConstrastFiltering::GridSortScaleSteps:
+            return "GridSortScaleSteps";
+        case EFeatureConstrastFiltering::GridSortOctaveSteps:
+            return "GridSortOctaveSteps";
+    }
+    throw std::invalid_argument("Unrecognized EFeatureConstrastFiltering: " + std::to_string(int(v)));
+}
+
+std::ostream& operator<<(std::ostream& os, EFeatureConstrastFiltering p)
+{
+    return os << EFeatureConstrastFiltering_enumToString(p);
+}
+
+std::istream& operator>>(std::istream& in, EFeatureConstrastFiltering& p)
+{
+    std::string token;
+    in >> token;
+    p = EFeatureConstrastFiltering_stringToEnum(token);
+    return in;
 }
 
 void ImageDescriber::Save(const Regions* regions, const std::string& sfileNameFeats, const std::string& sfileNameDescs) const

--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/config.hpp>
 #include <aliceVision/feature/sift/ImageDescriber_SIFT.hpp>
 #include <aliceVision/feature/sift/ImageDescriber_SIFT_vlfeatFloat.hpp>
+#include <aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.hpp>
 #include <aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp>
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
@@ -205,6 +206,9 @@ std::unique_ptr<ImageDescriber> createImageDescriber(EImageDescriberType imageDe
     case EImageDescriberType::SIFT:           describerPtr.reset(new ImageDescriber_SIFT(SiftParams(), true)); break;
     case EImageDescriberType::SIFT_FLOAT:     describerPtr.reset(new ImageDescriber_SIFT_vlfeatFloat(SiftParams())); break;
     case EImageDescriberType::SIFT_UPRIGHT:   describerPtr.reset(new ImageDescriber_SIFT(SiftParams(), false)); break;
+
+    case EImageDescriberType::DSPSIFT:        describerPtr.reset(new ImageDescriber_DSPSIFT_vlfeat(DspSiftParams(), true)); break;
+
     case EImageDescriberType::AKAZE:          describerPtr.reset(new ImageDescriber_AKAZE(AKAZEParams(AKAZEOptions(), feature::AKAZE_MSURF))); break;
     case EImageDescriberType::AKAZE_MLDB:     describerPtr.reset(new ImageDescriber_AKAZE(AKAZEParams(AKAZEOptions(), feature::AKAZE_MLDB))); break;
     case EImageDescriberType::AKAZE_LIOP:     describerPtr.reset(new ImageDescriber_AKAZE(AKAZEParams(AKAZEOptions(), feature::AKAZE_LIOP))); break;

--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -140,6 +140,8 @@ EFeatureConstrastFiltering EFeatureConstrastFiltering_stringToEnum(const std::st
         return EFeatureConstrastFiltering::GridSortScaleSteps;
     if(value == "gridsortoctavesteps")
         return EFeatureConstrastFiltering::GridSortOctaveSteps;
+    if(value == "nonextremafiltering")
+        return EFeatureConstrastFiltering::NonExtremaFiltering;
     throw std::invalid_argument("Invalid EFeatureConstrastFiltering: " + v);
 }
 
@@ -161,6 +163,8 @@ std::string EFeatureConstrastFiltering_enumToString(const EFeatureConstrastFilte
             return "GridSortScaleSteps";
         case EFeatureConstrastFiltering::GridSortOctaveSteps:
             return "GridSortOctaveSteps";
+        case EFeatureConstrastFiltering::NonExtremaFiltering:
+            return "NonExtremaFiltering";
     }
     throw std::invalid_argument("Unrecognized EFeatureConstrastFiltering: " + std::to_string(int(v)));
 }

--- a/src/aliceVision/feature/ImageDescriber.hpp
+++ b/src/aliceVision/feature/ImageDescriber.hpp
@@ -60,12 +60,12 @@ enum class EFeatureQuality
 
 inline std::string EFeatureQuality_information()
 {
-    return "Feature extraction contains a compromize between speed and precision:\n"
+    return "Feature extraction contains a trade-off between speed and result accuracy:\n"
            "* LOW: Very quick results.\n"
            "* MEDIUM: Quick results.\n"
            "* NORMAL: Default feature quality.\n"
            "* HIGH: Improved quality over performances.\n"
-           "* ULTRA: Perfect quality at the expense of high computational cost.\n";
+           "* ULTRA: Highest quality at the expense of high computational cost.\n";
 }
 
 EFeatureQuality EFeatureQuality_stringToEnum(const std::string& v);
@@ -79,13 +79,21 @@ std::istream& operator>>(std::istream& in, EFeatureQuality& v);
  */
 enum class EFeatureConstrastFiltering
 {
+    /// Use a fixed threshold for all the pixels
     Static = 0,
+    /// Use a threshold for each image based on image statistics
     AdaptiveToMedianVariance,
+    /// Disable contrast filtering
     NoFiltering,
+    /// Grid sort by peak value per octave and by scale at the end
     GridSortOctaves,
+    /// Grid sort by scale*peakValue per octave and at the end
     GridSort,
+    /// Grid sort per scale steps and at the end (scale and then peak value)
     GridSortScaleSteps,
+    /// Grid sort per octaves and at the end (scale and then peak value)
     GridSortOctaveSteps,
+    /// Filter non-extrema peak values
     NonExtremaFiltering
 };
 
@@ -94,7 +102,12 @@ inline std::string EFeatureConstrastFiltering_information()
     return "Contrast filtering method to ignore features with too low contrast that can be consided as noise:\n"
            "* Static: Fixed threshold.\n"
            "* AdaptiveToMedianVariance: Based on image content analysis.\n"
-           "* NoFiltering: Disable contrast filtering.\n";
+           "* NoFiltering: Disable contrast filtering.\n"
+           "* GridSortOctaves: Grid sort by peak value per octave and by scale at the end.\n"
+           "* GridSort: Grid sort by scale*peakValue per octave and at the end.\n"
+           "* GridSortScaleSteps: Grid sort per scale steps and at the end (scale and then peak value).\n"
+           "* GridSortOctaveSteps: Grid sort per octaves and at the end (scale and then peak value).\n"
+           "* NonExtremaFiltering: Filter non-extrema peak values.\n";
 }
 
 EFeatureConstrastFiltering EFeatureConstrastFiltering_stringToEnum(const std::string& v);
@@ -105,12 +118,12 @@ std::istream& operator>>(std::istream& in, EFeatureConstrastFiltering& v);
 
 struct ConfigurationPreset
 {
-    EImageDescriberPreset descPreset = EImageDescriberPreset::NORMAL;
-    int maxNbFeatures = 0;
-    EFeatureQuality quality = EFeatureQuality::NORMAL;
-    bool gridFiltering = true;
-    EFeatureConstrastFiltering contrastFiltering = EFeatureConstrastFiltering::Static;
-    float relativePeakThreshold = 0.02;
+    EImageDescriberPreset descPreset{EImageDescriberPreset::NORMAL};
+    int maxNbFeatures{0};
+    EFeatureQuality quality{EFeatureQuality::NORMAL};
+    bool gridFiltering{true};
+    EFeatureConstrastFiltering contrastFiltering{EFeatureConstrastFiltering::Static};
+    float relativePeakThreshold{0.02};
 
     inline ConfigurationPreset& setDescPreset(EImageDescriberPreset v)
     {

--- a/src/aliceVision/feature/ImageDescriber.hpp
+++ b/src/aliceVision/feature/ImageDescriber.hpp
@@ -85,7 +85,8 @@ enum class EFeatureConstrastFiltering
     GridSortOctaves,
     GridSort,
     GridSortScaleSteps,
-    GridSortOctaveSteps
+    GridSortOctaveSteps,
+    NonExtremaFiltering
 };
 
 inline std::string EFeatureConstrastFiltering_information()
@@ -105,6 +106,7 @@ std::istream& operator>>(std::istream& in, EFeatureConstrastFiltering& v);
 struct ConfigurationPreset
 {
     EImageDescriberPreset descPreset = EImageDescriberPreset::NORMAL;
+    int maxNbFeatures = 0;
     EFeatureQuality quality = EFeatureQuality::NORMAL;
     bool gridFiltering = true;
     EFeatureConstrastFiltering contrastFiltering = EFeatureConstrastFiltering::Static;

--- a/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp
+++ b/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp
@@ -114,9 +114,9 @@ public:
    * @brief Use a preset to control the number of detected regions
    * @param[in] preset The preset configuration
    */
-  void setConfigurationPreset(EImageDescriberPreset preset) override
+  void setConfigurationPreset(ConfigurationPreset preset) override
   {
-    switch(preset)
+    switch(preset.descPreset)
     {
       case EImageDescriberPreset::LOW:
       {
@@ -148,6 +148,11 @@ public:
       }
       default:
         throw std::out_of_range("Invalid image describer preset enum");
+    }
+    if(!preset.gridFiltering)
+    {
+        // disable grid filtering
+        _params.options.maxTotalKeypoints = 0;
     }
   }
 

--- a/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp
+++ b/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp
@@ -120,17 +120,17 @@ public:
     {
       case EImageDescriberPreset::LOW:
       {
-         _params.options.maxTotalKeypoints = 1000;
+         _params.options.maxTotalKeypoints = 5000;
          break;
       }
       case EImageDescriberPreset::MEDIUM:
       {
-         _params.options.maxTotalKeypoints = 5000;
+         _params.options.maxTotalKeypoints = 10000;
          break;
       }
       case EImageDescriberPreset::NORMAL:
       {
-         _params.options.maxTotalKeypoints = 10000;
+         _params.options.maxTotalKeypoints = 20000;
          _params.options.threshold = AKAZEOptions().threshold;
         break;
       }

--- a/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
+++ b/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.cpp
@@ -67,9 +67,9 @@ void ImageDescriber_CCTAG::allocate(std::unique_ptr<Regions> &regions) const
   regions.reset( new CCTAG_Regions );
 }
 
-void ImageDescriber_CCTAG::setConfigurationPreset(EImageDescriberPreset preset)
+void ImageDescriber_CCTAG::setConfigurationPreset(ConfigurationPreset preset)
 {
-  _params.setPreset(preset);
+  _params.setPreset(preset.descPreset);
 }
 
 EImageDescriberType ImageDescriber_CCTAG::getDescriberType() const

--- a/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.hpp
+++ b/src/aliceVision/feature/cctag/ImageDescriber_CCTAG.hpp
@@ -85,7 +85,7 @@ public:
    * @param[in] preset The preset configuration
    * @return True if configuration succeed. (here always false)
    */
-  void setConfigurationPreset(EImageDescriberPreset preset) override;
+  void setConfigurationPreset(ConfigurationPreset preset) override;
 
   /**
    * @brief Detect regions on the 8-bit image and compute their attributes (description)

--- a/src/aliceVision/feature/imageDescriberCommon.cpp
+++ b/src/aliceVision/feature/imageDescriberCommon.cpp
@@ -45,6 +45,9 @@ std::string EImageDescriberType_enumToString(EImageDescriberType imageDescriberT
     case EImageDescriberType::SIFT:          return "sift";
     case EImageDescriberType::SIFT_FLOAT:    return "sift_float";
     case EImageDescriberType::SIFT_UPRIGHT:  return "sift_upright";
+
+    case EImageDescriberType::DSPSIFT:       return "dspsift";
+
     case EImageDescriberType::AKAZE:         return "akaze";
     case EImageDescriberType::AKAZE_LIOP:    return "akaze_liop";
     case EImageDescriberType::AKAZE_MLDB:    return "akaze_mldb";
@@ -64,7 +67,7 @@ std::string EImageDescriberType_enumToString(EImageDescriberType imageDescriberT
     case EImageDescriberType::UNKNOWN:       return "unknown";
     case EImageDescriberType::UNINITIALIZED: break; // Should throw an error.
   }
-  throw std::out_of_range("Invalid imageDescriber enum");
+  throw std::out_of_range("Invalid imageDescriber enum: " + std::to_string(int(imageDescriberType)));
 }
 
 EImageDescriberType EImageDescriberType_stringToEnum(const std::string& imageDescriberType)
@@ -75,6 +78,9 @@ EImageDescriberType EImageDescriberType_stringToEnum(const std::string& imageDes
   if(type == "sift")          return EImageDescriberType::SIFT;
   if(type == "sift_float")    return EImageDescriberType::SIFT_FLOAT;
   if(type == "sift_upright")  return EImageDescriberType::SIFT_UPRIGHT;
+
+  if(type == "dspsift")       return EImageDescriberType::DSPSIFT;
+
   if(type == "akaze")         return EImageDescriberType::AKAZE;
   if(type == "akaze_liop")    return EImageDescriberType::AKAZE_LIOP;
   if(type == "akaze_mldb")    return EImageDescriberType::AKAZE_MLDB;

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -23,7 +23,6 @@ enum class EImageDescriberType: unsigned char
   , SIFT = 10
   , SIFT_FLOAT = 11
   , SIFT_UPRIGHT = 12
-
   , DSPSIFT = 13
 
   , AKAZE = 20

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -23,6 +23,9 @@ enum class EImageDescriberType: unsigned char
   , SIFT = 10
   , SIFT_FLOAT = 11
   , SIFT_UPRIGHT = 12
+
+  , DSPSIFT = 13
+
   , AKAZE = 20
   , AKAZE_LIOP = 21
   , AKAZE_MLDB = 22
@@ -85,16 +88,19 @@ inline float getStrongSupportCoeff(EImageDescriberType imageDescriberType)
 {
   switch(imageDescriberType)
   {
-    case EImageDescriberType::SIFT:          return 0.14f;
-    case EImageDescriberType::SIFT_FLOAT:    return 0.14f;
-    case EImageDescriberType::SIFT_UPRIGHT:  return 0.14f;
-    case EImageDescriberType::AKAZE:         return 0.14f;
-    case EImageDescriberType::AKAZE_LIOP:    return 0.14f;
-    case EImageDescriberType::AKAZE_MLDB:    return 0.14f;
+    case EImageDescriberType::SIFT:
+    case EImageDescriberType::SIFT_FLOAT:
+    case EImageDescriberType::SIFT_UPRIGHT:
+    case EImageDescriberType::DSPSIFT:
+    case EImageDescriberType::AKAZE:
+    case EImageDescriberType::AKAZE_LIOP:
+    case EImageDescriberType::AKAZE_MLDB:
+        return 0.14f;
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
-    case EImageDescriberType::CCTAG3:        return 1.0f;
-    case EImageDescriberType::CCTAG4:        return 1.0f;
+    case EImageDescriberType::CCTAG3:
+    case EImageDescriberType::CCTAG4:
+        return 1.0f;
 #endif
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
@@ -104,7 +110,8 @@ inline float getStrongSupportCoeff(EImageDescriberType imageDescriberType)
     case EImageDescriberType::AKAZE_OCV:     return 0.14f;
 #endif //ALICEVISION_HAVE_OPENCV
 
-    case EImageDescriberType::UNKNOWN:       return 1.0f;
+    case EImageDescriberType::UNKNOWN:
+        return 1.0f;
     case EImageDescriberType::UNINITIALIZED: break; // Should throw an error.
   }
   throw std::out_of_range("Invalid imageDescriber enum");

--- a/src/aliceVision/feature/imageStats.cpp
+++ b/src/aliceVision/feature/imageStats.cpp
@@ -1,0 +1,82 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// Copyright (c) 2012 openMVG contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "imageStats.hpp"
+
+#include <aliceVision/image/all.hpp>
+
+namespace aliceVision {
+namespace feature {
+
+float computeAutomaticContrastFactor(const image::Image<float>& image, const float percentile)
+{
+    const size_t nbBins = 300;
+    const int height = image.Height();
+    const int width = image.Width();
+
+    // smooth the image
+    image::Image<float> smoothed;
+    image::ImageGaussianFilter(image, 1.f, smoothed, 0, 0);
+
+    // compute gradient
+    image::Image<float> Lx, Ly;
+    image::ImageScharrXDerivative(smoothed, Lx, false);
+    image::ImageScharrYDerivative(smoothed, Ly, false);
+
+    // reuse smoothed to avoid new allocation
+    image::Image<float>& grad = smoothed;
+    // grad = sqrt(Lx^2 + Ly^2)
+    grad.array() = (Lx.array().square() + Ly.array().square()).sqrt();
+
+    const float gradMax = grad.maxCoeff();
+
+    // compute histogram
+    std::vector<std::size_t> histo(nbBins, 0);
+
+    int nbValues = 0;
+
+    for(int i = 1; i < height - 1; ++i)
+    {
+        for(int j = 1; j < width - 1; ++j)
+        {
+            const float val = grad(i, j);
+
+            if(val > 0)
+            {
+                int binId = floor((val / gradMax) * static_cast<float>(nbBins));
+
+                // handle overflow (need to do it in a cleaner way)
+                if(binId == nbBins)
+                    --binId;
+
+                // accumulate
+                ++histo[binId];
+                ++nbValues;
+            }
+        }
+    }
+
+    const std::size_t searchId = percentile * static_cast<float>(nbValues);
+
+    int binId = 0;
+    std::size_t acc = 0;
+
+    while(acc < searchId && binId < nbBins)
+    {
+        acc += histo[binId];
+        ++binId;
+    }
+
+    // handle 0 bin search
+    if(acc < searchId)
+        return 0.03f; // only empiric value
+
+    return gradMax * static_cast<float>(binId) / static_cast<float>(nbBins);
+}
+
+}  // namespace feature
+}  // namespace aliceVision

--- a/src/aliceVision/feature/imageStats.hpp
+++ b/src/aliceVision/feature/imageStats.hpp
@@ -1,0 +1,89 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// Copyright (c) 2012 openMVG contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/image/all.hpp>
+
+
+namespace aliceVision {
+namespace feature {
+
+/**
+ * @brief Compute Contrast Factor
+ * @param[in] image Input image for the given octave
+ * @param[in] percentile
+ * @return contrastFactor
+ */
+inline float computeAutomaticContrastFactor(const image::Image<float>& image, const float percentile)
+{
+    const size_t nbBins = 300;
+    const int height = image.Height();
+    const int width = image.Width();
+
+    // smooth the image
+    image::Image<float> smoothed;
+    image::ImageGaussianFilter(image, 1.f, smoothed, 0, 0);
+
+    // compute gradient
+    image::Image<float> Lx, Ly;
+    image::ImageScharrXDerivative(smoothed, Lx, false);
+    image::ImageScharrYDerivative(smoothed, Ly, false);
+
+    // reuse smoothed to avoid new allocation
+    image::Image<float>& grad = smoothed;
+    // grad = sqrt(Lx^2 + Ly^2)
+    grad.array() = (Lx.array().square() + Ly.array().square()).sqrt();
+
+    const float gradMax = grad.maxCoeff();
+
+    // compute histogram
+    std::vector<std::size_t> histo(nbBins, 0);
+
+    int nbValues = 0;
+
+    for(int i = 1; i < height - 1; ++i)
+    {
+        for(int j = 1; j < width - 1; ++j)
+        {
+            const float val = grad(i, j);
+
+            if(val > 0)
+            {
+                int binId = floor((val / gradMax) * static_cast<float>(nbBins));
+
+                // handle overflow (need to do it in a cleaner way)
+                if(binId == nbBins)
+                    --binId;
+
+                // accumulate
+                ++histo[binId];
+                ++nbValues;
+            }
+        }
+    }
+
+    const std::size_t searchId = percentile * static_cast<float>(nbValues);
+
+    int binId = 0;
+    std::size_t acc = 0;
+
+    while(acc < searchId && binId < nbBins)
+    {
+        acc += histo[binId];
+        ++binId;
+    }
+
+    // handle 0 bin search
+    if(acc < searchId)
+        return 0.03f; // only empiric value
+
+    return gradMax * static_cast<float>(binId) / static_cast<float>(nbBins);
+}
+
+}  // namespace feature
+}  // namespace aliceVision

--- a/src/aliceVision/feature/imageStats.hpp
+++ b/src/aliceVision/feature/imageStats.hpp
@@ -7,83 +7,20 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 
 namespace aliceVision {
 namespace feature {
 
 /**
- * @brief Compute Contrast Factor
+ * @brief Estimate a contrast factor using the percentile of the image gradients.
+ *
  * @param[in] image Input image for the given octave
  * @param[in] percentile
  * @return contrastFactor
  */
-inline float computeAutomaticContrastFactor(const image::Image<float>& image, const float percentile)
-{
-    const size_t nbBins = 300;
-    const int height = image.Height();
-    const int width = image.Width();
-
-    // smooth the image
-    image::Image<float> smoothed;
-    image::ImageGaussianFilter(image, 1.f, smoothed, 0, 0);
-
-    // compute gradient
-    image::Image<float> Lx, Ly;
-    image::ImageScharrXDerivative(smoothed, Lx, false);
-    image::ImageScharrYDerivative(smoothed, Ly, false);
-
-    // reuse smoothed to avoid new allocation
-    image::Image<float>& grad = smoothed;
-    // grad = sqrt(Lx^2 + Ly^2)
-    grad.array() = (Lx.array().square() + Ly.array().square()).sqrt();
-
-    const float gradMax = grad.maxCoeff();
-
-    // compute histogram
-    std::vector<std::size_t> histo(nbBins, 0);
-
-    int nbValues = 0;
-
-    for(int i = 1; i < height - 1; ++i)
-    {
-        for(int j = 1; j < width - 1; ++j)
-        {
-            const float val = grad(i, j);
-
-            if(val > 0)
-            {
-                int binId = floor((val / gradMax) * static_cast<float>(nbBins));
-
-                // handle overflow (need to do it in a cleaner way)
-                if(binId == nbBins)
-                    --binId;
-
-                // accumulate
-                ++histo[binId];
-                ++nbValues;
-            }
-        }
-    }
-
-    const std::size_t searchId = percentile * static_cast<float>(nbValues);
-
-    int binId = 0;
-    std::size_t acc = 0;
-
-    while(acc < searchId && binId < nbBins)
-    {
-        acc += histo[binId];
-        ++binId;
-    }
-
-    // handle 0 bin search
-    if(acc < searchId)
-        return 0.03f; // only empiric value
-
-    return gradMax * static_cast<float>(binId) / static_cast<float>(nbBins);
-}
+float computeAutomaticContrastFactor(const image::Image<float>& image, const float percentile);
 
 }  // namespace feature
 }  // namespace aliceVision

--- a/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.hpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.hpp
@@ -78,7 +78,7 @@ public:
    * @param[in] preset The preset configuration
    * @return True if configuration succeed. (here always false)
    */
-  void setConfigurationPreset(EImageDescriberPreset preset) override
+  void setConfigurationPreset(ConfigurationPreset preset) override
   {
     ALICEVISION_LOG_DEBUG("Image describer preset ignored for AKAZE_OCV.");
   }

--- a/src/aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.cpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.cpp
@@ -1,0 +1,393 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2020 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ImageDescriber_DSPSIFT_vlfeat.hpp"
+
+#include <aliceVision/feature/Descriptor.hpp>
+#include <aliceVision/feature/ImageDescriber.hpp>
+#include <aliceVision/feature/regionsFactory.hpp>
+#include <aliceVision/feature/sift/SIFT.hpp>
+
+extern "C" {
+#include <nonFree/sift/vl/covdet.h>
+#include <nonFree/sift/vl/sift.h>
+}
+
+#include <iostream>
+#include <numeric>
+
+namespace aliceVision {
+namespace feature {
+
+
+void DspSiftParams::setPreset(ConfigurationPreset preset)
+{
+    SiftParams::setPreset(preset);
+
+    domainSizePooling = true;
+    estimateAffineShape = false;
+
+    // Parameters selection in the original paper:
+    // "Improvements are observed as soon as more than one scale is used,
+    // with diminishing return: Performance decreases with domain size pooling radius exceeding sigma/2.
+    // Although the more samples the merrier, three size samples are sufficient to outperform ordinary SIFT,
+    // and improvement beyond 10 samples is minimal. Additional samples do not further increase the mean average
+    // precision, but incur more computational cost."
+    switch(preset.quality)
+    {
+        case EFeatureQuality::LOW:
+        {
+            domainSizePooling = false;
+            dspNumScales = 1;
+            break;
+        }
+        case EFeatureQuality::MEDIUM:
+        {
+            dspNumScales = 3;
+            break;
+        }
+        case EFeatureQuality::NORMAL:
+        {
+            dspNumScales = 6;
+            break;
+        }
+        case EFeatureQuality::HIGH:
+        {
+            dspNumScales = 9;
+            break;
+        }
+        case EFeatureQuality::ULTRA:
+        {
+            dspNumScales = 10;
+            break;
+        }
+    }
+}
+
+template <typename T>
+bool extractDSPSIFT(const image::Image<float>& image, std::unique_ptr<Regions>& regions, const DspSiftParams& params,
+                    bool orientation, const image::Image<unsigned char>* mask)
+{
+    // Setup covariant SIFT detector.
+    std::unique_ptr<VlCovDet, void (*)(VlCovDet*)> covdet(vl_covdet_new(VL_COVDET_METHOD_DOG), &vl_covdet_delete);
+    
+    // keep numOctaves=auto (-1)
+    vl_covdet_set_first_octave(covdet.get(), params._firstOctave);
+    vl_covdet_set_octave_resolution(covdet.get(), params._numScales);
+    vl_covdet_set_edge_threshold(covdet.get(), params._edgeThreshold);
+    // vl_covdet_set_non_extrema_suppression_threshold(covdet.get(), 0.0f); // vl_covdet default is 0.5
+
+    switch(params._contrastFiltering)
+    {
+        case EFeatureConstrastFiltering::Static:
+        {
+            ALICEVISION_LOG_TRACE("SIFT constrastTreshold Static: " << params._peakThreshold);
+            if(params._peakThreshold >= 0)
+            {
+                vl_covdet_set_peak_threshold(covdet.get(), params._peakThreshold / params._numScales);
+            }
+            break;
+        }
+        case EFeatureConstrastFiltering::AdaptiveToMedianVariance:
+        {
+            const float medianOfGradiants = computeAutomaticContrastFactor(image, 0.5);
+            const float relativePeakThreshold = 0.02f;
+            const float dynPeakTreshold = relativePeakThreshold * medianOfGradiants;
+            ALICEVISION_LOG_TRACE("SIFT relativePeakThreshold * medianOfGradiants: \n"
+                                  << " - relativePeakThreshold: " << relativePeakThreshold << "\n"
+                                  << " - medianOfGradiants: " << medianOfGradiants << "\n"
+                                  << " - peakTreshold: " << dynPeakTreshold);
+            vl_covdet_set_peak_threshold(covdet.get(), dynPeakTreshold / params._numScales);
+            break;
+        }
+        case EFeatureConstrastFiltering::NoFiltering:
+        {
+            vl_covdet_set_peak_threshold(covdet.get(), 0.0);
+            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold NoFiltering.");
+            break;
+        }
+        case EFeatureConstrastFiltering::GridSortOctaves:
+        {
+            vl_covdet_set_peak_threshold(covdet.get(), 0.0);
+            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold GridSortOctaves.");
+            break;
+        }
+        case EFeatureConstrastFiltering::GridSort:
+        {
+            vl_covdet_set_peak_threshold(covdet.get(), 0.0);
+            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold GridSort.");
+            break;
+        }
+        case EFeatureConstrastFiltering::NonExtremaFiltering:
+        {
+            vl_covdet_set_peak_threshold(covdet.get(), 0.0);
+            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold NonExtremaFiltering.");
+            break;
+        }
+    }
+
+    vl_covdet_put_image(covdet.get(), image.data(), image.Width(), image.Height());
+
+    vl_covdet_detect(covdet.get());
+
+    const double kBoundaryMargin = 2.0;
+    vl_covdet_drop_features_outside(covdet.get(), kBoundaryMargin);
+
+    if(orientation)
+    {
+        VlCovDetBuffer internalBuffer;
+        vl_covdetbuffer_init(&internalBuffer);
+        if(params.estimateAffineShape)
+        {
+            vl_covdet_extract_affine_shape(covdet.get(), &internalBuffer);
+        }
+
+        vl_covdet_extract_orientations(covdet.get(), &internalBuffer);
+
+        vl_covdetbuffer_clear(&internalBuffer);
+    }
+
+    VlCovDet const* plopD = covdet.get();
+
+    int nbFeatures = vl_covdet_get_num_features(covdet.get());
+    VlCovDetFeature* features = vl_covdet_get_features(covdet.get());
+
+    using SIFT_Region_T = ScalarRegions<T, 128>;
+    SIFT_Region_T* regionsCasted = new SIFT_Region_T();
+    regions.reset(regionsCasted);
+
+    // Build alias to cached data
+    // reserve some memory for faster keypoint saving
+    const std::size_t reserveSize = (params._gridSize && params._maxTotalKeypoints) ? params._maxTotalKeypoints : nbFeatures;
+    regionsCasted->Features().reserve(reserveSize);
+
+    std::vector<float> featuresPeakValue(nbFeatures, 0.0f);
+
+    std::vector<IndexT> indexSort(nbFeatures);
+    // Sorting the extracted features according to their scale
+    {
+        std::iota(indexSort.begin(), indexSort.end(), 0);
+        if(params._contrastFiltering == EFeatureConstrastFiltering::GridSortScaleSteps)
+        {
+            std::sort(indexSort.begin(), indexSort.end(), [&](std::size_t a, std::size_t b) {
+                const int scaleA = int(log2(features[a].sigma) * 3.0f); // 3 scale steps per octave
+                const int scaleB = int(log2(features[b].sigma) * 3.0f);
+                if(scaleA == scaleB)
+                {
+                    return features[a].peakScore > features[b].peakScore;
+                }
+                return scaleA > scaleB;
+            });
+        }
+        else if(params._contrastFiltering == EFeatureConstrastFiltering::GridSortOctaveSteps)
+        {
+            std::sort(indexSort.begin(), indexSort.end(), [&](std::size_t a, std::size_t b) {
+                const int scaleA = int(log2(features[a].sigma)); // 3 scale steps per octave
+                const int scaleB = int(log2(features[b].sigma));
+                if(scaleA == scaleB)
+                {
+                    return features[a].peakScore > features[b].peakScore;
+                }
+                return scaleA > scaleB;
+            });
+        }
+        else if(params._contrastFiltering == EFeatureConstrastFiltering::GridSort)
+        {
+            std::sort(indexSort.begin(), indexSort.end(), [&](std::size_t a, std::size_t b) {
+                return features[a].sigma * features[a].peakScore > features[b].sigma * features[b].peakScore;
+            });
+        }
+        else
+        {
+            // sort from largest scales to smallest ones
+            std::sort(indexSort.begin(), indexSort.end(),
+                      [&](std::size_t a, std::size_t b) { return features[a].sigma > features[b].sigma; });
+        }
+    }
+
+    if(params._maxTotalKeypoints && params._contrastFiltering == EFeatureConstrastFiltering::NonExtremaFiltering)
+    {
+        // Only filter features if we have more features than the maxTotalKeypoints
+        if(indexSort.size() > params._maxTotalKeypoints)
+        {
+            std::vector<float> radiusMaxima(indexSort.size(), std::numeric_limits<float>::max());
+            for(IndexT ii = 0; ii < indexSort.size(); ++ii)
+            {
+                const IndexT i = indexSort[ii];
+                const auto& keypointI = features[i];
+                for(IndexT jj = 0; jj < indexSort.size(); ++jj)
+                {
+                    const IndexT j = indexSort[jj];
+                    const auto& keypointJ = features[j];
+                    if(featuresPeakValue[j] > featuresPeakValue[i])
+                    {
+                        const float dx = (keypointJ.frame.x - keypointI.frame.x);
+                        const float dy = (keypointJ.frame.y - keypointI.frame.y);
+                        const float radius = dx * dx + dy * dy;
+                        if(radius < radiusMaxima[i])
+                            radiusMaxima[i] = radius;
+                    }
+                }
+            }
+
+            std::size_t maxNbKeypoints = std::min(params._maxTotalKeypoints, indexSort.size());
+            std::partial_sort(indexSort.begin(), indexSort.begin() + maxNbKeypoints,
+                              indexSort.end(),
+                              [&](int a, int b) { return radiusMaxima[a] > radiusMaxima[b]; });
+            indexSort.resize(maxNbKeypoints);
+
+            ALICEVISION_LOG_TRACE(
+                "DSPSIFT Features: before: " << nbFeatures
+                << ", after grid filtering: " << indexSort.size());
+        }
+    }
+    // Grid filtering of the keypoints to ensure a global repartition
+    else if(params._gridSize && params._maxTotalKeypoints && (params._contrastFiltering != EFeatureConstrastFiltering::Static))
+    {
+        // Only filter features if we have more features than the maxTotalKeypoints
+        if(nbFeatures > params._maxTotalKeypoints)
+        {
+            std::vector<IndexT> filteredIndexes;
+            std::vector<IndexT> rejectedIndexes;
+            filteredIndexes.reserve(std::min(std::size_t(nbFeatures), params._maxTotalKeypoints));
+            rejectedIndexes.reserve(nbFeatures);
+
+            const std::size_t sizeMat = params._gridSize * params._gridSize;
+            std::vector<std::size_t> countFeatPerCell(sizeMat, 0);
+            const std::size_t keypointsPerCell = params._maxTotalKeypoints / sizeMat;
+            const double regionWidth = image.Width() / double(params._gridSize);
+            const double regionHeight = image.Height() / double(params._gridSize);
+
+            for(IndexT ii = 0; ii < indexSort.size(); ++ii)
+            {
+                const IndexT i = indexSort[ii];
+                const auto& keypoint = features[i];
+
+                const std::size_t cellX = std::min(std::size_t(keypoint.frame.x / regionWidth), params._gridSize);
+                const std::size_t cellY = std::min(std::size_t(keypoint.frame.y / regionHeight), params._gridSize);
+
+                std::size_t& count = countFeatPerCell[cellX * params._gridSize + cellY];
+                ++count;
+
+                if(count < keypointsPerCell)
+                    filteredIndexes.push_back(i);
+                else
+                    rejectedIndexes.push_back(i);
+            }
+            // If we do not have enough features (less than maxTotalKeypoints) after the grid filtering (empty regions in
+            // the grid for example). We add the best other ones, without repartition constraint.
+            if(filteredIndexes.size() < params._maxTotalKeypoints)
+            {
+                const std::size_t remainingElements =
+                    std::min(rejectedIndexes.size(), params._maxTotalKeypoints - filteredIndexes.size());
+                ALICEVISION_LOG_TRACE("Grid filtering -- Copy remaining points: " << remainingElements);
+                filteredIndexes.insert(filteredIndexes.end(), rejectedIndexes.begin(),
+                                        rejectedIndexes.begin() + remainingElements);
+            }
+            indexSort.swap(filteredIndexes);
+            ALICEVISION_LOG_TRACE("SIFT Features: before: " << nbFeatures
+                                                            << ", after grid filtering: " << filteredIndexes.size());
+        }
+    }
+    else if(params._maxTotalKeypoints)
+    {
+        // Retrieve extracted features
+        if(indexSort.size() > params._maxTotalKeypoints)
+            indexSort.resize(params._maxTotalKeypoints);
+    }
+
+    // Compute the descriptors for the detected keypoints.
+    {
+        regionsCasted->Features().resize(indexSort.size());
+        regionsCasted->Descriptors().resize(indexSort.size());
+
+        std::unique_ptr<VlSiftFilt, void (*)(VlSiftFilt*)> sift(vl_sift_new(16, 16, 1, params._numScales, 0),
+                                                                &vl_sift_delete);
+
+        // All constant parameters
+        const size_t kPatchResolution = 15;
+        const size_t kPatchSide = 2 * kPatchResolution + 1;
+        const double kPatchRelativeExtent = 7.5;
+        const double kPatchRelativeSmoothing = 1;
+        const double kPatchStep = kPatchRelativeExtent / kPatchResolution;
+        const double kSigma = kPatchRelativeExtent / (3.0 * (4 + 1) / 2) / kPatchStep;
+        // DSP parameters
+        float dspMinScale = 1;
+        float dspScaleStep = 0;
+        int dspNumScales = 1;
+        if(params.domainSizePooling)
+        {
+            dspMinScale = params.dspMinScale;
+            dspScaleStep = (params.dspMaxScale - params.dspMinScale) / params.dspNumScales;
+            dspNumScales = params.dspNumScales;
+        }
+
+#pragma omp parallel
+        {
+            VlCovDetBuffer internalBuffer;
+            vl_covdetbuffer_init(&internalBuffer);
+            Eigen::Matrix<float, Eigen::Dynamic, 128, Eigen::RowMajor> descriptorsOverDspScales(dspNumScales, 128);
+            std::vector<float> patch(kPatchSide * kPatchSide);
+            std::vector<float> patchXY(2 * kPatchSide * kPatchSide);
+
+#pragma omp for
+            for(int oIndex = 0; oIndex < indexSort.size(); ++oIndex)
+            {
+                const int iIndex = indexSort[oIndex];
+                const auto& inFeat = features[iIndex];
+
+                for(int s = 0; s < dspNumScales; ++s)
+                {
+                    const double dspScale = dspMinScale + s * dspScaleStep;
+
+                    VlFrameOrientedEllipse frameAtScale = inFeat.frame;
+                    frameAtScale.a11 *= dspScale;
+                    frameAtScale.a12 *= dspScale;
+                    frameAtScale.a21 *= dspScale;
+                    frameAtScale.a22 *= dspScale;
+
+                    vl_covdet_extract_patch_for_frame(covdet.get(), patch.data(), kPatchResolution, &internalBuffer,
+                                                      kPatchRelativeExtent, kPatchRelativeSmoothing, frameAtScale);
+
+                    vl_imgradient_polar_f(patchXY.data(), patchXY.data() + 1, 2, 2 * kPatchSide, patch.data(),
+                                          kPatchSide, kPatchSide, kPatchSide);
+
+                    vl_sift_calc_raw_descriptor(sift.get(), patchXY.data(), descriptorsOverDspScales.row(s).data(),
+                                                kPatchSide, kPatchSide, kPatchResolution, kPatchResolution, kSigma, /*angle0=*/0);
+                }
+
+                Eigen::Matrix<float, 1, 128> descriptor;
+                if(dspNumScales > 1)
+                {
+                    descriptor = descriptorsOverDspScales.colwise().mean();
+                }
+                else
+                {
+                    descriptor = descriptorsOverDspScales;
+                }
+
+                regionsCasted->Features()[oIndex] = PointFeature(inFeat.frame.x, inFeat.frame.y, inFeat.sigma, inFeat.orientationScore);
+                Descriptor<T, 128>& outDescriptor = regionsCasted->Descriptors()[oIndex];
+                convertSIFT<T>(descriptor.data(), outDescriptor, params._rootSift);
+            }
+
+            vl_covdetbuffer_clear(&internalBuffer);
+        }
+    }
+
+    return true;
+}
+
+template bool extractDSPSIFT<float>(const image::Image<float>& image, std::unique_ptr<Regions>& regions,
+                                    const DspSiftParams& params, bool orientation, const image::Image<unsigned char>* mask);
+
+template bool extractDSPSIFT<unsigned char>(const image::Image<float>& image, std::unique_ptr<Regions>& regions,
+                                            const DspSiftParams& params, bool orientation,
+                                            const image::Image<unsigned char>* mask);
+
+
+} // namespace feature
+} // namespace aliceVision

--- a/src/aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.cpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.cpp
@@ -104,27 +104,14 @@ bool extractDSPSIFT(const image::Image<float>& image, std::unique_ptr<Regions>& 
             break;
         }
         case EFeatureConstrastFiltering::NoFiltering:
-        {
-            vl_covdet_set_peak_threshold(covdet.get(), 0.0);
-            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold NoFiltering.");
-            break;
-        }
         case EFeatureConstrastFiltering::GridSortOctaves:
-        {
-            vl_covdet_set_peak_threshold(covdet.get(), 0.0);
-            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold GridSortOctaves.");
-            break;
-        }
+        case EFeatureConstrastFiltering::GridSortOctaveSteps:
         case EFeatureConstrastFiltering::GridSort:
-        {
-            vl_covdet_set_peak_threshold(covdet.get(), 0.0);
-            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold GridSort.");
-            break;
-        }
+        case EFeatureConstrastFiltering::GridSortScaleSteps:
         case EFeatureConstrastFiltering::NonExtremaFiltering:
         {
             vl_covdet_set_peak_threshold(covdet.get(), 0.0);
-            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold NonExtremaFiltering.");
+            ALICEVISION_LOG_TRACE("DSP-SIFT constrastTreshold: " << EFeatureConstrastFiltering_enumToString(params._contrastFiltering));
             break;
         }
     }

--- a/src/aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.hpp
@@ -1,0 +1,161 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2020 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/feature/Descriptor.hpp>
+#include <aliceVision/feature/ImageDescriber.hpp>
+#include <aliceVision/feature/regionsFactory.hpp>
+#include <aliceVision/feature/sift/SIFT.hpp>
+
+extern "C" {
+#include <nonFree/sift/vl/sift.h>
+}
+
+#include <iostream>
+#include <numeric>
+
+namespace aliceVision {
+namespace feature {
+
+struct DspSiftParams : public SiftParams
+{
+    bool domainSizePooling = true;
+    bool estimateAffineShape = false;
+    double dspMinScale = 1.0 / 6.0;
+    double dspMaxScale = 3.0;
+    int dspNumScales = 10;
+
+    void setPreset(ConfigurationPreset preset) override;
+};
+
+
+template <typename T>
+bool extractDSPSIFT(const image::Image<float>& image, std::unique_ptr<Regions>& regions, const DspSiftParams& params,
+                    bool orientation, const image::Image<unsigned char>* mask);
+
+/**
+ * @brief Create an ImageDescriber interface for VLFeat SIFT feature extractor
+ *
+ * "Domain-Size Pooling in Local Descriptors: DSP-SIFT", CVPR 2015
+ * Jingming Dong, Stefano Soatto, University of California
+ * https://www.cv-foundation.org/openaccess/content_cvpr_2015/papers/Dong_Domain-Size_Pooling_in_2015_CVPR_paper.pdf
+ *
+ * "A Theory of Local Matching: SIFT and Beyond", 2016
+ * Hossein Mobahi CSAIL MIT, Stefano Soatto, CS Dept. UCLA
+ * https://arxiv.org/pdf/1601.05116.pdf
+ *
+ * DSP-SIFT has been shown to outperform other SIFT variants and learned descriptors in
+ * "Comparative Evaluation of Hand-Crafted and Learned Local Features", CVPR 2016
+ * Schönberger, Hardmeier, Sattler, Pollefeys
+ * https://openaccess.thecvf.com/content_cvpr_2017/papers/Schonberger_Comparative_Evaluation_of_CVPR_2017_paper.pdf
+ */
+class ImageDescriber_DSPSIFT_vlfeat : public ImageDescriber
+{
+public:
+  explicit ImageDescriber_DSPSIFT_vlfeat(const DspSiftParams& params = DspSiftParams(), bool isOriented = true)
+    : ImageDescriber()
+    , _params(params)
+    , _isOriented(isOriented)
+  {
+    // Configure VLFeat
+    VLFeatInstance::initialize();
+  }
+
+  ~ImageDescriber_DSPSIFT_vlfeat() override
+  {
+    VLFeatInstance::destroy();
+  }
+
+  /**
+   * @brief Check if the image describer use CUDA
+   * @return True if the image describer use CUDA
+   */
+  bool useCuda() const override
+  {
+    return false;
+  }
+
+  /**
+   * @brief Check if the image describer use float image
+   * @return True if the image describer use float image
+   */
+  bool useFloatImage() const override
+  {
+    return true;
+  }
+
+  /**
+   * @brief Get the corresponding EImageDescriberType
+   * @return EImageDescriberType
+   */
+  EImageDescriberType getDescriberType() const override
+  {
+    return EImageDescriberType::DSPSIFT;
+  }
+
+  /**
+   * @brief Get the total amount of RAM needed for a
+   * feature extraction of an image of the given dimension.
+   * @param[in] width The image width
+   * @param[in] height The image height
+   * @return total amount of memory needed
+   */
+  std::size_t getMemoryConsumption(std::size_t width, std::size_t height) const override
+  {
+    return getMemoryConsumptionVLFeat(width, height, _params);
+  }
+
+  /**
+   * @brief Set image describer always upRight
+   * @param[in] upRight
+   */
+  void setUpRight(bool upRight) override
+  {
+    _isOriented = !upRight;
+  }
+
+  /**
+   * @brief Use a preset to control the number of detected regions
+   * @param[in] preset The preset configuration
+   */
+  void setConfigurationPreset(ConfigurationPreset preset) override
+  {
+    _params.setPreset(preset);
+  }
+
+  /**
+   * @brief Detect regions on the float image and compute their attributes (description)
+   * @param[in] image Image.
+   * @param[out] regions The detected regions and attributes (the caller must delete the allocated data)
+   * @param[in] mask 8-bit grayscale image for keypoint filtering (optional)
+   *    Non-zero values depict the region of interest.
+   * @return True if detection succed.
+   */
+  bool describe(const image::Image<float>& image,
+    std::unique_ptr<Regions>& regions,
+    const image::Image<unsigned char>* mask = nullptr) override
+  {
+    return extractDSPSIFT<unsigned char>(image, regions, _params, _isOriented, mask);
+  }
+
+
+  /**
+   * @brief Allocate Regions type depending of the ImageDescriber
+   * @param[in,out] regions
+   */
+  void allocate(std::unique_ptr<Regions>& regions) const override
+  {
+    regions.reset(new SIFT_Regions);
+  }
+
+private:
+  DspSiftParams _params;
+  bool _isOriented;
+};
+
+} // namespace feature
+} // namespace aliceVision

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT.hpp
@@ -121,7 +121,7 @@ public:
    * @brief Use a preset to control the number of detected regions
    * @param[in] preset The preset configuration
    */
-  void setConfigurationPreset(EImageDescriberPreset preset) override
+  void setConfigurationPreset(ConfigurationPreset preset) override
   {
      _params.setPreset(preset);
      _imageDescriberImpl->setConfigurationPreset(preset);

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
@@ -22,7 +22,7 @@ namespace feature {
 std::unique_ptr<PopSift> ImageDescriber_SIFT_popSIFT::_popSift = nullptr;
 std::atomic<int> ImageDescriber_SIFT_popSIFT::_instanceCounter{0};
 
-void ImageDescriber_SIFT_popSIFT::setConfigurationPreset(EImageDescriberPreset preset)
+void ImageDescriber_SIFT_popSIFT::setConfigurationPreset(ConfigurationPreset preset)
 {
     _params.setPreset(preset);
     _popSift.reset(nullptr); // reset by describe method

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
@@ -85,7 +85,6 @@ void ImageDescriber_SIFT_popSIFT::resetConfiguration()
 
   // reset configuration
   popsift::Config config;
-  config.setOctaves(_params._numOctaves);
   config.setLevels(_params._numScales);
   config.setDownsampling(_params._firstOctave);
   config.setThreshold(_params._peakThreshold);

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.cpp
@@ -19,7 +19,7 @@
 namespace aliceVision {
 namespace feature {
 
-std::unique_ptr<PopSift> ImageDescriber_SIFT_popSIFT::_popSift = nullptr;
+std::unique_ptr<PopSift> ImageDescriber_SIFT_popSIFT::_popSift{nullptr};
 std::atomic<int> ImageDescriber_SIFT_popSIFT::_instanceCounter{0};
 
 void ImageDescriber_SIFT_popSIFT::setConfigurationPreset(ConfigurationPreset preset)

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_popSIFT.hpp
@@ -83,7 +83,7 @@ public:
    * @brief Use a preset to control the number of detected regions
    * @param[in] preset The preset configuration
    */
-  void setConfigurationPreset(EImageDescriberPreset preset) override;
+  void setConfigurationPreset(ConfigurationPreset preset) override;
 
   /**
    * @brief Detect regions on the 8-bit image and compute their attributes (description)

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeat.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeat.hpp
@@ -96,7 +96,7 @@ public:
    * @brief Use a preset to control the number of detected regions
    * @param[in] preset The preset configuration
    */
-  void setConfigurationPreset(EImageDescriberPreset preset) override
+  void setConfigurationPreset(ConfigurationPreset preset) override
   {
     _params.setPreset(preset);
   }

--- a/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeatFloat.hpp
+++ b/src/aliceVision/feature/sift/ImageDescriber_SIFT_vlfeatFloat.hpp
@@ -94,7 +94,7 @@ public:
    * @brief Use a preset to control the number of detected regions
    * @param[in] preset The preset configuration
    */
-  void setConfigurationPreset(EImageDescriberPreset preset) override
+  void setConfigurationPreset(ConfigurationPreset preset) override
   {
     return _params.setPreset(preset);
   }

--- a/src/aliceVision/feature/sift/SIFT.cpp
+++ b/src/aliceVision/feature/sift/SIFT.cpp
@@ -17,19 +17,19 @@ void SiftParams::setPreset(ConfigurationPreset preset)
     {
         case EImageDescriberPreset::LOW:
         {
-            _maxTotalKeypoints = 1000;
+            _maxTotalKeypoints = 5000;
             _peakThreshold = 0.02f;
             break;
         }
         case EImageDescriberPreset::MEDIUM:
         {
-            _maxTotalKeypoints = 5000;
+            _maxTotalKeypoints = 10000;
             _peakThreshold = 0.01f;
             break;
         }
         case EImageDescriberPreset::NORMAL:
         {
-            _maxTotalKeypoints = 10000;
+            _maxTotalKeypoints = 20000;
             _peakThreshold = 0.005f;
             break;
         }

--- a/src/aliceVision/feature/sift/SIFT.cpp
+++ b/src/aliceVision/feature/sift/SIFT.cpp
@@ -97,14 +97,14 @@ std::size_t getMemoryConsumptionVLFeat(std::size_t width, std::size_t height, co
   double scaleFactor = 1.0;
 
   // if image resolution is low, increase resolution for extraction
-  const int firstOctave = params._firstOctave - (width*height < 5000*4000 ? 1 : 0);
+  const int firstOctave = params.getImageFirstOctave(width, height);
   if(firstOctave > 0)
       scaleFactor = 1.0 / std::pow(2.0, firstOctave);
   else if(firstOctave < 0)
       scaleFactor = std::pow(2.0, std::abs(firstOctave));
   const std::size_t fullImgSize = width * height * scaleFactor * scaleFactor;
 
-  const int numOctaves = std::max(int(std::floor(std::log2(std::min(width, height))) - params._firstOctave - 3), 1);
+  const int numOctaves = std::max(int(std::floor(std::log2(std::min(width, height))) - firstOctave - 3), 1);
 
   std::size_t pyramidMemoryConsuption = 0;
   double downscale = 1.0;
@@ -144,7 +144,7 @@ bool extractSIFT(const image::Image<float>& image, std::unique_ptr<Regions>& reg
     const int w = image.Width(), h = image.Height();
     const int numOctaves = -1; // auto
     // if image resolution is low, increase resolution for extraction
-    const int firstOctave = params._firstOctave - (w * h < 5000 * 4000 ? 1 : 0);
+    const int firstOctave = params.getImageFirstOctave(w, h);
     VlSiftFilt* filt = vl_sift_new(w, h, numOctaves, params._numScales, firstOctave);
     if(params._edgeThreshold >= 0)
         vl_sift_set_edge_thresh(filt, params._edgeThreshold);

--- a/src/aliceVision/feature/sift/SIFT.cpp
+++ b/src/aliceVision/feature/sift/SIFT.cpp
@@ -11,6 +11,84 @@ namespace feature {
 
 int VLFeatInstance::nbInstances = 0;
 
+void SiftParams::setPreset(ConfigurationPreset preset)
+{
+    switch(preset.descPreset)
+    {
+        case EImageDescriberPreset::LOW:
+        {
+            _maxTotalKeypoints = 1000;
+            _peakThreshold = 0.02f;
+            break;
+        }
+        case EImageDescriberPreset::MEDIUM:
+        {
+            _maxTotalKeypoints = 5000;
+            _peakThreshold = 0.01f;
+            break;
+        }
+        case EImageDescriberPreset::NORMAL:
+        {
+            _maxTotalKeypoints = 10000;
+            _peakThreshold = 0.005f;
+            break;
+        }
+        case EImageDescriberPreset::HIGH:
+        {
+            _maxTotalKeypoints = 50000;
+            _peakThreshold = 0.001f;
+            break;
+        }
+        case EImageDescriberPreset::ULTRA:
+        {
+            _maxTotalKeypoints = 100000;
+            _peakThreshold = 0.0001f;
+            break;
+        }
+        default:
+            throw std::out_of_range("Invalid image describer preset enum");
+    }
+    switch(preset.quality)
+    {
+        case EFeatureQuality::LOW:
+        {
+            _firstOctave = 2;
+            _numScales = 3;
+            break;
+        }
+        case EFeatureQuality::MEDIUM:
+        {
+            _firstOctave = 1;
+            _numScales = 3;
+            break;
+        }
+        case EFeatureQuality::NORMAL:
+        {
+            _firstOctave = 0;
+            _numScales = 3;
+            break;
+        }
+        case EFeatureQuality::HIGH:
+        {
+            _firstOctave = 0;
+            _numScales = 6;
+            break;
+        }
+        case EFeatureQuality::ULTRA:
+        {
+            _firstOctave = -1;
+            _numScales = 6;
+            break;
+        }
+    }
+    if(!preset.gridFiltering)
+    {
+        _gridSize = 0;
+    }
+    _contrastFiltering = preset.contrastFiltering;
+}
+
+
 std::size_t getMemoryConsumptionVLFeat(std::size_t width, std::size_t height, const SiftParams& params)
 {
   double scaleFactor = 1.0;
@@ -50,6 +128,376 @@ void VLFeatInstance::destroy()
   if(nbInstances <= 0)
     vl_destructor();
 }
+
+template <typename T>
+bool extractSIFT(const image::Image<float>& image, std::unique_ptr<Regions>& regions, const SiftParams& params,
+                 bool orientation, const image::Image<unsigned char>* mask)
+{
+    const int w = image.Width(), h = image.Height();
+    const int numOctaves = params._numOctaves + (params._firstOctave < 0 ? 1 : 0); // if first octave is -a, add one octave
+    VlSiftFilt* filt = vl_sift_new(w, h, numOctaves, params._numScales, params._firstOctave);
+    if(params._edgeThreshold >= 0)
+        vl_sift_set_edge_thresh(filt, params._edgeThreshold);
+
+    switch(params._contrastFiltering)
+    {
+        case EFeatureConstrastFiltering::Static:
+        {
+            ALICEVISION_LOG_TRACE("SIFT constrastTreshold Static: " << params._peakThreshold);
+            if(params._peakThreshold >= 0)
+            {
+                vl_sift_set_peak_thresh(filt, params._peakThreshold / params._numScales);
+            }
+            break;
+        }
+        case EFeatureConstrastFiltering::AdaptiveToMedianVariance:
+        {
+            const float medianOfGradiants = computeAutomaticContrastFactor(image, 0.5);
+            const float relativePeakThreshold = 0.02f;
+            const float dynPeakTreshold = relativePeakThreshold * medianOfGradiants;
+            ALICEVISION_LOG_TRACE("SIFT relativePeakThreshold * medianOfGradiants: \n"
+                                  << " - relativePeakThreshold: " << relativePeakThreshold << "\n"
+                                  << " - medianOfGradiants: " << medianOfGradiants << "\n"
+                                  << " - peakTreshold: " << dynPeakTreshold);
+            vl_sift_set_peak_thresh(filt, dynPeakTreshold / params._numScales);
+            break;
+        }
+        case EFeatureConstrastFiltering::NoFiltering:
+        {
+            ALICEVISION_LOG_TRACE("SIFT constrastTreshold NoFiltering.");
+            break;
+        }
+        case EFeatureConstrastFiltering::GridSortOctaves:
+        {
+            ALICEVISION_LOG_TRACE("SIFT constrastTreshold GridSortOctaves.");
+            break;
+        }
+        case EFeatureConstrastFiltering::GridSort:
+        {
+            ALICEVISION_LOG_TRACE("SIFT constrastTreshold GridSort.");
+            break;
+        }
+        case EFeatureConstrastFiltering::GridSortScaleSteps:
+        case EFeatureConstrastFiltering::GridSortOctaveSteps:
+        {
+            break;
+        }
+    }
+
+    Descriptor<vl_sift_pix, 128> vlFeatDescriptor;
+    Descriptor<T, 128> descriptor;
+
+    // Process SIFT computation
+    vl_sift_process_first_octave(filt, image.data());
+
+    using SIFT_Region_T = ScalarRegions<T, 128>;
+    SIFT_Region_T* regionsCasted = new SIFT_Region_T();
+    regions.reset(regionsCasted);
+
+    // Build alias to cached data
+    // reserve some memory for faster keypoint saving
+    const std::size_t reserveSize = (params._gridSize && params._maxTotalKeypoints) ? params._maxTotalKeypoints : 2000;
+    regionsCasted->Features().reserve(reserveSize);
+    regionsCasted->Descriptors().reserve(reserveSize);
+    std::vector<float> featuresPeakValue;
+    featuresPeakValue.reserve(reserveSize);
+
+    // TODO: params._numOctaves
+    size_t maxOctaveKeypoints = params._maxTotalKeypoints;
+
+    while(true)
+    {
+        vl_sift_detect(filt);
+
+        VlSiftKeypoint const* keys = vl_sift_get_keypoints(filt);
+        const int nkeys = vl_sift_get_nkeypoints(filt);
+
+        std::vector<IndexT> filteredKeypointsIndex;
+
+        // TODO: should we reduce maxOctaveKeypoints per octave?
+
+        // grid filtering at the octave level
+        if(params._gridSize && params._maxTotalKeypoints &&
+           (params._contrastFiltering == EFeatureConstrastFiltering::GridSort ||
+            params._contrastFiltering == EFeatureConstrastFiltering::GridSortScaleSteps ||
+            params._contrastFiltering == EFeatureConstrastFiltering::GridSortOctaves))
+        {
+            // Only filter features if we have more features than the maxTotalKeypoints
+            if(nkeys > maxOctaveKeypoints)
+            {
+                // Sorting the extracted features according to their dog value (peak threshold)
+                std::vector<std::size_t> keysIndexSort(nkeys);
+                std::iota(keysIndexSort.begin(), keysIndexSort.end(), 0);
+
+                if(params._contrastFiltering == EFeatureConstrastFiltering::GridSortScaleSteps)
+                {
+                    std::sort(keysIndexSort.begin(), keysIndexSort.end(), [&](std::size_t a, std::size_t b) {
+                        const int scaleA = int(log2(keys[a].sigma) * 3.0f); // 3 scale steps per octave
+                        const int scaleB = int(log2(keys[b].sigma) * 3.0f);
+                        if(scaleA == scaleB)
+                        {
+                            // sort by peak value, when we are in the same scale
+                            return keys[a].peak_value > keys[b].peak_value;
+                        }
+                        return scaleA > scaleB;
+                    });
+                }
+                else if(params._contrastFiltering == EFeatureConstrastFiltering::GridSortOctaveSteps)
+                {
+                    std::sort(keysIndexSort.begin(), keysIndexSort.end(), [&](std::size_t a, std::size_t b) {
+                        const int scaleA = int(log2(keys[a].sigma)); // 3 scale steps per octave
+                        const int scaleB = int(log2(keys[b].sigma));
+                        if(scaleA == scaleB)
+                        {
+                            // sort by peak value, when we are in the same scale
+                            return keys[a].peak_value > keys[b].peak_value;
+                        }
+                        return scaleA > scaleB;
+                    });
+                }
+                else if(params._contrastFiltering == EFeatureConstrastFiltering::GridSort)
+                {
+                    std::sort(keysIndexSort.begin(), keysIndexSort.end(), [&](std::size_t a, std::size_t b) {
+                        return keys[a].sigma * keys[a].peak_value > keys[b].sigma * keys[b].peak_value;
+                    });
+                }
+                else // GridSortOctaves
+                {
+                    // sort from largest peaks to smallest ones
+                    std::sort(keysIndexSort.begin(), keysIndexSort.end(),
+                              [&](std::size_t a, std::size_t b) { return keys[a].peak_value > keys[b].peak_value; });
+                }
+
+                std::vector<IndexT> rejected_indexes;
+                filteredKeypointsIndex.reserve(maxOctaveKeypoints);
+                rejected_indexes.reserve(nkeys);
+
+                const std::size_t sizeMat = params._gridSize * params._gridSize;
+                std::vector<std::size_t> countFeatPerCell(sizeMat, 0);
+                for(int idx = 0; idx < sizeMat; ++idx)
+                {
+                    countFeatPerCell[idx] = 0;
+                }
+                const std::size_t keypointsPerCell = params._maxTotalKeypoints / sizeMat;
+                const double regionWidth = w / double(params._gridSize);
+                const double regionHeight = h / double(params._gridSize);
+
+                for(IndexT ii = 0; ii < nkeys; ++ii)
+                {
+                    const IndexT i = keysIndexSort[ii]; // use sorted keypoints
+                    const auto& keypoint = keys[i];
+
+                    const std::size_t cellX = std::min(std::size_t(keypoint.x / regionWidth), params._gridSize);
+                    const std::size_t cellY = std::min(std::size_t(keypoint.y / regionHeight), params._gridSize);
+
+                    std::size_t& count = countFeatPerCell[cellX * params._gridSize + cellY];
+                    ++count;
+
+                    if(count < keypointsPerCell)
+                        filteredKeypointsIndex.push_back(i);
+                    else
+                        rejected_indexes.push_back(i);
+                }
+                // If we don't have enough features (less than maxTotalKeypoints) after the grid filtering (empty
+                // regions in the grid for example). We add the best other ones, without repartition constraint.
+                if(filteredKeypointsIndex.size() < params._maxTotalKeypoints && !rejected_indexes.empty())
+                {
+                    const std::size_t remainingElements =
+                        std::min(rejected_indexes.size(), params._maxTotalKeypoints - filteredKeypointsIndex.size());
+                    ALICEVISION_LOG_TRACE("Octave Grid filtering -- Copy remaining points: " << remainingElements);
+                    filteredKeypointsIndex.insert(filteredKeypointsIndex.end(), rejected_indexes.begin(),
+                                            rejected_indexes.begin() + remainingElements);
+                }
+
+                ALICEVISION_LOG_TRACE("Octave SIFT keypoints:\n"
+                                      << " * detected: " << nkeys << "\n"
+                                      << " * max octave keypoints: " << maxOctaveKeypoints << "\n"
+                                      << " * after grid filtering: " << filteredKeypointsIndex.size());
+            }
+        }
+
+        if(filteredKeypointsIndex.empty())
+        {
+            ALICEVISION_LOG_TRACE("Octave SIFT nb keypoints:\n" << nkeys << " (no grid filtering)");
+            filteredKeypointsIndex.resize(nkeys);
+            std::iota(filteredKeypointsIndex.begin(), filteredKeypointsIndex.end(), 0);
+        }
+
+        // Update gradient before launching parallel extraction
+        vl_sift_update_gradient(filt);
+
+#pragma omp parallel for private(vlFeatDescriptor, descriptor)
+        for(int ii = 0; ii < filteredKeypointsIndex.size(); ++ii)
+        {
+            const int i = filteredKeypointsIndex[ii];
+
+            // Feature masking
+            if(mask)
+            {
+                const image::Image<unsigned char>& maskIma = *mask;
+                if(maskIma(keys[i].y, keys[i].x) > 0)
+                    continue;
+            }
+
+            double angles[4] = {0.0, 0.0, 0.0, 0.0};
+            int nangles = 1; // by default (1 upright feature)
+            if(orientation)
+            { // compute from 1 to 4 orientations
+                nangles = vl_sift_calc_keypoint_orientations(filt, angles, keys + i);
+            }
+
+            for(int q = 0; q < nangles; ++q)
+            {
+                vl_sift_calc_keypoint_descriptor(filt, &vlFeatDescriptor[0], keys + i, angles[q]);
+                const PointFeature fp(keys[i].x, keys[i].y, keys[i].sigma, static_cast<float>(angles[q]));
+
+                convertSIFT<T>(&vlFeatDescriptor[0], descriptor, params._rootSift);
+
+#pragma omp critical
+                {
+                    regionsCasted->Descriptors().push_back(descriptor);
+                    regionsCasted->Features().push_back(fp);
+                    featuresPeakValue.push_back(keys[i].peak_value);
+                }
+            }
+        }
+
+        if(vl_sift_process_next_octave(filt))
+            break; // Last octave
+    }
+    vl_sift_delete(filt);
+
+    const auto& features = regionsCasted->Features();
+    const auto& descriptors = regionsCasted->Descriptors();
+    assert(features.size() == descriptors.size());
+
+    // Sorting the extracted features according to their scale
+    {
+        std::vector<std::size_t> indexSort(features.size());
+        std::iota(indexSort.begin(), indexSort.end(), 0);
+        if(params._contrastFiltering == EFeatureConstrastFiltering::GridSortScaleSteps)
+        {
+            std::sort(indexSort.begin(), indexSort.end(), [&](std::size_t a, std::size_t b) {
+                const int scaleA = int(log2(features[a].scale()) * 3.0f); // 3 scale steps per octave
+                const int scaleB = int(log2(features[b].scale()) * 3.0f);
+                if(scaleA == scaleB)
+                {
+                    return featuresPeakValue[a] > featuresPeakValue[b];
+                }
+                return scaleA > scaleB;
+            });
+        }
+        else if(params._contrastFiltering == EFeatureConstrastFiltering::GridSortOctaveSteps)
+        {
+            std::sort(indexSort.begin(), indexSort.end(), [&](std::size_t a, std::size_t b) {
+                const int scaleA = int(log2(features[a].scale())); // 3 scale steps per octave
+                const int scaleB = int(log2(features[b].scale()));
+                if(scaleA == scaleB)
+                {
+                    return featuresPeakValue[a] > featuresPeakValue[b];
+                }
+                return scaleA > scaleB;
+            });
+        }
+        else if(params._contrastFiltering == EFeatureConstrastFiltering::GridSort)
+        {
+            std::sort(indexSort.begin(), indexSort.end(), [&](std::size_t a, std::size_t b) {
+                return features[a].scale() * featuresPeakValue[a] > features[b].scale() * featuresPeakValue[b];
+            });
+        }
+        else
+        {
+            // sort from largest scales to smallest ones
+            std::sort(indexSort.begin(), indexSort.end(), [&](std::size_t a, std::size_t b) {
+                return features[a].scale() > features[b].scale();
+            });
+        }
+
+        std::vector<PointFeature> sortedFeatures(features.size());
+        std::vector<typename SIFT_Region_T::DescriptorT> sortedDescriptors(features.size());
+        for(std::size_t i : indexSort)
+        {
+            sortedFeatures[i] = features[indexSort[i]];
+            sortedDescriptors[i] = descriptors[indexSort[i]];
+        }
+        regionsCasted->Features().swap(sortedFeatures);
+        regionsCasted->Descriptors().swap(sortedDescriptors);
+    }
+
+    // Grid filtering of the keypoints to ensure a global repartition
+    if(params._gridSize && params._maxTotalKeypoints)
+    {
+        // Only filter features if we have more features than the maxTotalKeypoints
+        if(features.size() > params._maxTotalKeypoints)
+        {
+            std::vector<IndexT> filtered_indexes;
+            std::vector<IndexT> rejected_indexes;
+            filtered_indexes.reserve(std::min(features.size(), params._maxTotalKeypoints));
+            rejected_indexes.reserve(features.size());
+
+            const std::size_t sizeMat = params._gridSize * params._gridSize;
+            std::vector<std::size_t> countFeatPerCell(sizeMat, 0);
+            for(int Indice = 0; Indice < sizeMat; Indice++)
+            {
+                countFeatPerCell[Indice] = 0;
+            }
+            const std::size_t keypointsPerCell = params._maxTotalKeypoints / sizeMat;
+            const double regionWidth = w / double(params._gridSize);
+            const double regionHeight = h / double(params._gridSize);
+
+            for(IndexT i = 0; i < features.size(); ++i)
+            {
+                const auto& keypoint = features.at(i);
+
+                const std::size_t cellX = std::min(std::size_t(keypoint.x() / regionWidth), params._gridSize);
+                const std::size_t cellY = std::min(std::size_t(keypoint.y() / regionHeight), params._gridSize);
+
+                std::size_t& count = countFeatPerCell[cellX * params._gridSize + cellY];
+                ++count;
+
+                if(count < keypointsPerCell)
+                    filtered_indexes.push_back(i);
+                else
+                    rejected_indexes.push_back(i);
+            }
+            // If we don't have enough features (less than maxTotalKeypoints) after the grid filtering (empty regions in
+            // the grid for example). We add the best other ones, without repartition constraint.
+            if(filtered_indexes.size() < params._maxTotalKeypoints)
+            {
+                const std::size_t remainingElements =
+                    std::min(rejected_indexes.size(), params._maxTotalKeypoints - filtered_indexes.size());
+                ALICEVISION_LOG_TRACE("Grid filtering -- Copy remaining points: " << remainingElements);
+                filtered_indexes.insert(filtered_indexes.end(), rejected_indexes.begin(),
+                                        rejected_indexes.begin() + remainingElements);
+            }
+
+            std::vector<PointFeature> filtered_features(filtered_indexes.size());
+            std::vector<typename SIFT_Region_T::DescriptorT> filtered_descriptors(filtered_indexes.size());
+            for(IndexT i = 0; i < filtered_indexes.size(); ++i)
+            {
+                filtered_features[i] = features[filtered_indexes[i]];
+                filtered_descriptors[i] = descriptors[filtered_indexes[i]];
+            }
+
+            ALICEVISION_LOG_TRACE("SIFT Features: before: " << features.size()
+                                                           << ", after grid filtering: " << filtered_features.size());
+
+            regionsCasted->Features().swap(filtered_features);
+            regionsCasted->Descriptors().swap(filtered_descriptors);
+        }
+    }
+    ALICEVISION_LOG_TRACE("SIFT Features: " << features.size() << " (max: " << params._maxTotalKeypoints << ").");
+    assert(features.size() == descriptors.size());
+
+    return true;
+}
+
+
+template bool extractSIFT<float>(const image::Image<float>& image, std::unique_ptr<Regions>& regions, const SiftParams& params,
+                 bool orientation, const image::Image<unsigned char>* mask);
+
+template bool extractSIFT<unsigned char>(const image::Image<float>& image, std::unique_ptr<Regions>& regions,
+                                 const SiftParams& params, bool orientation, const image::Image<unsigned char>* mask);
 
 } //namespace feature
 } //namespace aliceVision

--- a/src/aliceVision/feature/sift/SIFT.cpp
+++ b/src/aliceVision/feature/sift/SIFT.cpp
@@ -73,7 +73,7 @@ void SiftParams::setPreset(ConfigurationPreset preset)
         case EFeatureQuality::HIGH:
         {
             // Increase scale space sampling to improve feature repeatability.
-            // "Aa analysis of scale-space sampling in SIFT, Ives Rey-Otero, Jean-Michel Morel, Mauricio Delbracio
+            // "An analysis of scale-space sampling in SIFT, Ives Rey-Otero, Jean-Michel Morel, Mauricio Delbracio
             // https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.703.9294&rep=rep1&type=pdf
             _numScales = 6;
             break;

--- a/src/aliceVision/feature/sift/SIFT.hpp
+++ b/src/aliceVision/feature/sift/SIFT.hpp
@@ -34,44 +34,24 @@ namespace feature {
 
 struct SiftParams
 {
-  SiftParams(int firstOctave = 0,
-             int numOctaves = 6,
-             int numScales = 3,
-             float edgeThreshold = 10.0f,
-             float peakThreshold = 0.04f,
-             std::size_t gridSize = 4,
-             std::size_t maxTotalKeypoints = 1000,
-             bool rootSift = true)
-    : _firstOctave(firstOctave)
-    , _numOctaves(numOctaves)
-    , _numScales(numScales)
-    , _edgeThreshold(edgeThreshold)
-    , _peakThreshold(peakThreshold)
-    , _gridSize(gridSize)
-    , _maxTotalKeypoints(maxTotalKeypoints)
-    , _rootSift(rootSift)
-  {}
-
-  // Parameters
-
   /// Use original image, or perform an upscale if == -1
-  int _firstOctave;
+  int _firstOctave = 0;
   /// Max octaves count
-  int _numOctaves;
+  int _numOctaves = 6;
   /// Scales per octave
-  int _numScales;
+  int _numScales = 3;
   /// Max ratio of Hessian eigenvalues
-  float _edgeThreshold;
+  float _edgeThreshold = 10.0f;
   /// Min contrast
-  float _peakThreshold;
+  float _peakThreshold = 0.005f;
   /// Min contrast (relative to variance median)
-  float _relativePeakThreshold = 0.01;
-  EFeatureConstrastFiltering _contrastFiltering;
+  float _relativePeakThreshold = 0.01f;
+  EFeatureConstrastFiltering _contrastFiltering = EFeatureConstrastFiltering::GridSort;
 
-  std::size_t _gridSize;
-  std::size_t _maxTotalKeypoints;
+  std::size_t _gridSize = 4;
+  std::size_t _maxTotalKeypoints = 10000;
   /// see [1]
-  bool _rootSift;
+  bool _rootSift = true;
   
   void setPreset(ConfigurationPreset preset);
 };

--- a/src/aliceVision/feature/sift/SIFT.hpp
+++ b/src/aliceVision/feature/sift/SIFT.hpp
@@ -51,6 +51,11 @@ struct SiftParams
   bool _rootSift = true;
   
   virtual void setPreset(ConfigurationPreset preset);
+
+  int getImageFirstOctave(int w, int h) const
+  {
+    return _firstOctave - (w * h < 5000 * 4000 ? 1 : 0);
+  }
 };
 
 // VLFeat Instance management

--- a/src/aliceVision/feature/sift/SIFT.hpp
+++ b/src/aliceVision/feature/sift/SIFT.hpp
@@ -31,13 +31,10 @@ namespace feature {
  * [1] R. Arandjelović, A. Zisserman.
  * Three things everyone should know to improve object retrieval. CVPR2012.
  */
-
 struct SiftParams
 {
   /// Use original image, or perform an upscale if == -1
   int _firstOctave = 0;
-  /// Max octaves count
-  int _numOctaves = 6;
   /// Scales per octave
   int _numScales = 3;
   /// Max ratio of Hessian eigenvalues
@@ -53,7 +50,7 @@ struct SiftParams
   /// see [1]
   bool _rootSift = true;
   
-  void setPreset(ConfigurationPreset preset);
+  virtual void setPreset(ConfigurationPreset preset);
 };
 
 // VLFeat Instance management

--- a/src/aliceVision/localization/ILocalizer.hpp
+++ b/src/aliceVision/localization/ILocalizer.hpp
@@ -24,13 +24,14 @@ struct LocalizerParameters
     : _visualDebug("")
     , _refineIntrinsics(false)
     , _fDistRatio(0.8)
-    , _featurePreset(feature::EImageDescriberPreset::ULTRA)
     , _errorMax(std::numeric_limits<double>::infinity())
     , _resectionEstimator(robustEstimation::ERobustEstimator::ACRANSAC)
     , _matchingEstimator(robustEstimation::ERobustEstimator::ACRANSAC)
     , _useLocalizeRigNaive(false)
     , _angularThreshold(degreeToRadian(0.1))
-  {}
+  {
+    _featurePreset.setDescPreset(feature::EImageDescriberPreset::ULTRA);
+  }
 
   virtual ~LocalizerParameters() = 0;
 
@@ -41,7 +42,7 @@ struct LocalizerParameters
   /// the distance ratio to use when matching feature with the ratio test
   float _fDistRatio;
   /// the preset to use for feature extraction of the query image
-  feature::EImageDescriberPreset _featurePreset;
+  feature::ConfigurationPreset _featurePreset;
   /// maximum reprojection error allowed for resectioning
   double _errorMax;
   /// the type of *sac framework to use for resection

--- a/src/aliceVision/matching/svgVisualization.cpp
+++ b/src/aliceVision/matching/svgVisualization.cpp
@@ -25,6 +25,8 @@ std::string describerTypeColor(feature::EImageDescriberType descType )
     case feature::EImageDescriberType::SIFT:           return "yellow";
     case feature::EImageDescriberType::SIFT_FLOAT:     return "yellow";
     case feature::EImageDescriberType::SIFT_UPRIGHT:   return "yellow";
+    case feature::EImageDescriberType::DSPSIFT:        return "yellow";
+
     case feature::EImageDescriberType::AKAZE:          return "purple";
     case feature::EImageDescriberType::AKAZE_LIOP:     return "purple";
     case feature::EImageDescriberType::AKAZE_MLDB:     return "purple";

--- a/src/aliceVision/multiview/RelativePoseKernel.hpp
+++ b/src/aliceVision/multiview/RelativePoseKernel.hpp
@@ -46,7 +46,7 @@ public:
     , _N2(3, 3)
     , _pointToLine(pointToLine)
   {
-    ALICEVISION_LOG_INFO("RelativePoseKernel: x1: " << x1.rows() << "x" << x1.cols() << ", x2: " << x2.rows() << "x" << x2.cols());
+    ALICEVISION_LOG_TRACE("RelativePoseKernel: x1: " << x1.rows() << "x" << x1.cols() << ", x2: " << x2.rows() << "x" << x2.cols());
     assert(2 == x1.rows());
     assert(x1.rows() == x2.rows());
     assert(x1.cols() == x2.cols());
@@ -195,7 +195,7 @@ public:
         : PFRansacKernel(x1, x2)  // provide a reference to the input matrices
         , _logalpha0(M_PI)
     {
-        ALICEVISION_LOG_INFO("RelativePoseSphericalKernel: x1: " << x1.rows() << "x" << x1.cols() << ", x2: " << x2.rows() << "x" << x2.cols());
+        ALICEVISION_LOG_TRACE("RelativePoseSphericalKernel: x1: " << x1.rows() << "x" << x1.cols() << ", x2: " << x2.rows() << "x" << x2.cols());
         assert(x1.rows() == 3);
         assert(x1.cols() > 0);
         assert(x1.rows() == x2.rows());

--- a/src/aliceVision/voctree/descriptorLoader.cpp
+++ b/src/aliceVision/voctree/descriptorLoader.cpp
@@ -103,10 +103,7 @@ void getListOfDescriptorFiles(const sfmData::SfMData& sfmData, const std::vector
     {
       std::stringstream ss;
 
-      for(const std::string& featureFolder : featuresFolders)
-        ss << "\t- " << featureFolder << std::endl;
-
-      for(const std::string& featureFolder : sfmData.getFeaturesFolders())
+      for(const std::string& featureFolder : allFeaturesFolders)
         ss << "\t- " << featureFolder << std::endl;
 
       throw std::runtime_error("Can't find descriptor of view " + std::to_string(view.first) + " in:\n" + ss.str());

--- a/src/nonFree/sift/CMakeLists.txt
+++ b/src/nonFree/sift/CMakeLists.txt
@@ -42,6 +42,7 @@ set(FEATS_H
 )
 
 set_source_files_properties(${FEATS} ${FEATS_H} PROPERTIES LANGUAGE C)
+set_source_files_properties(${FEATS_H} PROPERTIES HEADER_FILE_ONLY TRUE)
 
 add_definitions(-DVL_DISABLE_AVX -DVL_BUILD_DLL)
 

--- a/src/nonFree/sift/CMakeLists.txt
+++ b/src/nonFree/sift/CMakeLists.txt
@@ -44,15 +44,14 @@ set(FEATS_H
 set_source_files_properties(${FEATS} ${FEATS_H} PROPERTIES LANGUAGE C)
 set_source_files_properties(${FEATS_H} PROPERTIES HEADER_FILE_ONLY TRUE)
 
-add_definitions(-DVL_DISABLE_AVX -DVL_BUILD_DLL)
-
-add_library(vlsift ${FEATS} ${FEATS_H})
-
-
-install(TARGETS vlsift
-  DESTINATION lib
-  EXPORT aliceVision-targets
-)
+alicevision_add_library(vlsift
+  SOURCES
+    ${FEATS} ${FEATS_H}
+  PUBLIC_DEFINITIONS
+    -DVL_DISABLE_AVX
+  PRIVATE_DEFINITIONS
+    -DVL_BUILD_DLL
+  )
 
 set_property(TARGET vlsift
   PROPERTY FOLDER nonFree

--- a/src/nonFree/sift/CMakeLists.txt
+++ b/src/nonFree/sift/CMakeLists.txt
@@ -1,5 +1,5 @@
 # libs should be static
-set(BUILD_SHARED_LIBS OFF)
+set(BUILD_SHARED_LIBS ON)
 
 # use PIC code for link into shared lib
 if(UNIX)
@@ -9,20 +9,44 @@ endif()
 include_directories(./vl)
 
 set(FEATS
+  vl/covdet.c
   vl/generic.c
-  vl/imopv_sse2.c
-  vl/sift.c
-  vl/imopv.c
-  vl/mathop_sse2.c
-  vl/sift.c
   vl/host.c
+  vl/imopv.c
+  vl/imopv_sse2.c
   vl/mathop.c
+  vl/mathop_avx.c
+  vl/mathop_sse2.c
+  vl/mser.c
   vl/random.c
+  vl/scalespace.c
+  vl/sift.c
+  vl/stringop.c
 )
 
-set_source_files_properties(${FEATS} PROPERTIES LANGUAGE C)
+set(FEATS_H
+  vl/covdet.h
+  vl/float.th
+  vl/generic.h
+  vl/host.h
+  vl/imopv.h
+  vl/imopv_sse2.h
+  vl/mathop.h
+  vl/mathop_avx.h
+  vl/mathop_sse2.h
+  vl/mser.h
+  vl/random.h
+  vl/scalespace.h
+  vl/sift.h
+  vl/stringop.h
+)
 
-add_library(vlsift ${FEATS})
+set_source_files_properties(${FEATS} ${FEATS_H} PROPERTIES LANGUAGE C)
+
+add_definitions(-DVL_DISABLE_AVX -DVL_BUILD_DLL)
+
+add_library(vlsift ${FEATS} ${FEATS_H})
+
 
 install(TARGETS vlsift
   DESTINATION lib

--- a/src/nonFree/sift/vl/covdet.c
+++ b/src/nonFree/sift/vl/covdet.c
@@ -1,0 +1,3511 @@
+/** @file covdet.c
+ ** @brief Covariant feature detectors - Definition
+ ** @author Karel Lenc
+ ** @author Andrea Vedaldi
+ ** @author Michal Perdoch
+ **/
+
+/*
+Copyright (C) 2013-14 Andrea Vedaldi.
+Copyright (C) 2012 Karel Lenc, Andrea Vedaldi and Michal Perdoch.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+/**
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page covdet Covariant feature detectors
+@author Karel Lenc
+@author Andrea Vedaldi
+@author Michal Perdoch
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+@ref covdet.h implements a number of covariant feature detectors, based
+on three cornerness measures (determinant of the Hessian, trace of the Hessian
+(aka Difference of Gaussians, and Harris). It supprots affine adaptation,
+orientation estimation, as well as Laplacian scale detection.
+
+- @subpage covdet-fundamentals
+- @subpage covdet-principles
+- @subpage covdet-differential
+- @subpage covdet-corner-types
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-starting Getting started
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+The ::VlCovDet object implements a number of covariant feature
+detectors: Difference of Gaussian, Harris, determinant of Hessian.
+Variant of the basic detectors support scale selection by maximizing
+the Laplacian measure as well as affine normalization.
+
+@code
+// create a detector object
+VlCovDet * covdet = vl_covdet_new(method) ;
+
+// set various parameters (optional)
+vl_covdet_set_first_octave(covdet, -1) ; // start by doubling the image resolution
+vl_covdet_set_octave_resolution(covdet, octaveResolution) ;
+vl_covdet_set_peak_threshold(covdet, peakThreshold) ;
+vl_covdet_set_edge_threshold(covdet, edgeThreshold) ;
+
+// process the image and run the detector
+vl_covdet_put_image(covdet, image, numRows, numCols) ;
+vl_covdet_detect(covdet) ;
+
+// drop features on the margin (optional)
+vl_covdet_drop_features_outside (covdet, boundaryMargin) ;
+
+// compute the affine shape of the features (optional)
+vl_covdet_extract_affine_shape(covdet) ;
+
+// compute the orientation of the features (optional)
+vl_covdet_extract_orientations(covdet) ;
+
+// get feature frames back
+vl_size numFeatures = vl_covdet_get_num_features(covdet) ;
+VlCovDetFeature const * feature = vl_covdet_get_features(covdet) ;
+
+// get normalized feature appearance patches (optional)
+vl_size w = 2*patchResolution + 1 ;
+for (i = 0 ; i < numFeatures ; ++i) {
+  float * patch = malloc(w*w*sizeof(*desc)) ;
+  vl_covdet_extract_patch_for_frame(covdet,
+                                    patch,
+                                    patchResolution,
+                                    patchRelativeExtent,
+                                    patchRelativeSmoothing,
+                                    feature[i].frame) ;
+  // do something with patch
+}
+@endcode
+
+This example code:
+
+- Calls ::vl_covdet_new constructs a new detector object. @ref
+  covdet.h supports a variety of different detectors (see
+  ::VlCovDetMethod).
+- Optionally calls various functions to set the detector parameters if
+  needed (e.g. ::vl_covdet_set_peak_threshold).
+- Calls ::vl_covdet_put_image to start processing a new image. It
+  causes the detector to compute the scale space representation of the
+  image, but does not compute the features yet.
+- Calls ::vl_covdet_detect runs the detector. At this point features are
+  ready to be extracted. However, one or all of the following steps
+  may be executed in order to process the features further.
+- Optionally calls ::vl_covdet_drop_features_outside to drop features
+  outside the image boundary.
+- Optionally calls ::vl_covdet_extract_affine_shape to compute the
+  affine shape of features using affine adaptation.
+- Optionally calls ::vl_covdet_extract_orientations to compute the
+  dominant orientation of features looking for the dominant gradient
+  orientation in patches.
+- Optionally calls ::vl_covdet_extract_patch_for_frame to extract a
+  normalized feature patch, for example to compute an invariant
+  feature descriptor.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@page covdet-fundamentals Covariant detectors fundamentals
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+This page describes the fundamental concepts required to understand a
+covariant feature detector, the geometry of covariant features, and
+the process of feature normalization.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@section covdet-covariance Covariant detection
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+The purpose of a *covariant detector* is to extract from an image a
+set of local features in a manner which is consistent with spatial
+transformations of the image itself. For instance, a covariant
+detector that extracts interest points $\bx_1,\dots,\bx_n$ from image
+$\ell$ extracts the translated points $\bx_1+T,\dots,\bx_n+T$ from the
+translated image $\ell'(\bx) = \ell(\bx-T)$.
+
+More in general, consider a image $\ell$ and a transformed version
+$\ell' = \ell \circ w^{-1}$ of it, as in the following figure:
+
+@image html covdet.png "Covariant detection of local features."
+
+The transformation or <em>warp</em> $w : \real^2 \mapsto \real^2$ is a
+deformation of the image domain which may capture a change of camera
+viewpoint or similar imaging factor. Examples of warps typically
+considered are translations, scaling, rotations, and general affine
+transformations; however, in $w$ could be another type of continuous
+and invertible transformation.
+
+Given an image $\ell$, a **detector** selects features $R_1,\dots,R_n$
+(one such features is shown in the example as a green circle). The
+detector is said to be **covariant** with the warps $w$ if it extracts
+the transformed features $w[R_1],\dots, w[R_n]$ from the transformed
+image $w[\ell]$. Intuitively, this means that the &ldquo;same
+features&rdquo; are extracted in both cases up to the transformation
+$w$. This property is described more formally in @ref
+covdet-principles.
+
+Covariance is a key property of local feature detectors as it allows
+extracting corresponding features from two or more images, making it
+possible to match them in a meaningful way.
+
+The @ref covdet.h module in VLFeat implements an array of feature
+detection algorithm that have are covariant to different classes of
+transformations.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@section covdet-frame Feature geometry and feature frames
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+As we have seen, local features are subject to image transformations,
+and they apply a fundamental role in matching and normalizing
+images. To operates effectively with local features is therefore
+necessary to understand their geometry.
+
+The geometry of a local feature is captured by a <b>feature frame</b>
+$R$. In VLFeat, depending on the specific detector, the frame can be
+either a point, a disc, an ellipse, an oriented disc, or an oriented
+ellipse.
+
+A frame captures both the extent of the local features, useful to know
+which portions of two images are put in correspondence, as well their
+shape.  The latter can be used to associate to diagnose the
+transformation that affects a feature and remove it through the
+process of **normalization**.
+
+More precisely, in covariant detection feature frames are constructed
+to be compatible with a certain class of transformations. For example,
+circles are compatible with similarity transformations as they are
+closed under them. Likewise, ellipses are compatible with affine
+transformations.
+
+Beyond this closure property, the key idea here is that all feature
+occurrences can be seen as transformed versions of a base or
+<b>canonical</b> feature. For example, all discs $R$ can be obtained
+by applying a similarity transformation to the unit disc $\bar R$
+centered at the origin. $\bar R$ is an example of canonical frame
+as any other disc can be written as $R = w[\bar R]$ for a suitable
+similarity $w$.
+
+@image html frame-canonical.png "The idea of canonical frame and normalization"
+
+The equation $R = w[\bar R_0]$ matching the canonical and detected
+feature frames establishes a constraint on the warp $w$, very similar
+to the way two reference frames in geometry establish a transformation
+between spaces. The transformation $w$ can be thought as a the
+**pose** of the detected feature, a generalization of its location.
+
+In the case of discs and similarity transformations, the equation $R =
+w[\bar R_0]$ fixes $w$ up to a residual rotation. This can be
+addressed by considering oriented discs instead. An **oriented disc**
+is a disc with a radius highlighted to represent the feature
+orientation.
+
+While discs are appropriate for similarity transformations, they are
+not closed under general affine transformations. In this case, one
+should consider the more general class of (oriented) ellipses. The
+following image illustrates the five types of feature frames used in
+VLFeat:
+
+@image html frame-types.png "Types of local feature frames: points, discs, oriented discs, ellipses, oriented ellipses."
+
+Note that these frames are described respectively by 2, 3, 4, 5 and 6
+parameters. The most general type are the oriented ellipses, which can
+be used to represent all the other frame types as well.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@section covdet-frame-transformation Transforming feature frames
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+Consider a warp $w$ mapping image $\ell$ into image $\ell'$ as in the
+figure below. A feature $R$ in the first image co-variantly transform
+into a feature $R'=w[R]$ in the second image:
+
+@image html covdet-normalization.png "Normalization removes the effect of an image deformation."
+
+The poses $u,u'$ of $R=u[R_0]$ and $R' = u'[R_0]$ are then related by
+the simple expression:
+
+\[
+  u' = w \circ u.
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@section covdet-frame-normalization Normalizing feature frames
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+In the example above, the poses $u$ and $u'$ relate the two
+occurrences $R$ and $R'$ of the feature to its canonical version
+$R_0$. If the pose $u$ of the feature in image $\ell$ is known, the
+canonical feature appearance can be computed by un-warping it:
+
+\[
+ \ell_0 = u^{-1}[\ell] = \ell \circ u.
+\]
+
+This process is known as **normalization** and is the key in the
+computation of invariant feature descriptors as well as in the
+construction of most co-variant detectors.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@page covdet-principles Principles of covariant detection
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+The goals of a co-variant detector were discussed in @ref
+covdet-fundamentals. This page introduces a few general principles
+that are at the basis of most covariant detection algorithms. Consider
+an input image $\ell$ and a two dimensional continuous and invertible
+warp $w$. The *warped image* $w[\ell]$ is defined to be
+
+\[
+ w[\ell] = \ell \circ w^{-1},
+\]
+
+or, equivalently,
+
+\[
+ w[\ell](x,y) =  \ell(w^{-1}(x,y)), \qquad \forall (x,y)\in\real^2.
+\]
+
+Note that, while $w$ pushes pixels forward, from the original to the
+transformed image domain, defining the transformed image $\ell'$
+requires inverting the warp and composing $\ell$ with $w^{-1}$.
+
+The goal a covariant detector is to extract the same local features
+irregardless of image transformations. The detector is said to be
+<b>covariant</b> or <b>equivariant</b> with a class of warps
+$w\in\mathcal{W}$ if, when the feature $R$ is detected in image
+$\ell$, then the transformed feature $w[R]$ is detected in the
+transformed image $w[\ell]$.
+
+The net effect is that a covariant feature detector appears to
+&ldquo;track&rdquo; image transformations; however, it is important to
+note that a detector *is not a tracker* because it processes images
+individually rather than jointly as part of a sequence.
+
+An intuitive way to construct a covariant feature detector is to
+extract features in correspondence of images structures that are
+easily identifiable even after a transformation. Example of specific
+structures include dots, corners, and blobs. These will be generically
+indicated as **corners** in the followup.
+
+A covariant detector faces two challenges. First, corners have, in
+practice, an infinite variety of individual appearances and the
+detector must be able to capture them to be of general applicability.
+Second, the way corners are identified and detected must remain stable
+under transformations of the image. These two problems are addressed
+in @ref covdet-cornerness-localmax and @ref
+covdet-cornerness-normalization respectively.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-cornerness Detection using a cornerness measure
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+One way to decide whether an image region $R$ contains a corner is to
+compare the local appearance to a model or template of the corner; the
+result of this comparisons produces a *cornerness score* at that
+location. This page describe general theoretical properties of the
+cornerness and the detection process. Concrete examples of cornerness
+are given in @ref covdet-corner-types.
+
+A **cornerness measure** associate a score to all possible feature
+locations in an image $\ell$. As described in @ref covdet-frame, the
+location or, more in general, pose $u$ of a feature $R$ is the warp
+$w$ that maps the canonical feature frame $R_0$ to $R$:
+
+\[
+    R = u[R_0].
+\]
+
+The goal of a cornerness measure is to associate a score $F(u;\ell)$
+to all possible feature poses $u$ and use this score to extract a
+finite number of co-variant features from any image.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@subsection covdet-cornerness-localmax Local maxima of a cornerness measure
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+Given the cornerness of each candidate feature, the detector must
+extract a finite number of them. However, the cornerness of features
+with nearly identical pose must be similar (otherwise the cornerness
+measure would be unstable). As such, simply thresholding $F(w;\ell)$
+would detect an infinite number of nearly identical features rather
+than a finite number.
+
+The solution is to detect features in correspondence of the local
+maxima of the score measure:
+
+\[
+ \{w_1,\dots,w_n\} = \operatorname{localmax}_{w\in\mathcal{W}} F(w;\ell).
+\]
+
+This also means that features are never detected in isolation, but by
+comparing neighborhoods of them.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@subsection covdet-cornerness-normalization Covariant detection by normalization
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+The next difficulty is to guarantee that detection is co-variant with
+image transformations. Hence, if $u$ is the pose of a feature
+extracted from image $\ell$, then the transformed pose $u' = w[u]$
+must be detected in the transformed image $\ell' = w[\ell]$.
+
+Since features are extracted in correspondence of the local maxima of
+the cornerness score, a sufficient condition is that corresponding
+features attain the same score in the two images:
+
+\[
+\forall u\in\mathcal{W}: \quad F(u;\ell) = F(w[u];w[\ell]),
+\qquad\text{or}\qquad
+F(u;\ell) = F(w \circ u ;\ell \circ w^{-1}).
+\]
+
+One simple way to satisfy this equation is to compute a cornerness
+score *after normalizing the image* by the inverse of the candidate
+feature pose warp $u$, as follows:
+
+\[
+  F(u;\ell) = F(1;u^{-1}[\ell]) = F(1;\ell \circ u) = \mathcal{F}(\ell \circ u),
+\]
+
+where $1 = u^{-1} \circ u$ is the identity transformation and
+$\mathcal{F}$ is an arbitrary functional. Intuitively, co-variant
+detection is obtained by looking if the appearance of the feature
+resembles a corner only *after normalization*. Formally:
+
+@f{align*}
+F(w[u];w[\ell])
+&=
+F(w \circ u ;\ell \circ w^{-1})
+\\
+&=
+F(1; \ell \circ w^{-1} \circ w \circ u)
+\\
+&=
+\mathcal{F}(\ell\circ u)
+\\
+&=
+F(u;\ell).
+@f}
+
+Concrete examples of the functional $\mathcal{F}$ are given in @ref
+covdet-corner-types.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@subsection covdet-locality Locality of the detected features
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+In the definition above, the cornenress functional $\mathcal{F}$ is an
+arbitrary functional of the entire normalized image $u^{-1}[\ell]$.
+In practice, one is always interested in detecting **local features**
+(at the very least because the image extent is finite).
+
+This is easily obtained by considering a cornerness $\mathcal{F}$
+which only looks in a small region of the normalized image, usually
+corresponding to the extent of the canonical feature $R_0$ (e.g. a
+unit disc centered at the origin).
+
+In this case the extent of the local feature in the original image is
+simply given by $R = u[R_0]$.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-partial Partial and iterated normalization
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+Practical detectors implement variants of the ideas above. Very often,
+for instance, detection is an iterative process, in which successive
+parameters of the pose of a feature are determined. For instance, it
+is typical to first detect the location and scale of a feature using a
+rotation-invariant cornerness score $\mathcal{F}$. Once these two
+parameters are known, the rotation can be determined using a different
+score, sensitive to the orientation of the local image structures.
+
+Certain detectors (such as Harris-Laplace and Hessian-Laplace) use
+even more sophisticated schemes, in which different scores are used to
+jointly (rather than in succession) different parameters of the pose
+of a feature, such as its translation and scale. While a formal
+treatment of these cases is possible as well, we point to the original
+papers.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page covdet-differential Differential and integral image operations
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+Dealing with covariant interest point detector requires working a good
+deal with derivatives, convolutions, and transformations of images.
+The notation and fundamental properties of interest here are discussed
+next.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-derivatives Derivative operations: gradients
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+For the derivatives, we borrow the notation of
+@cite{kinghorn96integrals}. Let $f: \mathbb{R}^m \rightarrow
+\mathbb{R}^n, \bx \mapsto f(\bx)$ be a vector function. The derivative
+of the function with respect to $\bx$ is given by its *Jacobian
+matrix* denoted by the symbol:
+
+\[
+\frac{\partial f}{\partial \bx^\top}
+=
+\begin{bmatrix}
+  \frac{\partial f_1}{x_1} & \frac{\partial f_1}{x_2} & \dots \\
+  \frac{\partial f_2}{x_1} & \frac{\partial f_2}{x_2} & \dots \\
+  \vdots & \vdots & \ddots \\
+\end{bmatrix}.
+\]
+
+When the function $ f $ is scalar ($n=1$), the Jacobian is the same as
+the gradient of the function (or, in fact, its transpose). More
+precisely, the <b>gradient</b> $\nabla f $ of $ f $ denotes the column
+vector of partial derivatives:
+
+\[
+\nabla f
+ = \frac{\partial f}{\partial \bx}
+ =
+ \begin{bmatrix}
+  \frac{\partial f}{\partial x_1} \\
+  \frac{\partial f}{\partial x_2} \\
+  \vdots
+\end{bmatrix}.
+\]
+
+The second derivative $H_f $ of a scalar function $ f $, or
+<b>Hessian</b>, is denoted as
+
+\[
+H_f
+= \frac{\partial f}{\partial \bx \partial \bx^\top}
+= \frac{\partial \nabla f}{\partial \bx^\top}
+=
+\begin{bmatrix}
+  \frac{\partial f}{\partial x_1 \partial x_1} & \frac{\partial f}{\partial x_1 \partial x_2} & \dots \\
+  \frac{\partial f}{\partial x_2 \partial x_1} & \frac{\partial f}{\partial x_2 \partial x_2} & \dots \\
+  \vdots & \vdots & \ddots \\
+\end{bmatrix}.
+\]
+
+The determinant of the Hessian is also known as <b>Laplacian</b> and denoted as
+
+\[
+ \Delta f = \operatorname{det} H_f =
+\frac{\partial f}{\partial x_1^2} +
+\frac{\partial f}{\partial x_2^2} +
+\dots
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@subsection covdet-derivative-transformations Derivative and image warps
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+In the following, we will often been interested in domain warpings $u:
+\mathbb{R}^m \rightarrow \mathbb{R}^n, \bx \mapsto u(\bx)$ of a
+function $f(\bar\bx) $ and its effect on the derivatives of the
+function. The key transformation is the chain rule:
+
+\[
+\frac{\partial f \circ u}{\partial \bx^\top}
+=
+\left(\frac{\partial f}{\partial \bar\bx^\top} \circ u\right)
+\frac{\partial u}{\partial \bx^\top}
+\]
+
+In particular, for an affine transformation $u = (A,T) : \bx \mapsto
+A\bx + T$, one obtains the transformation rules:
+
+\[
+\begin{align*}
+\frac{\partial f \circ (A,T)}{\partial \bx^\top}
+&=
+\left(\frac{\partial f}{\partial \bar\bx^\top} \circ (A,T)\right)A,
+\\
+\nabla (f \circ (A,T))
+&= A^\top (\nabla f) \circ (A,T),
+\\
+H_{f \circ(A,T)}
+&= A^\top (H_f \circ (A,T)) A,
+\\
+\Delta (f \circ(A,T))
+&= \det(A)^2\, (\Delta f) \circ (A,T).
+\end{align*}
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-smoothing Integral operations: smoothing
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+In practice, given an image $\ell$ expressed in digital format, good
+derivative approximations can be computed only if the bandwidth of the
+image is limited and, in particular, compatible with the sampling
+density. Since it is unreasonable to expect real images to be
+band-limited, the bandwidth is artificially constrained by suitably
+smoothing the image prior to computing its derivatives. This is also
+interpreted as a form of regularization or as a way of focusing on the
+image content at a particular scale.
+
+Formally, we will focus on Gaussian smoothing kernels. For the 2D case
+$\bx\in\real^2$, the Gaussian kernel of covariance $\Sigma$ is given
+by
+
+\[
+g_{\Sigma}(\bx) = \frac{1}{2\pi \sqrt{\det\Sigma}}
+  \exp\left(
+  - \frac{1}{2} \bx^\top \Sigma^{-1} \bx
+  \right).
+\]
+
+The symbol $g_{\sigma^2}$ will be used to denote a Gaussian kernel
+with isotropic standard deviation $\sigma$, i.e. $\Sigma = \sigma^2
+I$. Given an image $\ell$, the symbol $\ell_\Sigma$ will be used to
+denote the image smoothed by the Gaussian kernel of parameter
+$\Sigma$:
+
+\[
+\ell_\Sigma(\bx) = (g_\Sigma * \ell)(\bx)
+=
+\int_{\real^m}
+g_\Sigma(\bx - \by) \ell(\by)\,d\by.
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@subsection covdet-smoothing-transformations Smoothing and image warps
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+One advantage of Gaussian kernels is that they are (up to
+renormalization) closed under a linear warp:
+
+\[
+ |A|\, g_\Sigma \circ A = g_{A^{-1} \Sigma A^{-\top}}
+\]
+
+This also means that smoothing a warped image is the same as warping
+the result of smoothing the original image by a suitably adjusted
+Gaussian kernel:
+
+\[
+g_{\Sigma} * (\ell \circ (A,T))
+=
+(g_{A\Sigma A^\top} * \ell) \circ (A,T).
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page covdet-corner-types Cornerness measures
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+The goal of a cornerness measure (@ref covdet-cornerness) is to
+associate to an image patch a score proportional to how strongly the
+patch contain a certain strucuture, for example a corner or a
+blob. This page reviews the most important cornerness measures as
+implemented in VLFeat:
+
+- @ref covdet-harris
+- @ref covdet-laplacian
+- @ref covdet-hessian
+
+This page makes use of notation introduced in @ref
+covdet-differential.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-harris Harris corners
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+This section introduces the fist of the cornerness measure
+$\mathcal{F}[\ell]$. Recall (@ref covdet-cornerness) that the goal of
+this functional is to respond strongly to images $\ell$ of corner-like
+structure.
+
+Rather than explicitly encoding the appearance of corners, the idea of
+the Harris measure is to label as corner *any* image patch whose
+appearance is sufficiently distinctive to allow accurate
+localization. In particular, consider an image patch $\ell(\bx),
+\bx\in\Omega$, where $\Omega$ is a smooth circular window of radius
+approximately $\sigma_i$; at necessary condition for the patch to
+allow accurate localization is that even a small translation
+$\ell(\bx+\delta)$ causes the appearance to vary significantly (if not
+the origin and location $\delta$ would not be distinguishable from the
+image alone). This variation is measured by the sum of squared
+differences
+
+\[
+E(\delta) = \int g_{\sigma_i^2}(\bx)
+(\ell_{\sigma_d^2}(\bx+\delta) -
+ \ell_{\sigma_d^2}(\bx))^2 \,d\bx
+\]
+
+Note that images are compared at scale $\sigma_d$, known as
+ *differentiation scale* for reasons that will be clear in a moment,
+and that the squared differences are summed over a window softly
+defined by $\sigma_i$, also known as *integration scale*. This
+function can be approximated as $E(\delta)\approx \delta^\top
+M[\ell;\sigma_i^2,\sigma_d^2] \delta$ where
+
+\[
+  M[\ell;\sigma_i^2,\sigma_d^2]
+= \int  g_{\sigma_i^2}(\bx)
+ (\nabla \ell_{\sigma_d^2}(\bx))
+ (\nabla \ell_{\sigma_d^2}(\bx))^\top \, d\bx.
+\]
+
+is the so called **structure tensor**.
+
+A corner is identified when the sum of squared differences $E(\delta)$
+is large for displacements $\delta$ in all directions. This condition
+is obtained when both the eignenvalues $\lambda_1,\lambda_2$ of the
+structure tensor $M$ are large. The **Harris cornerness measure**
+captures this fact:
+
+\[
+ \operatorname{Harris}[\ell;\sigma_i^2,\sigma_d^2] =
+ \det M - \kappa \operatorname{trace}^2 M =
+ \lambda_1\lambda_2 - \kappa (\lambda_1+\lambda_2)^2
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@subsection covdet-harris-warped Harris in the warped domain
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+The cornerness measure of a feature a location $u$ (recall that
+locations $u$ are in general defined as image warps) should be
+computed after normalizing the image (by applying to it the warp
+$u^{-1}$). This section shows that, for affine warps, the Harris
+cornerness measure can be computed directly in the Gaussian affine
+scale space of the image. In particular, for similarities, it can be
+computed in the standard Gaussian scale space.
+
+To this end, let $u=(A,T)$ be an affine warp identifying a feature
+location in image $\ell(\bx)$. Let $\bar\ell(\bar\bx) =
+\ell(A\bar\bx+T)$ be the normalized image and rewrite the structure
+tensor of the normalized image as follows:
+
+\[
+ M[\bar\ell; \bar\Sigma_i, \bar\Sigma_d]
+=
+ M[\bar\ell; \bar\Sigma_i, \bar\Sigma_d](\mathbf{0})
+=
+\left[
+g_{\bar\Sigma_i} *
+(\nabla\bar\ell_{\bar\Sigma_d})
+(\nabla\bar\ell_{\bar\Sigma_d})^\top
+\right](\mathbf{0})
+\]
+
+This notation emphasizes that the structure tensor is obtained by
+taking derivatives and convolutions of the image. Using the fact that
+$\nabla g_{\bar\Sigma_d} * \bar\ell = A^\top (\nabla g_{A\bar\Sigma
+A^\top} * \ell) \circ (A,T)$ and that $g_{\bar\Sigma} * \bar \ell =
+(g_{A\bar\Sigma A^\top} * \ell) \circ (A,T)$, we get the equivalent
+expression:
+
+\[
+ M[\bar\ell; \bar\Sigma_i, \bar\Sigma_d](\mathbf{0})
+ =
+A^\top
+\left[
+g_{A\bar\Sigma_i A^\top} *
+(\nabla\ell_{A\bar\Sigma_dA^\top})(\nabla\ell_{A\bar\Sigma_d A^\top})^\top
+\right](A\mathbf{0}+T)
+A.
+\]
+
+In other words, the structure tensor of the normalized image can be
+computed as:
+
+\[
+M[\bar\ell; \bar\Sigma_i, \bar\Sigma_d](\mathbf{0})
+=
+A^\top M[\ell; \Sigma_i, \Sigma_d](T) A,
+\quad
+\Sigma_{i} = A\bar\Sigma_{i}A^\top,
+\quad
+\Sigma_{d} = A\bar\Sigma_{d}A^\top.
+\]
+
+This equation allows to compute the structure tensor for feature at
+all locations directly in the original image. In particular, features
+at all translations $T$ can be evaluated efficiently by computing
+convolutions and derivatives of the image
+$\ell_{A\bar\Sigma_dA^\top}$.
+
+A case of particular instance is when $\bar\Sigma_i= \bar\sigma_i^2 I$
+and $\bar\Sigma_d = \bar\sigma_d^2$ are both isotropic covariance
+matrices and the affine transformation is a similarity $A=sR$.  Using
+the fact that $\det\left( s^2 R^\top M R \right)= s^4 \det M$ and
+$\operatorname{tr}\left(s^2 R^\top M R\right) = s^2 \operatorname{tr}
+M$, one obtains the relation
+
+\[
+ \operatorname{Harris}[\bar \ell;\bar\sigma_i^2,\bar\sigma_d^2] =
+ s^4 \operatorname{Harris}[\ell;s^2\bar\sigma_i^2,s^2\bar\sigma_d^2](T).
+\]
+
+This equation indicates that, for similarity transformations, not only
+the structure tensor, but directly the Harris cornerness measure can
+be computed on the original image and then be transferred back to the
+normalized domain. Note, however, that this requires rescaling the
+measure by the factor $s^4$.
+
+Another important consequence of this relation is that the Harris
+measure is invariant to pure image rotations. It cannot, therefore, be
+used to associate an orientation to the detected features.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-hessian Hessian blobs
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+The *(determinant of the) Hessian* cornerness measure is given
+determinant of the Hessian of the image:
+
+\[
+ \operatorname{DetHess}[\ell;\sigma_d^2]
+ =
+ \det H_{g_{\sigma_d^2} * \ell}(\mathbf{0})
+\]
+
+This number is large and positive if the image is locally curved
+(peaked), roughly corresponding to blob-like structures in the image.
+In particular, a large score requires the product of the eigenvalues
+of the Hessian to be large, which requires both of them to have the
+same sign and are large in absolute value.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@subsection covdet-hessian-warped Hessian in the warped domain
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+Similarly to the Harris measure, it is possible to work with the
+Hessian measure on the original unnormalized image. As before, let
+$\bar\ell(\bar\bx) = \ell(A\bar\bx+T)$ be the normalized image and
+rewrite the Hessian of the normalized image as follows:
+
+\[
+H_{g_{\bar\Sigma_d} * \bar\ell}(\mathbf{0}) = A^\top \left(H_{g_{\Sigma_d} * \ell}(T)\right) A.
+\]
+
+Then
+
+\[
+ \operatorname{DetHess}[\bar\ell;\bar\Sigma_d]
+ =
+ (\det A)^2 \operatorname{DetHess}[\ell;A\bar\Sigma_d A^\top](T).
+\]
+
+In particular, for isotropic covariance matrices and similarity
+transformations $A=sR$:
+
+\[
+ \operatorname{DetHess}[\bar\ell;\bar\sigma_d^2]
+ =
+ s^4 \operatorname{DetHess}[\ell;s^2\bar\sigma_d^2](T)
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section covdet-laplacian Laplacian and Difference of Gaussians blobs
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+The **Laplacian of Gaussian (LoG)** or **trace of the Hessian**
+cornerness measure is given by the trace of the Hessian of the image:
+
+\[
+ \operatorname{Lap}[\ell;\sigma_d^2]
+ =
+ \operatorname{tr} H_{g_{\sigma_d}^2 * \ell}
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@subsection covdet-laplacian-warped Laplacian in the warped domain
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+Similarly to the Hessian measure, the Laplacian cornenress can often
+be efficiently computed for features at all locations in the original
+unnormalized image domain. In particular, if the derivative covariance
+matrix $\Sigma_d$ is isotropic and one considers as warpings
+similarity transformations $A=sR$, where $R$ is a rotatin and $s$ a
+rescaling, one has
+
+\[
+ \operatorname{Lap}[\bar\ell;\bar\sigma_d^2]
+ =
+ s^2 \operatorname{Lap}[\ell;s^2\bar\sigma_d^2](T)
+\]
+
+Note that, comparing to the Harris and determinant of Hessian
+measures, the scaling for the Laplacian is $s^2$ rather than $s^4$.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@subsection covdet-laplacian-matched Laplacian as a matched filter
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+The Laplacian is given by the trace of the Hessian
+operator. Differently from the determinant of the Hessian, this is a
+linear operation. This means that computing the Laplacian cornerness
+measure can be seen as applying a linear filtering operator to the
+image. This filter can then be interpreted as a *template* of a corner
+being matched to the image. Hence, the Laplacian cornerness measure
+can be interpreted as matching this corner template at all possible
+image locations.
+
+To see this formally, compute the Laplacian score in the input image domain:
+
+\[
+ \operatorname{Lap}[\bar\ell;\bar\sigma_d^2]
+ =
+ s^2 \operatorname{Lap}[\ell;s^2\bar\sigma_d^2](T)
+ =
+ s^2 (\Delta g_{s^2\bar\sigma_d^2} * \ell)(T)
+\]
+
+The Laplacian fitler is obtained by moving the Laplacian operator from
+the image to the Gaussian smoothing kernel:
+
+\[
+ s^2 (\Delta g_{s^2\bar\sigma_d^2} * \ell)
+=
+ (s^2 \Delta g_{s^2\bar\sigma_d^2}) * \ell
+\]
+
+Note that the filter is rescaled by the $s^2$; sometimes, this factor
+is incorporated in the Laplacian operator, yielding the so-called
+normalized Laplacian.
+
+The Laplacian of Gaussian is also called *top-hat function* and has
+the expression:
+
+\[
+\Delta g_{\sigma^2}(x,y)
+=
+\frac{x^2+y^2 - 2 \sigma^2}{\sigma^4} g_{\sigma^2}(x,y).
+\]
+
+This filter, which acts as corner template, resembles a blob (a dark
+disk surrounded by a bright ring).
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@subsection covdet-laplacian-dog Difference of Gaussians
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+The **Difference of Gaussian** (DoG) cornerness measure can be
+interpreted as an approximation of the Laplacian that is easy to
+obtain once a scalespace of the input image has been computed.
+
+As noted above, the Laplacian cornerness of the normalized feature can
+be computed directly from the input image by convolving the image by
+the normalized Laplacian of Gaussian filter $s^2 \Delta
+g_{s^2\bar\sigma_d^2}$.
+
+Like the other derivative operators, this filter is simpe to
+discriteize. However, it is often approximated by computing the the
+*Difference of Gaussians* (DoG) approximation instead. This
+approximation is obtained from the easily-proved identity:
+
+\[
+  \frac{\partial}{\partial \sigma} g_{\sigma^2} =
+  \sigma \Delta g_{\sigma^2}.
+\]
+
+This indicates that computing the normalized Laplacian of a Gaussian
+filter is, in the limit, the same as taking the difference between
+Gaussian filters of slightly increasing standard deviation $\sigma$
+and $\kappa\sigma$, where $\kappa \approx 1$:
+
+\[
+\sigma^2 \Delta g_{\sigma^2}
+\approx
+\sigma \frac{g_{(\kappa\sigma)^2} - g_{\sigma^2}}{\kappa\sigma - \sigma}
+=
+\frac{1}{\kappa - 1}
+(g_{(\kappa\sigma)^2} - g_{\sigma^2}).
+\]
+
+One nice propery of this expression is that the factor $\sigma$
+cancels out in the right-hand side. Usually, scales $\sigma$ and
+$\kappa\sigma$ are pre-computed in the image scale-space and
+successive scales are sampled with uniform geometric spacing, meaning
+that the factor $\kappa$ is the same for all scales. Then, up to a
+overall scaling factor, the LoG cornerness measure can be obtained by
+taking the difference of successive scale space images
+$\ell_{(\kappa\sigma)^2}$ and $\ell_{\sigma^2}$.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page covdet-affine-adaptation Affine adaptation
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page covdet-dominant-orientation Dominant orientation
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+**/
+
+#include "covdet.h"
+#include <string.h>
+
+/** @brief Reallocate buffer
+ ** @param buffer
+ ** @param bufferSize
+ ** @param targetSize
+ ** @return error code
+ **/
+
+static int
+_vl_resize_buffer (void ** buffer, vl_size * bufferSize, vl_size targetSize) {
+  void * newBuffer ;
+  if (*buffer == NULL) {
+    *buffer = vl_malloc(targetSize) ;
+    if (*buffer) {
+      *bufferSize = targetSize ;
+      return VL_ERR_OK ;
+    } else {
+      *bufferSize = 0 ;
+      return VL_ERR_ALLOC ;
+    }
+  }
+  newBuffer = vl_realloc(*buffer, targetSize) ;
+  if (newBuffer) {
+    *buffer = newBuffer ;
+    *bufferSize = targetSize ;
+    return VL_ERR_OK ;
+  } else {
+    return VL_ERR_ALLOC ;
+  }
+}
+
+/** @brief Enlarge buffer
+ ** @param buffer
+ ** @param bufferSize
+ ** @param targetSize
+ ** @return error code
+ **/
+
+static int
+_vl_enlarge_buffer (void ** buffer, vl_size * bufferSize, vl_size targetSize) {
+  if (*bufferSize >= targetSize) return VL_ERR_OK ;
+  return _vl_resize_buffer(buffer,bufferSize,targetSize) ;
+}
+
+/* ---------------------------------------------------------------- */
+/*                                            Finding local extrema */
+/* ---------------------------------------------------------------- */
+
+/* Todo: make this generally available in the library */
+
+typedef struct _VlCovDetExtremum2
+{
+  vl_index xi ;
+  vl_index yi ;
+  float x ;
+  float y ;
+  float peakScore ;
+  float edgeScore ;
+} VlCovDetExtremum2 ;
+
+typedef struct _VlCovDetExtremum3
+{
+  vl_index xi ;
+  vl_index yi ;
+  vl_index zi ;
+  float x ;
+  float y ;
+  float z ;
+  float peakScore ;
+  float edgeScore ;
+} VlCovDetExtremum3 ;
+
+VL_EXPORT vl_size
+vl_find_local_extrema_3 (vl_index ** extrema, vl_size * bufferSize,
+                         float const * map,
+                         vl_size width, vl_size height, vl_size depth,
+                         double threshold) ;
+
+VL_EXPORT vl_size
+vl_find_local_extrema_2 (vl_index ** extrema, vl_size * bufferSize,
+                         float const * map,
+                         vl_size width, vl_size height,
+                         double threshold) ;
+
+VL_EXPORT vl_bool
+vl_refine_local_extreum_3 (VlCovDetExtremum3 * refined,
+                           float const * map,
+                           vl_size width, vl_size height, vl_size depth,
+                           vl_index x, vl_index y, vl_index z) ;
+
+VL_EXPORT vl_bool
+vl_refine_local_extreum_2 (VlCovDetExtremum2 * refined,
+                           float const * map,
+                           vl_size width, vl_size height,
+                           vl_index x, vl_index y) ;
+
+/** @internal
+ ** @brief Find the extrema of a 3D function
+ ** @param extrema buffer containing the extrema found (in/out).
+ ** @param bufferSize size of the @a extrema buffer in bytes (in/out).
+ ** @param map a 3D array representing the map.
+ ** @param width of the map.
+ ** @param height of the map.
+ ** @param depth of the map.
+ ** @param threshold minumum extremum value.
+ ** @return number of extrema found.
+ ** @see @ref ::vl_refine_local_extreum_2.
+ **/
+
+vl_size
+vl_find_local_extrema_3 (vl_index ** extrema, vl_size * bufferSize,
+                         float const * map,
+                         vl_size width, vl_size height, vl_size depth,
+                         double threshold)
+{
+  vl_index x, y, z ;
+  vl_size const xo = 1 ;
+  vl_size const yo = width ;
+  vl_size const zo = width * height ;
+  float const *pt = map + xo + yo + zo ;
+
+  vl_size numExtrema = 0 ;
+  vl_size requiredSize = 0 ;
+
+#define CHECK_NEIGHBORS_3(v,CMP,SGN)     (\
+v CMP ## = SGN threshold &&               \
+v CMP *(pt + xo) &&                       \
+v CMP *(pt - xo) &&                       \
+v CMP *(pt + zo) &&                       \
+v CMP *(pt - zo) &&                       \
+v CMP *(pt + yo) &&                       \
+v CMP *(pt - yo) &&                       \
+\
+v CMP *(pt + yo + xo) &&                  \
+v CMP *(pt + yo - xo) &&                  \
+v CMP *(pt - yo + xo) &&                  \
+v CMP *(pt - yo - xo) &&                  \
+\
+v CMP *(pt + xo      + zo) &&             \
+v CMP *(pt - xo      + zo) &&             \
+v CMP *(pt + yo      + zo) &&             \
+v CMP *(pt - yo      + zo) &&             \
+v CMP *(pt + yo + xo + zo) &&             \
+v CMP *(pt + yo - xo + zo) &&             \
+v CMP *(pt - yo + xo + zo) &&             \
+v CMP *(pt - yo - xo + zo) &&             \
+\
+v CMP *(pt + xo      - zo) &&             \
+v CMP *(pt - xo      - zo) &&             \
+v CMP *(pt + yo      - zo) &&             \
+v CMP *(pt - yo      - zo) &&             \
+v CMP *(pt + yo + xo - zo) &&             \
+v CMP *(pt + yo - xo - zo) &&             \
+v CMP *(pt - yo + xo - zo) &&             \
+v CMP *(pt - yo - xo - zo) )
+
+  for (z = 1 ; z < (signed)depth - 1 ; ++z) {
+    for (y = 1 ; y < (signed)height - 1 ; ++y) {
+      for (x = 1 ; x < (signed)width - 1 ; ++x) {
+        float value = *pt ;
+        if (CHECK_NEIGHBORS_3(value,>,+) || CHECK_NEIGHBORS_3(value,<,-)) {
+          numExtrema ++ ;
+          requiredSize += sizeof(vl_index) * 3 ;
+          if (*bufferSize < requiredSize) {
+            int err = _vl_resize_buffer((void**)extrema, bufferSize,
+                                        requiredSize + 2000 * 3 * sizeof(vl_index)) ;
+            if (err != VL_ERR_OK) abort() ;
+          }
+          (*extrema) [3 * (numExtrema - 1) + 0] = x ;
+          (*extrema) [3 * (numExtrema - 1) + 1] = y ;
+          (*extrema) [3 * (numExtrema - 1) + 2] = z ;
+        }
+        pt += xo ;
+      }
+      pt += 2*xo ;
+    }
+    pt += 2*yo ;
+  }
+  return numExtrema ;
+}
+
+/** @internal
+ ** @brief Find extrema in a 2D function
+ ** @param extrema buffer containing the found extrema (in/out).
+ ** @param bufferSize size of the @a extrema buffer in bytes (in/out).
+ ** @param map a 3D array representing the map.
+ ** @param width of the map.
+ ** @param height of the map.
+ ** @param threshold minumum extremum value.
+ ** @return number of extrema found.
+ **
+ ** An extremum contains 2 ::vl_index values; they are arranged
+ ** sequentially.
+ **
+ ** The function can reuse an already allocated buffer if
+ ** @a extrema and @a bufferSize are initialized on input.
+ ** It may have to @a realloc the memory if the buffer is too small.
+ **/
+
+vl_size
+vl_find_local_extrema_2 (vl_index ** extrema, vl_size * bufferSize,
+                         float const* map,
+                         vl_size width, vl_size height,
+                         double threshold)
+{
+  vl_index x, y ;
+  vl_size const xo = 1 ;
+  vl_size const yo = width ;
+  float const *pt = map + xo + yo ;
+
+  vl_size numExtrema = 0 ;
+  vl_size requiredSize = 0 ;
+#define CHECK_NEIGHBORS_2(v,CMP,SGN)     (\
+v CMP ## = SGN threshold &&               \
+v CMP *(pt + xo) &&                       \
+v CMP *(pt - xo) &&                       \
+v CMP *(pt + yo) &&                       \
+v CMP *(pt - yo) &&                       \
+\
+v CMP *(pt + yo + xo) &&                  \
+v CMP *(pt + yo - xo) &&                  \
+v CMP *(pt - yo + xo) &&                  \
+v CMP *(pt - yo - xo) )
+
+  for (y = 1 ; y < (signed)height - 1 ; ++y) {
+    for (x = 1 ; x < (signed)width - 1 ; ++x) {
+      float value = *pt ;
+      if (CHECK_NEIGHBORS_2(value,>,+) || CHECK_NEIGHBORS_2(value,<,-)) {
+        numExtrema ++ ;
+        requiredSize += sizeof(vl_index) * 2 ;
+        if (*bufferSize < requiredSize) {
+          int err = _vl_resize_buffer((void**)extrema, bufferSize,
+                                      requiredSize + 2000 * 2 * sizeof(vl_index)) ;
+          if (err != VL_ERR_OK) abort() ;
+        }
+        (*extrema) [2 * (numExtrema - 1) + 0] = x ;
+        (*extrema) [2 * (numExtrema - 1) + 1] = y ;
+      }
+      pt += xo ;
+    }
+    pt += 2*xo ;
+  }
+  return numExtrema ;
+}
+
+/** @internal
+ ** @brief Refine the location of a local extremum of a 3D map
+ ** @param refined refined extremum (out).
+ ** @param map a 3D array representing the map.
+ ** @param width of the map.
+ ** @param height of the map.
+ ** @param depth of the map.
+ ** @param x initial x position.
+ ** @param y initial y position.
+ ** @param z initial z position.
+ ** @return a flat indicating whether the extrema refinement was stable.
+ **/
+
+VL_EXPORT vl_bool
+vl_refine_local_extreum_3 (VlCovDetExtremum3 * refined,
+                           float const * map,
+                           vl_size width, vl_size height, vl_size depth,
+                           vl_index x, vl_index y, vl_index z)
+{
+  vl_size const xo = 1 ;
+  vl_size const yo = width ;
+  vl_size const zo = width * height ;
+
+  double Dx=0,Dy=0,Dz=0,Dxx=0,Dyy=0,Dzz=0,Dxy=0,Dxz=0,Dyz=0 ;
+  double A [3*3], b [3] ;
+
+#define at(dx,dy,dz) (*(pt + (dx)*xo + (dy)*yo + (dz)*zo))
+#define Aat(i,j) (A[(i)+(j)*3])
+
+  float const * pt ;
+  vl_index dx = 0 ;
+  vl_index dy = 0 ;
+  /*vl_index dz = 0 ;*/
+  vl_index iter ;
+  int err ;
+
+  assert (map) ;
+  assert (1 <= x && x <= (signed)width - 2) ;
+  assert (1 <= y && y <= (signed)height - 2) ;
+  assert (1 <= z && z <= (signed)depth - 2) ;
+
+  for (iter = 0 ; iter < 5 ; ++iter) {
+    x += dx ;
+    y += dy ;
+    pt = map + x*xo + y*yo + z*zo ;
+
+    /* compute the gradient */
+    Dx = 0.5 * (at(+1,0,0) - at(-1,0,0)) ;
+    Dy = 0.5 * (at(0,+1,0) - at(0,-1,0));
+    Dz = 0.5 * (at(0,0,+1) - at(0,0,-1)) ;
+
+    /* compute the Hessian */
+    Dxx = (at(+1,0,0) + at(-1,0,0) - 2.0 * at(0,0,0)) ;
+    Dyy = (at(0,+1,0) + at(0,-1,0) - 2.0 * at(0,0,0)) ;
+    Dzz = (at(0,0,+1) + at(0,0,-1) - 2.0 * at(0,0,0)) ;
+
+    Dxy = 0.25 * (at(+1,+1,0) + at(-1,-1,0) - at(-1,+1,0) - at(+1,-1,0)) ;
+    Dxz = 0.25 * (at(+1,0,+1) + at(-1,0,-1) - at(-1,0,+1) - at(+1,0,-1)) ;
+    Dyz = 0.25 * (at(0,+1,+1) + at(0,-1,-1) - at(0,-1,+1) - at(0,+1,-1)) ;
+
+    /* solve linear system */
+    Aat(0,0) = Dxx ;
+    Aat(1,1) = Dyy ;
+    Aat(2,2) = Dzz ;
+    Aat(0,1) = Aat(1,0) = Dxy ;
+    Aat(0,2) = Aat(2,0) = Dxz ;
+    Aat(1,2) = Aat(2,1) = Dyz ;
+
+    b[0] = - Dx ;
+    b[1] = - Dy ;
+    b[2] = - Dz ;
+
+    err = vl_solve_linear_system_3(b, A, b) ;
+
+    if (err != VL_ERR_OK) {
+      b[0] = 0 ;
+      b[1] = 0 ;
+      b[2] = 0 ;
+      break ;
+    }
+
+    /* Keep going if there is sufficient translation */
+
+    dx = (b[0] > 0.6 && x < (signed)width - 2 ?  1 : 0)
+    + (b[0] < -0.6 && x > 1 ? -1 : 0) ;
+
+    dy = (b[1] > 0.6 && y < (signed)height - 2 ?  1 : 0)
+    + (b[1] < -0.6 && y > 1 ? -1 : 0) ;
+
+    if (dx == 0 && dy == 0) break ;
+  }
+
+  /* check threshold and other conditions */
+  {
+    double peakScore = at(0,0,0)
+    + 0.5 * (Dx * b[0] + Dy * b[1] + Dz * b[2]) ;
+    double alpha = (Dxx+Dyy)*(Dxx+Dyy) / (Dxx*Dyy - Dxy*Dxy) ;
+    double edgeScore ;
+
+    if (alpha < 0) {
+      /* not an extremum */
+      edgeScore = VL_INFINITY_D ;
+    } else {
+      edgeScore = (0.5*alpha - 1) + sqrt(VL_MAX(0.25*alpha - 1,0)*alpha) ;
+    }
+
+    refined->xi = x ;
+    refined->yi = y ;
+    refined->zi = z ;
+    refined->x = x + b[0] ;
+    refined->y = y + b[1] ;
+    refined->z = z + b[2] ;
+    refined->peakScore = peakScore ;
+    refined->edgeScore = edgeScore ;
+
+    return
+    err == VL_ERR_OK &&
+    vl_abs_d(b[0]) < 1.5 &&
+    vl_abs_d(b[1]) < 1.5 &&
+    vl_abs_d(b[2]) < 1.5 &&
+    0 <= refined->x && refined->x <= (signed)width - 1 &&
+    0 <= refined->y && refined->y <= (signed)height - 1 &&
+    0 <= refined->z && refined->z <= (signed)depth - 1 ;
+  }
+#undef Aat
+#undef at
+}
+
+/** @internal
+ ** @brief Refine the location of a local extremum of a 2D map
+ ** @param refined refined extremum (out).
+ ** @param map a 2D array representing the map.
+ ** @param width of the map.
+ ** @param height of the map.
+ ** @param x initial x position.
+ ** @param y initial y position.
+ ** @return a flat indicating whether the extrema refinement was stable.
+ **/
+
+VL_EXPORT vl_bool
+vl_refine_local_extreum_2 (VlCovDetExtremum2 * refined,
+                           float const * map,
+                           vl_size width, vl_size height,
+                           vl_index x, vl_index y)
+{
+  vl_size const xo = 1 ;
+  vl_size const yo = width ;
+
+  double Dx=0,Dy=0,Dxx=0,Dyy=0,Dxy=0;
+  double A [2*2], b [2] ;
+
+#define at(dx,dy) (*(pt + (dx)*xo + (dy)*yo ))
+#define Aat(i,j) (A[(i)+(j)*2])
+
+  float const * pt ;
+  vl_index dx = 0 ;
+  vl_index dy = 0 ;
+  vl_index iter ;
+  int err ;
+
+  assert (map) ;
+  assert (1 <= x && x <= (signed)width - 2) ;
+  assert (1 <= y && y <= (signed)height - 2) ;
+
+  for (iter = 0 ; iter < 5 ; ++iter) {
+    x += dx ;
+    y += dy ;
+    pt = map + x*xo + y*yo  ;
+
+    /* compute the gradient */
+    Dx = 0.5 * (at(+1,0) - at(-1,0)) ;
+    Dy = 0.5 * (at(0,+1) - at(0,-1));
+
+    /* compute the Hessian */
+    Dxx = (at(+1,0) + at(-1,0) - 2.0 * at(0,0)) ;
+    Dyy = (at(0,+1) + at(0,-1) - 2.0 * at(0,0)) ;
+    Dxy = 0.25 * (at(+1,+1) + at(-1,-1) - at(-1,+1) - at(+1,-1)) ;
+
+    /* solve linear system */
+    Aat(0,0) = Dxx ;
+    Aat(1,1) = Dyy ;
+    Aat(0,1) = Aat(1,0) = Dxy ;
+
+    b[0] = - Dx ;
+    b[1] = - Dy ;
+
+    err = vl_solve_linear_system_2(b, A, b) ;
+
+    if (err != VL_ERR_OK) {
+      b[0] = 0 ;
+      b[1] = 0 ;
+      break ;
+    }
+
+    /* Keep going if there is sufficient translation */
+
+    dx = (b[0] > 0.6 && x < (signed)width - 2 ?  1 : 0)
+    + (b[0] < -0.6 && x > 1 ? -1 : 0) ;
+
+    dy = (b[1] > 0.6 && y < (signed)height - 2 ?  1 : 0)
+    + (b[1] < -0.6 && y > 1 ? -1 : 0) ;
+
+    if (dx == 0 && dy == 0) break ;
+  }
+
+  /* check threshold and other conditions */
+  {
+    double peakScore = at(0,0) + 0.5 * (Dx * b[0] + Dy * b[1]) ;
+    double alpha = (Dxx+Dyy)*(Dxx+Dyy) / (Dxx*Dyy - Dxy*Dxy) ;
+    double edgeScore ;
+
+    if (alpha < 0) {
+      /* not an extremum */
+      edgeScore = VL_INFINITY_D ;
+    } else {
+      edgeScore = (0.5*alpha - 1) + sqrt(VL_MAX(0.25*alpha - 1,0)*alpha) ;
+    }
+
+    refined->xi = x ;
+    refined->yi = y ;
+    refined->x = x + b[0] ;
+    refined->y = y + b[1] ;
+    refined->peakScore = peakScore ;
+    refined->edgeScore = edgeScore ;
+
+    return
+    err == VL_ERR_OK &&
+    vl_abs_d(b[0]) < 1.5 &&
+    vl_abs_d(b[1]) < 1.5 &&
+    0 <= refined->x && refined->x <= (signed)width - 1 &&
+    0 <= refined->y && refined->y <= (signed)height - 1 ;
+  }
+#undef Aat
+#undef at
+}
+
+/* ---------------------------------------------------------------- */
+/*                                                Covarant detector */
+/* ---------------------------------------------------------------- */
+
+#define VL_COVDET_MAX_NUM_ORIENTATIONS 4
+#define VL_COVDET_MAX_NUM_LAPLACIAN_SCALES 4
+#define VL_COVDET_AA_PATCH_RESOLUTION 20
+#define VL_COVDET_AA_MAX_NUM_ITERATIONS 15
+#define VL_COVDET_OR_NUM_ORIENTATION_HISTOGAM_BINS 36
+#define VL_COVDET_AA_RELATIVE_INTEGRATION_SIGMA 3
+#define VL_COVDET_AA_RELATIVE_DERIVATIVE_SIGMA 1
+#define VL_COVDET_AA_MAX_ANISOTROPY 5
+#define VL_COVDET_AA_CONVERGENCE_THRESHOLD 1.001
+#define VL_COVDET_AA_ACCURATE_SMOOTHING VL_FALSE
+#define VL_COVDET_AA_PATCH_EXTENT (3*VL_COVDET_AA_RELATIVE_INTEGRATION_SIGMA)
+#define VL_COVDET_OR_ADDITIONAL_PEAKS_RELATIVE_SIZE 0.8
+#define VL_COVDET_LAP_NUM_LEVELS 10
+#define VL_COVDET_LAP_PATCH_RESOLUTION 16
+#define VL_COVDET_LAP_DEF_PEAK_THRESHOLD 0.01
+#define VL_COVDET_DOG_DEF_PEAK_THRESHOLD VL_COVDET_LAP_DEF_PEAK_THRESHOLD
+#define VL_COVDET_DOG_DEF_EDGE_THRESHOLD 10.0
+#define VL_COVDET_HARRIS_DEF_PEAK_THRESHOLD 0.000002
+#define VL_COVDET_HARRIS_DEF_EDGE_THRESHOLD 10.0
+#define VL_COVDET_HESSIAN_DEF_PEAK_THRESHOLD 0.003
+#define VL_COVDET_HESSIAN_DEF_EDGE_THRESHOLD 10.0
+#define VL_COVDET_GSS_BASE_SCALE 1.6
+
+/** @brief Covariant feature detector */
+struct _VlCovDet
+{
+  VlScaleSpace *gss ;          /**< Gaussian scale space. */
+  VlScaleSpace *css ;          /**< Cornerness scale space. */
+  VlCovDetMethod method ;      /**< feature extraction method. */
+  double peakThreshold ;       /**< peak threshold. */
+  double edgeThreshold ;       /**< edge threshold. */
+  double lapPeakThreshold;     /**< peak threshold for Laplacian scale selection. */
+  vl_size octaveResolution ;   /**< resolution of each octave. */
+  vl_index numOctaves ;        /**< number of octaves */
+  vl_index firstOctave ;       /**< index of the first octave. */
+  double baseScale ;           /**< the base scale of the gss. */
+  vl_size maxNumOrientations ; /**< max number of detected orientations. */
+
+  double nonExtremaSuppression ;
+  vl_size numNonExtremaSuppressed ;
+
+  VlCovDetFeature *features ;
+  vl_size numFeatures ;
+  vl_size numFeatureBufferSize ;
+
+  float * patch ;
+  vl_size patchBufferSize ;
+
+  vl_bool transposed ;
+  VlCovDetFeatureOrientation orientations [VL_COVDET_MAX_NUM_ORIENTATIONS] ;
+  VlCovDetFeatureLaplacianScale scales [VL_COVDET_MAX_NUM_LAPLACIAN_SCALES] ;
+
+  vl_bool aaAccurateSmoothing ;
+  float aaPatch [(2*VL_COVDET_AA_PATCH_RESOLUTION+1)*(2*VL_COVDET_AA_PATCH_RESOLUTION+1)] ;
+  float aaPatchX [(2*VL_COVDET_AA_PATCH_RESOLUTION+1)*(2*VL_COVDET_AA_PATCH_RESOLUTION+1)] ;
+  float aaPatchY [(2*VL_COVDET_AA_PATCH_RESOLUTION+1)*(2*VL_COVDET_AA_PATCH_RESOLUTION+1)] ;
+  float aaMask [(2*VL_COVDET_AA_PATCH_RESOLUTION+1)*(2*VL_COVDET_AA_PATCH_RESOLUTION+1)] ;
+
+  float lapPatch [(2*VL_COVDET_LAP_PATCH_RESOLUTION+1)*(2*VL_COVDET_LAP_PATCH_RESOLUTION+1)] ;
+  float laplacians [(2*VL_COVDET_LAP_PATCH_RESOLUTION+1)*(2*VL_COVDET_LAP_PATCH_RESOLUTION+1)*VL_COVDET_LAP_NUM_LEVELS] ;
+  vl_size numFeaturesWithNumScales [VL_COVDET_MAX_NUM_LAPLACIAN_SCALES + 1] ;
+
+  vl_bool allowPaddedWarping ;
+}  ;
+
+VlEnumerator vlCovdetMethods [VL_COVDET_METHOD_NUM] = {
+  {"DoG" ,              (vl_index)VL_COVDET_METHOD_DOG               },
+  {"Hessian",           (vl_index)VL_COVDET_METHOD_HESSIAN           },
+  {"HessianLaplace",    (vl_index)VL_COVDET_METHOD_HESSIAN_LAPLACE   },
+  {"HarrisLaplace",     (vl_index)VL_COVDET_METHOD_HARRIS_LAPLACE    },
+  {"MultiscaleHessian", (vl_index)VL_COVDET_METHOD_MULTISCALE_HESSIAN},
+  {"MultiscaleHarris",  (vl_index)VL_COVDET_METHOD_MULTISCALE_HARRIS },
+  {0,                   0                                            }
+} ;
+
+/** @brief Create a new object instance
+ ** @param method method for covariant feature detection.
+ ** @return new covariant detector.
+ **/
+
+VlCovDet *
+vl_covdet_new (VlCovDetMethod method)
+{
+  VlCovDet * self = vl_calloc(sizeof(VlCovDet),1) ;
+  self->method = method ;
+  self->octaveResolution = 3 ;
+  self->numOctaves = -1 ;
+  self->firstOctave = -1 ;
+  self->baseScale = VL_COVDET_GSS_BASE_SCALE ;
+  self->maxNumOrientations = VL_COVDET_MAX_NUM_ORIENTATIONS ;
+  switch (self->method) {
+    case VL_COVDET_METHOD_DOG :
+      self->peakThreshold = VL_COVDET_DOG_DEF_PEAK_THRESHOLD ;
+      self->edgeThreshold = VL_COVDET_DOG_DEF_EDGE_THRESHOLD ;
+      self->lapPeakThreshold = 0  ; /* not used */
+      break ;
+    case VL_COVDET_METHOD_HARRIS_LAPLACE:
+    case VL_COVDET_METHOD_MULTISCALE_HARRIS:
+      self->peakThreshold = VL_COVDET_HARRIS_DEF_PEAK_THRESHOLD ;
+      self->edgeThreshold = VL_COVDET_HARRIS_DEF_EDGE_THRESHOLD ;
+      self->lapPeakThreshold = VL_COVDET_LAP_DEF_PEAK_THRESHOLD ;
+      break ;
+    case VL_COVDET_METHOD_HESSIAN :
+    case VL_COVDET_METHOD_HESSIAN_LAPLACE:
+    case VL_COVDET_METHOD_MULTISCALE_HESSIAN:
+      self->peakThreshold = VL_COVDET_HESSIAN_DEF_PEAK_THRESHOLD ;
+      self->edgeThreshold = VL_COVDET_HESSIAN_DEF_EDGE_THRESHOLD ;
+      self->lapPeakThreshold = VL_COVDET_LAP_DEF_PEAK_THRESHOLD ;
+      break;
+    default:
+      assert(0) ;
+  }
+
+  self->nonExtremaSuppression = 0.5 ;
+  self->features = NULL ;
+  self->numFeatures = 0 ;
+  self->numFeatureBufferSize = 0 ;
+  self->patch = NULL ;
+  self->patchBufferSize = 0 ;
+  self->transposed = VL_FALSE ;
+  self->aaAccurateSmoothing = VL_COVDET_AA_ACCURATE_SMOOTHING ;
+  self->allowPaddedWarping = VL_TRUE ;
+
+  {
+    vl_index const w = VL_COVDET_AA_PATCH_RESOLUTION ;
+    vl_index i,j ;
+    double step = (2.0 * VL_COVDET_AA_PATCH_EXTENT) / (2*w+1) ;
+    double sigma = VL_COVDET_AA_RELATIVE_INTEGRATION_SIGMA ;
+    for (j = -w ; j <= w ; ++j) {
+      for (i = -w ; i <= w ; ++i) {
+        double dx = i*step/sigma ;
+        double dy = j*step/sigma ;
+        self->aaMask[(i+w) + (2*w+1)*(j+w)] = exp(-0.5*(dx*dx+dy*dy)) ;
+      }
+    }
+  }
+
+  {
+    /*
+     Covers one octave of Laplacian filters, from sigma=1 to sigma=2.
+     The spatial sampling step is 0.5.
+     */
+    vl_index s ;
+    for (s = 0 ; s < VL_COVDET_LAP_NUM_LEVELS ; ++s) {
+      double sigmaLap = pow(2.0, -0.5 +
+                            (double)s / (VL_COVDET_LAP_NUM_LEVELS - 1)) ;
+      double const sigmaImage = 1.0 / sqrt(2.0) ;
+      double const step = 0.5 * sigmaImage ;
+      double const sigmaDelta = sqrt(sigmaLap*sigmaLap - sigmaImage*sigmaImage) ;
+      vl_size const w = VL_COVDET_LAP_PATCH_RESOLUTION ;
+      vl_size const num = 2 * w + 1  ;
+      float * pt = self->laplacians + s * (num * num) ;
+
+      memset(pt, 0, num * num * sizeof(float)) ;
+
+#define at(x,y) pt[(x+w)+(y+w)*(2*w+1)]
+      at(0,0) = - 4.0 ;
+      at(-1,0) = 1.0 ;
+      at(+1,0) = 1.0 ;
+      at(0,1) = 1.0 ;
+      at(0,-1) = 1.0 ;
+#undef at
+
+      vl_imsmooth_f(pt, num,
+                    pt, num, num, num,
+                    sigmaDelta / step, sigmaDelta / step) ;
+
+#if 0
+      {
+        char name [200] ;
+        snprintf(name, 200, "/tmp/%f-lap.pgm", sigmaDelta) ;
+        vl_pgm_write_f(name, pt, num, num) ;
+      }
+#endif
+
+    }
+  }
+  return self ;
+}
+
+/** @brief Reset object
+ ** @param self object.
+ **
+ ** This function removes any buffered features and frees other
+ ** internal buffers.
+ **/
+
+void
+vl_covdet_reset (VlCovDet * self)
+{
+  if (self->features) {
+    vl_free(self->features) ;
+    self->features = NULL ;
+  }
+  if (self->css) {
+    vl_scalespace_delete(self->css) ;
+    self->css = NULL ;
+  }
+  if (self->gss) {
+    vl_scalespace_delete(self->gss) ;
+    self->gss = NULL ;
+  }
+}
+
+/** @brief Delete object instance
+ ** @param self object.
+ **/
+
+void
+vl_covdet_delete (VlCovDet * self)
+{
+  vl_covdet_reset(self) ;
+  if (self->patch) vl_free (self->patch) ;
+  vl_free(self) ;
+}
+
+/** @brief Append a feature to the internal buffer.
+ ** @param self object.
+ ** @param feature a pointer to the feature to append.
+ ** @return status.
+ **
+ ** The feature is copied. The function may fail with @c status
+ ** equal to ::VL_ERR_ALLOC if there is insufficient memory.
+ **/
+
+int
+vl_covdet_append_feature (VlCovDet * self, VlCovDetFeature const * feature)
+{
+  vl_size requiredSize ;
+  assert(self) ;
+  assert(feature) ;
+  self->numFeatures ++ ;
+  requiredSize = self->numFeatures * sizeof(VlCovDetFeature) ;
+  if (requiredSize > self->numFeatureBufferSize) {
+    int err = _vl_resize_buffer((void**)&self->features, &self->numFeatureBufferSize,
+                                (self->numFeatures + 1000) * sizeof(VlCovDetFeature)) ;
+    if (err) {
+      self->numFeatures -- ;
+      return err ;
+    }
+  }
+  self->features[self->numFeatures - 1] = *feature ;
+  return VL_ERR_OK ;
+}
+
+/* ---------------------------------------------------------------- */
+/*                                              Process a new image */
+/* ---------------------------------------------------------------- */
+
+/** @brief Detect features in an image
+ ** @param self object.
+ ** @param image image to process.
+ ** @param width image width.
+ ** @param height image height.
+ ** @return status.
+ **
+ ** @a width and @a height must be at least one pixel. The function
+ ** fails by returing ::VL_ERR_ALLOC if the memory is insufficient.
+ **/
+
+int
+vl_covdet_put_image (VlCovDet * self,
+                     float const * image,
+                     vl_size width, vl_size height)
+{
+  vl_size const minOctaveSize = 16 ;
+  vl_index lastOctave ;
+  vl_index octaveFirstSubdivision ;
+  vl_index octaveLastSubdivision ;
+  VlScaleSpaceGeometry geom = vl_scalespace_get_default_geometry(width,height) ;
+
+  assert (self) ;
+  assert (image) ;
+  assert (width >= 1) ;
+  assert (height >= 1) ;
+
+  /* (minOctaveSize - 1) 2^lastOctave <= min(width,height) - 1 */
+  lastOctave = vl_floor_d(vl_log2_d(VL_MIN((double)width-1,(double)height-1) / (minOctaveSize - 1))) ;
+  if (self->numOctaves > 0) {
+      lastOctave = VL_MIN((vl_index)self->numOctaves - self->firstOctave - 1, lastOctave);
+  }
+
+  if (self->method == VL_COVDET_METHOD_DOG) {
+    octaveFirstSubdivision = -1 ;
+    octaveLastSubdivision = self->octaveResolution + 1 ;
+  } else if (self->method == VL_COVDET_METHOD_HESSIAN) {
+    octaveFirstSubdivision = -1 ;
+    octaveLastSubdivision = self->octaveResolution ;
+  } else {
+    octaveFirstSubdivision = 0 ;
+    octaveLastSubdivision = self->octaveResolution - 1 ;
+  }
+
+  geom.width = width ;
+  geom.height = height ;
+  geom.firstOctave = self->firstOctave ;
+  geom.lastOctave = lastOctave ;
+  geom.octaveResolution = self->octaveResolution ;
+  geom.baseScale = self->baseScale * pow(2.0, 1.0 / self->octaveResolution) ;
+  geom.octaveFirstSubdivision = octaveFirstSubdivision ;
+  geom.octaveLastSubdivision = octaveLastSubdivision ;
+
+  if (self->gss == NULL ||
+      ! vl_scalespacegeometry_is_equal (geom,
+                                        vl_scalespace_get_geometry(self->gss)))
+  {
+    if (self->gss) vl_scalespace_delete(self->gss) ;
+    self->gss = vl_scalespace_new_with_geometry(geom) ;
+    if (self->gss == NULL) return VL_ERR_ALLOC ;
+  }
+  vl_scalespace_put_image(self->gss, image) ;
+  return VL_ERR_OK ;
+}
+
+/* ---------------------------------------------------------------- */
+/*                                              Cornerness measures */
+/* ---------------------------------------------------------------- */
+
+/** @brief Scaled derminant of the Hessian filter
+ ** @param hessian output image.
+ ** @param image input image.
+ ** @param width image width.
+ ** @param height image height.
+ ** @param step image sampling step (pixel size).
+ ** @param sigma Gaussian smoothing of the input image.
+ **/
+
+static void
+_vl_det_hessian_response (float * hessian,
+                          float const * image,
+                          vl_size width, vl_size height,
+                          double step, double sigma)
+{
+  float factor = (float) pow(sigma/step, 4.0) ;
+  vl_index const xo = 1 ; /* x-stride */
+  vl_index const yo = width;  /* y-stride */
+  vl_size r, c;
+
+  float p11, p12, p13, p21, p22, p23, p31, p32, p33;
+
+  /* setup input pointer to be centered at 0,1 */
+  float const *in = image + yo ;
+
+  /* setup output pointer to be centered at 1,1 */
+  float *out = hessian + xo + yo;
+
+  /* move 3x3 window and convolve */
+  for (r = 1; r < height - 1; ++r)
+  {
+    /* fill in shift registers at the beginning of the row */
+    p11 = in[-yo]; p12 = in[xo - yo];
+    p21 = in[  0]; p22 = in[xo     ];
+    p31 = in[+yo]; p32 = in[xo + yo];
+    /* setup input pointer to (2,1) of the 3x3 square */
+    in += 2;
+    for (c = 1; c < width - 1; ++c)
+    {
+      float Lxx, Lyy, Lxy;
+      /* fetch remaining values (last column) */
+      p13 = in[-yo]; p23 = *in; p33 = in[+yo];
+
+      /* Compute 3x3 Hessian values from pixel differences. */
+      Lxx = (-p21 + 2*p22 - p23);
+      Lyy = (-p12 + 2*p22 - p32);
+      Lxy = ((p11 - p31 - p13 + p33)/4.0f);
+
+      /* normalize and write out */
+      *out = (Lxx * Lyy - Lxy * Lxy) * factor ;
+
+      /* move window */
+      p11=p12; p12=p13;
+      p21=p22; p22=p23;
+      p31=p32; p32=p33;
+
+      /* move input/output pointers */
+      in++; out++;
+    }
+    out += 2;
+  }
+
+  /* Copy the computed values to borders */
+  in = hessian + yo + xo ;
+  out = hessian + xo ;
+
+  /* Top row without corners */
+  memcpy(out, in, (width - 2)*sizeof(float));
+  out--;
+  in -= yo;
+
+  /* Left border columns without last row */
+  for (r = 0; r < height - 1; r++){
+    *out = *in;
+    *(out + yo - 1) = *(in + yo - 3);
+    in += yo;
+    out += yo;
+  }
+
+  /* Bottom corners */
+  in -= yo;
+  *out = *in;
+  *(out + yo - 1) = *(in + yo - 3);
+
+  /* Bottom row without corners */
+  out++;
+  memcpy(out, in, (width - 2)*sizeof(float));
+}
+
+/** @brief Scale-normalised Harris response
+ ** @param harris output image.
+ ** @param image input image.
+ ** @param width image width.
+ ** @param height image height.
+ ** @param step image sampling step (pixel size).
+ ** @param sigma Gaussian smoothing of the input image.
+ ** @param sigmaI integration scale.
+ ** @param alpha factor in the definition of the Harris score.
+ **/
+
+static void
+_vl_harris_response (float * harris,
+                     float const * image,
+                     vl_size width, vl_size height,
+                     double step, double sigma,
+                     double sigmaI, double alpha)
+{
+  float factor = (float) pow(sigma/step, 4.0) ;
+  vl_index k ;
+
+  float * LxLx ;
+  float * LyLy ;
+  float * LxLy ;
+
+  LxLx = vl_malloc(sizeof(float) * width * height) ;
+  LyLy = vl_malloc(sizeof(float) * width * height) ;
+  LxLy = vl_malloc(sizeof(float) * width * height) ;
+
+  vl_imgradient_f (LxLx, LyLy, 1, width, image, width, height, width) ;
+
+  for (k = 0 ; k < (signed)(width * height) ; ++k) {
+    float dx = LxLx[k] ;
+    float dy = LyLy[k] ;
+    LxLx[k] = dx*dx ;
+    LyLy[k] = dy*dy ;
+    LxLy[k] = dx*dy ;
+  }
+
+  vl_imsmooth_f(LxLx, width, LxLx, width, height, width,
+                sigmaI / step, sigmaI / step) ;
+
+  vl_imsmooth_f(LyLy, width, LyLy, width, height, width,
+                sigmaI / step, sigmaI / step) ;
+
+  vl_imsmooth_f(LxLy, width, LxLy, width, height, width,
+                sigmaI / step, sigmaI / step) ;
+
+  for (k = 0 ; k < (signed)(width * height) ; ++k) {
+    float a = LxLx[k] ;
+    float b = LyLy[k] ;
+    float c = LxLy[k] ;
+
+    float determinant = a * b - c * c ;
+    float trace = a + b ;
+
+    harris[k] = factor * (determinant - alpha * (trace * trace)) ;
+  }
+
+  vl_free(LxLy) ;
+  vl_free(LyLy) ;
+  vl_free(LxLx) ;
+}
+
+/** @brief Difference of Gaussian
+ ** @param dog output image.
+ ** @param level1 input image at the smaller Gaussian scale.
+ ** @param level2 input image at the larger Gaussian scale.
+ ** @param width image width.
+ ** @param height image height.
+ **/
+
+static void
+_vl_dog_response (float * dog,
+                  float const * level1,
+                  float const * level2,
+                  vl_size width, vl_size height)
+{
+  vl_index k ;
+  for (k = 0 ; k < (signed)(width*height) ; ++k) {
+    dog[k] = level2[k] - level1[k] ;
+  }
+}
+
+/* ---------------------------------------------------------------- */
+/*                                                  Detect features */
+/* ---------------------------------------------------------------- */
+
+/** @brief Detect scale-space features
+ ** @param self object.
+ **
+ ** This function runs the configured feature detector on the image
+ ** that was passed by using ::vl_covdet_put_image.
+ **/
+
+void
+vl_covdet_detect (VlCovDet * self)
+{
+  VlScaleSpaceGeometry geom = vl_scalespace_get_geometry(self->gss) ;
+  VlScaleSpaceGeometry cgeom ;
+  float * levelxx = NULL ;
+  float * levelyy = NULL ;
+  float * levelxy = NULL ;
+  vl_index o, s ;
+
+  assert (self) ;
+  assert (self->gss) ;
+
+  /* clear previous detections if any */
+  self->numFeatures = 0 ;
+
+  /* prepare buffers ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+  cgeom = geom ;
+  if (self->method == VL_COVDET_METHOD_DOG) {
+    cgeom.octaveLastSubdivision -= 1 ;
+  }
+  if (!self->css ||
+      !vl_scalespacegeometry_is_equal(cgeom,
+                                      vl_scalespace_get_geometry(self->css)))
+  {
+    if (self->css) vl_scalespace_delete(self->css) ;
+    self->css = vl_scalespace_new_with_geometry(cgeom) ;
+  }
+  if (self->method == VL_COVDET_METHOD_HARRIS_LAPLACE ||
+      self->method == VL_COVDET_METHOD_MULTISCALE_HARRIS) {
+    VlScaleSpaceOctaveGeometry oct = vl_scalespace_get_octave_geometry(self->gss, geom.firstOctave) ;
+    levelxx = vl_malloc(oct.width * oct.height * sizeof(float)) ;
+    levelyy = vl_malloc(oct.width * oct.height * sizeof(float)) ;
+    levelxy = vl_malloc(oct.width * oct.height * sizeof(float)) ;
+  }
+
+  /* compute cornerness ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+  for (o = cgeom.firstOctave ; o <= cgeom.lastOctave ; ++o) {
+    VlScaleSpaceOctaveGeometry oct = vl_scalespace_get_octave_geometry(self->css, o) ;
+
+    for (s = cgeom.octaveFirstSubdivision ; s <= cgeom.octaveLastSubdivision ; ++s) {
+      float * level = vl_scalespace_get_level(self->gss, o, s) ;
+      float * clevel = vl_scalespace_get_level(self->css, o, s) ;
+      double sigma = vl_scalespace_get_level_sigma(self->css, o, s) ;
+      switch (self->method) {
+        case VL_COVDET_METHOD_DOG:
+          _vl_dog_response(clevel,
+                           vl_scalespace_get_level(self->gss, o, s + 1),
+                           level,
+                           oct.width, oct.height) ;
+          break ;
+
+        case VL_COVDET_METHOD_HARRIS_LAPLACE:
+        case VL_COVDET_METHOD_MULTISCALE_HARRIS:
+          _vl_harris_response(clevel,
+                              level, oct.width, oct.height, oct.step,
+                              sigma, 1.4 * sigma, 0.05) ;
+          break ;
+
+        case VL_COVDET_METHOD_HESSIAN:
+        case VL_COVDET_METHOD_HESSIAN_LAPLACE:
+        case VL_COVDET_METHOD_MULTISCALE_HESSIAN:
+          _vl_det_hessian_response(clevel, level, oct.width, oct.height, oct.step, sigma) ;
+          break ;
+
+        default:
+          assert(0) ;
+      }
+    }
+  }
+
+  /* find and refine local maxima ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+  {
+    vl_index * extrema = NULL ;
+    vl_size extremaBufferSize = 0 ;
+    vl_size numExtrema ;
+    vl_size index ;
+    for (o = cgeom.firstOctave ; o <= cgeom.lastOctave ; ++o) {
+      VlScaleSpaceOctaveGeometry octgeom = vl_scalespace_get_octave_geometry(self->css, o) ;
+      double step = octgeom.step ;
+      vl_size width = octgeom.width ;
+      vl_size height = octgeom.height ;
+      vl_size depth = cgeom.octaveLastSubdivision - cgeom.octaveFirstSubdivision + 1 ;
+
+      switch (self->method) {
+        case VL_COVDET_METHOD_DOG:
+        case VL_COVDET_METHOD_HESSIAN:
+        {
+          /* scale-space extrema */
+          float const * octave =
+          vl_scalespace_get_level(self->css, o, cgeom.octaveFirstSubdivision) ;
+          numExtrema = vl_find_local_extrema_3(&extrema, &extremaBufferSize,
+                                               octave, width, height, depth,
+                                               0.8 * self->peakThreshold);
+          for (index = 0 ; index < numExtrema ; ++index) {
+            VlCovDetExtremum3 refined ;
+            VlCovDetFeature feature ;
+            vl_bool ok ;
+            memset(&feature, 0, sizeof(feature)) ;
+            ok = vl_refine_local_extreum_3(&refined,
+                                           octave, width, height, depth,
+                                           extrema[3*index+0],
+                                           extrema[3*index+1],
+                                           extrema[3*index+2]) ;
+            ok &= fabs(refined.peakScore) > self->peakThreshold ;
+            ok &= refined.edgeScore < self->edgeThreshold ;
+            if (ok) {
+              double sigma = cgeom.baseScale *
+              pow(2.0, o + (refined.z + cgeom.octaveFirstSubdivision)
+                  / cgeom.octaveResolution) ;
+              feature.frame.x = refined.x * step ;
+              feature.frame.y = refined.y * step ;
+              feature.frame.a11 = sigma ;
+              feature.frame.a12 = 0.0 ;
+              feature.frame.a21 = 0.0 ;
+              feature.frame.a22 = sigma;
+              feature.sigma = sigma;
+              feature.peakScore = refined.peakScore ;
+              feature.edgeScore = refined.edgeScore ;
+              vl_covdet_append_feature(self, &feature) ;
+            }
+          }
+          break ;
+        }
+
+        default:
+        {
+          for (s = cgeom.octaveFirstSubdivision ; s < cgeom.octaveLastSubdivision ; ++s) {
+            /* space extrema */
+            float const * level = vl_scalespace_get_level(self->css,o,s) ;
+            numExtrema = vl_find_local_extrema_2(&extrema, &extremaBufferSize,
+                                                 level,
+                                                 width, height,
+                                                 0.8 * self->peakThreshold);
+            for (index = 0 ; index < numExtrema ; ++index) {
+              VlCovDetExtremum2 refined ;
+              VlCovDetFeature feature ;
+              vl_bool ok ;
+              memset(&feature, 0, sizeof(feature)) ;
+              ok = vl_refine_local_extreum_2(&refined,
+                                             level, width, height,
+                                             extrema[2*index+0],
+                                             extrema[2*index+1]);
+              ok &= fabs(refined.peakScore) > self->peakThreshold ;
+              ok &= refined.edgeScore < self->edgeThreshold ;
+              if (ok) {
+                double sigma = cgeom.baseScale *
+                pow(2.0, o + (double)s / cgeom.octaveResolution) ;
+                feature.frame.x = refined.x * step ;
+                feature.frame.y = refined.y * step ;
+                feature.frame.a11 = sigma ;
+                feature.frame.a12 = 0.0 ;
+                feature.frame.a21 = 0.0 ;
+                feature.frame.a22 = sigma;
+                feature.sigma = sigma;
+                feature.peakScore = refined.peakScore ;
+                feature.edgeScore = refined.edgeScore ;
+                vl_covdet_append_feature(self, &feature) ;
+              }
+            }
+          }
+          break ;
+        }
+      }
+    } /* next octave */
+
+    if (extrema) { vl_free(extrema) ; extrema = 0 ; }
+  }
+
+  /* Laplacian scale selection for certain methods */
+  switch (self->method) {
+    case VL_COVDET_METHOD_HARRIS_LAPLACE :
+    case VL_COVDET_METHOD_HESSIAN_LAPLACE :
+      vl_covdet_extract_laplacian_scales (self) ;
+      break ;
+    default:
+      break ;
+  }
+
+  if (self->nonExtremaSuppression) {
+    vl_index i, j ;
+    double tol = self->nonExtremaSuppression ;
+    self->numNonExtremaSuppressed = 0 ;
+    for (i = 0 ; i < (signed)self->numFeatures ; ++i) {
+      double x = self->features[i].frame.x ;
+      double y = self->features[i].frame.y ;
+      double sigma = self->features[i].frame.a11 ;
+      double score = self->features[i].peakScore ;
+
+      for (j = 0 ; j < (signed)self->numFeatures ; ++j) {
+        double dx_ = self->features[j].frame.x - x ;
+        double dy_ = self->features[j].frame.y - y ;
+        double sigma_ = self->features[j].frame.a11 ;
+        double score_ = self->features[j].peakScore ;
+        if (score_ == 0) continue ;
+        if (sigma < (1+tol) * sigma_ &&
+            sigma_ < (1+tol) * sigma &&
+            vl_abs_d(dx_) < tol * sigma &&
+            vl_abs_d(dy_) < tol * sigma &&
+            vl_abs_d(score) > vl_abs_d(score_)) {
+          self->features[j].peakScore = 0 ;
+          self->numNonExtremaSuppressed ++ ;
+        }
+      }
+    }
+    j = 0 ;
+    for (i = 0 ; i < (signed)self->numFeatures ; ++i) {
+      VlCovDetFeature feature = self->features[i] ;
+      if (self->features[i].peakScore != 0) {
+        self->features[j++] = feature ;
+      }
+    }
+    self->numFeatures = j ;
+  }
+
+  if (levelxx) vl_free(levelxx) ;
+  if (levelyy) vl_free(levelyy) ;
+  if (levelxy) vl_free(levelxy) ;
+}
+
+/* ---------------------------------------------------------------- */
+/*                                                  Extract patches */
+/* ---------------------------------------------------------------- */
+
+/** @internal
+ ** @brief Helper for extracting patches
+ ** @param self object.
+ ** @param[out] sigma1 actual patch smoothing along the first axis.
+ ** @param[out] sigma2 actual patch smoothing along the second axis.
+ ** @param patch buffer.
+ ** @param resolution patch resolution.
+ ** @param extent patch extent.
+ ** @param sigma desired smoothing in the patch frame.
+ ** @param A_ linear transfomration from patch to image.
+ ** @param T_ translation from patch to image.
+ ** @param d1 first singular value @a A.
+ ** @param d2 second singular value of @a A.
+ **/
+
+vl_bool
+vl_covdet_extract_patch_helper (VlCovDet * self,
+                                double * sigma1,
+                                double * sigma2,
+                                float * patch,
+                                vl_size resolution,
+                                double extent,
+                                double sigma,
+                                double A_ [4],
+                                double T_ [2],
+                                double d1, double d2)
+{
+  vl_index o, s ;
+  double factor ;
+  double sigma_ ;
+  float const * level ;
+  vl_size width, height ;
+  double step ;
+
+  double A [4] = {A_[0], A_[1], A_[2], A_[3]} ;
+  double T [2] = {T_[0], T_[1]} ;
+
+  VlScaleSpaceGeometry geom = vl_scalespace_get_geometry(self->gss) ;
+  VlScaleSpaceOctaveGeometry oct ;
+
+  /* Starting from a pre-smoothed image at scale sigma_
+     because of the mapping A the resulting smoothing in
+     the warped patch is S, where
+
+        sigma_^2 I = A S A',
+
+        S = sigma_^2 inv(A) inv(A)' = sigma_^2 V D^-2 V',
+
+        A = U D V'.
+
+     Thus we rotate A by V to obtain an axis-aligned smoothing:
+
+        A = U*D,
+
+        S = sigma_^2 D^-2.
+
+     Then we search the scale-space for the best sigma_ such
+     that the target smoothing is approximated from below:
+
+        max sigma_(o,s) :    simga_(o,s) factor <= sigma,
+        factor = max{abs(D11), abs(D22)}.
+   */
+
+
+  /*
+   Determine the best level (o,s) such that sigma_(o,s) factor <= sigma.
+   This can be obtained by scanning octaves from smallest to largest
+   and stopping when no level in the octave satisfies the relation.
+
+   Given the range of octave availables, do the best you can.
+   */
+
+  factor = 1.0 / VL_MIN(d1, d2) ;
+
+  for (o = geom.firstOctave + 1 ; o <= geom.lastOctave ; ++o) {
+    s = vl_floor_d(vl_log2_d(sigma / (factor * geom.baseScale)) - o) ;
+    s = VL_MAX(s, geom.octaveFirstSubdivision) ;
+    s = VL_MIN(s, geom.octaveLastSubdivision) ;
+    sigma_ = geom.baseScale * pow(2.0, o + (double)s / geom.octaveResolution) ;
+    /*VL_PRINTF(".. %d D=%g %g; sigma_=%g factor*sigma_=%g\n", o, d1, d2, sigma_, factor* sigma_) ;*/
+    if (factor * sigma_ > sigma) {
+      o -- ;
+      break ;
+    }
+  }
+  o = VL_MIN(o, geom.lastOctave) ;
+  s = vl_floor_d(vl_log2_d(sigma / (factor * geom.baseScale)) - o) ;
+  s = VL_MAX(s, geom.octaveFirstSubdivision) ;
+  s = VL_MIN(s, geom.octaveLastSubdivision) ;
+  sigma_ = geom.baseScale * pow(2.0, o + (double)s / geom.octaveResolution) ;
+  if (sigma1) *sigma1 = sigma_ / d1 ;
+  if (sigma2) *sigma2 = sigma_ / d2 ;
+
+  /*VL_PRINTF("%d %d %g %g %g %g\n", o, s, factor, sigma_, factor * sigma_, sigma) ;*/
+
+  /*
+   Now the scale space level to be used for this warping has been
+   determined.
+
+   If the patch is partially or completely out of the image boundary,
+   create a padded copy of the required region first.
+   */
+
+  level = vl_scalespace_get_level(self->gss, o, s) ;
+  oct = vl_scalespace_get_octave_geometry(self->gss, o) ;
+  width = oct.width ;
+  height = oct.height ;
+  step = oct.step ;
+
+  A[0] /= step ;
+  A[1] /= step ;
+  A[2] /= step ;
+  A[3] /= step ;
+  T[0] /= step ;
+  T[1] /= step ;
+
+  {
+    /*
+     Warp the patch domain [x0hat,y0hat,x1hat,y1hat] to the image domain/
+     Obtain a box [x0,y0,x1,y1] enclosing that wrapped box, and then
+     an integer vertexes version [x0i, y0i, x1i, y1i], making room
+     for one pixel at the boundary to simplify bilinear interpolation
+     later on.
+     */
+    vl_index x0i, y0i, x1i, y1i ;
+    double x0 = +VL_INFINITY_D ;
+    double x1 = -VL_INFINITY_D ;
+    double y0 = +VL_INFINITY_D ;
+    double y1 = -VL_INFINITY_D ;
+    double boxx [4] = {extent, extent, -extent, -extent} ;
+    double boxy [4] = {-extent, extent, extent, -extent} ;
+    int i ;
+    for (i = 0 ; i < 4 ; ++i) {
+      double x = A[0] * boxx[i] + A[2] * boxy[i] + T[0] ;
+      double y = A[1] * boxx[i] + A[3] * boxy[i] + T[1] ;
+      x0 = VL_MIN(x0, x) ;
+      x1 = VL_MAX(x1, x) ;
+      y0 = VL_MIN(y0, y) ;
+      y1 = VL_MAX(y1, y) ;
+    }
+
+    if ((x0 < 0 || x1 > (signed)width-1 || y0 < 0 || y1 > (signed)height-1) &&
+        !self->allowPaddedWarping) {
+      return vl_set_last_error(VL_ERR_EOF, "Frame out of image.");
+    }
+
+    /* Leave one pixel border for bilinear interpolation. */
+    x0i = floor(x0) - 1 ;
+    y0i = floor(y0) - 1 ;
+    x1i = ceil(x1) + 1 ;
+    y1i = ceil(y1) + 1 ;
+
+    /*
+     If the box [x0i,y0i,x1i,y1i] is not fully contained in the
+     image domain, then create a copy of this region by padding
+     the image. The image is extended by continuity.
+     */
+
+    if (x0i < 0 || x1i > (signed)width-1 ||
+        y0i < 0 || y1i > (signed)height-1) {
+     
+      vl_index xi, yi ;
+
+      /* compute the amount of l,r,t,b padding needed to complete the patch */
+      vl_index padx0 = VL_MAX(0, - x0i) ;
+      vl_index pady0 = VL_MAX(0, - y0i) ;
+      vl_index padx1 = VL_MAX(0, x1i - ((signed)width - 1)) ;
+      vl_index pady1 = VL_MAX(0, y1i - ((signed)height - 1)) ;
+
+      /* make enough room for the patch */
+      vl_index patchWidth = x1i - x0i + 1 ;
+      vl_index patchHeight = y1i - y0i + 1 ;
+      vl_size patchBufferSize = patchWidth * patchHeight * sizeof(float) ;
+      if (patchBufferSize > self->patchBufferSize) {
+        int err = _vl_resize_buffer((void**)&self->patch, &self->patchBufferSize, patchBufferSize) ;
+        if (err) return vl_set_last_error(VL_ERR_ALLOC, "Unable to allocate data.") ;
+      }
+
+      if (pady0 < patchHeight - pady1) {
+        /* start by filling the central horizontal band */
+        for (yi = y0i + pady0 ; yi < y0i + patchHeight - pady1 ; ++ yi) {
+          float *dst = self->patch + (yi - y0i) * patchWidth ;
+          float const *src = level + yi * width + VL_MIN(VL_MAX(0, x0i),(signed)width-1) ;
+          for (xi = x0i ; xi < x0i + padx0 ; ++xi) *dst++ = *src ;
+          for ( ; xi < x0i + patchWidth - padx1 - 2 ; ++xi) *dst++ = *src++ ;
+          for ( ; xi < x0i + patchWidth ; ++xi) *dst++ = *src ;
+        }
+        /* now extend the central band up and down */
+        for (yi = 0 ; yi < pady0 ; ++yi) {
+          memcpy(self->patch + yi * patchWidth,
+                 self->patch + pady0 * patchWidth,
+                 patchWidth * sizeof(float)) ;
+        }
+        for (yi = patchHeight - pady1 ; yi < patchHeight ; ++yi) {
+          memcpy(self->patch + yi * patchWidth,
+                 self->patch + (patchHeight - pady1 - 1) * patchWidth,
+                 patchWidth * sizeof(float)) ;
+        }
+      } else {
+        /* should be handled better! */
+        memset(self->patch, 0, self->patchBufferSize) ;
+      }
+#if 0
+      {
+        char name [200] ;
+        snprintf(name, 200, "/tmp/%20.0f-ext.pgm", 1e10*vl_get_cpu_time()) ;
+        vl_pgm_write_f(name, patch, patchWidth, patchWidth) ;
+      }
+#endif
+
+      level = self->patch ;
+      width = patchWidth ;
+      height = patchHeight ;
+      T[0] -= x0i ;
+      T[1] -= y0i ;
+    }
+  }
+
+  /*
+   Resample by using bilinear interpolation.
+   */
+  {
+    float * pt = patch ;
+    double yhat = -extent ;
+    vl_index xxi ;
+    vl_index yyi ;
+    double stephat = extent / resolution ;
+
+    for (yyi = 0 ; yyi < 2 * (signed)resolution + 1 ; ++yyi) {
+      double xhat = -extent ;
+      double rx = A[2] * yhat + T[0] ;
+      double ry = A[3] * yhat + T[1] ;
+      for (xxi = 0 ; xxi < 2 * (signed)resolution + 1 ; ++xxi) {
+        double x = A[0] * xhat + rx ;
+        double y = A[1] * xhat + ry ;
+        vl_index xi = vl_floor_d(x) ;
+        vl_index yi = vl_floor_d(y) ;
+        double i00 = level[yi * width + xi] ;
+        double i10 = level[yi * width + xi + 1] ;
+        double i01 = level[(yi + 1) * width + xi] ;
+        double i11 = level[(yi + 1) * width + xi + 1] ;
+        double wx = x - xi ;
+        double wy = y - yi ;
+
+        assert(xi >= 0 && xi <= (signed)width - 1) ;
+        assert(yi >= 0 && yi <= (signed)height - 1) ;
+
+        *pt++ =
+        (1.0 - wy) * ((1.0 - wx) * i00 + wx * i10) +
+        wy * ((1.0 - wx) * i01 + wx * i11) ;
+
+        xhat += stephat ;
+      }
+      yhat += stephat ;
+    }
+  }
+#if 0
+    {
+      char name [200] ;
+      snprintf(name, 200, "/tmp/%20.0f.pgm", 1e10*vl_get_cpu_time()) ;
+      vl_pgm_write_f(name, patch, 2*resolution+1, 2*resolution+1) ;
+    }
+#endif
+  return VL_ERR_OK ;
+}
+
+/** @brief Helper for extracting patches
+ ** @param self object.
+ ** @param patch buffer.
+ ** @param resolution patch resolution.
+ ** @param extent patch extent.
+ ** @param sigma desired smoothing in the patch frame.
+ ** @param frame feature frame.
+ **
+ ** The function considers a patch of extent <code>[-extent,extent]</code>
+ ** on each side, with a side counting <code>2*resolution+1</code> pixels.
+ ** In attempts to extract from the scale space a patch
+ ** based on the affine warping specified by @a frame in such a way
+ ** that the resulting smoothing of the image is @a sigma (in the
+ ** patch frame).
+ **
+ ** The transformation is specified by the matrices @c A and @c T
+ ** embedded in the feature @a frame. Note that this transformation maps
+ ** pixels from the patch frame to the image frame.
+ **/
+
+vl_bool
+vl_covdet_extract_patch_for_frame (VlCovDet * self,
+                                   float * patch,
+                                   vl_size resolution,
+                                   double extent,
+                                   double sigma,
+                                   VlFrameOrientedEllipse frame)
+{
+  double A[2*2] = {frame.a11, frame.a21, frame.a12, frame.a22} ;
+  double T[2] = {frame.x, frame.y} ;
+  double D[4], U[4], V[4] ;
+
+  vl_svd2(D, U, V, A) ;
+
+  return vl_covdet_extract_patch_helper
+  (self, NULL, NULL, patch, resolution, extent, sigma, A, T, D[0], D[3]) ;
+}
+
+/* ---------------------------------------------------------------- */
+/*                                                     Affine shape */
+/* ---------------------------------------------------------------- */
+
+/** @brief Extract the affine shape for a feature frame
+ ** @param self object.
+ ** @param adapted the shape-adapted frame.
+ ** @param frame the input frame.
+ ** @return ::VL_ERR_OK if affine adaptation is successful.
+ **
+ ** This function may fail if adaptation is unsuccessful or if
+ ** memory is insufficient.
+ **/
+
+int
+vl_covdet_extract_affine_shape_for_frame (VlCovDet * self,
+                                          VlFrameOrientedEllipse * adapted,
+                                          VlFrameOrientedEllipse frame)
+{
+  vl_index iter = 0 ;
+
+  double A [2*2] = {frame.a11, frame.a21, frame.a12, frame.a22} ;
+  double T [2] = {frame.x, frame.y} ;
+  double U [2*2] ;
+  double V [2*2] ;
+  double D [2*2] ;
+  double M [2*2] ;
+  double P [2*2] ;
+  double P_ [2*2] ;
+  double Q [2*2] ;
+  double sigma1, sigma2 ;
+  double sigmaD = VL_COVDET_AA_RELATIVE_DERIVATIVE_SIGMA ;
+  double factor ;
+  double anisotropy ;
+  double referenceScale ;
+  vl_size const resolution = VL_COVDET_AA_PATCH_RESOLUTION ;
+  vl_size const side = 2*VL_COVDET_AA_PATCH_RESOLUTION + 1 ;
+  double const extent = VL_COVDET_AA_PATCH_EXTENT ;
+
+
+  *adapted = frame ;
+
+  while (1) {
+    double lxx = 0, lxy = 0, lyy = 0 ;
+    vl_index k ;
+    int err ;
+
+    /* A = U D V' */
+    vl_svd2(D, U, V, A) ;
+    anisotropy = VL_MAX(D[0]/D[3], D[3]/D[0]) ;
+
+    /* VL_PRINTF("anisot: %g\n", anisotropy); */
+
+    if (anisotropy > VL_COVDET_AA_MAX_ANISOTROPY) {
+      /* diverged, give up with current solution */
+      break ;
+    }
+
+    /* make sure that the smallest singluar value stays fixed
+       after the first iteration */
+    if (iter == 0) {
+      referenceScale = VL_MIN(D[0], D[3]) ;
+      factor = 1.0 ;
+    } else {
+      factor = referenceScale / VL_MIN(D[0],D[3]) ;
+    }
+
+    D[0] *= factor ;
+    D[3] *= factor ;
+
+    A[0] = U[0] * D[0] ;
+    A[1] = U[1] * D[0] ;
+    A[2] = U[2] * D[3] ;
+    A[3] = U[3] * D[3] ;
+
+    adapted->a11 = A[0] ;
+    adapted->a21 = A[1] ;
+    adapted->a12 = A[2] ;
+    adapted->a22 = A[3] ;
+
+    if (++iter >= VL_COVDET_AA_MAX_NUM_ITERATIONS) break ;
+
+    err = vl_covdet_extract_patch_helper(self,
+                                         &sigma1, &sigma2,
+                                         self->aaPatch,
+                                         resolution,
+                                         extent,
+                                         sigmaD,
+                                         A, T, D[0], D[3]) ;
+    if (err) return err ;
+
+    if (self->aaAccurateSmoothing ) {
+      double deltaSigma1 = sqrt(VL_MAX(sigmaD*sigmaD - sigma1*sigma1,0)) ;
+      double deltaSigma2 = sqrt(VL_MAX(sigmaD*sigmaD - sigma2*sigma2,0)) ;
+      double stephat = extent / resolution ;
+      vl_imsmooth_f(self->aaPatch, side,
+                    self->aaPatch, side, side, side,
+                    deltaSigma1 / stephat, deltaSigma2 / stephat) ;
+    }
+
+    /* compute second moment matrix */
+    vl_imgradient_f (self->aaPatchX, self->aaPatchY, 1, side,
+                     self->aaPatch, side, side, side) ;
+
+    for (k = 0 ; k < (signed)(side*side) ; ++k) {
+      double lx = self->aaPatchX[k] ;
+      double ly = self->aaPatchY[k] ;
+      lxx += lx * lx * self->aaMask[k] ;
+      lyy += ly * ly * self->aaMask[k] ;
+      lxy += lx * ly * self->aaMask[k] ;
+    }
+    M[0] = lxx ;
+    M[1] = lxy ;
+    M[2] = lxy ;
+    M[3] = lyy ;
+
+    if (lxx == 0 || lyy == 0) {
+      *adapted = frame ;
+      break ;
+    }
+
+    /* decompose M = P * Q * P' */
+    vl_svd2 (Q, P, P_, M) ;
+
+    /*
+     Setting A <- A * dA results in M to change approximatively as
+
+     M --> dA'  M dA = dA' P Q P dA
+
+     To make this proportional to the identity, we set
+
+     dA ~= P Q^1/2
+
+     we also make it so the smallest singular value of A is unchanged.
+     */
+
+    if (Q[3]/Q[0] < VL_COVDET_AA_CONVERGENCE_THRESHOLD &&
+        Q[0]/Q[3] < VL_COVDET_AA_CONVERGENCE_THRESHOLD) {
+      break ;
+    }
+
+    {
+      double Ap [4] ;
+      double q0 = sqrt(Q[0]) ;
+      double q1 = sqrt(Q[3]) ;
+      Ap[0] = (A[0] * P[0] + A[2] * P[1]) / q0 ;
+      Ap[1] = (A[1] * P[0] + A[3] * P[1]) / q0 ;
+      Ap[2] = (A[0] * P[2] + A[2] * P[3]) / q1 ;
+      Ap[3] = (A[1] * P[2] + A[3] * P[3]) / q1 ;
+      memcpy(A,Ap,4*sizeof(double)) ;
+    }
+
+  } /* next iteration */
+
+  /*
+   Make upright.
+
+   Shape adaptation does not estimate rotation. This is fixed by default
+   so that a selected axis is not rotated at all (usually this is the
+   vertical axis for upright features). To do so, the frame is rotated
+   as follows.
+   */
+  {
+    double A [2*2] = {adapted->a11, adapted->a21, adapted->a12, adapted->a22} ;
+    double ref [2] ;
+    double ref_ [2] ;
+    double angle ;
+    double angle_ ;
+    double dangle ;
+    double r1, r2 ;
+
+    if (self->transposed) {
+      /* up is the x axis */
+      ref[0] = 1 ;
+      ref[1] = 0 ;
+    } else {
+      /* up is the y axis */
+      ref[0] = 0 ;
+      ref[1] = 1 ;
+    }
+
+    vl_solve_linear_system_2 (ref_, A, ref) ;
+    angle = atan2(ref[1], ref[0]) ;
+    angle_ = atan2(ref_[1], ref_[0]) ;
+    dangle = angle_ - angle ;
+    r1 = cos(dangle) ;
+    r2 = sin(dangle) ;
+    adapted->a11 = + A[0] * r1 + A[2] * r2 ;
+    adapted->a21 = + A[1] * r1 + A[3] * r2 ;
+    adapted->a12 = - A[0] * r2 + A[2] * r1 ;
+    adapted->a22 = - A[1] * r2 + A[3] * r1 ;
+  }
+
+  return VL_ERR_OK ;
+}
+
+/** @brief Extract the affine shape for the stored features
+ ** @param self object.
+ **
+ ** This function may discard features for which no affine
+ ** shape can reliably be detected.
+ **/
+
+void
+vl_covdet_extract_affine_shape (VlCovDet * self)
+{
+  vl_index i, j = 0 ;
+  vl_size numFeatures = vl_covdet_get_num_features(self) ;
+  VlCovDetFeature * feature = vl_covdet_get_features(self);
+  for (i = 0 ; i < (signed)numFeatures ; ++i) {
+    int status ;
+    VlFrameOrientedEllipse adapted ;
+    status = vl_covdet_extract_affine_shape_for_frame(self, &adapted, feature[i].frame) ;
+    if (status == VL_ERR_OK) {
+      feature[j] = feature[i] ;
+      feature[j].frame = adapted ;
+      ++ j ;
+    }
+  }
+  self->numFeatures = j ;
+}
+
+/* ---------------------------------------------------------------- */
+/*                                                      Orientation */
+/* ---------------------------------------------------------------- */
+
+static int
+_vl_covdet_compare_orientations_descending (void const * a_,
+                                            void const * b_)
+{
+  VlCovDetFeatureOrientation const * a = a_ ;
+  VlCovDetFeatureOrientation const * b = b_ ;
+  if (a->score > b->score) return -1 ;
+  if (a->score < b->score) return +1 ;
+  return 0 ;
+}
+
+/** @brief Extract the orientation(s) for a feature
+ ** @param self object.
+ ** @param numOrientations the number of detected orientations.
+ ** @param frame pose of the feature.
+ ** @return an array of detected orientations with their scores.
+ **
+ ** The returned array is a matrix of size @f$ 2 \times n @f$
+ ** where <em>n</em> is the number of detected orientations.
+ **
+ ** The function returns @c NULL if memory is insufficient.
+ **/
+
+VlCovDetFeatureOrientation *
+vl_covdet_extract_orientations_for_frame (VlCovDet * self,
+                                          vl_size * numOrientations,
+                                          VlFrameOrientedEllipse frame)
+{
+  int err ;
+  vl_index k, i ;
+  vl_index iter ;
+
+  double extent = VL_COVDET_AA_PATCH_EXTENT ;
+  vl_size resolution = VL_COVDET_AA_PATCH_RESOLUTION ;
+  vl_size side = 2 * resolution + 1  ;
+
+  vl_size const numBins = VL_COVDET_OR_NUM_ORIENTATION_HISTOGAM_BINS ;
+  double hist [VL_COVDET_OR_NUM_ORIENTATION_HISTOGAM_BINS] ;
+  double const binExtent = 2 * VL_PI / VL_COVDET_OR_NUM_ORIENTATION_HISTOGAM_BINS ;
+  double const peakRelativeSize = VL_COVDET_OR_ADDITIONAL_PEAKS_RELATIVE_SIZE ;
+  double maxPeakValue ;
+
+  double A [2*2] = {frame.a11, frame.a21, frame.a12, frame.a22} ;
+  double T [2] = {frame.x, frame.y} ;
+  double U [2*2] ;
+  double V [2*2] ;
+  double D [2*2] ;
+  double sigma1, sigma2 ;
+  double sigmaD = 1.0 ;
+  double theta0 ;
+
+  assert(self);
+  assert(numOrientations) ;
+
+  /*
+   The goal is to estimate a rotation R(theta) such that the patch given
+   by the transformation A R(theta) has the strongest average
+   gradient pointing right (or down for transposed conventions).
+
+   To compensate for tha anisotropic smoothing due to warping,
+   A is decomposed as A = U D V' and the patch is warped by
+   U D only, meaning that the matrix R_(theta) will be estimated instead,
+   where:
+
+      A R(theta) = U D V' R(theta) = U D R_(theta)
+
+   such that R(theta) = V R(theta). That is an extra rotation of
+   theta0 = atan2(V(2,1),V(1,1)).
+   */
+
+  /* axis aligned anisotropic smoothing for easier compensation */
+  vl_svd2(D, U, V, A) ;
+
+  A[0] = U[0] * D[0] ;
+  A[1] = U[1] * D[0] ;
+  A[2] = U[2] * D[3] ;
+  A[3] = U[3] * D[3] ;
+
+  theta0 = atan2(V[1],V[0]) ;
+
+  err = vl_covdet_extract_patch_helper(self,
+                                       &sigma1, &sigma2,
+                                       self->aaPatch,
+                                       resolution,
+                                       extent,
+                                       sigmaD,
+                                       A, T, D[0], D[3]) ;
+
+  if (err) {
+    *numOrientations = 0 ;
+    return NULL ;
+  }
+
+  if (1) {
+    double deltaSigma1 = sqrt(VL_MAX(sigmaD*sigmaD - sigma1*sigma1,0)) ;
+    double deltaSigma2 = sqrt(VL_MAX(sigmaD*sigmaD - sigma2*sigma2,0)) ;
+    double stephat = extent / resolution ;
+    vl_imsmooth_f(self->aaPatch, side,
+                  self->aaPatch, side, side, side,
+                  deltaSigma1 / stephat, deltaSigma2 / stephat) ;
+  }
+
+  /* histogram of oriented gradients */
+  vl_imgradient_polar_f (self->aaPatchX, self->aaPatchY, 1, side,
+                         self->aaPatch, side, side, side) ;
+
+  memset (hist, 0, sizeof(double) * numBins) ;
+
+  for (k = 0 ; k < (signed)(side*side) ; ++k) {
+    double modulus = self->aaPatchX[k] ;
+    double angle = self->aaPatchY[k] ;
+    double weight = self->aaMask[k] ;
+
+    double x = angle / binExtent ;
+    vl_index bin = vl_floor_d(x) ;
+    double w2 = x - bin ;
+    double w1 = 1.0 - w2 ;
+
+    hist[(bin + numBins) % numBins] += w1 * (modulus * weight) ;
+    hist[(bin + numBins + 1) % numBins] += w2 * (modulus * weight) ;
+  }
+
+  /* smooth histogram */
+  for (iter = 0; iter < 6; iter ++) {
+    double prev = hist [numBins - 1] ;
+    double first = hist [0] ;
+    vl_index i ;
+    for (i = 0; i < (signed)numBins - 1; ++i) {
+      double curr = (prev + hist[i] + hist[(i + 1) % numBins]) / 3.0 ;
+      prev = hist[i] ;
+      hist[i] = curr ;
+    }
+    hist[i] = (prev + hist[i] + first) / 3.0 ;
+  }
+
+  /* find the histogram maximum */
+  maxPeakValue = 0 ;
+  for (i = 0 ; i < (signed)numBins ; ++i) {
+    maxPeakValue = VL_MAX (maxPeakValue, hist[i]) ;
+  }
+
+  /* find peaks within 80% from max */
+  *numOrientations = 0 ;
+  for(i = 0 ; i < (signed)numBins ; ++i) {
+    double h0 = hist [i] ;
+    double hm = hist [(i - 1 + numBins) % numBins] ;
+    double hp = hist [(i + 1 + numBins) % numBins] ;
+
+    /* is this a peak? */
+    if (h0 > peakRelativeSize * maxPeakValue && h0 > hm && h0 > hp) {
+      /* quadratic interpolation */
+      double di = - 0.5 * (hp - hm) / (hp + hm - 2 * h0) ;
+      double th = binExtent * (i + di) + theta0 ;
+      if (self->transposed) {
+        /* the axis to the right is y, measure orientations from this */
+        th = th - VL_PI/2 ;
+      }
+      self->orientations[*numOrientations].angle = th ;
+      self->orientations[*numOrientations].score = h0 ;
+      *numOrientations += 1 ;
+      //VL_PRINTF("%d %g\n", *numOrientations, th) ;
+
+      if (*numOrientations >= self->maxNumOrientations) break ;
+    }
+  }
+
+  /* sort the orientations by decreasing scores */
+  qsort(self->orientations,
+        *numOrientations,
+        sizeof(VlCovDetFeatureOrientation),
+        _vl_covdet_compare_orientations_descending) ;
+
+  return self->orientations ;
+}
+
+/** @brief Extract the orientation(s) for the stored features.
+ ** @param self object.
+ **
+ ** Note that, since more than one orientation can be detected
+ ** for each feature, this function may create copies of them,
+ ** one for each orientation.
+ **/
+
+void
+vl_covdet_extract_orientations (VlCovDet * self)
+{
+  vl_index i, j  ;
+  vl_size numFeatures = vl_covdet_get_num_features(self) ;
+  for (i = 0 ; i < (signed)numFeatures ; ++i) {
+    vl_size numOrientations ;
+    VlCovDetFeature feature = self->features[i] ;
+    VlCovDetFeatureOrientation* orientations =
+    vl_covdet_extract_orientations_for_frame(self, &numOrientations, feature.frame) ;
+
+    for (j = 0 ; j < (signed)numOrientations ; ++j) {
+      double A [2*2] = {
+        feature.frame.a11,
+        feature.frame.a21,
+        feature.frame.a12,
+        feature.frame.a22} ;
+      double r1 = cos(orientations[j].angle) ;
+      double r2 = sin(orientations[j].angle) ;
+      VlCovDetFeature * oriented ;
+
+      if (j == 0) {
+        oriented = & self->features[i] ;
+      } else {
+        vl_covdet_append_feature(self, &feature) ;
+        oriented = & self->features[self->numFeatures -1] ;
+      }
+
+      oriented->orientationScore = orientations[j].score ;
+      oriented->frame.a11 = + A[0] * r1 + A[2] * r2 ;
+      oriented->frame.a21 = + A[1] * r1 + A[3] * r2 ;
+      oriented->frame.a12 = - A[0] * r2 + A[2] * r1 ;
+      oriented->frame.a22 = - A[1] * r2 + A[3] * r1 ;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------- */
+/*                                                 Laplacian scales */
+/* ---------------------------------------------------------------- */
+
+/** @brief Extract the Laplacian scale(s) for a feature frame.
+ ** @param self object.
+ ** @param numScales the number of detected scales.
+ ** @param frame pose of the feature.
+ ** @return an array of detected scales.
+ **
+ ** The function returns @c NULL if memory is insufficient.
+ **/
+
+VlCovDetFeatureLaplacianScale *
+vl_covdet_extract_laplacian_scales_for_frame (VlCovDet * self,
+                                              vl_size * numScales,
+                                              VlFrameOrientedEllipse frame)
+{
+  /*
+   We try to explore one octave, with the nominal detection scale 1.0
+   (in the patch reference frame) in the middle. Thus the goal is to sample
+   the response of the tr-Laplacian operator at logarithmically
+   spaced scales in 1/sqrt(2), sqrt(2).
+
+   To this end, the patch is warped with a smoothing of at most
+   sigmaImage = 1 / sqrt(2) (beginning of the scale), sampled at
+   roughly twice the Nyquist frequency (so step = 1 / (2*sqrt(2))).
+   This maes it possible to approximate the Laplacian operator at
+   that scale by simple finite differences.
+
+   */
+  int err ;
+  double const sigmaImage = 1.0 / sqrt(2.0) ;
+  double const step = 0.5 * sigmaImage ;
+  double actualSigmaImage ;
+  vl_size const resolution = VL_COVDET_LAP_PATCH_RESOLUTION ;
+  vl_size const num = 2 * resolution + 1 ;
+  double extent = step * resolution ;
+  double scores [VL_COVDET_LAP_NUM_LEVELS] ;
+  double factor = 1.0 ;
+  float const * pt ;
+  vl_index k ;
+
+  double A[2*2] = {frame.a11, frame.a21, frame.a12, frame.a22} ;
+  double T[2] = {frame.x, frame.y} ;
+  double D[4], U[4], V[4] ;
+  double sigma1, sigma2 ;
+
+  assert(self) ;
+  assert(numScales) ;
+
+  *numScales = 0 ;
+
+  vl_svd2(D, U, V, A) ;
+
+  err = vl_covdet_extract_patch_helper
+  (self, &sigma1, &sigma2, self->lapPatch, resolution, extent, sigmaImage, A, T, D[0], D[3]) ;
+  if (err) return NULL ;
+
+  /* the actual smoothing after warping is never the target one */
+  if (sigma1 == sigma2) {
+    actualSigmaImage = sigma1 ;
+  } else {
+    /* here we could compensate */
+    actualSigmaImage = sqrt(sigma1*sigma2) ;
+  }
+
+  /* now multiply by the bank of Laplacians */
+  pt = self->laplacians ;
+  for (k = 0 ; k < VL_COVDET_LAP_NUM_LEVELS ; ++k) {
+    vl_index q ;
+    double score = 0 ;
+    double sigmaLap = pow(2.0, -0.5 + (double)k / (VL_COVDET_LAP_NUM_LEVELS - 1)) ;
+    /* note that the sqrt argument cannot be negative since by construction
+     sigmaLap >= sigmaImage */
+    sigmaLap = sqrt(sigmaLap*sigmaLap
+                    - sigmaImage*sigmaImage
+                    + actualSigmaImage*actualSigmaImage) ;
+
+    for (q = 0 ; q < (signed)(num * num) ; ++q) {
+      score += (*pt++) * self->lapPatch[q] ;
+    }
+    scores[k] = score * sigmaLap * sigmaLap ;
+  }
+
+  /* find and interpolate maxima */
+  for (k = 1 ; k < VL_COVDET_LAP_NUM_LEVELS - 1 ; ++k) {
+    double a = scores[k-1] ;
+    double b = scores[k] ;
+    double c = scores[k+1] ;
+    double t = self->lapPeakThreshold ;
+
+    if ((((b > a) && (b > c)) || ((b < a) && (b < c))) && (vl_abs_d(b) >= t)) {
+      double dk = - 0.5 * (c - a) / (c + a - 2 * b) ;
+      double s = k + dk ;
+      double sigmaLap = pow(2.0, -0.5 + s / (VL_COVDET_LAP_NUM_LEVELS - 1)) ;
+      double scale ;
+      sigmaLap = sqrt(sigmaLap*sigmaLap
+                      - sigmaImage*sigmaImage
+                      + actualSigmaImage*actualSigmaImage) ;
+      scale = sigmaLap / 1.0 ;
+      /*
+       VL_PRINTF("** k:%d, s:%f, sigmaLapFilter:%f, sigmaLap%f, scale:%f (%f %f %f)\n",
+       k,s,sigmaLapFilter,sigmaLap,scale,a,b,c) ;
+       */
+      if (*numScales < VL_COVDET_MAX_NUM_LAPLACIAN_SCALES) {
+        self->scales[*numScales].scale = scale * factor ;
+        self->scales[*numScales].score = b + 0.5 * (c - a) * dk ;
+        *numScales += 1 ;
+      }
+    }
+  }
+  return self->scales ;
+}
+
+/** @brief Extract the Laplacian scales for the stored features
+ ** @param self object.
+ **
+ ** Note that, since more than one orientation can be detected
+ ** for each feature, this function may create copies of them,
+ ** one for each orientation.
+ **/
+void
+vl_covdet_extract_laplacian_scales (VlCovDet * self)
+{
+  vl_index i, j  ;
+  vl_bool dropFeaturesWithoutScale = VL_TRUE ;
+  vl_size numFeatures = vl_covdet_get_num_features(self) ;
+  memset(self->numFeaturesWithNumScales, 0,
+         sizeof(self->numFeaturesWithNumScales)) ;
+
+  for (i = 0 ; i < (signed)numFeatures ; ++i) {
+    vl_size numScales ;
+    VlCovDetFeature feature = self->features[i] ;
+    VlCovDetFeatureLaplacianScale const * scales =
+    vl_covdet_extract_laplacian_scales_for_frame(self, &numScales, feature.frame) ;
+
+    self->numFeaturesWithNumScales[numScales] ++ ;
+
+    if (numScales == 0 && dropFeaturesWithoutScale) {
+      self->features[i].peakScore = 0 ;
+    }
+
+    for (j = 0 ; j < (signed)numScales ; ++j) {
+      VlCovDetFeature * scaled ;
+
+      if (j == 0) {
+        scaled = & self->features[i] ;
+      } else {
+        vl_covdet_append_feature(self, &feature) ;
+        scaled = & self->features[self->numFeatures -1] ;
+      }
+
+      scaled->laplacianScaleScore = scales[j].score ;
+      scaled->frame.a11 *= scales[j].scale ;
+      scaled->frame.a21 *= scales[j].scale ;
+      scaled->frame.a12 *= scales[j].scale ;
+      scaled->frame.a22 *= scales[j].scale ;
+    }
+  }
+  if (dropFeaturesWithoutScale) {
+    j = 0 ;
+    for (i = 0 ; i < (signed)self->numFeatures ; ++i) {
+      VlCovDetFeature feature = self->features[i] ;
+      if (feature.peakScore) {
+        self->features[j++] = feature ;
+      }
+    }
+    self->numFeatures = j ;
+  }
+
+}
+
+/* ---------------------------------------------------------------- */
+/*                       Checking that features are inside an image */
+/* ---------------------------------------------------------------- */
+
+vl_bool
+_vl_covdet_check_frame_inside (VlCovDet * self, VlFrameOrientedEllipse frame, double margin)
+{
+  double extent = margin ;
+  double A [2*2] = {frame.a11, frame.a21, frame.a12, frame.a22} ;
+  double T[2] = {frame.x, frame.y} ;
+  double x0 = +VL_INFINITY_D ;
+  double x1 = -VL_INFINITY_D ;
+  double y0 = +VL_INFINITY_D ;
+  double y1 = -VL_INFINITY_D ;
+  double boxx [4] = {extent, extent, -extent, -extent} ;
+  double boxy [4] = {-extent, extent, extent, -extent} ;
+  VlScaleSpaceGeometry geom = vl_scalespace_get_geometry(self->gss) ;
+  int i ;
+  for (i = 0 ; i < 4 ; ++i) {
+    double x = A[0] * boxx[i] + A[2] * boxy[i] + T[0] ;
+    double y = A[1] * boxx[i] + A[3] * boxy[i] + T[1] ;
+    x0 = VL_MIN(x0, x) ;
+    x1 = VL_MAX(x1, x) ;
+    y0 = VL_MIN(y0, y) ;
+    y1 = VL_MAX(y1, y) ;
+  }
+
+  return
+  0 <= x0 && x1 <= geom.width-1 &&
+  0 <= y0 && y1 <= geom.height-1 ;
+}
+
+/** @brief Drop features (partially) outside the image
+ ** @param self object.
+ ** @param margin geometric marging.
+ **
+ ** The feature extent is defined by @c maring. A bounding box
+ ** in the normalised feature frame containin a circle of radius
+ ** @a maring is created and mapped to the image by
+ ** the feature frame transformation. Then the feature
+ ** is dropped if the bounding box is not contained in the image.
+ **
+ ** For example, setting @c margin to zero drops a feature only
+ ** if its center is not contained.
+ **
+ ** Typically a valua of @c margin equal to 1 or 2 is used.
+ **/
+
+void
+vl_covdet_drop_features_outside (VlCovDet * self, double margin)
+{
+  vl_index i, j = 0 ;
+  vl_size numFeatures = vl_covdet_get_num_features(self) ;
+  for (i = 0 ; i < (signed)numFeatures ; ++i) {
+    vl_bool inside =
+    _vl_covdet_check_frame_inside (self, self->features[i].frame, margin) ;
+    if (inside) {
+      self->features[j] = self->features[i] ;
+      ++j ;
+    }
+  }
+  self->numFeatures = j ;
+}
+
+/* ---------------------------------------------------------------- */
+/*                                              Setters and getters */
+/* ---------------------------------------------------------------- */
+
+/* ---------------------------------------------------------------- */
+/** @brief Get wether images are passed in transposed
+ ** @param self object.
+ ** @return whether images are transposed.
+ **/
+vl_bool
+vl_covdet_get_transposed (VlCovDet const  * self)
+{
+  return self->transposed ;
+}
+
+/** @brief Set the index of the first octave
+ ** @param self object.
+ ** @param t whether images are transposed.
+ **/
+void
+vl_covdet_set_transposed (VlCovDet * self, vl_bool t)
+{
+  self->transposed = t ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the edge threshold
+ ** @param self object.
+ ** @return the edge threshold.
+ **/
+double
+vl_covdet_get_edge_threshold (VlCovDet const * self)
+{
+  return self->edgeThreshold ;
+}
+
+/** @brief Set the edge threshold
+ ** @param self object.
+ ** @param edgeThreshold the edge threshold.
+ **
+ ** The edge threshold must be non-negative.
+ **/
+void
+vl_covdet_set_edge_threshold (VlCovDet * self, double edgeThreshold)
+{
+  assert(edgeThreshold >= 0) ;
+  self->edgeThreshold = edgeThreshold ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the peak threshold
+ ** @param self object.
+ ** @return the peak threshold.
+ **/
+double
+vl_covdet_get_peak_threshold (VlCovDet const * self)
+{
+  return self->peakThreshold ;
+}
+
+/** @brief Set the peak threshold
+ ** @param self object.
+ ** @param peakThreshold the peak threshold.
+ **
+ ** The peak threshold must be non-negative.
+ **/
+void
+vl_covdet_set_peak_threshold (VlCovDet * self, double peakThreshold)
+{
+  assert(peakThreshold >= 0) ;
+  self->peakThreshold = peakThreshold ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the Laplacian peak threshold
+ ** @param self object.
+ ** @return the Laplacian peak threshold.
+ **
+ ** This parameter affects only the detecors using the Laplacian
+ ** scale selectino method such as Harris-Laplace.
+ **/
+double
+vl_covdet_get_laplacian_peak_threshold (VlCovDet const * self)
+{
+  return self->lapPeakThreshold ;
+}
+
+/** @brief Set the Laplacian peak threshold
+ ** @param self object.
+ ** @param peakThreshold the Laplacian peak threshold.
+ **
+ ** The peak threshold must be non-negative.
+ **/
+void
+vl_covdet_set_laplacian_peak_threshold (VlCovDet * self, double peakThreshold)
+{
+  assert(peakThreshold >= 0) ;
+  self->lapPeakThreshold = peakThreshold ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the index of the first octave
+ ** @param self object.
+ ** @return index of the first octave.
+ **/
+vl_index
+vl_covdet_get_first_octave (VlCovDet const * self)
+{
+  return self->firstOctave ;
+}
+
+/** @brief Set the index of the first octave
+ ** @param self object.
+ ** @param o index of the first octave.
+ **
+ ** Calling this function resets the detector.
+ **/
+void
+vl_covdet_set_first_octave (VlCovDet * self, vl_index o)
+{
+  self->firstOctave = o ;
+  vl_covdet_reset(self) ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the max number of octaves
+ ** @param self object.
+ ** @return maximal number of octaves.
+ **/
+vl_size
+vl_covdet_get_num_octaves (VlCovDet const * self)
+{
+  return self->numOctaves ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the GSS base scale
+ ** @param self object.
+ ** @return The base scale.
+ **/
+double
+vl_covdet_get_base_scale (VlCovDet const * self)
+{
+  return self->baseScale ;
+}
+
+/** @brief Set the max number of octaves
+ ** @param self object.
+ ** @param o max number of octaves.
+ **
+ ** Calling this function resets the detector.
+ **/
+void
+vl_covdet_set_num_octaves (VlCovDet * self, vl_size o)
+{
+  self->numOctaves = o ;
+  vl_covdet_reset(self) ;
+}
+
+/** @brief Set the GSS base scale
+ ** @param self object.
+ ** @param s the base scale.
+ **
+ ** Calling this function resets the detector.
+ **/
+void
+vl_covdet_set_base_scale (VlCovDet * self, double s)
+{
+  self->baseScale = s ;
+  vl_covdet_reset(self) ;
+}
+
+/* ---------------------------------------------------------------- */
+
+/** @brief Set the max number of orientations
+ ** @param self object.
+ ** @param m the max number of orientations.
+ **
+ ** Calling this function resets the detector.
+ **/
+void
+vl_covdet_set_max_num_orientations (VlCovDet * self, vl_size m)
+{
+  self->maxNumOrientations = m ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the octave resolution.
+ ** @param self object.
+ ** @return octave resolution.
+ **/
+
+vl_size
+vl_covdet_get_octave_resolution (VlCovDet const * self)
+{
+  return self->octaveResolution ;
+}
+
+/** @brief Set the octave resolutuon.
+ ** @param self object.
+ ** @param r octave resoltuion.
+ **
+ ** Calling this function resets the detector.
+ **/
+
+void
+vl_covdet_set_octave_resolution (VlCovDet * self, vl_size r)
+{
+  self->octaveResolution = r ;
+  vl_covdet_reset(self) ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get whether affine adaptation uses accurate smoothing.
+ ** @param self object.
+ ** @return @c true if accurate smoothing is used.
+ **/
+
+vl_bool
+vl_covdet_get_aa_accurate_smoothing (VlCovDet const * self)
+{
+  return self->aaAccurateSmoothing ;
+}
+
+/** @brief Set whether affine adaptation uses accurate smoothing.
+ ** @param self object.
+ ** @param x whether accurate smoothing should be usd.
+ **/
+
+void
+vl_covdet_set_aa_accurate_smoothing (VlCovDet * self, vl_bool x)
+{
+  self->aaAccurateSmoothing = x ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the max number of orientations
+ ** @param self object.
+ ** @return maximal number of orientations.
+ **/
+vl_size
+vl_covdet_get_max_num_orientations( VlCovDet const * self)
+{
+  return self->maxNumOrientations ;
+}
+
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the non-extrema suppression threshold
+ ** @param self object.
+ ** @return threshold.
+ **/
+
+double
+vl_covdet_get_non_extrema_suppression_threshold (VlCovDet const * self)
+{
+  return self->nonExtremaSuppression ;
+}
+
+/** @brief Set the non-extrema suppression threshod
+ ** @param self object.
+ ** @param x threshold.
+ **/
+
+void
+vl_covdet_set_non_extrema_suppression_threshold (VlCovDet * self, double x)
+{
+  self->nonExtremaSuppression = x ;
+}
+
+/** @brief Get the number of non-extrema suppressed
+ ** @param self object.
+ ** @return number.
+ **/
+
+vl_size
+vl_covdet_get_num_non_extrema_suppressed (VlCovDet const * self)
+{
+  return self->numNonExtremaSuppressed ;
+}
+
+
+/* ---------------------------------------------------------------- */
+/** @brief Get number of stored frames
+ ** @return number of frames stored in the detector.
+ **/
+vl_size
+vl_covdet_get_num_features (VlCovDet const * self)
+{
+  return self->numFeatures ;
+}
+
+/** @brief Get the stored frames
+ ** @return frames stored in the detector.
+ **/
+VlCovDetFeature*
+vl_covdet_get_features (VlCovDet * self)
+{
+  return self->features ;
+}
+
+/** @brief Get the Gaussian scale space
+ ** @return Gaussian scale space.
+ **
+ ** A Gaussian scale space exists only after calling ::vl_covdet_put_image.
+ ** Otherwise the function returns @c NULL.
+ **/
+
+VlScaleSpace *
+vl_covdet_get_gss (VlCovDet const * self)
+{
+  return self->gss ;
+}
+
+/** @brief Get the cornerness measure scale space
+ ** @return cornerness measure scale space.
+ **
+ ** A cornerness measure scale space exists only after calling
+ ** ::vl_covdet_detect. Otherwise the function returns @c NULL.
+ **/
+
+VlScaleSpace *
+vl_covdet_get_css (VlCovDet const * self)
+{
+  return self->css ;
+}
+
+/** @brief Get the number of features found with a certain number of scales
+ ** @param self object.
+ ** @param numScales length of the histogram (out).
+ ** @return histogram.
+ **
+ ** Calling this function makes sense only after running a detector
+ ** that uses the Laplacian as a secondary measure for scale
+ ** detection
+ **/
+
+vl_size const *
+vl_covdet_get_laplacian_scales_statistics (VlCovDet const * self,
+                                           vl_size * numScales)
+{
+  *numScales = VL_COVDET_MAX_NUM_LAPLACIAN_SCALES ;
+  return self->numFeaturesWithNumScales ;
+}
+
+
+
+/* ---------------------------------------------------------------- */
+/** @brief Get wether to compute padded warped patches  
+ ** @param self object.
+ ** @return whether padded warped patches are computed.
+ **/
+vl_bool
+vl_covdet_get_allow_padded_warping (VlCovDet const  * self)
+{
+  return self->allowPaddedWarping ;
+}
+
+/** @brief Set wether to compute padded warped patches  
+ ** @param self object.
+ ** @param t whether padded warped patches are computed.
+ **/
+void
+vl_covdet_set_allow_padded_warping (VlCovDet * self, vl_bool t)
+{
+  self->allowPaddedWarping = t ;
+}

--- a/src/nonFree/sift/vl/covdet.c
+++ b/src/nonFree/sift/vl/covdet.c
@@ -2134,11 +2134,13 @@ vl_covdet_detect (VlCovDet * self)
   switch (self->method) {
     case VL_COVDET_METHOD_HARRIS_LAPLACE :
     case VL_COVDET_METHOD_HESSIAN_LAPLACE :
+    {
       VlCovDetBuffer internalBuffer;
       vl_covdetbuffer_init(&internalBuffer);
       vl_covdet_extract_laplacian_scales(self, &internalBuffer);
       vl_covdetbuffer_clear(&internalBuffer);
       break ;
+    }
     default:
       break ;
   }

--- a/src/nonFree/sift/vl/covdet.h
+++ b/src/nonFree/sift/vl/covdet.h
@@ -1,0 +1,269 @@
+/** @file covdet.h
+ ** @brief Covariant feature detectors (@ref covdet)
+ ** @author Karel Lenc
+ ** @author Andrea Vedaldi
+ ** @author Michal Perdoch
+ **/
+
+/*
+Copyright (C) 2013-14 Andrea Vedaldi.
+Copyright (C) 2012 Karel Lenc, Andrea Vedaldi and Michal Perdoch.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+#ifndef VL_COVDET_H
+#define VL_COVDET_H
+
+#include "generic.h"
+#include "stringop.h"
+#include "scalespace.h"
+
+#include <stdio.h>
+
+/* ---------------------------------------------------------------- */
+/*                                                   Feature Frames */
+/* ---------------------------------------------------------------- */
+
+/** @name Feature frames
+ ** @{ */
+
+/** @brief Types of feature frames */
+typedef enum _VlFrameType {
+  VL_FRAMETYPE_DISC = 1,         /**< A disc. */
+  VL_FRAMETYPE_ORIENTED_DISC,    /**< An oriented disc. */
+  VL_FRAMETYPE_ELLIPSE,          /**< An ellipse. */
+  VL_FRAMETYPE_ORIENTED_ELLIPSE, /**< An oriented ellipse. */
+  VL_FRAMETYPE_NUM
+} VlFrameType ;
+
+/** @brief Names of the frame types */
+VL_EXPORT const char* vlFrameNames [VL_FRAMETYPE_NUM] ;
+
+/** @brief Mapping between string values and VlFrameType values */
+VL_EXPORT VlEnumerator vlFrameTypes [VL_FRAMETYPE_NUM] ;
+
+/** @brief Disc feature frame */
+typedef struct _VlFrameDisc
+{
+  float x ;     /**< center x-coordinate */
+  float y ;     /**< center y-coordinate */
+  float sigma ; /**< radius or scale */
+} VlFrameDisc ;
+
+/** @brief Oriented disc feature frame
+ ** An upright frame has @c angle equal to zero.
+ **/
+typedef struct _VlFrameOrientedDisc {
+  float x ;     /**< center x-coordinate */
+  float y ;     /**< center y-coordinate */
+  float sigma ; /**< radius or scale */
+  float angle ; /**< rotation angle (rad) */
+} VlFrameOrientedDisc ;
+
+/** @brief Ellipse feature frame */
+typedef struct _VlFrameEllipse {
+  float x ;     /**< center x-coordinate */
+  float y ;     /**< center y-coordinate */
+  float e11 ;   /**< */
+  float e12 ;
+  float e22 ;
+} VlFrameEllipse ;
+
+/** @brief Oriented ellipse feature frame
+ ** The affine transformation transforms the ellipse shape into
+ ** a circular region. */
+typedef struct _VlFrameOrientedEllipse {
+  float x ;     /**< center x-coordinate */
+  float y ;     /**< center y-coordinate */
+  float a11 ;   /**< */
+  float a12 ;
+  float a21 ;
+  float a22 ;
+} VlFrameOrientedEllipse;
+
+/** @brief Get the size of a frame structure
+ ** @param frameType identifier of the type of frame.
+ ** @return size of the corresponding frame structure in bytes.
+ **/
+VL_INLINE vl_size
+vl_get_frame_size (VlFrameType frameType) {
+  switch (frameType) {
+    case VL_FRAMETYPE_DISC: return sizeof(VlFrameDisc);
+    case VL_FRAMETYPE_ORIENTED_DISC: return sizeof(VlFrameOrientedDisc);
+    case VL_FRAMETYPE_ELLIPSE: return sizeof(VlFrameEllipse);
+    case VL_FRAMETYPE_ORIENTED_ELLIPSE: return sizeof(VlFrameOrientedEllipse);
+    default:
+      assert(0);
+      break;
+  }
+  return 0;
+}
+
+/** @brief Get the size of a frame structure
+ ** @param affineAdaptation whether the detector use affine adaptation.
+ ** @param orientation whether the detector estimates the feature orientation.
+ ** @return the type of extracted frame.
+ **
+ ** Depedning on whether the detector estimate the affine shape
+ ** and orientation of a feature, different frame types
+ ** are extracted. */
+
+VL_INLINE VlFrameType
+vl_get_frame_type (vl_bool affineAdaptation, vl_bool orientation)
+{
+  if (affineAdaptation) {
+    if (orientation) {
+      return VL_FRAMETYPE_ORIENTED_ELLIPSE;
+    } else {
+      return VL_FRAMETYPE_ELLIPSE;
+    }
+  } else {
+    if (orientation) {
+      return VL_FRAMETYPE_ORIENTED_DISC;
+    } else {
+      return VL_FRAMETYPE_DISC;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------- */
+/*                                       Covariant Feature Detector */
+/* ---------------------------------------------------------------- */
+
+/** @brief A detected feature shape and location */
+typedef struct _VlCovDetFeature
+{
+  VlFrameOrientedEllipse frame ; /**< feature frame. */
+  float sigma;      /**< sigma */
+  float peakScore ; /**< peak score. */
+  float edgeScore ; /**< edge score. */
+  float orientationScore ; /**< orientation score. */
+  float laplacianScaleScore ; /**< Laplacian scale score. */
+} VlCovDetFeature ;
+
+/** @brief A detected feature orientation */
+typedef struct _VlCovDetFeatureOrientation
+{
+  double angle ;
+  double score ;
+} VlCovDetFeatureOrientation ;
+
+/** @brief A detected feature Laplacian scale */
+typedef struct _VlCovDetFeatureLaplacianScale
+{
+  double scale ;
+  double score ;
+} VlCovDetFeatureLaplacianScale ;
+
+/** @brief Covariant feature detection method */
+typedef enum _VlCovDetMethod
+{
+  VL_COVDET_METHOD_DOG = 1,
+  VL_COVDET_METHOD_HESSIAN,
+  VL_COVDET_METHOD_HESSIAN_LAPLACE,
+  VL_COVDET_METHOD_HARRIS_LAPLACE,
+  VL_COVDET_METHOD_MULTISCALE_HESSIAN,
+  VL_COVDET_METHOD_MULTISCALE_HARRIS,
+  VL_COVDET_METHOD_NUM
+} VlCovDetMethod;
+
+/** @brief Mapping between strings and ::VlCovDetMethod values */
+VL_EXPORT VlEnumerator vlCovdetMethods [VL_COVDET_METHOD_NUM] ;
+
+#ifdef __DOXYGEN__
+/** @brief Covariant feature detector
+ ** @see @ref covdet */
+struct _VlCovDet { }
+#endif
+
+/** @brief Covariant feature detector
+ ** @see @ref covdet */
+typedef struct _VlCovDet VlCovDet ;
+
+/** @name Create and destroy
+ ** @{ */
+VL_EXPORT VlCovDet * vl_covdet_new (VlCovDetMethod method) ;
+VL_EXPORT void vl_covdet_delete (VlCovDet * self) ;
+VL_EXPORT void vl_covdet_reset (VlCovDet * self) ;
+/** @} */
+
+/** @name Process data
+ ** @{ */
+VL_EXPORT int vl_covdet_put_image (VlCovDet * self,
+                                    float const * image,
+                                    vl_size width, vl_size height) ;
+
+VL_EXPORT void vl_covdet_detect (VlCovDet * self) ;
+VL_EXPORT int vl_covdet_append_feature (VlCovDet * self, VlCovDetFeature const * feature) ;
+VL_EXPORT void vl_covdet_extract_orientations (VlCovDet * self) ;
+VL_EXPORT void vl_covdet_extract_laplacian_scales (VlCovDet * self) ;
+VL_EXPORT void vl_covdet_extract_affine_shape (VlCovDet * self) ;
+
+VL_EXPORT VlCovDetFeatureOrientation *
+vl_covdet_extract_orientations_for_frame (VlCovDet * self,
+                                          vl_size *numOrientations,
+                                          VlFrameOrientedEllipse frame) ;
+
+VL_EXPORT VlCovDetFeatureLaplacianScale *
+vl_covdet_extract_laplacian_scales_for_frame (VlCovDet * self,
+                                              vl_size * numScales,
+                                              VlFrameOrientedEllipse frame) ;
+VL_EXPORT int
+vl_covdet_extract_affine_shape_for_frame (VlCovDet * self,
+                                          VlFrameOrientedEllipse * adapted,
+                                          VlFrameOrientedEllipse frame) ;
+
+VL_EXPORT vl_bool
+vl_covdet_extract_patch_for_frame (VlCovDet * self, float * patch,
+                                   vl_size resolution,
+                                   double extent,
+                                   double sigma,
+                                   VlFrameOrientedEllipse frame) ;
+
+VL_EXPORT void
+vl_covdet_drop_features_outside (VlCovDet * self, double margin) ;
+/** @} */
+
+/** @name Retrieve data and parameters
+ ** @{ */
+VL_EXPORT vl_size vl_covdet_get_num_features (VlCovDet const * self) ;
+VL_EXPORT VlCovDetFeature* vl_covdet_get_features(VlCovDet* self);
+VL_EXPORT vl_index vl_covdet_get_first_octave (VlCovDet const * self) ;
+VL_EXPORT vl_size vl_covdet_get_num_octaves (VlCovDet const * self) ;
+VL_EXPORT double vl_covdet_get_base_scale (VlCovDet const * self) ;
+VL_EXPORT vl_size vl_covdet_get_octave_resolution (VlCovDet const * self) ;
+VL_EXPORT double vl_covdet_get_peak_threshold (VlCovDet const * self) ;
+VL_EXPORT double vl_covdet_get_edge_threshold (VlCovDet const * self) ;
+VL_EXPORT double vl_covdeg_get_laplacian_peak_threshold (VlCovDet const * self) ;
+VL_EXPORT vl_size vl_covdet_get_max_num_orientations (VlCovDet const * self) ;
+VL_EXPORT vl_bool vl_covdet_get_transposed (VlCovDet const * self) ;
+VL_EXPORT VlScaleSpace *  vl_covdet_get_gss (VlCovDet const * self) ;
+VL_EXPORT VlScaleSpace *  vl_covdet_get_css (VlCovDet const * self) ;
+VL_EXPORT vl_bool vl_covdet_get_aa_accurate_smoothing (VlCovDet const * self) ;
+VL_EXPORT vl_size const * vl_covdet_get_laplacian_scales_statistics (VlCovDet const * self, vl_size * numScales) ;
+VL_EXPORT double vl_covdet_get_non_extrema_suppression_threshold (VlCovDet const * self) ;
+VL_EXPORT vl_size vl_covdet_get_num_non_extrema_suppressed (VlCovDet const * self) ;
+VL_EXPORT vl_bool vl_covdet_get_allow_padded_warping (VlCovDet const * self) ;
+/** @} */
+
+/** @name Set parameters
+ ** @{ */
+VL_EXPORT void vl_covdet_set_first_octave (VlCovDet * self, vl_index o) ;
+VL_EXPORT void vl_covdet_set_num_octaves (VlCovDet * self, vl_size o) ;
+VL_EXPORT void vl_covdet_set_base_scale (VlCovDet * self, double s) ;
+VL_EXPORT void vl_covdet_set_octave_resolution (VlCovDet * self, vl_size r) ;
+VL_EXPORT void vl_covdet_set_peak_threshold (VlCovDet * self, double peakThreshold) ;
+VL_EXPORT void vl_covdet_set_edge_threshold (VlCovDet * self, double edgeThreshold) ;
+VL_EXPORT void vl_covdet_set_laplacian_peak_threshold (VlCovDet * self, double peakThreshold) ;
+VL_EXPORT void vl_covdet_set_max_num_orientations (VlCovDet * self, vl_size m) ;
+VL_EXPORT void vl_covdet_set_transposed (VlCovDet * self, vl_bool t) ;
+VL_EXPORT void vl_covdet_set_aa_accurate_smoothing (VlCovDet * self, vl_bool x) ;
+VL_EXPORT void vl_covdet_set_non_extrema_suppression_threshold (VlCovDet * self, double x) ;
+VL_EXPORT void vl_covdet_set_allow_padded_warping (VlCovDet * self, vl_bool x) ;
+/** @} */
+
+/* VL_COVDET_H */
+#endif

--- a/src/nonFree/sift/vl/covdet.h
+++ b/src/nonFree/sift/vl/covdet.h
@@ -183,11 +183,22 @@ struct _VlCovDet { }
  ** @see @ref covdet */
 typedef struct _VlCovDet VlCovDet ;
 
+typedef struct _VlCovDetBuffer
+{
+    float* patch;
+    vl_size patchBufferSize;
+} VlCovDetBuffer;
+
 /** @name Create and destroy
  ** @{ */
 VL_EXPORT VlCovDet * vl_covdet_new (VlCovDetMethod method) ;
 VL_EXPORT void vl_covdet_delete (VlCovDet * self) ;
-VL_EXPORT void vl_covdet_reset (VlCovDet * self) ;
+VL_EXPORT void vl_covdet_reset(VlCovDet* self);
+VL_EXPORT VlCovDetBuffer* vl_covdetbuffer_new();
+VL_EXPORT void vl_covdetbuffer_init(VlCovDetBuffer* self);
+VL_EXPORT void vl_covdetbuffer_clear(VlCovDetBuffer* self);
+VL_EXPORT void vl_covdetbuffer_delete(VlCovDetBuffer* self);
+
 /** @} */
 
 /** @name Process data
@@ -198,27 +209,31 @@ VL_EXPORT int vl_covdet_put_image (VlCovDet * self,
 
 VL_EXPORT void vl_covdet_detect (VlCovDet * self) ;
 VL_EXPORT int vl_covdet_append_feature (VlCovDet * self, VlCovDetFeature const * feature) ;
-VL_EXPORT void vl_covdet_extract_orientations (VlCovDet * self) ;
-VL_EXPORT void vl_covdet_extract_laplacian_scales (VlCovDet * self) ;
-VL_EXPORT void vl_covdet_extract_affine_shape (VlCovDet * self) ;
+VL_EXPORT void vl_covdet_extract_orientations (VlCovDet * self, VlCovDetBuffer* internalBuffer) ;
+VL_EXPORT void vl_covdet_extract_laplacian_scales (VlCovDet * self, VlCovDetBuffer* internalBuffer) ;
+VL_EXPORT void vl_covdet_extract_affine_shape (VlCovDet * self, VlCovDetBuffer* internalBuffer) ;
 
 VL_EXPORT VlCovDetFeatureOrientation *
 vl_covdet_extract_orientations_for_frame (VlCovDet * self,
+                                          VlCovDetBuffer* internalBuffer,
                                           vl_size *numOrientations,
                                           VlFrameOrientedEllipse frame) ;
 
 VL_EXPORT VlCovDetFeatureLaplacianScale *
 vl_covdet_extract_laplacian_scales_for_frame (VlCovDet * self,
+                                              VlCovDetBuffer* internalBuffer,
                                               vl_size * numScales,
                                               VlFrameOrientedEllipse frame) ;
 VL_EXPORT int
 vl_covdet_extract_affine_shape_for_frame (VlCovDet * self,
+                                          VlCovDetBuffer* internalBuffer,
                                           VlFrameOrientedEllipse * adapted,
                                           VlFrameOrientedEllipse frame) ;
 
 VL_EXPORT vl_bool
 vl_covdet_extract_patch_for_frame (VlCovDet * self, float * patch,
                                    vl_size resolution,
+                                   VlCovDetBuffer* internalBuffer,
                                    double extent,
                                    double sigma,
                                    VlFrameOrientedEllipse frame) ;

--- a/src/nonFree/sift/vl/float.th
+++ b/src/nonFree/sift/vl/float.th
@@ -1,9 +1,12 @@
 /** @file float.th
  ** @brief Float - Template
  ** @author Andrea Vedaldi
+ ** @author David Novotny
  **/
 
 /*
+Copyright (C) 2014 Andrea Vedaldi.
+Copyright (C) 2013 David Novotny.
 Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
 All rights reserved.
 
@@ -18,22 +21,66 @@ the terms of the BSD license (see the COPYING file).
 #undef  VSIZE
 #undef  VSFX
 #undef  VTYPE
+#undef  VSIZEavx
+#undef  VSFXavx
+#undef  VTYPEavx
 
 #if (FLT == VL_TYPE_FLOAT)
-#  define T      float
-#  define SFX    f
+#  define T float
+#  define SFX f
 #elif (FLT == VL_TYPE_DOUBLE)
-#  define T      double
-#  define SFX    d
+#  define T double
+#  define SFX d
 #elif (FLT == VL_TYPE_UINT32)
-#  define T      vl_uint32
-#  define SFX    ui32
+#  define T vl_uint32
+#  define SFX ui32
 #elif (FLT == VL_TYPE_INT32)
-#  define T      vl_int32
-#  define SFX    i32
+#  define T vl_int32
+#  define SFX i32
 #endif
 
-#ifdef  __SSE2__
+/* ---------------------------------------------------------------- */
+/*                                                              AVX */
+/* ---------------------------------------------------------------- */
+
+#ifdef __AVX__
+
+#if (FLT == VL_TYPE_FLOAT)
+#  define VSIZEavx  8
+#  define VSFXavx   s
+#  define VTYPEavx  __m256
+#elif (FLT == VL_TYPE_DOUBLE)
+#  define VSIZEavx  4
+#  define VSFXavx   d
+#  define VTYPEavx  __m256d
+#endif
+
+#define VALIGNEDavx(x) (! (((vl_uintptr)(x)) & 0x1F))
+
+#define VMULavx  VL_XCAT(_mm256_mul_p,     VSFX)
+#define VDIVavx  VL_XCAT(_mm256_div_p,     VSFX)
+#define VADDavx  VL_XCAT(_mm256_add_p,     VSFX)
+#define VHADDavx  VL_XCAT(_mm_hadd_p,     VSFX)
+#define VHADD2avx  VL_XCAT(_mm256_hadd_p,     VSFX)
+#define VSUBavx  VL_XCAT(_mm256_sub_p,     VSFX)
+#define VSTZavx  VL_XCAT(_mm256_setzero_p, VSFX)
+#define VLD1avx  VL_XCAT(_mm256_broadcast_s,   VSFX)
+#define VLDUavx  VL_XCAT(_mm256_loadu_p,   VSFX)
+#define VST1avx  VL_XCAT(_mm256_store_s,   VSFX)
+#define VST2avx  VL_XCAT(_mm256_store_p,   VSFX)
+#define VST2Uavx VL_XCAT(_mm256_storeu_p,  VSFX)
+#define VPERMavx VL_XCAT(_mm256_permute2f128_p,  VSFX)
+//#define VCSTavx VL_XCAT( _mm256_castps256_ps128,  VSFX)
+#define VCSTavx  VL_XCAT5(_mm256_castp,VSFX,256_p,VSFX,128)
+
+/* __AVX__ */
+#endif
+
+/* ---------------------------------------------------------------- */
+/*                                                             SSE2 */
+/* ---------------------------------------------------------------- */
+
+#ifdef __SSE2__
 
 #if (FLT == VL_TYPE_FLOAT)
 #  define VSIZE  4
@@ -61,6 +108,9 @@ the terms of the BSD license (see the COPYING file).
 #define VNEQ  VL_XCAT(_mm_cmpneq_p,  VSFX)
 #define VAND  VL_XCAT(_mm_and_p,     VSFX)
 #define VANDN VL_XCAT(_mm_andnot_p,  VSFX)
+#define VST2  VL_XCAT(_mm_store_p,   VSFX)
+#define VST2U VL_XCAT(_mm_storeu_p,  VSFX)
 
 /* __SSE2__ */
 #endif
+

--- a/src/nonFree/sift/vl/generic.c
+++ b/src/nonFree/sift/vl/generic.c
@@ -1513,8 +1513,9 @@ vl_thread_specific_state_delete (VlThreadState * self)
  */
 
 #if (defined(VL_OS_LINUX) || defined(VL_OS_MACOSX)) && defined(VL_COMPILER_GNUC)
-static void vl_constructor () __attribute__ ((constructor)) ;
-static void vl_destructor () __attribute__ ((destructor))  ;
+// Warning: constructor/desctructor commented, should be called explicitely
+void vl_constructor () ; // __attribute__ ((constructor)) ;
+void vl_destructor () ; // __attribute__ ((destructor))  ;
 #endif
 
 #if defined(VL_OS_WIN)

--- a/src/nonFree/sift/vl/generic.c
+++ b/src/nonFree/sift/vl/generic.c
@@ -1020,7 +1020,7 @@ vl_get_thread_specific_state (void)
   return vl_get_state()->threadState ;
 #else
   VlState * state ;
-  VlThreadState * threadState ;
+  VlThreadState * threadState = NULL;
 
   vl_lock_state() ;
   state = vl_get_state() ;

--- a/src/nonFree/sift/vl/generic.c
+++ b/src/nonFree/sift/vl/generic.c
@@ -1512,52 +1512,53 @@ vl_thread_specific_state_delete (VlThreadState * self)
  * in different ways depending on the operating system.
  */
 
-#if (defined(VL_OS_LINUX) || defined(VL_OS_MACOSX)) && defined(VL_COMPILER_GNUC)
-// Warning: constructor/desctructor commented, should be called explicitely
-void vl_constructor () ; // __attribute__ ((constructor)) ;
-void vl_destructor () ; // __attribute__ ((destructor))  ;
-#endif
+// WARNING: constructor/desctructor is commented and should now be called explicitely
 
-#if defined(VL_OS_WIN)
-static void vl_constructor () ;
-static void vl_destructor () ;
-
-BOOL WINAPI DllMain(
-    HINSTANCE hinstDLL,  // handle to DLL module
-    DWORD fdwReason,     // reason for calling function
-    LPVOID lpReserved )  // reserved
-{
-  VlState * state ;
-  VlThreadState * threadState ;
-  switch (fdwReason) {
-    case DLL_PROCESS_ATTACH:
-      /* Initialize once for each new process */
-      vl_constructor () ;
-      break ;
-
-    case DLL_THREAD_ATTACH:
-      /* Do thread-specific initialization */
-      break ;
-
-    case DLL_THREAD_DETACH:
-      /* Do thread-specific cleanup */
-#if ! defined(VL_DISABLE_THREADS) && defined(VL_THREADS_WIN)
-      state = vl_get_state() ;
-      threadState = (VlThreadState*) TlsGetValue(state->tlsIndex) ;
-      if (threadState) {
-        vl_thread_specific_state_delete (threadState) ;
-      }
-#endif
-      break;
-
-    case DLL_PROCESS_DETACH:
-      /* Perform any necessary cleanup */
-      vl_destructor () ;
-      break;
-    }
-    return TRUE ; /* Successful DLL_PROCESS_ATTACH */
-}
-#endif /* VL_OS_WIN */
+//#if (defined(VL_OS_LINUX) || defined(VL_OS_MACOSX)) && defined(VL_COMPILER_GNUC)
+//void vl_constructor () __attribute__ ((constructor)) ;
+//void vl_destructor () __attribute__ ((destructor))  ;
+//#endif
+//
+//#if defined(VL_OS_WIN)
+//static void vl_constructor () ;
+//static void vl_destructor () ;
+//
+//BOOL WINAPI DllMain(
+//    HINSTANCE hinstDLL,  // handle to DLL module
+//    DWORD fdwReason,     // reason for calling function
+//    LPVOID lpReserved )  // reserved
+//{
+//  VlState * state ;
+//  VlThreadState * threadState ;
+//  switch (fdwReason) {
+//    case DLL_PROCESS_ATTACH:
+//      /* Initialize once for each new process */
+//      vl_constructor () ;
+//      break ;
+//
+//    case DLL_THREAD_ATTACH:
+//      /* Do thread-specific initialization */
+//      break ;
+//
+//    case DLL_THREAD_DETACH:
+//      /* Do thread-specific cleanup */
+//#if ! defined(VL_DISABLE_THREADS) && defined(VL_THREADS_WIN)
+//      state = vl_get_state() ;
+//      threadState = (VlThreadState*) TlsGetValue(state->tlsIndex) ;
+//      if (threadState) {
+//        vl_thread_specific_state_delete (threadState) ;
+//      }
+//#endif
+//      break;
+//
+//    case DLL_PROCESS_DETACH:
+//      /* Perform any necessary cleanup */
+//      vl_destructor () ;
+//      break;
+//    }
+//    return TRUE ; /* Successful DLL_PROCESS_ATTACH */
+//}
+//#endif /* VL_OS_WIN */
 
 /* ---------------------------------------------------------------- */
 /*                               Library constructor and destructor */

--- a/src/nonFree/sift/vl/generic.h
+++ b/src/nonFree/sift/vl/generic.h
@@ -4,6 +4,7 @@
  **/
 
 /*
+Copyright (C) 2013,18 Andrea Vedaldi.
 Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
 All rights reserved.
 
@@ -22,21 +23,13 @@ the terms of the BSD license (see the COPYING file).
 #include <time.h>
 #include <assert.h>
 
-#if defined(VL_OS_WIN)
-#include <Windows.h>
-#endif
-
-#if ! defined(VL_DISABLE_THREADS) && defined(VL_THREADS_POSIX)
-#include <pthread.h>
-#endif
-
 /** @brief Library version string */
-#define VL_VERSION_STRING "0.9.16"
+#define VL_VERSION_STRING "0.9.21"
 
 /** @brief Maximum length (in characters) of an error message */
 #define VL_ERR_MSG_LEN 1024
 
-/** @name Type identidifers for atomic data types
+/** @name Type identifiers for atomic data types
  ** @{ */
 
 #define VL_TYPE_FLOAT   1     /**< @c float type */
@@ -104,91 +97,28 @@ vl_get_type_size (vl_type type)
   }
   return dataSize ;
 }
-
 /** @} */
 
-/** ------------------------------------------------------------------
- ** @name Library state and configuration
+VL_EXPORT char const * vl_get_version_string (void) ;
+VL_EXPORT char * vl_configuration_to_string_copy (void) ;
+VL_EXPORT void vl_set_simd_enabled (vl_bool x) ;
+VL_EXPORT vl_bool vl_get_simd_enabled (void) ;
+VL_EXPORT vl_bool vl_cpu_has_avx (void) ;
+VL_EXPORT vl_bool vl_cpu_has_sse3 (void) ;
+VL_EXPORT vl_bool vl_cpu_has_sse2 (void) ;
+VL_EXPORT vl_size vl_get_num_cpus (void) ;
+VL_EXPORT VlRand * vl_get_rand (void) ;
+
+/** @name Multi-thread computations
  ** @{ */
-
-/** @internal @brief VLFeat thread state */
-typedef struct _VlThreadSpecificState
-{
-  /* errors */
-  int lastError ;
-  char lastErrorMessage [VL_ERR_MSG_LEN] ;
-
-  /* random number generator */
-  VlRand rand ;
-
-  /* time */
-#if defined(VL_OS_WIN)
-  LARGE_INTEGER ticFreq ;
-  LARGE_INTEGER ticMark ;
-#else
-  clock_t ticMark ;
-#endif
-} VlThreadSpecificState ;
-
-/** @internal @brief VLFeat global state */
-typedef struct _VlState
-{
-
-#if ! defined(VL_DISABLE_THREADS)
-#if   defined(VL_THREADS_POSIX)
-  pthread_key_t threadKey ;
-  pthread_mutex_t mutex ;
-  pthread_t mutexOwner ;
-  pthread_cond_t mutexCondition ;
-  size_t mutexCount ;
-#elif defined(VL_THREADS_WIN)
-  DWORD tlsIndex ;
-  CRITICAL_SECTION mutex ;
-#endif
-#else
-  VlThreadSpecificState * threadState ;
-#endif
-
-  int   (*printf_func)  (char const * format, ...) ;
-  void *(*malloc_func)  (size_t) ;
-  void *(*realloc_func) (void*,size_t) ;
-  void *(*calloc_func)  (size_t, size_t) ;
-  void  (*free_func)    (void*) ;
-
-#if defined(VL_ARCH_IX86) || defined(VL_ARCH_X64) || defined(VL_ARCH_IA64)
-  VlX86CpuInfo cpuInfo ;
-#endif
-  vl_size numCPUs ;
-
-  vl_bool simdEnabled ;
-  vl_size maxNumThreads ;
-
-} VlState ;
-
-/** @internal @brief VLFeat global state */
-VL_EXPORT VlState _vl_state ;
-
-VL_INLINE VlState * vl_get_state () ;
-VL_INLINE VlThreadSpecificState * vl_get_thread_specific_state () ;
-VL_EXPORT void vl_lock_state () ;
-VL_EXPORT void vl_unlock_state () ;
-VL_EXPORT VlThreadSpecificState * vl_thread_specific_state_new () ;
-VL_EXPORT void vl_thread_specific_state_delete (VlThreadSpecificState * self) ;
-VL_EXPORT char const * vl_get_version_string () ;
-VL_EXPORT char * vl_configuration_to_string_copy () ;
-VL_INLINE void vl_set_simd_enabled (vl_bool x) ;
-VL_INLINE vl_bool vl_get_simd_enabled () ;
-VL_INLINE vl_bool vl_cpu_has_sse3 () ;
-VL_INLINE vl_bool vl_cpu_has_sse2 () ;
-VL_INLINE vl_size vl_get_num_cpus () ;
-VL_EXPORT VlRand * vl_get_rand () ;
-
-/** @} */
+VL_EXPORT vl_size vl_get_max_threads (void) ;
+VL_EXPORT void vl_set_num_threads (vl_size n) ;
+VL_EXPORT vl_size vl_get_thread_limit (void) ;
+/** @} (*/
 
 /** ------------------------------------------------------------------
  ** @name Error handling
  ** @{ */
-
 #define VL_ERR_OK       0  /**< No error */
 #define VL_ERR_OVERFLOW 1  /**< Buffer overflow error */
 #define VL_ERR_ALLOC    2  /**< Resource allocation error */
@@ -197,68 +127,60 @@ VL_EXPORT VlRand * vl_get_rand () ;
 #define VL_ERR_EOF      5  /**< End-of-file or end-of-sequence error */
 #define VL_ERR_NO_MORE  5  /**< End-of-sequence @deprecated */
 
-VL_INLINE int vl_get_last_error () ;
-VL_INLINE char const *  vl_get_last_error_message () ;
+VL_EXPORT int vl_get_last_error (void) ;
+VL_EXPORT char const *  vl_get_last_error_message (void) ;
 VL_EXPORT int vl_set_last_error (int error, char const * errorMessage, ...) ;
-
 /** @} */
 
 /** ------------------------------------------------------------------
  ** @name Memory allocation
  ** @{ */
-
 VL_EXPORT void
 vl_set_alloc_func (void *(*malloc_func)  (size_t),
                    void *(*realloc_func) (void*,size_t),
                    void *(*calloc_func)  (size_t, size_t),
                    void  (*free_func)    (void*)) ;
-VL_INLINE void *vl_malloc  (size_t n) ;
-VL_INLINE void *vl_realloc (void *ptr, size_t n) ;
-VL_INLINE void *vl_calloc  (size_t n, size_t size) ;
-VL_INLINE void  vl_free    (void* ptr) ;
-
+VL_EXPORT void *vl_malloc (size_t n) ;
+VL_EXPORT void *vl_realloc (void *ptr, size_t n) ;
+VL_EXPORT void *vl_calloc (size_t n, size_t size) ;
+VL_EXPORT void *vl_memalign (size_t n, size_t size) ;
+VL_EXPORT void  vl_free (void* ptr) ;
 /** @} */
 
 /** ------------------------------------------------------------------
  ** @name Logging
  ** @{ */
-
-/** ------------------------------------------------------------------
- ** @brief Customizable printf function pointer type */
+/** @brief Customizable printf function pointer type */
 typedef int(*printf_func_t) (char const *format, ...) ;
-
-/** @brief Set printf function
- ** @param printf_func  pointer to @c printf.
- ** Let @c print_func be NULL to disable printf.
- **/
 VL_EXPORT void vl_set_printf_func (printf_func_t printf_func) ;
+VL_EXPORT printf_func_t vl_get_printf_func (void) ;
 
 /** @def VL_PRINTF
  ** @brief Call user-customizable @c printf function
  **
  ** The function calls the user customizable @c printf.
  **/
-#define VL_PRINTF (*vl_get_state()->printf_func)
 
 /** @def VL_PRINT
  ** @brief Same as ::VL_PRINTF (legacy code)
  **/
-#define VL_PRINT (*vl_get_state()->printf_func)
 
+#define VL_PRINTF (*vl_get_printf_func())
+#define VL_PRINT (*vl_get_printf_func())
 /** @} */
 
 /** ------------------------------------------------------------------
  ** @name Common operations
  ** @{ */
 
-/** @brief Min operation
+/** @brief Compute the minimum between two values
  ** @param x value
  ** @param y value
  ** @return the minimum of @a x and @a y.
  **/
 #define VL_MIN(x,y) (((x)<(y))?(x):(y))
 
-/** @brief Max operation
+/** @brief Compute the maximum between two values
  ** @param x value.
  ** @param y value.
  ** @return the maximum of @a x and @a y.
@@ -266,13 +188,11 @@ VL_EXPORT void vl_set_printf_func (printf_func_t printf_func) ;
 #define VL_MAX(x,y) (((x)>(y))?(x):(y))
 
 /** @brief Signed left shift operation
- **
- ** The macro is equivalent to the builtin @c << operator, but it
- ** supports negative shifts too.
- **
  ** @param x value.
  ** @param n number of shift positions.
  ** @return @c x << n .
+ ** The macro is equivalent to the builtin @c << operator, but it
+ ** supports negative shifts too.
  **/
 #define VL_SHIFT_LEFT(x,n) (((n)>=0)?((x)<<(n)):((x)>>-(n)))
 /* @} */
@@ -281,132 +201,13 @@ VL_EXPORT void vl_set_printf_func (printf_func_t printf_func) ;
  ** @name Measuring time
  ** @{
  **/
-VL_EXPORT void vl_tic () ;
-VL_EXPORT double vl_toc () ;
-VL_EXPORT double vl_get_cpu_time () ;
+VL_EXPORT void vl_tic (void) ;
+VL_EXPORT double vl_toc (void) ;
+VL_EXPORT double vl_get_cpu_time (void) ;
 /** @} */
 
-VL_EXPORT void vl_constructor () ;
-VL_EXPORT void vl_destructor () ;
-
-
-/* -------------------------------------------------------------------
- *                                                    Inline functions
- * ---------------------------------------------------------------- */
-
-
-
-VL_INLINE VlState *
-vl_get_state ()
-{
-  return &_vl_state ;
-}
-
-VL_INLINE VlThreadSpecificState *
-vl_get_thread_specific_state ()
-{
-#ifdef VL_DISABLE_THREADS
-  return vl_get_state()->threadState ;
-#else
-  VlState * state ;
-  VlThreadSpecificState * threadState ;
-
-  vl_lock_state() ;
-  state = vl_get_state() ;
-
-#if defined(VL_THREADS_POSIX)
-  threadState = (VlThreadSpecificState *) pthread_getspecific(state->threadKey) ;
-#elif defined(VL_THREADS_WIN)
-  threadState = (VlThreadSpecificState *) TlsGetValue(state->tlsIndex) ;
-#endif
-
-  if (! threadState) {
-    threadState = vl_thread_specific_state_new () ;
-  }
-
-#if defined(VL_THREADS_POSIX)
-  pthread_setspecific(state->threadKey, threadState) ;
-#elif defined(VL_THREADS_WIN)
-  TlsSetValue(state->tlsIndex, threadState) ;
-#endif
-
-  vl_unlock_state() ;
-  return threadState ;
-#endif
-}
-
-VL_INLINE void
-vl_set_simd_enabled (vl_bool x)
-{
-  vl_get_state()->simdEnabled = x ;
-}
-
-VL_INLINE vl_bool
-vl_get_simd_enabled ()
-{
-  return vl_get_state()->simdEnabled ;
-}
-
-VL_INLINE vl_bool
-vl_cpu_has_sse3 ()
-{
-#if defined(VL_ARCH_IX86) || defined(VL_ARCH_X64) || defined(VL_ARCH_IA64)
-  return vl_get_state()->cpuInfo.hasSSE3 ;
-#else
-  return 0 ;
-#endif
-}
-
-VL_INLINE vl_bool
-vl_cpu_has_sse2 ()
-{
-#if defined(VL_ARCH_IX86) || defined(VL_ARCH_X64) || defined(VL_ARCH_IA64)
-  return vl_get_state()->cpuInfo.hasSSE2 ;
-#else
-  return 0 ;
-#endif
-}
-
-VL_INLINE vl_size
-vl_get_num_cpus ()
-{
-  return vl_get_state()->numCPUs ;
-}
-
-VL_INLINE int
-vl_get_last_error () {
-  return vl_get_thread_specific_state()->lastError ;
-}
-
-VL_INLINE char const *
-vl_get_last_error_message ()
-{
-  return vl_get_thread_specific_state()->lastErrorMessage ;
-}
-
-VL_INLINE void*
-vl_malloc (size_t n)
-{
-  return (vl_get_state()->malloc_func)(n) ;
-}
-
-VL_INLINE void*
-vl_realloc (void* ptr, size_t n)
-{
-  return (vl_get_state()->realloc_func)(ptr, n) ;
-}
-
-VL_INLINE void*
-vl_calloc (size_t n, size_t size)
-{
-  return (vl_get_state()->calloc_func)(n, size) ;
-}
-
-VL_INLINE void
-vl_free (void *ptr)
-{
-  (vl_get_state()->free_func)(ptr) ;
-}
+VL_EXPORT void vl_constructor (void) ;
+VL_EXPORT void vl_destructor(void);
 
 /* VL_GENERIC_H */
 #endif

--- a/src/nonFree/sift/vl/host.c
+++ b/src/nonFree/sift/vl/host.c
@@ -1,6 +1,7 @@
 /** @file host.c
  ** @brief Host - Definition
  ** @author Andrea Vedaldi
+ ** @see @ref portability
  **/
 
 /*
@@ -12,235 +13,238 @@ the terms of the BSD license (see the COPYING file).
 */
 
 /**
- @file host.h
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page portability Portability features
+@author Andrea Vedaldi
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
 
- This module provides functionalities to identify the
- host operating system, C compiler,
- and CPU architecture. It also provides a few features
- to abstract from such details.
+Platform dependent details are isolated in the @ref host.h.  This
+module provides functionalities to identify the host operating system,
+C compiler, and CPU architecture. It also provides a few features to
+abstract from such details.
 
- - @ref host-os "Host operating system"
- - @ref host-compiler "Host compiler"
-   - @ref host-compiler-data-model "Data models"
-   - @ref host-compiler-other "Other compiler specific features"
- - @ref host-arch "Host CPU architecture"
-   - @ref host-arch-endianness "Endianness"
+@see http://predef.sourceforge.net/index.php
+@see http://en.wikipedia.org/wiki/64-bit_computing
 
- @see http://predef.sourceforge.net/index.php
+@section host-os Host operating system
 
- @section host-os Host operating system
+The module defines a symbol to identify the host operating system:
+::VL_OS_WIN for Windows, ::VL_OS_LINUX for Linux, ::VL_OS_MACOSX for
+Mac OS X, and so on.
 
- The module defines a symbol to identify the host operating system:
- ::VL_OS_WIN for Windows, ::VL_OS_LINUX for Linux, ::VL_OS_MACOSX for
- Mac OS X, and so on.
+@section host-compiler Host compiler
 
- @section host-compiler Host compiler
+The module defines a symbol to identify the host compiler:
+::VL_COMPILER_MSC for Microsoft Visual C++, ::VL_COMPILER_GNUC for
+GNU C, and so on. The (integer) value of such symbols corresponds the
+version of the compiler.
 
- The module defines a symbol to identify the host compiler:
- ::VL_COMPILER_MSC for Microsoft Visual C++, ::VL_COMPILER_GNUC for
- GNU C, and so on. The (integer) value of such symbols corresponds the
- version of the compiler.
+The module defines a symbol to identify the data model of the
+compiler: ::VL_COMPILER_ILP32, ::VL_COMPILER_LP64, or
+::VL_COMPILER_LLP64 (see Sect. @ref host-compiler-data-model).  For
+convenience, it also defines a number of atomic types of prescribed
+width (::vl_int8, ::vl_int16, ::vl_int32, etc.).
 
- The module defines a symbol to identify the data model of the
- compiler: ::VL_COMPILER_ILP32, ::VL_COMPILER_LP64, or
- ::VL_COMPILER_LLP64 (see Sect. @ref host-compiler-data-model).  For
- convenience, it also defines a number of atomic types of prescribed
- width (::vl_int8, ::vl_int16, ::vl_int32, etc.).
+@remark While some of such functionalities are provided by the
+standard header @c stdint.h, the latter is not supported by all
+platforms.
 
- @remark While some of such functionalities are provided by the
- standard header @c stdint.h, the latter is not supported by all
- platforms.
+@subsection host-compiler-data-model Data models
 
- @subsection host-compiler-data-model Data models
+The C language defines a number of atomic data types (such as @c char,
+@c short, @c int and so on). The number of bits (width) used to
+represent each data type depends on the compiler data model. The
+different models are *ILP32* (@c int, @c long, and pointer 32 bit),
+*LP64* (@c int 32 bit, @c long and pointer 64 bit), *ILP64* (@c int,
+@c long, and pointer 64 bit), and *LLP64* (@c int, @c long 32 bit and
+pointer 64 -- and `long long` -- 64 bit). Note in particular that
+`long long` is 64 bit in all models of interest. The following table
+summarizes them:
 
- The C language defines a number of atomic data types (such as @c
- char, @c short, @c int and so on). The number of bits (width) used to
- represent each data type depends on the compiler data model.  The
- following table summarizes the relevant conventions:
+<table><caption><b>Compiler data models.</b> </caption>
+<tr style="font-weight:bold;">
+<td>Data model</td>
+<td><code>short</code></td>
+<td><code>int</code></td>
+<td><code>long</code></td>
+<td><code>long long</code></td>
+<td><code>void*</code></td>
+<td>Compiler</td>
+</tr>
+<tr>
+<td>ILP32</td>
+<td style="background-color:#ffa;">16</td>
+<td style="background-color:#afa;">32</td>
+<td style="background-color:#afa;">32</td>
+<td>64</td>
+<td style="background-color:#afa;">32</td>
+<td>Most 32 bit architectures.</td>
+</tr>
+<tr>
+<td>LP64</td>
+<td style="background-color:#ffa;">16</td>
+<td style="background-color:#afa;">32</td>
+<td>64</td>
+<td>64</td>
+<td>64</td>
+<td>UNIX-64 (Linux, Mac OS X)</td>
+</tr>
+<tr>
+<td>ILP64</td>
+<td style="background-color:#ffa;">16</td>
+<td>64</td>
+<td>64</td>
+<td>64</td>
+<td>64</td>
+<td>Alpha, Cray</td>
+</tr>
+<tr>
+<td>SLIP64</td>
+<td>64</td>
+<td>64</td>
+<td>64</td>
+<td>64</td>
+<td>64</td>
+<td></td>
+</tr>
+<tr>
+<td>LLP64</td>
+<td style="background-color:#ffa;">16</td>
+<td style="background-color:#afa;">32</td>
+<td style="background-color:#afa;">32</td>
+<td>64</td>
+<td>64</td>
+<td>Windows-64</td>
+</tr>
+</table>
 
- <table><caption><b>Compiler data models.</b> The table shows
- how many bits are allocated to each atomic data type according to
- each model.</caption>
- <tr style="font-weight:bold;">
- <td>Data model</td>
- <td><code>short</code></td>
- <td><code>int</code></td>
- <td><code>long</code></td>
- <td><code>long long</code></td>
- <td><code>void*</code></td>
- <td>Compiler</td>
- </tr>
- <tr>
- <td>ILP32</td>
- <td style="background-color:#ffa;">16</td>
- <td style="background-color:#afa;">32</td>
- <td style="background-color:#afa;">32</td>
- <td >64</td>
- <td style="background-color:#afa;">32</td>
- <td>common 32 bit architectures</td>
- </tr>
- <tr>
- <td>LP64</td>
- <td style="background-color:#ffa;">16</td>
- <td style="background-color:#afa;">32</td>
- <td>64</td>
- <td>64</td>
- <td>64</td>
- <td>UNIX-64 (Linux, Mac OS X)</td>
- </tr>
- <tr>
- <td>ILP64</td>
- <td style="background-color:#ffa;">16</td>
- <td>64</td>
- <td>64</td>
- <td>64</td>
- <td>64</td>
- <td>Alpha, Cray</td>
- </tr>
- <tr>
- <td>SLIP64</td>
- <td>64</td>
- <td>64</td>
- <td>64</td>
- <td>64</td>
- <td>64</td>
- <td></td>
- </tr>
- <tr>
- <td>LLP64</td>
- <td style="background-color:#ffa;">16</td>
- <td style="background-color:#afa;">32</td>
- <td style="background-color:#afa;">32</td>
- <td>64</td>
- <td>64</td>
- <td>Windows-64</td>
- </tr>
- </table>
+Macros such as ::VL_UINT32_C can be used to generate integer literal
+with the correct suffix for a type of a given width.
 
- @subsection host-compiler-other Other compiler-specific features
+@subsection host-compiler-other Other compiler-specific features
 
- The module provides the macro ::VL_EXPORT to declare symbols exported
- from the library and the macro ::VL_INLINE to declare inline
- functions.  Such features are not part of the C89 standard, and
- change depending on the compiler.
+The module provides the macro ::VL_EXPORT to declare symbols exported
+from the library and the macro ::VL_INLINE to declare inline
+functions.  Such features are not part of the C89 standard, and
+change depending on the compiler.
 
- @par "Example:"
- The following header file declares a function @c f that
- should be visible from outside the library.
- @code
- #include <vl/generic.h>
- VL_EXPORT void f () ;
- VL_EXPORT int i ;
- @endcode
- Notice that the macro ::VL_EXPORT needs not to be included again
- when the function is defined.
+@par "Example:"
+The following header file declares a function @c f that
+should be visible from outside the library.
+@code
+#include <vl/generic.h>
+VL_EXPORT void f () ;
+VL_EXPORT int i ;
+@endcode
+Notice that the macro ::VL_EXPORT needs not to be included again
+when the function is defined.
 
- @par "Example:"
- The following header file declares an inline function @c f:
- @code
- #include <vl/generic.h>
- VL_INLINE int f() ;
+@par "Example:"
+The following header file declares an inline function @c f:
+@code
+#include <vl/generic.h>
+VL_INLINE int f() ;
 
- VL_INLINE int f() { return 1 ; }
- @endcode
+VL_INLINE int f() { return 1 ; }
+@endcode
 
- Here the first instruction defines the function @c f, where the
- second declares it. Notice that since this is an inline function, its
- definition must be found in the header file rather than in an
- implementation file.  Notice also that definition and declaration can
- be merged.
+Here the first instruction defines the function @c f, where the
+second declares it. Notice that since this is an inline function, its
+definition must be found in the header file rather than in an
+implementation file.  Notice also that definition and declaration can
+be merged.
 
- These macros translate according to the following tables:
+These macros translate according to the following tables:
 
- <table class="doxtable" style="font-size:70%;">
- <caption>Macros for exporting library symbols</caption>
- <tr>
- <td>Platform</td>
- <td>Macro name</td>
- <td>Value when building the library</td>
- <td>Value when importing the library</td>
- </tr>
- <tr>
- <td>Unix/GCC</td>
- <td>::VL_EXPORT</td>
- <td>empty (assumes <c>-visibility=hidden</c> GCC option)</td>
- <td><c>__attribute__((visibility ("default")))</c></td>
- </tr>
- <tr>
- <td>Win/Visual C++</td>
- <td>::VL_EXPORT</td>
- <td>@c __declspec(dllexport)</td>
- <td>@c __declspec(dllimport)</td>
- </tr>
- </table>
+<table class="doxtable" style="font-size:70%;">
+<caption>Macros for exporting library symbols</caption>
+<tr>
+<td>Platform</td>
+<td>Macro name</td>
+<td>Value when building the library</td>
+<td>Value when importing the library</td>
+</tr>
+<tr>
+<td>Unix/GCC</td>
+<td>::VL_EXPORT</td>
+<td>empty (assumes <c>-visibility=hidden</c> GCC option)</td>
+<td><c>__attribute__((visibility ("default")))</c></td>
+</tr>
+<tr>
+<td>Win/Visual C++</td>
+<td>::VL_EXPORT</td>
+<td>@c __declspec(dllexport)</td>
+<td>@c __declspec(dllimport)</td>
+</tr>
+</table>
 
- <table class="doxtable" style="font-size:70%;">
- <caption>Macros for declaring inline functions</caption>
- <tr>
- <td>Platform</td>
- <td>Macro name</td>
- <td>Value</td>
- </tr>
- <tr>
- <td>Unix/GCC</td>
- <td>::VL_INLINE</td>
- <td>static inline</td>
- </tr>
- <tr>
- <td>Win/Visual C++</td>
- <td>::VL_INLINE</td>
- <td>static __inline</td>
- </tr>
- </table>
+<table class="doxtable" style="font-size:70%;">
+<caption>Macros for declaring inline functions</caption>
+<tr>
+<td>Platform</td>
+<td>Macro name</td>
+<td>Value</td>
+</tr>
+<tr>
+<td>Unix/GCC</td>
+<td>::VL_INLINE</td>
+<td>static inline</td>
+</tr>
+<tr>
+<td>Win/Visual C++</td>
+<td>::VL_INLINE</td>
+<td>static __inline</td>
+</tr>
+</table>
 
- @section host-arch Host CPU architecture
+@section host-arch Host CPU architecture
 
- The module defines a symbol to identify the host CPU architecture:
- ::VL_ARCH_IX86 for Intel x86, ::VL_ARCH_IA64 for Intel 64, and so on.
+The module defines a symbol to identify the host CPU architecture:
+::VL_ARCH_IX86 for Intel x86, ::VL_ARCH_IA64 for Intel 64, and so on.
 
- @subsection host-arch-endianness Endianness
+@subsection host-arch-endianness Endianness
 
- The module defines a symbol to identify the host CPU endianness:
- ::VL_ARCH_BIG_ENDIAN for big endian and ::VL_ARCH_LITTLE_ENDIAN for
- little endian. The functions ::vl_swap_host_big_endianness_8(),
- ::vl_swap_host_big_endianness_4(), ::vl_swap_host_big_endianness_2()
- to change the endianness of data (from/to host and network order).
+The module defines a symbol to identify the host CPU endianness:
+::VL_ARCH_BIG_ENDIAN for big endian and ::VL_ARCH_LITTLE_ENDIAN for
+little endian. The functions ::vl_swap_host_big_endianness_8(),
+::vl_swap_host_big_endianness_4(), ::vl_swap_host_big_endianness_2()
+to change the endianness of data (from/to host and network order).
 
- Recall that <em>endianness</em> concerns the way multi-byte data
- types (such as 16, 32 and 64 bits integers) are stored into the
- addressable memory.  All CPUs uses a contiguous address range to
- store atomic data types (e.g. a 16-bit integer could be assigned to
- the addresses <c>0x10001</c> and <c>0x10002</c>), but the order may
- differ.
+Recall that <em>endianness</em> concerns the way multi-byte data
+types (such as 16, 32 and 64 bits integers) are stored into the
+addressable memory.  All CPUs uses a contiguous address range to
+store atomic data types (e.g. a 16-bit integer could be assigned to
+the addresses <c>0x10001</c> and <c>0x10002</c>), but the order may
+differ.
 
- - The convention is <em>big endian</em>, or in <em>network
-   order</em>, if the most significant byte of the multi-byte data
-   types is assigned to the smaller memory address. This is the
-   convention used for instance by the PPC architecture.
+- The convention is <em>big endian</em>, or in <em>network
+  order</em>, if the most significant byte of the multi-byte data
+  types is assigned to the smaller memory address. This is the
+  convention used for instance by the PPC architecture.
 
- - The convention is <em>little endian</em> if the least significant
-   byte is assigned to the smaller memory address. This is the
-   convention used for instance by the x86 architecture.
+- The convention is <em>little endian</em> if the least significant
+  byte is assigned to the smaller memory address. This is the
+  convention used for instance by the x86 architecture.
 
- @remark The names &ldquo;big endian&rdquo; and &ldquo;little
- endian&rdquo; are a little confusing. &ldquo;Big endian&rdquo; means
- &ldquo;big endian first&rdquo;, i.e.  the address of the most
- significant byte comes first. Similarly, &ldquo;little endian&rdquo;
- means &ldquo;little endian first&rdquo;, in the sense that the
- address of the least significant byte comes first.
+@remark The names &ldquo;big endian&rdquo; and &ldquo;little
+endian&rdquo; are a little confusing. &ldquo;Big endian&rdquo; means
+&ldquo;big endian first&rdquo;, i.e.  the address of the most
+significant byte comes first. Similarly, &ldquo;little endian&rdquo;
+means &ldquo;little endian first&rdquo;, in the sense that the
+address of the least significant byte comes first.
 
- Endianness is a concern when data is either exchanged with processors
- that use different conventions, transmitted over a network, or stored
- to a file. For the latter two cases, one usually saves data in big
- endian (network) order regardless of the host CPU.
+Endianness is a concern when data is either exchanged with processors
+that use different conventions, transmitted over a network, or stored
+to a file. For the latter two cases, one usually saves data in big
+endian (network) order regardless of the host CPU.
 
 @section host-threads Multi-threading
 
 The file defines #VL_THREADS_WIN if multi-threading support is
 enabled and the host supports Windows threads and #VL_THREADS_POSIX if
 it supports POSIX threads.
-
- **/
+**/
 
 /** @def VL_OS_LINUX
  ** @brief Defined if the host operating system is Linux.
@@ -295,6 +299,37 @@ it supports POSIX threads.
  ** @see @ref host-compiler-data-model
  **/
 
+/** @def VL_INT8_C(x)
+ ** @brief Create an integer constant of the specified width and sign
+ ** @param x integer constant.
+ ** @return @a x with the correct suffix for the given sign and size.
+ ** The suffix used depends on the @ref host-compiler-data-model.
+ ** @par "Example:"
+ ** The macro <code>VL_INT64_C(1234)</code> is expanded as @c 123L in
+ ** a LP64 system and as @c 123LL in a LLP64 system.
+ **/
+
+/** @def VL_INT16_C(x)
+ ** @copydoc VL_INT8_C */
+
+/** @def VL_INT32_C(x)
+ ** @copydoc VL_INT8_C */
+
+/** @def VL_INT64_C(x)
+ ** @copydoc VL_INT8_C */
+
+/** @def VL_UINT8_C(x)
+ ** @copydoc VL_INT8_C */
+
+/** @def VL_UINT16_C(x)
+ ** @copydoc VL_INT8_C */
+
+/** @def VL_UINT32_C(x)
+ ** @copydoc VL_INT8_C */
+
+/** @def VL_UINT64_C(x)
+ ** @copydoc VL_INT8_C */
+
 /** @def VL_ARCH_IX86
  ** @brief Defined if the host CPU is of the Intel x86 family.
  ** @see @ref host-arch
@@ -336,7 +371,14 @@ it supports POSIX threads.
  ** @brief Defined if multi-threading support is disabled
  **
  ** Define this symbol during compilation of the library and linking
- ** to anogher project to disable VLFeat multi-threading support.
+ ** to another project to disable VLFeat multi-threading support.
+ **/
+
+/** @def VL_DISABLE_OPENMP
+ ** @brief Defined if OpenMP support is disabled
+ **
+ ** Define this symbol during compilation of the library and linking
+ ** to another project to disable VLFeat OpenMP support.
  **/
 
 /** @def VL_THREADS_WIN
@@ -399,6 +441,7 @@ _vl_cpuid (vl_int32* info, int function)
 
 #endif
 
+#if defined(HAS_CPUID)
 void
 _vl_x86cpu_info_init (VlX86CpuInfo *self)
 {
@@ -418,8 +461,10 @@ _vl_x86cpu_info_init (VlX86CpuInfo *self)
     self->hasSSE3  = info[2] & (1 <<  0) ;
     self->hasSSE41 = info[2] & (1 << 19) ;
     self->hasSSE42 = info[2] & (1 << 20) ;
+    self->hasAVX   = info[2] & (1 << 28) ;
   }
 }
+#endif
 
 char *
 _vl_x86cpu_info_to_string_copy (VlX86CpuInfo const *self)
@@ -431,14 +476,15 @@ _vl_x86cpu_info_to_string_copy (VlX86CpuInfo const *self)
       string = vl_malloc(sizeof(char) * length) ;
       if (string == NULL) break ;
     }
-    length = snprintf(string, length, "%s%s%s%s%s%s%s",
+    length = snprintf(string, length, "%s%s%s%s%s%s%s%s",
                       self->vendor.string,
                       self->hasMMX   ? " MMX" : "",
                       self->hasSSE   ? " SSE" : "",
                       self->hasSSE2  ? " SSE2" : "",
                       self->hasSSE3  ? " SSE3" : "",
                       self->hasSSE41 ? " SSE41" : "",
-                      self->hasSSE42 ? " SSE42" : "") ;
+                      self->hasSSE42 ? " SSE42" : "",
+                      self->hasAVX   ? " AVX" : "") ;
     length += 1 ;
   }
   return string ;
@@ -492,6 +538,9 @@ vl_static_configuration_to_string_copy ()
 #endif
 #ifndef VL_DISABLE_SSE2
   ", SSE2"
+#endif
+#if defined(_OPENMP)
+  ", OpenMP"
 #endif
   ;
 

--- a/src/nonFree/sift/vl/host.h
+++ b/src/nonFree/sift/vl/host.h
@@ -1,10 +1,11 @@
 /** @file host.h
  ** @brief Host
  ** @author Andrea Vedaldi
+ ** @sa @ref portability
  **/
 
 /*
-Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+Copyright (C) 2007-12,18 Andrea Vedaldi and Brian Fulkerson.
 All rights reserved.
 
 This file is part of the VLFeat library and is made available under
@@ -18,13 +19,10 @@ the terms of the BSD license (see the COPYING file).
  ** @name Configuration options
  ** @{ */
 
- #if defined __clang__
-#define VL_DISABLE_THREADS
-#endif
-
 #if defined(__DOXYGEN__)
 #define VL_DISABLE_THREADS
 #define VL_DISABLE_SSE2
+#define VL_DISABLE_OPENMP
 #endif
 
 /** @} */
@@ -45,7 +43,6 @@ the terms of the BSD license (see the COPYING file).
  ** @{ */
 
 /** @brief Convert the argument to a string
- **
  ** @param x value to be stringified.
  **
  ** This macro stringifies the argument @a x by means of the
@@ -69,7 +66,6 @@ the terms of the BSD license (see the COPYING file).
 #define VL_STRINGIFY(x) # x
 
 /** @brief Expand and then convert the argument to a string
- **
  ** @param x value to be macro-expanded and converted.
  **
  ** This macro macro-expands the argument @a x and stringifies the
@@ -89,7 +85,6 @@ the terms of the BSD license (see the COPYING file).
 #define VL_XSTRINGIFY(x) VL_STRINGIFY(x)
 
 /** @brief Concatenate two arguments into a lexical unit
- **
  ** @param x first argument to be concatenated.
  ** @param y second argument to be concatenated.
  **
@@ -105,7 +100,6 @@ the terms of the BSD license (see the COPYING file).
 #define VL_CAT(x,y) x ## y
 
 /** @brief Expand and then concatenate two arguments into a lexical unit
- **
  ** @param x first argument to be concatenated.
  ** @param y second argument to be concatenated.
  **
@@ -118,7 +112,6 @@ the terms of the BSD license (see the COPYING file).
 #define VL_XCAT(x,y) VL_CAT(x,y)
 
 /** @brief Expand and then concatenate three arguments into a lexical unit
- **
  ** @param x first argument to be concatenated.
  ** @param y second argument to be concatenated.
  ** @param z third argument to be concatenated.
@@ -131,7 +124,6 @@ the terms of the BSD license (see the COPYING file).
 #define VL_XCAT3(x,y,z) VL_XCAT(VL_XCAT(x,y),z)
 
 /** @brief Expand and then concatenate four arguments into a lexical unit
- **
  ** @param x first argument to be concatenated.
  ** @param y second argument to be concatenated.
  ** @param z third argument to be concatenated.
@@ -145,7 +137,6 @@ the terms of the BSD license (see the COPYING file).
 #define VL_XCAT4(x,y,z,u) VL_XCAT(VL_XCAT3(x,y,z),u)
 
 /** @brief Expand and then concatenate five arguments into a lexical unit
- **
  ** @param x first argument to be concatenated.
  ** @param y second argument to be concatenated.
  ** @param z third argument to be concatenated.
@@ -159,12 +150,12 @@ the terms of the BSD license (see the COPYING file).
 
 #define VL_XCAT5(x,y,z,u,v) VL_XCAT(VL_XCAT4(x,y,z,u),v)
 
-/** @} */
-
 /** @brief Convert a boolean to "yes" or "no" strings
  ** @param x boolean to convert.
+ **
  ** A pointer to either the string "yes" (if @a x is true)
  ** or the string "no".
+ **
  ** @par Example
  ** @code
  ** VL_PRINTF("Is x true? %s.", VL_YESNO(x))
@@ -172,6 +163,8 @@ the terms of the BSD license (see the COPYING file).
  **/
 
 #define VL_YESNO(x) ((x)?"yes":"no")
+
+/** @} */
 
 /*
  The following macros identify the host OS, architecture and compiler.
@@ -316,14 +309,13 @@ defined(__DOXYGEN__)
 #endif
 /** @} */
 
-
 #if defined(VL_COMPILER_MSC) & ! defined(__DOXYGEN__)
 #  define VL_UNUSED
 #  define VL_INLINE static __inline
-#if _MSC_VER <= 1800
-#  define snprintf _snprintf
-#  define isnan _isnan
-#endif
+#  if _MSC_VER <= 1800
+#    define snprintf _snprintf
+#    define isnan _isnan
+#  endif
 #  ifdef VL_BUILD_DLL
 #    ifdef __cplusplus
 #      define VL_EXPORT extern "C" __declspec(dllexport)
@@ -332,13 +324,12 @@ defined(__DOXYGEN__)
 #    endif
 #  else
 #    ifdef __cplusplus
-#      define VL_EXPORT extern "C" //__declspec(dllimport)
+#      define VL_EXPORT extern "C" __declspec(dllimport)
 #    else
-#      define VL_EXPORT extern //__declspec(dllimport)
+#      define VL_EXPORT extern __declspec(dllimport)
 #    endif
 #  endif
 #endif
-
 
 #if defined(VL_COMPILER_LCC) & ! defined(__DOXYGEN__)
 #  define VL_UNUSED
@@ -370,12 +361,6 @@ VL_INLINE float fabsf(float x) { return (float) fabs((double) x) ; }
 #    endif
 #  endif
 #endif
-
-# if defined(VL_OS_MACOSX)
-# undef VL_EXPORT
-# define VL_EXPORT extern
-#endif
-
 
 VL_EXPORT char * vl_static_configuration_to_string_copy () ;
 
@@ -439,6 +424,34 @@ typedef vl_uint32           vl_uintptr ;
 typedef vl_uint32           vl_size ;
 typedef vl_int32            vl_index ;
 typedef vl_uint32           vl_uindex ;
+#endif
+/** @} */
+
+/** @name Creating integer constants
+ ** @{ */
+#if defined(VL_COMPILER_LP64) || defined(__DOXYGEN__)
+#define VL_INT8_C(x) x
+#define VL_INT16_C(x) x
+#define VL_INT32_C(x) x
+#define VL_INT64_C(x) x ## L
+
+#define VL_UINT8_C(x) x
+#define VL_UINT16_C(x) x
+#define VL_UINT32_C(x) x ## U
+#define VL_UINT64_C(x) x ## UL
+#endif
+
+#if (defined(VL_COMPILER_LLP64) || defined(VL_COMPILER_ILP32)) \
+    & !defined(__DOXYGEN__)
+#define VL_INT8_C(x) x
+#define VL_INT16_C(x) x
+#define VL_INT32_C(x) x
+#define VL_INT64_C(x) x ## LL
+
+#define VL_UINT8_C(x) x
+#define VL_UINT16_C(x) x
+#define VL_UINT32_C(x) x ## U
+#define VL_UINT64_C(x) x ## ULL
 #endif
 /** @} */
 
@@ -549,6 +562,7 @@ typedef struct _VlX86CpuInfo
     char string [0x20] ;
     vl_uint32 words [0x20 / 4] ;
   } vendor ;
+  vl_bool hasAVX ;
   vl_bool hasSSE42 ;
   vl_bool hasSSE41 ;
   vl_bool hasSSE3 ;
@@ -643,6 +657,11 @@ vl_swap_host_big_endianness_2 (void *dst, void* src)
     dst_ [1] = src_ [0] ;
 #endif
 }
+
+/* Linux: limit glibc to old versions for compatibility */
+#if defined(VL_COMPILER_GNUC) & defined(VL_OS_LINUX) & ! defined(__DOXYGEN__)
+__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+#endif
 
 /* VL_HOST_H */
 #endif

--- a/src/nonFree/sift/vl/imopv.c
+++ b/src/nonFree/sift/vl/imopv.c
@@ -67,7 +67,7 @@ the terms of the BSD license (see the COPYING file).
 
 #if (FLT == VL_TYPE_FLOAT || FLT == VL_TYPE_DOUBLE)
 
-/** @fn  vl_imconvcol_vd(double*,int,double const*,int,int,int,double const*,int,int,int,unsigned int)
+/** @fn vl_imconvcol_vd(double*,vl_size,double const*,vl_size,vl_size,vl_size,double const*,vl_index,vl_index,int,unsigned int)
  ** @brief Convolve image along columns
  **
  ** @param dst destination image.
@@ -112,8 +112,8 @@ the terms of the BSD license (see the COPYING file).
  ** boundary (::VL_PAD_BY_CONTINUITY).
  **/
 
-/** @fn vl_imconvcol_vf(float*,int,float const*,int,int,int,float const*,int,int,int,unsigned int)
- ** @see ::vl_imconvcol_vf()
+/** @fn vl_imconvcol_vf(float*,vl_size,float const*,vl_size,vl_size,vl_size,float const*,vl_index,vl_index,int,unsigned int)
+ ** @see ::vl_imconvcol_vd
  **/
 
 VL_EXPORT void
@@ -832,12 +832,12 @@ VL_XCAT(vl_imgradient_, SFX)
 
 
 /** @fn vl_imgradient_polar_d(double*,double*,vl_size,vl_size,double const*,vl_size,vl_size,vl_size)
- ** @brief Compute gradient amplitudes and directions of an image.
+ ** @brief Compute gradient mangitudes and directions of an image.
  ** @param amplitudeGradient Pointer to amplitude gradient plane
  ** @param angleGradient Pointer to angle gradient plane
  ** @param gradWidthStride Width of the gradient plane including padding
  ** @param gradHeightStride Height of the gradient plane including padding
- ** @param src Pointer to the source image
+ ** @param image Pointer to the source image
  ** @param imageWidth Source image width
  ** @param imageHeight Source image height
  ** @param imageStride Width of the source image including padding.
@@ -846,26 +846,27 @@ VL_XCAT(vl_imgradient_, SFX)
  **
  ** Gradient is computed simple by gradient kernel \f$ (-1 ~ 1) \f$,
  ** \f$ (-1 ~ 1)^T \f$ for border pixels and with sobel filter kernel
- ** \f$ (-0.5 ~ 0 ~ 0.5) \f$, \f$ (-0.5 ~ 0 ~ 0.5)^T \f$ otherwise on the input
- ** image @a image yielding x-gradient \f$ dx \f$, stored in @a xGradient and
- ** y-gradient \f$ dy \f$, stored in @a yGradient, respectively.
+ ** \f$ (-0.5 ~ 0 ~ 0.5) \f$, \f$ (-0.5 ~ 0 ~ 0.5)^T \f$ otherwise on
+ ** the input image @a image yielding x-gradient \f$ dx \f$, stored in
+ ** @a xGradient and y-gradient \f$ dy \f$, stored in @a yGradient,
+ ** respectively.
  **
- ** The amplitude of the gradient, stored in plane @a amplitudeGradient,
- ** is then calculated as \f$ \sqrt(dx^2+dy^2) \f$  and the angle
- ** of the gradient, stored in @a angleGradient is \f$ atan(\frac{dy}{dx}) \f$
- ** normalised into interval 0 and @f$ 2\pi @f$.
+ ** The amplitude of the gradient, stored in plane @a
+ ** amplitudeGradient, is then calculated as \f$ \sqrt(dx^2+dy^2) \f$
+ ** and the angle of the gradient, stored in @a angleGradient is \f$
+ ** atan(\frac{dy}{dx}) \f$ normalised into interval 0 and @f$ 2\pi
+ ** @f$.
  **
  ** This function also allows to process only part of the input image
- ** defining the @a imageStride as original image width and @a width as
- ** width of the sub-image.
+ ** defining the @a imageStride as original image width and @a width
+ ** as width of the sub-image.
  **
  ** Also it allows to easily align the output data by definition
  ** of the @a gradWidthStride and @a gradHeightStride .
  **/
 
 /** @fn vl_imgradient_polar_f(float*,float*,vl_size,vl_size,float const*,vl_size,vl_size,vl_size)
- ** @brief Compute gradient amplitudes and directions of an image.
- ** @see ::vl_imgradient_polar_f
+ ** @see ::vl_imgradient_polar_d
  **/
 
 #if (FLT == VL_TYPE_FLOAT || FLT == VL_TYPE_DOUBLE)

--- a/src/nonFree/sift/vl/imopv.h
+++ b/src/nonFree/sift/vl/imopv.h
@@ -11,8 +11,8 @@ This file is part of the VLFeat library and is made available under
 the terms of the BSD license (see the COPYING file).
 */
 
-#ifndef VL_IMPOV_H
-#define VL_IMPOV_H
+#ifndef VL_IMOPV_H
+#define VL_IMOPV_H
 
 #include "generic.h"
 

--- a/src/nonFree/sift/vl/imopv_sse2.c
+++ b/src/nonFree/sift/vl/imopv_sse2.c
@@ -20,6 +20,7 @@ the terms of the BSD license (see the COPYING file).
 #ifndef VL_IMOPV_SSE2_INSTANTIATING
 
 #include <emmintrin.h>
+
 #include "imopv.h"
 #include "imopv_sse2.h"
 

--- a/src/nonFree/sift/vl/mathop.c
+++ b/src/nonFree/sift/vl/mathop.c
@@ -1,9 +1,10 @@
 /** @file mathop.c
  ** @brief Math operations - Definition
- ** @author Andrea Vedaldi
+ ** @author Andrea Vedaldi, David Novotny
  **/
 
 /*
+Copyright (C) 2014 Andrea Vedaldi.
 Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
 All rights reserved.
 
@@ -11,121 +12,146 @@ This file is part of the VLFeat library and is made available under
 the terms of the BSD license (see the COPYING file).
 */
 
-/** @file mathop.h
+/**
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@page mathop Mathematical operations
+@author Andrea Vedaldi
+@author Brian Fulkerson
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
- @section mathop-usage-vector-comparison Comparing vectors
+VLFeat include several low-level routines to speedup common
+mathematical operations used throughout the library. Most are
+collected in the @ref mathop.h module.
 
- @ref mathop.h includes a number of functions to quickly compute
- distances or similarity of pairs of vector. Applications include
- clustering and evaluation of SVM-like classifiers.
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@section mathop-usage-vector-comparison Comparing vectors
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
- Use ::vl_get_vector_comparison_function_f or
- ::vl_get_vector_comparison_function_d obtain an approprite function
- to comprare vectors of floats or doubles, respectively.  Such
- functions are usually optimized (for instance, on X86 platforms they
- use the SSE vector extension) and are several times faster than a
- naive implementation.  ::vl_eval_vector_comparison_on_all_pairs_f and
- ::vl_eval_vector_comparison_on_all_pairs_d can be used to evaluate
- the comparison function on all pairs of one or two sequences of
- vectors.
+@ref mathop.h includes a number of functions to quickly compute
+distances or similarity of pairs of vector. Applications include
+clustering and evaluation of SVM-like classifiers.
 
- Let @f$ \mathbf{x} = (x_1,\dots,x_d) @f$ and @f$ \mathbf{y} =
- (y_1,\dots,y_d) @f$ be two vectors.  The following comparison
- functions are supported:
+Use ::vl_get_vector_comparison_function_f or
+::vl_get_vector_comparison_function_d obtain an approprite function
+to comprare vectors of floats or doubles, respectively.  Such
+functions are usually optimized (for instance, on X86 platforms they
+use the SSE vector extension) and are several times faster than a
+naive implementation.  ::vl_eval_vector_comparison_on_all_pairs_f and
+::vl_eval_vector_comparison_on_all_pairs_d can be used to evaluate
+the comparison function on all pairs of one or two sequences of
+vectors.
 
- <table>
- <tr>
- <td>@f$ l^1 @f$</td>
- <td>::VlDistanceL1</td>
- <td>@f$ \sum_{i=1}^d |x_i - y_i| @f$</td>
- <td>l1 distance (squared intersection metric)</td>
- </tr>
- <tr>
- <td>@f$ l^2 @f$</td>
- <td>::VlDistanceL2</td>
- <td>@f$\sum_{i=1}^d (x_i - y_i)^2@f$</td>
- <td>Squared Euclidean disance</td>
- </tr>
- <tr>
- <td>@f$ \chi^2 @f$</td>
- <td>::VlDistanceChi2</td>
- <td>@f$\sum_{i=1}^d \frac{(x_i - y_i)^2}{x_i + y_i}@f$</td>
- <td>Squared chi-square distance</td>
- </tr>
- <tr>
- <td>-</td>
- <td>::VlDistanceHellinger</td>
- <td>@f$\sum_{i=1}^d (\sqrt{x_i} - \sqrt{y_i})^2@f$</td>
- <td>Squared Hellinger's distance</td>
- </tr>
- <tr>
- <td>-</td>
- <td>::VlDistanceJS</td>
- <td>@f$
- \sum_{i=1}^d
- \left(
-   x_i \log\frac{2x_i}{x_i+y_i}
- + y_i \log\frac{2y_i}{x_i+y_i}
- \right)
- @f$
- </td>
- <td>Squared Jensen-Shannon distance</td>
- </tr>
- <tr>
- <td>@f$ l^1 @f$</td>
- <td>::VlKernelL1</td>
- <td>@f$ \sum_{i=1}^d \min\{ x_i, y_i \} @f$</td>
- <td>intersection kernel</td>
- </tr>
- <tr>
- <td>@f$ l^2 @f$</td>
- <td>::VlKernelL2</td>
- <td>@f$\sum_{i=1}^d x_iy_i @f$</td>
- <td>linear kernel</td>
- </tr>
- <tr>
- <td>@f$ \chi^2 @f$</td>
- <td>::VlKernelChi2</td>
- <td>@f$\sum_{i=1}^d 2 \frac{x_iy_i}{x_i + y_i}@f$</td>
- <td>chi-square kernel</td>
- </tr>
- <tr>
- <td>-</td>
- <td>::VlKernelHellinger</td>
- <td>@f$\sum_{i=1}^d 2 \sqrt{x_i y_i}@f$</td>
- <td>Hellinger's kernel (Bhattacharya coefficient)</td>
- </tr>
- <tr>
- <td>-</td>
- <td>::VlKernelJS</td>
- <td>@f$
- \sum_{i=1}^d
- \left(
-   \frac{x_i}{2} \log_2\frac{x_i+y_i}{x_i}
- + \frac{y_i}{2} \log_2\frac{x_i+y_i}{y_i}
- \right)
- @f$
- </td>
- <td>Jensen-Shannon kernel</td>
- </tr>
- </table>
+Let @f$ \mathbf{x} = (x_1,\dots,x_d) @f$ and @f$ \mathbf{y} =
+(y_1,\dots,y_d) @f$ be two vectors.  The following comparison
+functions are supported:
 
- @remark The definitions have been choosen so that corresponding kernels and
- distances are related by the equation:
- @f[
-  d^2(\mathbf{x},\mathbf{y})
-  =
-  k(\mathbf{x},\mathbf{x})
-  +k(\mathbf{y},\mathbf{y})
-  -k(\mathbf{x},\mathbf{y})
-  -k(\mathbf{y},\mathbf{x})
- @f]
- This means that each of these distances can be interpreted as a
- squared distance or metric in the corresponding reproducing kernel
- Hilbert space. Notice in particular that the @f$ l^1 @f$ or Manhattan
- distance is also a <em>squared</em> distance in this sense.
+<table>
+<tr>
+<td>@f$ l^1 @f$</td>
+<td>::VlDistanceL1</td>
+<td>@f$ \sum_{i=1}^d |x_i - y_i| @f$</td>
+<td>l1 distance (squared intersection metric)</td>
+</tr>
+<tr>
+<td>@f$ l^2 @f$</td>
+<td>::VlDistanceL2</td>
+<td>@f$\sum_{i=1}^d (x_i - y_i)^2@f$</td>
+<td>Squared Euclidean disance</td>
+</tr>
+<tr>
+<td>@f$ \chi^2 @f$</td>
+<td>::VlDistanceChi2</td>
+<td>@f$\sum_{i=1}^d \frac{(x_i - y_i)^2}{x_i + y_i}@f$</td>
+<td>Squared chi-square distance</td>
+</tr>
+<tr>
+<td>-</td>
+<td>::VlDistanceHellinger</td>
+<td>@f$\sum_{i=1}^d (\sqrt{x_i} - \sqrt{y_i})^2@f$</td>
+<td>Squared Hellinger's distance</td>
+</tr>
+<tr>
+<td>-</td>
+<td>::VlDistanceJS</td>
+<td>@f$
+\sum_{i=1}^d
+\left(
+  x_i \log\frac{2x_i}{x_i+y_i}
++ y_i \log\frac{2y_i}{x_i+y_i}
+\right)
+@f$
+</td>
+<td>Squared Jensen-Shannon distance</td>
+</tr>
+<tr>
+<td>@f$ l^1 @f$</td>
+<td>::VlKernelL1</td>
+<td>@f$ \sum_{i=1}^d \min\{ x_i, y_i \} @f$</td>
+<td>intersection kernel</td>
+</tr>
+<tr>
+<td>@f$ l^2 @f$</td>
+<td>::VlKernelL2</td>
+<td>@f$\sum_{i=1}^d x_iy_i @f$</td>
+<td>linear kernel</td>
+</tr>
+<tr>
+<td>@f$ \chi^2 @f$</td>
+<td>::VlKernelChi2</td>
+<td>@f$\sum_{i=1}^d 2 \frac{x_iy_i}{x_i + y_i}@f$</td>
+<td>chi-square kernel</td>
+</tr>
+<tr>
+<td>-</td>
+<td>::VlKernelHellinger</td>
+<td>@f$\sum_{i=1}^d 2 \sqrt{x_i y_i}@f$</td>
+<td>Hellinger's kernel (Bhattacharya coefficient)</td>
+</tr>
+<tr>
+<td>-</td>
+<td>::VlKernelJS</td>
+<td>@f$
+\sum_{i=1}^d
+\left(
+  \frac{x_i}{2} \log_2\frac{x_i+y_i}{x_i}
++ \frac{y_i}{2} \log_2\frac{x_i+y_i}{y_i}
+\right)
+@f$
+</td>
+<td>Jensen-Shannon kernel</td>
+</tr>
+</table>
 
- **/
+@remark The definitions have been choosen so that corresponding kernels and
+distances are related by the equation:
+@f[
+ d^2(\mathbf{x},\mathbf{y})
+ =
+ k(\mathbf{x},\mathbf{x})
+ +k(\mathbf{y},\mathbf{y})
+ -k(\mathbf{x},\mathbf{y})
+ -k(\mathbf{y},\mathbf{x})
+@f]
+This means that each of these distances can be interpreted as a
+squared distance or metric in the corresponding reproducing kernel
+Hilbert space. Notice in particular that the @f$ l^1 @f$ or Manhattan
+distance is also a <em>squared</em> distance in this sense.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@section mathop-integer-ops Fast basic functions operations
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+In certain algorithm it is useful to quickly compute integer
+approximation of certain mathematical operations. Presently, VLFeat
+includes and implementations of:
+
+- Fast single precision atan2: ::vl_fast_sqrt_f.
+- Fast inverse square root: ::vl_fast_resqrt_f, ::vl_fast_resqrt_d.
+- Fast square root: ::vl_fast_sqrt_f, ::vl_fast_sqrt_d.
+- Fast integer square root: ::vl_fast_sqrt_ui16, ::vl_fast_sqrt_ui32,
+  ::vl_fast_sqrt_ui64 (see also @subpage mathop-sqrti).
+**/
 
 /** @fn vl_get_vector_comparison_function_f(VlVectorComparisonType)
  **
@@ -165,11 +191,79 @@ the terms of the BSD license (see the COPYING file).
  ** @sa vl_eval_vector_comparison_on_all_pairs_f
  **/
 
+/**
+@page mathop-sqrti Fast integer square root algorithm
+@tableofcontents
+
+This section describes the fast integer square root algorithm used by
+vl_fast_sqrt_ui8, ::vl_fast_sqrt_ui16, ::vl_fast_sqrt_ui32,
+::vl_fast_sqrt_ui64.
+
+Given a non-negative integer $x \in \mathbb{Z}_+$, the goal of this
+algorithm is to quickly compute the integer approximation of the
+square root of an integer number:
+
+\[
+y = \max_{\bar y\in\mathbb{Z}} \bar y, \qquad \text{such that}\  \bar y^2 \leq x.
+\]
+
+Consider determining the k-th bit of $y$. To this end, decompose $y$
+in three parts:
+
+\[
+y = y_{k+1} + q 2^k + r,
+\qquad \text{where}\   y_{k+1} \geq 2^{k+1}, r < 2^k,
+\]
+
+and $q\in\{0,1\}$ is the bit to be determined. Here $y_{k+1}$ is a part
+of the result $y$ that has already been determined, while the bit $q$
+and the remainder $r$ are still unknown. Recall that the goal is to
+find the largest $y^2$ such that $y^2 \leq x$. Expanding $y^2$ this
+condition becomes
+
+\[
+q (2^{2k} + 2 y_{k+1} 2^k) + r(r + 2q 2^k + 2 y_{k+1}) \leq x - y_{k+1}^2.
+\]
+
+We can now determine if $q=1$ or $q=0$ based on the value of the
+residual $x - y_{k+1}^2$. Specifically, $q=1$ requires that:
+
+\[
+\boxed{
+2^{2k} + 2a2^k \leq x - y_{k+1}^2.
+}
+\]
+
+On the other hand, if this equation is satisfied, then setting $r=0$
+shows that there exists at least one $y$ such that $q=1$ and $y^2 \leq
+x$. In particular, greedily choosing $q=1$ in $x=y_{k+1} + 2^k q + r$ is
+optimal because $2^k > r$. This yields the algorithm:
+
+1. Note that if $x$ is stored in $n$ bits and $n$ is even, then the
+   integer square root $y$ does not require more than $m = n / 2$ bit
+   to be stored. Thus the first bit to be determined is $k \leftarrow
+   m - 1 = n/2 - 1$ and $y_{n/2}=0$.
+2. The algorithm stores and updates $y_k/2^{k}$ and $x - y_{k}^2$ for
+   convenience.
+3. During iteration $k$, $y_k$ is determined. On entering the
+   iteration, the first step is to compute $y_{k+1}/2^k = 2
+   y_{k+1}/2^{k+1}$.
+4. Then the bound $t = (2^{2k} + 2 y_{k+1})2^k = 2^{2k}(1 + 2
+   y_{k+1}/2^k)$.
+5. If $t \geq x - y_{k+1}$, the $k$-th bit of $y_k$ is set to
+   one. This means applying the update $\hat y_{k}/2^k \leftarrow
+   y_{k+1}/2^k + 1$. This also requires computing $x - y_{k}^2
+   \leftarrow x - y_{k+1}^2 - t$.
+6. Decrement $k \leftarrow k -1$ and, if $k\geq 0$, continue from 3.
+
+**/
+
 /* ---------------------------------------------------------------- */
 #ifndef VL_MATHOP_INSTANTIATING
 
 #include "mathop.h"
 #include "mathop_sse2.h"
+ #include "mathop_avx.h"
 #include <math.h>
 
 #undef FLT
@@ -188,10 +282,13 @@ the terms of the BSD license (see the COPYING file).
 #include "float.th"
 
 #undef COMPARISONFUNCTION_TYPE
+#undef COMPARISONFUNCTION3_TYPE
 #if (FLT == VL_TYPE_FLOAT)
 #  define COMPARISONFUNCTION_TYPE VlFloatVectorComparisonFunction
+#  define COMPARISONFUNCTION3_TYPE VlFloatVector3ComparisonFunction
 #else
 #  define COMPARISONFUNCTION_TYPE VlDoubleVectorComparisonFunction
+#  define COMPARISONFUNCTION3_TYPE VlDoubleVector3ComparisonFunction
 #endif
 
 /* ---------------------------------------------------------------- */
@@ -357,6 +454,19 @@ VL_XCAT(_vl_kernel_js_, SFX)
   return (T)0.5 * acc ;
 }
 
+VL_EXPORT T
+VL_XCAT(_vl_distance_mahalanobis_sq_, SFX)
+(vl_size dimension, T const * X, T const * MU, T const * S)
+{
+  T const * X_end = X + dimension ;
+  T acc = 0.0 ;
+  while (X < X_end) {
+    T d = *X++ - *MU++ ;
+    acc += d * d * (*S++) ;
+  }
+  return acc ;
+}
+
 /* ---------------------------------------------------------------- */
 
 VL_EXPORT COMPARISONFUNCTION_TYPE
@@ -364,16 +474,16 @@ VL_XCAT(vl_get_vector_comparison_function_, SFX)(VlVectorComparisonType type)
 {
   COMPARISONFUNCTION_TYPE function = 0 ;
   switch (type) {
-    case VlDistanceL2        : function = VL_XCAT(_vl_distance_l2_,        SFX) ; break ;
-    case VlDistanceL1        : function = VL_XCAT(_vl_distance_l1_,        SFX) ; break ;
-    case VlDistanceChi2      : function = VL_XCAT(_vl_distance_chi2_,      SFX) ; break ;
-    case VlDistanceHellinger : function = VL_XCAT(_vl_distance_hellinger_, SFX) ; break ;
-    case VlDistanceJS        : function = VL_XCAT(_vl_distance_js_,        SFX) ; break ;
-    case VlKernelL2          : function = VL_XCAT(_vl_kernel_l2_,          SFX) ; break ;
-    case VlKernelL1          : function = VL_XCAT(_vl_kernel_l1_,          SFX) ; break ;
-    case VlKernelChi2        : function = VL_XCAT(_vl_kernel_chi2_,        SFX) ; break ;
-    case VlKernelHellinger   : function = VL_XCAT(_vl_kernel_hellinger_,   SFX) ; break ;
-    case VlKernelJS          : function = VL_XCAT(_vl_kernel_js_,          SFX) ; break ;
+    case VlDistanceL2        : function = VL_XCAT(_vl_distance_l2_,             SFX) ; break ;
+    case VlDistanceL1        : function = VL_XCAT(_vl_distance_l1_,             SFX) ; break ;
+    case VlDistanceChi2      : function = VL_XCAT(_vl_distance_chi2_,           SFX) ; break ;
+    case VlDistanceHellinger : function = VL_XCAT(_vl_distance_hellinger_,      SFX) ; break ;
+    case VlDistanceJS        : function = VL_XCAT(_vl_distance_js_,             SFX) ; break ;
+    case VlKernelL2          : function = VL_XCAT(_vl_kernel_l2_,               SFX) ; break ;
+    case VlKernelL1          : function = VL_XCAT(_vl_kernel_l1_,               SFX) ; break ;
+    case VlKernelChi2        : function = VL_XCAT(_vl_kernel_chi2_,             SFX) ; break ;
+    case VlKernelHellinger   : function = VL_XCAT(_vl_kernel_hellinger_,        SFX) ; break ;
+    case VlKernelJS          : function = VL_XCAT(_vl_kernel_js_,               SFX) ; break ;
     default: abort() ;
   }
 
@@ -381,12 +491,56 @@ VL_XCAT(vl_get_vector_comparison_function_, SFX)(VlVectorComparisonType type)
   /* if a SSE2 implementation is available, use it */
   if (vl_cpu_has_sse2() && vl_get_simd_enabled()) {
     switch (type) {
-      case VlDistanceL2   : function = VL_XCAT(_vl_distance_l2_sse2_,   SFX) ; break ;
-      case VlDistanceL1   : function = VL_XCAT(_vl_distance_l1_sse2_,   SFX) ; break ;
-      case VlDistanceChi2 : function = VL_XCAT(_vl_distance_chi2_sse2_, SFX) ; break ;
-      case VlKernelL2     : function = VL_XCAT(_vl_kernel_l2_sse2_,     SFX) ; break ;
-      case VlKernelL1     : function = VL_XCAT(_vl_kernel_l1_sse2_,     SFX) ; break ;
-      case VlKernelChi2   : function = VL_XCAT(_vl_kernel_chi2_sse2_,   SFX) ; break ;
+      case VlDistanceL2    : function = VL_XCAT(_vl_distance_l2_sse2_,             SFX) ; break ;
+      case VlDistanceL1    : function = VL_XCAT(_vl_distance_l1_sse2_,             SFX) ; break ;
+      case VlDistanceChi2  : function = VL_XCAT(_vl_distance_chi2_sse2_,           SFX) ; break ;
+      case VlKernelL2      : function = VL_XCAT(_vl_kernel_l2_sse2_,               SFX) ; break ;
+      case VlKernelL1      : function = VL_XCAT(_vl_kernel_l1_sse2_,               SFX) ; break ;
+      case VlKernelChi2    : function = VL_XCAT(_vl_kernel_chi2_sse2_,             SFX) ; break ;
+      default: break ;
+    }
+  }
+#endif
+
+#ifndef VL_DISABLE_AVX
+  /* if an AVX implementation is available, use it */
+  if (vl_cpu_has_avx() && vl_get_simd_enabled()) {
+    switch (type) {
+      case VlDistanceL2    : function = VL_XCAT(_vl_distance_l2_avx_,             SFX) ; break ;
+      default: break ;
+    }
+  }
+#endif
+
+  return function ;
+}
+
+/* ---------------------------------------------------------------- */
+
+VL_EXPORT COMPARISONFUNCTION3_TYPE
+VL_XCAT(vl_get_vector_3_comparison_function_, SFX)(VlVectorComparisonType type)
+{
+  COMPARISONFUNCTION3_TYPE function = 0 ;
+  switch (type) {
+    case VlDistanceMahalanobis : function = VL_XCAT(_vl_distance_mahalanobis_sq_, SFX) ; break ;
+    default: abort() ;
+  }
+
+#ifndef VL_DISABLE_SSE2
+  /* if a SSE2 implementation is available, use it */
+  if (vl_cpu_has_sse2() && vl_get_simd_enabled()) {
+    switch (type) {
+      case VlDistanceMahalanobis : function = VL_XCAT(_vl_distance_mahalanobis_sq_sse2_, SFX) ; break ;
+      default: break ;
+    }
+  }
+#endif
+
+#ifndef VL_DISABLE_AVX
+  /* if an AVX implementation is available, use it */
+  if (vl_cpu_has_avx() && vl_get_simd_enabled()) {
+    switch (type) {
+      case VlDistanceMahalanobis : function = VL_XCAT(_vl_distance_mahalanobis_sq_avx_, SFX) ; break ;
       default: break ;
     }
   }
@@ -871,7 +1025,6 @@ vl_gaussian_elimination (double * A, vl_size numRows, vl_size numColumns)
 
   return VL_ERR_OK ;
 }
-
 
 /* VL_MATHOP_INSTANTIATING */
 #endif

--- a/src/nonFree/sift/vl/mathop.h
+++ b/src/nonFree/sift/vl/mathop.h
@@ -1,6 +1,6 @@
 /** @file mathop.h
- ** @brief Math operations
- ** @author Andrea Vedaldi
+ ** @brief Math operations (@ref mathop)
+ ** @author Andrea Vedaldi, David Novotny
  **/
 
 /*
@@ -16,6 +16,10 @@ the terms of the BSD license (see the COPYING file).
 
 #include "generic.h"
 #include <math.h>
+#include <float.h>
+
+/** @brief Euler constant*/
+#define VL_E 2.718281828459045
 
 /** @brief Logarithm of 2 (math constant)*/
 #define VL_LOG_OF_2 0.693147180559945
@@ -249,6 +253,11 @@ vl_abs_d (double x)
 #endif
 }
 
+/** @brief Base-2 logaritghm
+ ** @param x argument.
+ ** @return @c log(x).
+ **/
+
 VL_INLINE double
 vl_log2_d (double x)
 {
@@ -261,6 +270,7 @@ vl_log2_d (double x)
 #endif
 }
 
+/** @copydoc vl_log2_d */
 VL_INLINE float
 vl_log2_f (float x)
 {
@@ -270,6 +280,91 @@ vl_log2_f (float x)
   return logf(x) / 0.6931472F ;
 #else
   return log2(x) ;
+#endif
+}
+
+/** @brief Square root.
+ ** @param x argument.
+ ** @return @c sqrt(x).
+ **/
+
+VL_INLINE double
+vl_sqrt_d (double x)
+{
+#ifdef VL_COMPILER_GNUC
+  return __builtin_sqrt(x) ;
+#else
+  return sqrt(x) ;
+#endif
+}
+
+/** @copydoc vl_sqrt_d */
+VL_INLINE float
+vl_sqrt_f (float x)
+{
+#ifdef VL_COMPILER_GNUC
+  return __builtin_sqrtf(x) ;
+#else
+  return sqrtf(x) ;
+#endif
+}
+
+
+/** @brief Check whether a floating point value is NaN
+ ** @param x argument.
+ ** @return true if @a x is NaN.
+ **/
+VL_INLINE vl_bool
+vl_is_nan_f (float x)
+{
+#ifdef VL_COMPILER_GNUC
+  return __builtin_isnan (x) ;
+#elif VL_COMPILER_MSC
+  return _isnan(x) ;
+#else
+  return isnan(x) ;
+#endif
+}
+
+/** @copydoc vl_is_nan_f */
+VL_INLINE vl_bool
+vl_is_nan_d (double x)
+{
+#ifdef VL_COMPILER_GNUC
+  return __builtin_isnan (x) ;
+#elif VL_COMPILER_MSC
+  return _isnan(x) ;
+#else
+  return isnan(x) ;
+#endif
+}
+
+/** @brief Check whether a floating point value is infinity
+ ** @param x argument.
+ ** @return true if @a x is infinity.
+ **/
+VL_INLINE vl_bool
+vl_is_inf_f (float x)
+{
+#ifdef VL_COMPILER_GNUC
+  return __builtin_isinf (x) ;
+#elif VL_COMPILER_MSC
+  return ! _finite(x) ;
+#else
+  return isinf(x) ;
+#endif
+}
+
+/** @copydoc vl_is_inf_f */
+VL_INLINE vl_bool
+vl_is_inf_d (double x)
+{
+#ifdef VL_COMPILER_GNUC
+  return __builtin_isinf (x) ;
+#elif VL_COMPILER_MSC
+  return ! _finite(x) ;
+#else
+  return isinf(x) ;
 #endif
 }
 
@@ -441,45 +536,9 @@ vl_fast_resqrt_d (double x)
  ** @param x argument.
  ** @return approximation of @c sqrt(x).
  **
- ** The function computes a cheap approximation of @c sqrt(x).
- **
- ** @par Floating-point algorithm
- **
- ** For the floating point cases, the function uses ::vl_fast_resqrt_f
+ ** The function uses ::vl_fast_resqrt_f
  ** (or ::vl_fast_resqrt_d) to compute <code>x *
  ** vl_fast_resqrt_f(x)</code>.
- **
- ** @par Integer algorithm
- **
- ** We seek for the largest integer @e y such that @f$ y^2 \leq x @f$.
- ** Write @f$ y = w + b_k 2^k + z @f$ where the binary expansion of the
- ** various variable is
- **
- ** @f[
- **  x = \sum_{i=0}^{n-1} 2^i a_i, \qquad
- **  w = \sum_{i=k+1}^{m-1} 2^i b_i, \qquad
- **  z = \sum_{i=0}^{k-1} 2^i b_i.
- ** @f]
- **
- ** Assume @e w known. Expanding the square and using the fact that
- ** @f$ b_k^2=b_k @f$, we obtain the following constraint for @f$ b_k
- ** @f$ and @e z:
- **
- ** @f[
- **    x - w^2 \geq 2^k ( 2 w + 2^k ) b_k + z (z + 2wz + 2^{k+1}z b_k)
- ** @f]
- **
- ** A necessary condition for @f$ b_k = 1 @f$ is that this equation is
- ** satisfied for @f$ z = 0 @f$ (as the second term is always
- ** non-negative). In fact, this condition is also sufficient, since
- ** we are looking for the @e largest solution @e y.
- **
- ** This yields the following iterative algorithm. First, note that if
- ** @e x is stored in @e n bits, where @e n is even, then the integer
- ** square root does not require more than @f$ m = n / 2 @f$ bit to be
- ** stored.  Thus initially, @f$ w = 0 @f$ and @f$ k = m - 1 = n/2 - 1
- ** @f$. Then, at each iteration the equation is tested, determining
- ** @f$ b_{m-1}, b_{m-2}, ... @f$ in this order.
  **/
 
 VL_INLINE float
@@ -489,7 +548,7 @@ vl_fast_sqrt_f (float x)
 }
 
 /** @brief Fast @c sqrt approximation
- ** @sa vl_fast_sqrt_f
+ ** @copydoc vl_fast_sqrt_f
  **/
 
 VL_INLINE double
@@ -498,44 +557,45 @@ vl_fast_sqrt_d (float x)
   return (x < 1e-8) ? 0 : x * vl_fast_resqrt_d (x) ;
 }
 
-/** @brief Fast @c sqrt approximation
- ** @sa vl_fast_sqrt_f
+/** @brief Fast integer @c sqrt approximation
+ ** @param x non-negative integer.
+ ** @return largest integer $y$ such that $y^2 \leq x$.
+ ** @sa @ref mathop-sqrti "Algorithm"
  **/
+VL_INLINE vl_uint64 vl_fast_sqrt_ui64 (vl_uint64 x) ;
 
+/** @brief Fast @c sqrt approximation
+ ** @copydoc vl_fast_sqrt_ui64 */
 VL_INLINE vl_uint32 vl_fast_sqrt_ui32 (vl_uint32 x) ;
 
 /** @brief Fast @c sqrt approximation
- ** @sa vl_fast_sqrt_f
- **/
-
+ ** @copydoc vl_fast_sqrt_ui64 */
 VL_INLINE vl_uint16 vl_fast_sqrt_ui16 (vl_uint16 x) ;
 
 /** @brief Fast @c sqrt approximation
- ** @sa vl_fast_sqrt_f
- **/
-
+ ** @copydoc vl_fast_sqrt_ui64 */
 VL_INLINE vl_uint8  vl_fast_sqrt_ui8  (vl_uint8  x) ;
 
 #define VL_FAST_SQRT_UI(T,SFX)                                       \
-  VL_INLINE T                                                        \
-  vl_fast_sqrt_ ## SFX (T x)                                         \
+VL_INLINE T                                                          \
+vl_fast_sqrt_ ## SFX (T x)                                           \
 {                                                                    \
-    T y = 0 ; /* w / 2^k */                                          \
-    T tmp = 0 ;                                                      \
-    int twok ;                                                       \
-                                                                     \
-    for (twok = 8 * sizeof(T) - 2 ;                                  \
-         twok >= 0 ; twok -= 2) {                                    \
-      y <<= 1 ; /* y = 2 * y */                                      \
-      tmp = (2*y + 1) << twok ;                                      \
-      if (x >= tmp) {                                                \
-        x -= tmp ;                                                   \
-        y += 1 ;                                                     \
-      }                                                              \
+  T y = 0 ;                                                          \
+  T tmp = 0 ;                                                        \
+  int twice_k ;                                                      \
+  for (twice_k = 8 * sizeof(T) - 2 ;                                 \
+       twice_k >= 0 ; twice_k -= 2) {                                \
+    y <<= 1 ; /* y = 2 * y */                                        \
+    tmp = (2*y + 1) << twice_k ;                                     \
+    if (x >= tmp) {                                                  \
+      x -= tmp ;                                                     \
+      y += 1 ;                                                       \
     }                                                                \
-    return y ;                                                       \
-  }
+  }                                                                  \
+  return y ;                                                         \
+}
 
+VL_FAST_SQRT_UI(vl_uint64,ui64)
 VL_FAST_SQRT_UI(vl_uint32,ui32)
 VL_FAST_SQRT_UI(vl_uint16,ui16)
 VL_FAST_SQRT_UI(vl_uint8,ui8)
@@ -554,6 +614,16 @@ typedef float (*VlFloatVectorComparisonFunction)(vl_size dimension, float const 
  **/
 typedef double (*VlDoubleVectorComparisonFunction)(vl_size dimension, double const * X, double const * Y) ;
 
+/** @typedef VlFloatVector3ComparisonFunction
+ ** @brief Pointer to a function to compare 3 vectors of doubles
+ **/
+typedef float (*VlFloatVector3ComparisonFunction)(vl_size dimension, float const * X, float const * Y, float const * Z) ;
+
+/** @typedef VlDoubleVector3ComparisonFunction
+ ** @brief Pointer to a function to compare 3 vectors of doubles
+ **/
+typedef double (*VlDoubleVector3ComparisonFunction)(vl_size dimension, double const * X, double const * Y, double const * Z) ;
+
 /** @brief Vector comparison types */
 enum _VlVectorComparisonType {
   VlDistanceL1,        /**< l1 distance (squared intersection metric) */
@@ -561,6 +631,7 @@ enum _VlVectorComparisonType {
   VlDistanceChi2,      /**< squared Chi2 distance */
   VlDistanceHellinger, /**< squared Hellinger's distance */
   VlDistanceJS,        /**< squared Jensen-Shannon distance */
+  VlDistanceMahalanobis,     /**< squared mahalanobis distance */
   VlKernelL1,          /**< intersection kernel */
   VlKernelL2,          /**< l2 kernel */
   VlKernelChi2,        /**< Chi2 kernel */
@@ -583,6 +654,7 @@ vl_get_vector_comparison_type_name (int type)
     case VlDistanceL1   : return "l1" ;
     case VlDistanceL2   : return "l2" ;
     case VlDistanceChi2 : return "chi2" ;
+    case VlDistanceMahalanobis  : return "mahalanobis" ;
     case VlKernelL1     : return "kl1" ;
     case VlKernelL2     : return "kl2" ;
     case VlKernelChi2   : return "kchi2" ;
@@ -595,6 +667,13 @@ vl_get_vector_comparison_function_f (VlVectorComparisonType type) ;
 
 VL_EXPORT VlDoubleVectorComparisonFunction
 vl_get_vector_comparison_function_d (VlVectorComparisonType type) ;
+
+VL_EXPORT VlFloatVector3ComparisonFunction
+vl_get_vector_3_comparison_function_f (VlVectorComparisonType type) ;
+
+VL_EXPORT VlDoubleVector3ComparisonFunction
+vl_get_vector_3_comparison_function_d (VlVectorComparisonType type) ;
+
 
 VL_EXPORT void
 vl_eval_vector_comparison_on_all_pairs_f (float * result, vl_size dimension,

--- a/src/nonFree/sift/vl/mathop_avx.c
+++ b/src/nonFree/sift/vl/mathop_avx.c
@@ -1,0 +1,275 @@
+/** @file mathop_avx.c
+ ** @brief mathop for AVX - Definition
+ ** @author Andrea Vedaldi, David Novotny
+ **/
+
+/*
+Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+/* ---------------------------------------------------------------- */
+#if ! defined(VL_MATHOP_AVX_INSTANTIATING)
+
+#include "mathop_avx.h"
+
+#undef FLT
+#define FLT VL_TYPE_DOUBLE
+#define VL_MATHOP_AVX_INSTANTIATING
+#include "mathop_avx.c"
+
+#undef FLT
+#define FLT VL_TYPE_FLOAT
+#define VL_MATHOP_AVX_INSTANTIATING
+#include "mathop_avx.c"
+
+/* ---------------------------------------------------------------- */
+/* VL_MATHOP_AVX_INSTANTIATING */
+#else
+#ifndef VL_DISABLE_AVX
+
+#ifndef __AVX__
+#error Compiling AVX functions but AVX does not seem to be supported by the compiler.
+#endif
+
+#include <immintrin.h>
+#include "generic.h"
+#include "mathop.h"
+#include "float.th"
+
+VL_INLINE T
+VL_XCAT(_vl_vhsum_avx_, SFX)(VTYPEavx x)
+{
+  T acc ;
+#if (VSIZEavx == 8)
+  {
+    //VTYPEavx hsum = _mm256_hadd_ps(x, x);
+    //hsum = _mm256_add_ps(hsum, _mm256_permute2f128_ps(hsum, hsum, 0x1));
+    //_mm_store_ss(&acc, _mm_hadd_ps( _mm256_castps256_ps128(hsum), _mm256_castps256_ps128(hsum) ) );
+    VTYPEavx hsum = VHADD2avx(x, x);
+    hsum = VADDavx(hsum, VPERMavx(hsum, hsum, 0x1));
+    VST1(&acc, VHADDavx( VCSTavx(hsum), VCSTavx(hsum) ) );
+  }
+#else
+  {
+    //VTYPEavx hsum = _mm256_add_pd(x, _mm256_permute2f128_pd(x, x, 0x1));
+    VTYPEavx hsum = VADDavx(x, VPERMavx(x, x, 0x1));
+
+    //_mm_store_sd(&acc, _mm_hadd_pd( _mm256_castpd256_pd128(hsum), _mm256_castpd256_pd128(hsum) ) );
+    VST1(&acc, VHADDavx( VCSTavx(hsum), VCSTavx(hsum) ) );
+  }
+#endif
+  return acc ;
+}
+
+VL_EXPORT T
+VL_XCAT(_vl_distance_l2_avx_, SFX)
+(vl_size dimension, T const * X, T const * Y)
+{
+
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZEavx + 1 ;
+  T acc ;
+  VTYPEavx vacc = VSTZavx() ;
+  vl_bool dataAligned = VALIGNEDavx(X) & VALIGNEDavx(Y) ;
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPEavx a = *(VTYPEavx*)X ;
+      VTYPEavx b = *(VTYPEavx*)Y ;
+      VTYPEavx delta = VSUBavx(a, b) ;
+      VTYPEavx delta2 = VMULavx(delta, delta) ;
+      vacc = VADDavx(vacc, delta2) ;
+      X += VSIZEavx ;
+      Y += VSIZEavx ;
+    }
+  } else {
+    while (X < X_vec_end) {
+      VTYPEavx a = VLDUavx(X) ;
+      VTYPEavx b = VLDUavx(Y) ;
+      VTYPEavx delta = VSUBavx(a, b) ;
+      VTYPEavx delta2 = VMULavx(delta, delta) ;
+      vacc = VADDavx(vacc, delta2) ;
+      X += VSIZEavx ;
+      Y += VSIZEavx ;
+    }
+  }
+
+  acc = VL_XCAT(_vl_vhsum_avx_, SFX)(vacc) ;
+
+  while (X < X_end) {
+    T a = *X++ ;
+    T b = *Y++ ;
+    T delta = a - b ;
+    acc += delta * delta ;
+  }
+
+  return acc ;
+}
+
+VL_EXPORT T
+VL_XCAT(_vl_distance_mahalanobis_sq_avx_, SFX)
+(vl_size dimension, T const * X, T const * MU, T const * S)
+{
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZEavx + 1 ;
+  T acc ;
+  VTYPEavx vacc = VSTZavx() ;
+  vl_bool dataAligned = VALIGNEDavx(X) & VALIGNEDavx(MU) & VALIGNEDavx(S);
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPEavx a = *(VTYPEavx*)X ;
+      VTYPEavx b = *(VTYPEavx*)MU ;
+      VTYPEavx c = *(VTYPEavx*)S ;
+
+      VTYPEavx delta = VSUBavx(a, b) ;
+      VTYPEavx delta2 = VMULavx(delta, delta) ;
+      VTYPEavx delta2div = VMULavx(delta2,c);
+
+      vacc = VADDavx(vacc, delta2div) ;
+
+      X  += VSIZEavx ;
+      MU += VSIZEavx ;
+      S  += VSIZEavx ;
+    }
+  } else {
+    while (X < X_vec_end) {
+
+      VTYPEavx a = VLDUavx(X) ;
+      VTYPEavx b = VLDUavx(MU) ;
+      VTYPEavx c = VLDUavx(S) ;
+
+      VTYPEavx delta = VSUBavx(a, b) ;
+      VTYPEavx delta2 = VMULavx(delta, delta) ;
+      VTYPEavx delta2div = VMULavx(delta2,c);
+
+      vacc = VADDavx(vacc, delta2div) ;
+
+      X  += VSIZEavx ;
+      MU += VSIZEavx ;
+      S  += VSIZEavx ;
+    }
+  }
+
+  acc = VL_XCAT(_vl_vhsum_avx_, SFX)(vacc) ;
+
+  while (X < X_end) {
+    T a = *X++ ;
+    T b = *MU++ ;
+    T c = *S++ ;
+    T delta = a - b ;
+    acc += (delta * delta) * c;
+  }
+
+  return acc ;
+}
+
+VL_EXPORT void
+VL_XCAT(_vl_weighted_mean_avx_, SFX)
+(vl_size dimension, T * MU, T const * X, T const  W)
+{
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZEavx + 1 ;
+
+  vl_bool dataAligned = VALIGNEDavx(X) & VALIGNEDavx(MU);
+  VTYPEavx w = VLD1avx (&W) ;
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPEavx a = *(VTYPEavx*)X ;
+      VTYPEavx mu = *(VTYPEavx*)MU ;
+
+      VTYPEavx aw = VMULavx(a, w) ;
+      VTYPEavx meanStore = VADDavx(aw, mu);
+
+      *(VTYPEavx *)MU = meanStore;
+
+      X += VSIZEavx ;
+      MU += VSIZEavx ;
+    }
+  } else {
+    while (X < X_vec_end) {
+      VTYPEavx a  = VLDUavx(X) ;
+      VTYPEavx mu = VLDUavx(MU) ;
+
+      VTYPEavx aw = VMULavx(a, w) ;
+      VTYPEavx meanStore = VADDavx(aw, mu);
+
+      VST2Uavx(MU,meanStore);
+
+      X += VSIZEavx ;
+      MU += VSIZEavx ;
+    }
+  }
+
+  while (X < X_end) {
+    T a = *X++ ;
+    *MU += a * W ;
+    MU++;
+  }
+}
+
+VL_EXPORT void
+VL_XCAT(_vl_weighted_sigma_avx_, SFX)
+(vl_size dimension, T * S, T const * X, T const * Y, T const W)
+{
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZEavx + 1 ;
+
+  vl_bool dataAligned = VALIGNEDavx(X) & VALIGNEDavx(Y) & VALIGNEDavx(S);
+
+  VTYPEavx w = VLD1avx (&W) ;
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPEavx a = *(VTYPEavx*)X ;
+      VTYPEavx b = *(VTYPEavx*)Y ;
+      VTYPEavx s = *(VTYPEavx*)S ;
+
+      VTYPEavx delta = VSUBavx(a, b) ;
+      VTYPEavx delta2 = VMULavx(delta, delta) ;
+      VTYPEavx delta2w = VMULavx(delta2, w) ;
+      VTYPEavx sigmaStore = VADDavx(s,delta2w);
+
+      *(VTYPEavx *)S = sigmaStore;
+
+      X += VSIZEavx ;
+      Y += VSIZEavx ;
+      S += VSIZEavx ;
+    }
+  } else {
+    while (X < X_vec_end) {
+      VTYPEavx a = VLDUavx(X) ;
+      VTYPEavx b = VLDUavx(Y) ;
+      VTYPEavx s = VLDUavx(S) ;
+
+      VTYPEavx delta = VSUBavx(a, b) ;
+      VTYPEavx delta2 = VMULavx(delta, delta) ;
+      VTYPEavx delta2w = VMULavx(delta2, w) ;
+      VTYPEavx sigmaStore = VADDavx(s,delta2w);
+
+      VST2Uavx(S,sigmaStore);
+
+      X += VSIZEavx ;
+      Y += VSIZEavx ;
+      S += VSIZEavx ;
+    }
+  }
+
+  while (X < X_end) {
+    T a = *X++ ;
+    T b = *Y++ ;
+    T delta = a - b ;
+    *S += ((delta * delta)*W) ;
+    S++;
+  }
+}
+
+/* VL_DISABLE_AVX */
+#endif
+#undef VL_MATHOP_AVX_INSTANTIATING
+#endif

--- a/src/nonFree/sift/vl/mathop_avx.h
+++ b/src/nonFree/sift/vl/mathop_avx.h
@@ -1,0 +1,61 @@
+/** @file mathop_avx.h
+ ** @brief mathop for avx
+ ** @author Andrea Vedaldi
+ **/
+
+/*
+Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+/* ---------------------------------------------------------------- */
+#ifndef VL_MATHOP_AVX_H_INSTANTIATING
+
+#ifndef VL_MATHOP_AVX_H
+#define VL_MATHOP_AVX_H
+
+#undef FLT
+#define FLT VL_TYPE_DOUBLE
+#define VL_MATHOP_AVX_H_INSTANTIATING
+#include "mathop_avx.h"
+
+#undef FLT
+#define FLT VL_TYPE_FLOAT
+#define VL_MATHOP_AVX_H_INSTANTIATING
+#include "mathop_avx.h"
+
+/* VL_MATHOP_AVX_H */
+#endif
+
+/* ---------------------------------------------------------------- */
+/* VL_MATHOP_AVX_H_INSTANTIATING */
+#else
+
+#ifndef VL_DISABLE_AVX
+#include "generic.h"
+#include "float.th"
+
+VL_EXPORT T
+VL_XCAT(_vl_distance_mahalanobis_sq_avx_, SFX)
+(vl_size dimension, T const * X, T const * MU, T const * S);
+
+VL_EXPORT T
+VL_XCAT(_vl_distance_l2_avx_, SFX)
+(vl_size dimension, T const * X, T const * Y);
+
+VL_EXPORT void
+VL_XCAT(_vl_weighted_sigma_avx_, SFX)
+(vl_size dimension, T * S, T const * X, T const * Y, T const W);
+
+VL_EXPORT void
+VL_XCAT(_vl_weighted_mean_avx_, SFX)
+(vl_size dimension, T * MU, T const * X, T const W);
+
+/* ! VL_DISABLE_AVX */
+#endif
+
+#undef VL_MATHOP_AVX_H_INSTANTIATING
+#endif

--- a/src/nonFree/sift/vl/mathop_sse2.c
+++ b/src/nonFree/sift/vl/mathop_sse2.c
@@ -1,6 +1,6 @@
 /** @file mathop_sse2.c
  ** @brief mathop for SSE2 - Definition
- ** @author Andrea Vedaldi
+ ** @author Andrea Vedaldi, David Novotny
  **/
 
 /*
@@ -13,33 +13,31 @@ the terms of the BSD license (see the COPYING file).
 
 /* ---------------------------------------------------------------- */
 #ifndef VL_MATHOP_SSE2_INSTANTIATING
-#define VL_MATHOP_SSE2_INSTANTIATING
 
-#ifndef VL_DISABLE_SSE2
-#ifndef __SSE2__
-#  error "mathop_sse2.c must be compiled with SSE2 intrinsics enabled"
-#endif
-
-#include "generic.h"
-#include "mathop.h"
 #include "mathop_sse2.h"
-#include <emmintrin.h>
 
 #undef FLT
 #define FLT VL_TYPE_DOUBLE
+#define VL_MATHOP_SSE2_INSTANTIATING
 #include "mathop_sse2.c"
 
 #undef FLT
 #define FLT VL_TYPE_FLOAT
+#define VL_MATHOP_SSE2_INSTANTIATING
 #include "mathop_sse2.c"
-
-/* VL_DISABLE_SSE2 */
-#endif
 
 /* ---------------------------------------------------------------- */
 /* VL_MATHOP_SSE2_INSTANTIATING */
 #else
+#ifndef VL_DISABLE_SSE2
 
+#ifndef __SSE2__
+#error Compiling SSE2 functions but SSE2 does not to be supported by the compiler.
+#endif
+
+#include <emmintrin.h>
+#include "mathop.h"
+#include "generic.h"
 #include "float.th"
 
 VL_INLINE T
@@ -70,6 +68,49 @@ VL_XCAT(_vl_vhsum_sse2_, SFX)(VTYPE x)
   }
 #endif
   VST1(&acc, x);
+  return acc ;
+}
+
+
+
+VL_EXPORT T
+VL_XCAT(_vl_dot_sse2_, SFX)
+(vl_size dimension, T const * X, T const * Y)
+{
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZE + 1 ;
+  T acc ;
+  VTYPE vacc = VSTZ() ;
+  vl_bool dataAligned = VALIGNED(X) & VALIGNED(Y) ;
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPE a = *(VTYPE*)X ;
+      VTYPE b = *(VTYPE*)Y ;
+      VTYPE d = VMUL(a, b) ;
+      vacc = VADD(vacc, d) ;
+      X += VSIZE ;
+      Y += VSIZE ;
+    }
+  } else {
+    while (X < X_vec_end) {
+      VTYPE a = VLDU(X) ;
+      VTYPE b = VLDU(Y) ;
+      VTYPE d = VMUL(a, b) ;
+      vacc = VADD(vacc, d) ;
+      X += VSIZE ;
+      Y += VSIZE ;
+    }
+  }
+
+  acc = VL_XCAT(_vl_vhsum_sse2_, SFX)(vacc) ;
+
+  while (X < X_end) {
+    T a = *X++ ;
+    T b = *Y++ ;
+    acc += a * b ;
+  }
+
   return acc ;
 }
 
@@ -116,6 +157,66 @@ VL_XCAT(_vl_distance_l2_sse2_, SFX)
 
   return acc ;
 }
+
+VL_EXPORT T
+VL_XCAT(_vl_distance_mahalanobis_sq_sse2_, SFX)
+(vl_size dimension, T const * X, T const * MU, T const * S)
+{
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZE + 1 ;
+  T acc ;
+  VTYPE vacc = VSTZ() ;
+  vl_bool dataAligned = VALIGNED(X) & VALIGNED(MU) & VALIGNED(S);
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPE a = *(VTYPE*)X ;
+      VTYPE b = *(VTYPE*)MU ;
+      VTYPE c = *(VTYPE*)S ;
+
+      VTYPE delta = VSUB(a, b) ;
+      VTYPE delta2 = VMUL(delta, delta) ;
+      VTYPE delta2div = VMUL(delta2,c);
+
+      vacc = VADD(vacc, delta2div) ;
+
+      X  += VSIZE ;
+      MU += VSIZE ;
+      S  += VSIZE ;
+    }
+  } else {
+    while (X < X_vec_end) {
+
+      VTYPE a = VLDU(X) ;
+      VTYPE b = VLDU(MU) ;
+      VTYPE c = VLDU(S) ;
+
+      VTYPE delta = VSUB(a, b) ;
+      VTYPE delta2 = VMUL(delta, delta) ;
+      VTYPE delta2div = VMUL(delta2,c);
+
+      vacc = VADD(vacc, delta2div) ;
+
+      X  += VSIZE ;
+      MU += VSIZE ;
+      S  += VSIZE ;
+    }
+  }
+
+  acc = VL_XCAT(_vl_vhsum_sse2_, SFX)(vacc) ;
+
+  while (X < X_end) {
+    T a = *X++ ;
+    T b = *MU++ ;
+    T c = *S++ ;
+    T delta = a - b ;
+    acc += (delta * delta) * c;
+  }
+
+  return acc ;
+}
+
+
 
 VL_EXPORT T
 VL_XCAT(_vl_distance_l1_sse2_, SFX)
@@ -354,6 +455,110 @@ VL_XCAT(_vl_kernel_chi2_sse2_, SFX)
   }
   return ((T)2) * acc ;
 }
+//
+VL_EXPORT void
+VL_XCAT(_vl_weighted_sigma_sse2_, SFX)
+(vl_size dimension, T * S, T const * X, T const * Y, T const W)
+{
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZE + 1 ;
 
-/* VL_MATHOP_SSE2_INSTANTIATING */
+  vl_bool dataAligned = VALIGNED(X) & VALIGNED(Y) & VALIGNED(S);
+
+  VTYPE w = VLD1 (&W) ;
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPE a = *(VTYPE*)X ;
+      VTYPE b = *(VTYPE*)Y ;
+      VTYPE s = *(VTYPE*)S ;
+
+      VTYPE delta = VSUB(a, b) ;
+      VTYPE delta2 = VMUL(delta, delta) ;
+      VTYPE delta2w = VMUL(delta2, w) ;
+      VTYPE sigmaStore = VADD(s,delta2w);
+
+      *(VTYPE *)S = sigmaStore;
+
+      X += VSIZE ;
+      Y += VSIZE ;
+      S += VSIZE ;
+    }
+  } else {
+    while (X < X_vec_end) {
+      VTYPE a = VLDU(X) ;
+      VTYPE b = VLDU(Y) ;
+      VTYPE s = VLDU(S) ;
+
+      VTYPE delta = VSUB(a, b) ;
+      VTYPE delta2 = VMUL(delta, delta) ;
+      VTYPE delta2w = VMUL(delta2, w) ;
+      VTYPE sigmaStore = VADD(s,delta2w);
+
+      VST2U(S,sigmaStore);
+
+      X += VSIZE ;
+      Y += VSIZE ;
+      S += VSIZE ;
+    }
+  }
+
+
+  while (X < X_end) {
+    T a = *X++ ;
+    T b = *Y++ ;
+    T delta = a - b ;
+    *S += ((delta * delta)*W) ;
+    S++;
+  }
+}
+
+VL_EXPORT void
+VL_XCAT(_vl_weighted_mean_sse2_, SFX)
+(vl_size dimension, T * MU, T const * X, T const W)
+{
+  T const * X_end = X + dimension ;
+  T const * X_vec_end = X_end - VSIZE + 1 ;
+
+  vl_bool dataAligned = VALIGNED(X) & VALIGNED(MU);
+  VTYPE w = VLD1 (&W) ;
+
+  if (dataAligned) {
+    while (X < X_vec_end) {
+      VTYPE a = *(VTYPE*)X ;
+      VTYPE mu = *(VTYPE*)MU ;
+
+      VTYPE aw = VMUL(a, w) ;
+      VTYPE meanStore = VADD(aw, mu);
+
+      *(VTYPE *)MU = meanStore;
+
+      X += VSIZE ;
+      MU += VSIZE ;
+    }
+  } else {
+    while (X < X_vec_end) {
+      VTYPE a  = VLDU(X) ;
+      VTYPE mu = VLDU(MU) ;
+
+      VTYPE aw = VMUL(a, w) ;
+      VTYPE meanStore = VADD(aw, mu);
+
+      VST2U(MU,meanStore);
+
+      X += VSIZE ;
+      MU += VSIZE ;
+    }
+  }
+
+  while (X < X_end) {
+    T a = *X++ ;
+    *MU += a * W ;
+    MU++;
+  }
+}
+
+/* VL_DISABLE_SSE2 */
+#endif
+#undef VL_MATHOP_SSE2_INSTANTIATING
 #endif

--- a/src/nonFree/sift/vl/mathop_sse2.h
+++ b/src/nonFree/sift/vl/mathop_sse2.h
@@ -13,17 +13,18 @@ the terms of the BSD license (see the COPYING file).
 
 /* ---------------------------------------------------------------- */
 #ifndef VL_MATHOP_SSE2_H_INSTANTIATING
-#define VL_MATHOP_SSE2_H_INSTANTIATING
 
 #ifndef VL_MATHOP_SSE2_H
 #define VL_MATHOP_SSE2_H
 
 #undef FLT
 #define FLT VL_TYPE_DOUBLE
+#define VL_MATHOP_SSE2_H_INSTANTIATING
 #include "mathop_sse2.h"
 
 #undef FLT
 #define FLT VL_TYPE_FLOAT
+#define VL_MATHOP_SSE2_H_INSTANTIATING
 #include "mathop_sse2.h"
 
 /* VL_MATHOP_SSE2_H */
@@ -37,6 +38,10 @@ the terms of the BSD license (see the COPYING file).
 
 #include "generic.h"
 #include "float.th"
+
+VL_EXPORT T
+VL_XCAT(_vl_dot_sse2_, SFX)
+(vl_size dimension, T const * X, T const * Y) ;
 
 VL_EXPORT T
 VL_XCAT(_vl_distance_l2_sse2_, SFX)
@@ -62,8 +67,19 @@ VL_EXPORT T
 VL_XCAT(_vl_kernel_chi2_sse2_, SFX)
 (vl_size dimension, T const * X, T const * Y) ;
 
+VL_EXPORT T
+VL_XCAT(_vl_distance_mahalanobis_sq_sse2_, SFX)
+(vl_size dimension, T const * X, T const * MU, T const * S);
+
+VL_EXPORT void
+VL_XCAT(_vl_weighted_sigma_sse2_, SFX)
+(vl_size dimension, T * S, T const * X, T const * Y, T const W);
+
+VL_EXPORT void
+VL_XCAT(_vl_weighted_mean_sse2_, SFX)
+(vl_size dimension, T * MU, T const * X, T const W);
+
 /* ! VL_DISABLE_SSE2 */
 #endif
-
-/* VL_MATHOP_SSE2_INSTANTIATING */
+#undef VL_MATHOP_SSE2_INSTANTIATING
 #endif

--- a/src/nonFree/sift/vl/mser.h
+++ b/src/nonFree/sift/vl/mser.h
@@ -34,8 +34,6 @@ typedef vl_uint8 vl_mser_pix ;
  ** The MSER filter computes the Maximally Stable Extremal Regions of
  ** an image.
  **
- ** This structure is @ref main-glossary "opaque".
- **
  ** @sa @ref mser
  **/
 typedef struct _VlMserFilt VlMserFilt ;
@@ -104,7 +102,8 @@ VL_INLINE void  vl_mser_set_min_diversity   (VlMserFilt *f, double      x) ;
  *                                                   INLINE DEFINITIONS
  * ================================================================== */
 
-/** @internal @brief MSER accumulator data type
+/** @internal
+ ** @brief MSER accumulator data type
  **
  ** This is a large integer type. It should be large enough to contain
  ** a number equal to the area (volume) of the image by the image
@@ -121,7 +120,8 @@ typedef float vl_mser_acc ;
 #endif
 
 /* ----------------------------------------------------------------- */
-/** @internal @brief MSER: basic region (declaration)
+/** @internal
+ ** @brief MSER: basic region (declaration)
  **
  ** Extremal regions and maximally stable extremal regions are
  ** instances of image regions.
@@ -156,7 +156,8 @@ struct _VlMserReg
 typedef struct _VlMserReg VlMserReg ;
 
 /* ----------------------------------------------------------------- */
-/** @internal @brief MSER: extremal region (declaration)
+/** @internal
+ ** @brief MSER: extremal region (declaration)
  **
  ** Extremal regions (ER) are extracted from the region forest. Each
  ** region is represented by an instance of this structure. The
@@ -187,15 +188,17 @@ struct _VlMserExtrReg
   vl_mser_pix  value ;      /**< value of pivot pixel                         */
   vl_uint      shortcut ;   /**< shortcut used when building a tree           */
   vl_uint      area ;       /**< area of the region                           */
-  float    variation ;  /**< rel. area variation                          */
+  float        variation ;  /**< rel. area variation                          */
   vl_uint      max_stable ; /**< max stable number (=0 if not maxstable)      */
 } ;
 
-/** @internal @brief MSER: extremal region */
+/** @internal
+ ** @brief MSER: extremal region */
 typedef struct _VlMserExtrReg VlMserExtrReg ;
 
 /* ----------------------------------------------------------------- */
-/** @internal @brief MSER filter
+/** @internal
+ ** @brief MSER filter
  ** @see @ref mser
  **/
 struct _VlMserFilt
@@ -228,8 +231,8 @@ struct _VlMserFilt
 
   /** @name Ellipsoids fitting */
   /*@{*/
-  float         *acc ;     /**< moment accumulator.                    */
-  float         *ell ;     /**< ellipsoids list.                       */
+  float             *acc ;     /**< moment accumulator.                    */
+  float             *ell ;     /**< ellipsoids list.                       */
   int                rell ;    /**< size of ell buffer                     */
   int                nell ;    /**< number of ellipsoids extracted         */
   int                dof ;     /**< number of dof of ellipsoids.           */
@@ -239,7 +242,7 @@ struct _VlMserFilt
   /** @name Configuration */
   /*@{*/
   vl_bool   verbose ;          /**< be verbose                             */
-  int       delta ;            /**< delta filter parameter                  */
+  int       delta ;            /**< delta filter parameter                 */
   double    max_area ;         /**< badness test parameter                 */
   double    min_area ;         /**< badness test parameter                 */
   double    max_variation ;    /**< badness test parameter                 */

--- a/src/nonFree/sift/vl/random.c
+++ b/src/nonFree/sift/vl/random.c
@@ -5,46 +5,65 @@
 
 /*
 Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+Copyright (C) 2013 Andrea Vedaldi.
 All rights reserved.
 
 This file is part of the VLFeat library and is made available under
 the terms of the BSD license (see the COPYING file).
 */
 
-/** @file random.h
+/**
+<!-- ------------------------------------------------------------- -->
+@page random Random number generator
+@author Andrea Vedaldi
+@tableofcontents
+<!-- ------------------------------------------------------------- -->
 
- This module implements the popular Mersenne Twister algorithm (MATLAB
- random generator from version 7.4).
+The module @ref random.h implements random number generation in
+VLFeat.  The generator is based on the popular Mersenne Twister
+algorithm @cite{matsumoto98mersenne} (which is the same as MATLAB
+random generator from MATLAB version 7.4 onwards).
 
- @section random-overview Overview
+<!-- ------------------------------------------------------------- -->
+@section random-starting Getting started
+<!-- ------------------------------------------------------------- -->
 
- A random number generator can be initalized by
+In VLFeat, a random number generator is implemented by an object of
+type ::VlRand. The simplest way to obtain such an object is to get the
+default random generator by
 
- @code
- VlRand rand ;
- vl_rand_init (&rand) ;
- @endcode
+@code
+VlRand * rand = vl_get_rand() ;
+vl_int32 signedRandomInteger = vl_rand_int31(rand) ;
+@code
 
- ::VlRand is a simple structure holding the state of the
- random number generator. The generator can be seeded by
- ::vl_rand_seed and ::vl_rand_seed_by_array. For intsance:
+Note that there is one such generator per thread (see
+::vl_get_rand). If more control is desired, a new ::VlRand object can
+be easily created.  The object is lightweight, designed to be
+allocated on the stack:
 
- @code
- vl_rand_seed (&rand, clock()) ;
- @endcode
+@code
+VlRand rand ;
+vl_rand_init (&rand) ;
+@endcode
 
- The generator can be used to obtain random quantities of
- various types:
+The generator can be seeded by ::vl_rand_seed and ::vl_rand_seed_by_array.
+For instance:
 
- - ::vl_rand_int31, ::vl_rand_uint32 for 32-bit random integers;
- - ::vl_rand_real1 for a double in [0,1];
- - ::vl_rand_real2 for a double in [0,1);
- - ::vl_rand_real3 for a double in (0,1);
- - ::vl_rand_res53 for a double in [0,1) with high resolution.
+@code
+vl_rand_seed (&rand, clock()) ;
+@endcode
 
- There is no need to explicitly destroy a ::VlRand instance.
+The generator can be used to obtain random quantities of
+various types:
 
- [1] http://en.wikipedia.org/wiki/Mersenne_twister
+- ::vl_rand_int31, ::vl_rand_uint32 for 32-bit random integers;
+- ::vl_rand_real1 for a double in [0,1];
+- ::vl_rand_real2 for a double in [0,1);
+- ::vl_rand_real3 for a double in (0,1);
+- ::vl_rand_res53 for a double in [0,1) with high resolution.
+
+There is no need to explicitly destroy a ::VlRand instance.
 
 **/
 
@@ -99,9 +118,9 @@ email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
 /* Period parameters */
 #define N 624
 #define M 397
-#define MATRIX_A 0x9908b0dfUL   /* constant vector a */
-#define UPPER_MASK 0x80000000UL /* most significant w-r bits */
-#define LOWER_MASK 0x7fffffffUL /* least significant r bits */
+#define MATRIX_A VL_UINT32_C(0x9908b0df)   /* constant vector a */
+#define UPPER_MASK VL_UINT32_C(0x80000000) /* most asignificant w-r bits */
+#define LOWER_MASK VL_UINT32_C(0x7fffffff) /* least significant r bits */
 
 /* initializes mt[N] with a seed */
 
@@ -109,7 +128,7 @@ email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
  ** @param self number generator.
  **/
 
-VL_EXPORT void
+void
 vl_rand_init (VlRand * self)
 {
   memset (self->mt, 0, sizeof(self->mt[0]) * N) ;
@@ -121,20 +140,20 @@ vl_rand_init (VlRand * self)
  ** @param s seed.
  **/
 
-VL_EXPORT void
+void
 vl_rand_seed (VlRand * self, vl_uint32 s)
 {
 #define mti self->mti
 #define mt self->mt
-  mt[0]= s & 0xffffffffUL;
+  mt[0]= s & VL_UINT32_C(0xffffffff);
   for (mti=1; mti<N; mti++) {
     mt[mti] =
-      (1812433253UL * (mt[mti-1] ^ (mt[mti-1] >> 30)) + mti);
+      (VL_UINT32_C(1812433253) * (mt[mti-1] ^ (mt[mti-1] >> 30)) + mti);
     /* See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. */
     /* In the previous versions, MSBs of the seed affect   */
     /* only MSBs of the array mt[].                        */
     /* 2002/01/09 modified by Makoto Matsumoto             */
-    mt[mti] &= 0xffffffffUL;
+    mt[mti] &= VL_UINT32_C(0xffffffff);
     /* for >32 bit machines */
   }
 #undef mti
@@ -147,46 +166,66 @@ vl_rand_seed (VlRand * self, vl_uint32 s)
  ** @param keySize  length of the array.
  **/
 
-VL_EXPORT void
+void
 vl_rand_seed_by_array (VlRand * self, vl_uint32 const key [], vl_size keySize)
 {
 #define mti self->mti
 #define mt self->mt
   int i, j, k;
-  vl_rand_seed (self, 19650218UL);
+  vl_rand_seed (self, VL_UINT32_C(19650218));
   i=1; j=0;
   k = (N > keySize ? N : (int)keySize);
   for (; k; k--) {
-    mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1664525UL))
+    mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * VL_UINT32_C(1664525)))
       + key[j] + j; /* non linear */
-    mt[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
+    mt[i] &= VL_UINT32_C(0xffffffff); /* for WORDSIZE > 32 machines */
     i++; j++;
     if (i>=N) { mt[0] = mt[N-1]; i=1; }
     if (j>=(signed)keySize) j=0;
   }
   for (k=N-1; k; k--) {
-    mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1566083941UL))
+    mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * VL_UINT32_C(1566083941)))
       - i; /* non linear */
-    mt[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
+    mt[i] &= VL_UINT32_C(0xffffffff) ; /* for WORDSIZE > 32 machines */
     i++;
     if (i>=N) { mt[0] = mt[N-1]; i=1; }
   }
 
-  mt[0] = 0x80000000UL; /* MSB is 1; assuring non-zero initial array */
+  mt[0] = VL_UINT32_C(0x80000000); /* MSB is 1; assuring non-zero initial array */
 #undef mti
 #undef mt
 }
+
+/** @brief Randomly permute and array of indexes.
+ ** @param self random number generator.
+ ** @param array array of indexes.
+ ** @param size number of element in the array.
+ **
+ ** The function uses *Algorithm P*, also known as *Knuth shuffle*.
+ **/
+
+void
+vl_rand_permute_indexes (VlRand *self, vl_index *array, vl_size size)
+{
+  vl_index i, j, tmp;
+  for (i = size - 1 ; i > 0; i--) {
+    /* Pick a random index j in the range 0, i + 1 and swap it with i */
+    j = (vl_int) vl_rand_uindex (self, i + 1) ;
+    tmp = array[i] ; array[i] = array[j] ; array[j] = tmp ;
+  }
+}
+
 
 /** @brief Generate a random UINT32
  ** @param self random number generator.
  ** @return a random number in [0, 0xffffffff].
  **/
 
-VL_EXPORT vl_uint32
+vl_uint32
 vl_rand_uint32 (VlRand * self)
 {
-  unsigned long y;
-  static unsigned long mag01[2]={0x0UL, MATRIX_A};
+  vl_uint32 y;
+  static vl_uint32 mag01[2]={VL_UINT32_C(0x0), MATRIX_A};
   /* mag01[x] = x * MATRIX_A  for x=0,1 */
 
 #define mti self->mti
@@ -196,18 +235,18 @@ vl_rand_uint32 (VlRand * self)
     int kk;
 
     if (mti == N+1)   /* if init_genrand() has not been called, */
-      vl_rand_seed (self, 5489UL); /* a default initial seed is used */
+      vl_rand_seed (self, VL_UINT32_C(5489)); /* a default initial seed is used */
 
     for (kk=0;kk<N-M;kk++) {
       y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-      mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & 0x1UL];
+      mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & VL_UINT32_C(0x1)];
     }
     for (;kk<N-1;kk++) {
       y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-      mt[kk] = mt[kk+(M-N)] ^ (y >> 1) ^ mag01[y & 0x1UL];
+      mt[kk] = mt[kk+(M-N)] ^ (y >> 1) ^ mag01[y & VL_UINT32_C(0x1)];
     }
     y = (mt[N-1]&UPPER_MASK)|(mt[0]&LOWER_MASK);
-    mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & 0x1UL];
+    mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & VL_UINT32_C(0x1)];
 
     mti = 0;
   }
@@ -216,8 +255,8 @@ vl_rand_uint32 (VlRand * self)
 
   /* Tempering */
   y ^= (y >> 11);
-  y ^= (y << 7) & 0x9d2c5680UL;
-  y ^= (y << 15) & 0xefc60000UL;
+  y ^= (y << 7) & VL_UINT32_C(0x9d2c5680);
+  y ^= (y << 15) & VL_UINT32_C(0xefc60000);
   y ^= (y >> 18);
 
   return (vl_uint32)y;

--- a/src/nonFree/sift/vl/random.h
+++ b/src/nonFree/sift/vl/random.h
@@ -1,6 +1,7 @@
 /** @file random.h
- ** @brief Random number generator
+ ** @brief Random number generator (@ref random)
  ** @author Andrea Vedaldi
+ ** @see @ref random
  **/
 
 /*
@@ -19,7 +20,7 @@ the terms of the BSD license (see the COPYING file).
 /** @brief Random numbber generator state */
 typedef struct _VlRand {
   vl_uint32 mt [624] ;
-  vl_size mti ;
+  vl_uint32 mti ;
 } VlRand ;
 
 /** @name Setting and reading the state
@@ -45,6 +46,8 @@ VL_INLINE double    vl_rand_real3  (VlRand * self) ;
 VL_INLINE double    vl_rand_res53  (VlRand * self) ;
 VL_INLINE vl_uindex vl_rand_uindex (VlRand * self, vl_uindex range) ;
 /** @} */
+
+VL_EXPORT void vl_rand_permute_indexes (VlRand * self, vl_index* array, vl_size size) ;
 
 /* ---------------------------------------------------------------- */
 

--- a/src/nonFree/sift/vl/scalespace.c
+++ b/src/nonFree/sift/vl/scalespace.c
@@ -1,0 +1,821 @@
+/** @file scalespace.c
+ ** @brief Scale Space - Definition
+ ** @author Karel Lenc
+ ** @author Andrea Vedaldi
+ ** @author Michal Perdoch
+ **/
+
+/*
+Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+/**
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page scalespace Gaussian Scale Space (GSS)
+@author Karel Lenc
+@author Andrea Vedaldi
+@author Michal Perdoch
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+@ref scalespace.h implements a Gaussian scale space, a data structure
+representing an image at multiple resolutions
+@cite{witkin83scale-space} @cite{koenderink84the-structure}
+@cite{lindeberg94scale-space}. Scale spaces have many use, including
+the detection of co-variant local features
+@cite{lindeberg98principles} such as SIFT, Hessian-Affine,
+Harris-Affine, Harris-Laplace, etc. @ref scalespace-starting
+demonstreates how to use the C API to compute the scalespace of an
+image. For further details refer to:
+
+- @subpage scalespace-fundamentals
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+@section scalespace-starting Getting started
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+Given an input image `image`, the following example uses the
+::VlScaleSpace object to compute its Gaussian scale space and return
+the image `level` at scale `(o,s)`, where `o` is the octave and `s` is
+the octave subdivision or sublevel:
+
+@code
+float* level ;
+VlScaleSpace ss = vl_scalespace_new(imageWidth, imageHeight) ;
+vl_scalespace_put_image(ss, image) ;
+level = vl_scalespace_get_level(ss, o, s) ;
+@endcode
+
+The image `level` is obtained by convolving `image` by a Gaussian
+filter of isotropic standard deviation given by
+
+@code
+double sigma = vl_scalespace_get_sigma(ss, o, s) ;
+@endcode
+
+The resolution of `level` is in general different from the resolution
+of `image` and is determined by the octave `o`. It can be obtained as
+follows:
+
+@code
+VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(ss, o) ;
+ogeom.width // width of level (in number of pixels)
+ogeom.height // height of level (in number of pixels)
+ogeom.step // spatial sampling step
+@endcode
+
+The parameter `ogeom.step` is the sampling step relatively to the
+sampling of the input image `image`. The ranges of valid octaves and
+scale sublevels can be obtained as
+
+@code
+VlScaleSpaceGeometry geom = vl_scalespace_get_geometry(ss) ;
+geom.firstOctave // Index of the fisrt octave
+geom.lastOctave // Index of the last octave
+geom.octaveResolution ; // Number of octave subdivisions
+geom.octaveFirstSubdivision // Index of the first octave subdivision
+geom.octaveLastSubdivision  // Index of the last octave subdivision
+@endcode
+
+So for example `o` minimum value is `geom.firstOctave` and maximum
+value is `geom.lastOctave`. The subdivision index `s` naturally spans
+the range 0 to `geom.octaveResolution-1`. However, the scale space
+object is flexible in that it allows different ranges of subdivisions
+to be computed and `s` varies in the range
+`geom.octaveFirstSubdivision` to `geom.octaveLastSubdivision`. See
+@ref scalespace-fundamentals for further details.
+
+The geometry of the scale space can be customized upon creation, as
+follows:
+
+@code
+VlScaleSpaceGeometry geom = vl_scalespace_get_default_geometry(imageWidth, imageHeight) ;
+geom.firstOctave = -1 ;
+geom.octaveFirstSubdivision = -1 ;
+geom.octaveLastSubdivision = geom.octaveResolution ;
+VlScaleSpacae ss = vl_scalespace_new_with_geometry (geom) ;
+@endcode
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@page scalespace-fundamentals Gaussian scale space fundamentals
+@tableofcontents
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+This page discusses the notion of *Gaussian scale space* and the
+relative data structure. For the C API see @ref scalespace.h and @ref
+scalespace-starting.
+
+A *scale space* is representation of an image at multiple resolution
+levels. An image is a function $\ell(x,y)$ of two coordinates $x$,
+$y$; the scale space $\ell(x,y,\sigma)$ adds a third coordinate
+$\sigma$ indexing the *scale*. Here the focus is the Gaussian scale
+space, where the image $\ell(x,y,\sigma)$ is obtained by smoothing
+$\ell(x,y)$ by a Gaussian kernel of isotropic standard deviation
+$\sigma$.
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section scalespace-definition Scale space definition
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+Formally, the *Gaussian scale space* of an image $\ell(x,y)$ is
+defined as
+
+\[
+   \ell(x,y,\sigma) =
+   [g_{\sigma} * \ell](x,y,\sigma)
+\]
+
+where $g_\sigma$ denotes a 2D Gaussian kernel of isotropic standard
+deviation $\sigma$:
+
+\[
+  g_{\sigma}(x,y) = \frac{1}{2\pi\sigma^2}
+  \exp\left(
+  - \frac{x^2 + y^2}{2\sigma^2}
+  \right).
+\]
+
+An important detail is that the algorithm computing the scale space
+assumes that the input image $\ell(x,y)$ is pre-smoothed, roughly
+capturing the effect of the finite pixel size in a CCD. This is
+modelled by assuming that the input is not $\ell(x,y)$, but
+$\ell(x,y,\sigma_n)$, where $\sigma_n$ is a *nominal smoothing*,
+usually taken to be 0.5 (half a pixel standard deviation). This also
+means that $\sigma = \sigma_n = 0.5$ is the *finest scale* that can
+actually be computed.
+
+The scale space structure stores samples of the function
+$\ell(x,y,\sigma)$. The density of the sampling of the spatial
+coordinates $x$ and $y$ is adjusted as a function of the scale
+$\sigma$, corresponding to the intuition that images at a coarse
+resolution can be sampled more coarsely without loss of
+information. Thus, the scale space has the structure of a *pyramid*: a
+collection of digital images sampled at progressively coarser spatial
+resolution and hence of progressively smaller size (in pixels).
+
+The following figure illustrates the scale space pyramid structure:
+
+@image html scalespace-basic.png "A scalespace structure with 2 octaves and S=3 subdivisions per octave"
+
+The pyramid is organised in a number of *octaves*, indexed by a
+parameter `o`. Each octave is further subdivided into *sublevels*,
+indexed by a parameter `s`. These are related to the scale $\sigma$ by
+the equation
+
+\[
+  \sigma(s,o) = \sigma_o 2^{\displaystyle o + \frac{s}{\mathtt{octaveResolution}}}
+\]
+
+where `octaveResolution` is the resolution of the octave subsampling
+$\sigma_0$ is the *base smoothing*.
+
+At each octave the spatial resolution is doubled, in the sense that
+samples are take with a step of
+\[
+\mathtt{step} = 2^o.
+\]
+Hence, denoting as `level[i,j]` the corresponding samples, one has
+$\ell(x,y,\sigma) = \mathtt{level}[i,j]$, where
+\[
+ (x,y) = (i,j) \times \mathtt{step},
+\quad
+\sigma = \sigma(o,s),
+ \quad
+ 0 \leq i < \mathtt{lwidth},
+\quad
+ 0 \leq j < \mathtt{lheight},
+\]
+where
+\[
+  \mathtt{lwidth} = \lfloor \frac{\mathtt{width}}{2^\mathtt{o}}\rfloor, \quad
+  \mathtt{lheight} = \lfloor \frac{\mathtt{height}}{2^\mathtt{o}}\rfloor.
+\]
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section scalespace-geometry Scale space geometry
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+In addition to the parameters discussed above, the geometry of the
+data stored in a scale space structure depends on the range of
+allowable octaves `o` and scale sublevels `s`.
+
+While `o` may range in any reasonable value given the size of the
+input image `image`, usually its minimum value is either 0 or -1. The
+latter corresponds to doubling the resolution of the image in the
+first octave of the scale space and it is often used in feature
+extraction. While there is no information added to the image by
+upsampling in this manner, fine scale filters, including derivative
+filters, are much easier to compute by upsalmpling first. The maximum
+practical value is dictated by the image resolution, as it should be
+$2^o\leq\min\{\mathtt{width},\mathtt{height}\}$. VLFeat has the
+flexibility of specifying the range of `o` using the `firstOctave` and
+`lastOctave` parameters of the ::VlScaleSpaceGeometry structure.
+
+The sublevel `s` varies naturally in the range
+$\{0,\dots,\mathtt{octaveResolution}-1\}$. However, it is often
+convenient to store a few extra levels per octave (e.g. to compute the
+local maxima of a function in scale or the Difference of Gaussian
+cornerness measure). Thus VLFeat scale space structure allows this
+parameter to vary in an arbitrary range, specified by the parameters
+`octaveFirstSubdivision` and `octaveLastSubdivision` of
+::VlScaleSpaceGeometry.
+
+Overall the possible values of the indexes `o` and `s` are:
+
+\[
+\mathtt{firstOctave} \leq o \leq \mathtt{lastOctave},
+\qquad
+\mathtt{octaveFirstSubdivision} \leq s \leq \mathtt{octaveLastSubdivision}.
+\]
+
+Note that, depending on these ranges, there could be *redundant pairs*
+of indexes `o` and `s` that represent the *same* pyramid level at more
+than one sampling resolution. In practice, the ability to generate
+such redundant information is very useful in algorithms using
+scalespaces, as coding multiscale operations using a fixed sampling
+resolution is far easier. For example, the DoG feature detector
+computes the scalespace with three redundant levels per octave, as
+follows:
+
+@image html scalespace.png "A scalespace containing redundant representation of certain scale levels."
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+@section scalespace-algorithm Algorithm and limitations
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
+
+Given $\ell(x,y,\sigma_n)$, any of a vast number digitial filtering
+techniques can be used to compute the scale levels. Presently, VLFeat
+uses a basic FIR implementation of the Gaussian filters.
+
+The FIR implementation is obtained by sampling the Gaussian function
+and re-normalizing it to have unit norm. This simple construction does
+not account properly for sampling effect, which may be a problem for
+very small Gausisan kernels. As a rule of thumb, such filters work
+sufficiently well for, say, standard deviation $\sigma$ at least 1.6
+times the sampling step. A work around to apply this basic FIR
+implementation to very small Gaussian filters is to upsample the image
+first.
+
+The limitations on the FIR filters have relatively important for the
+pyramid construction, as the latter is obtained by *incremental
+smoothing*: each successive level is obtained from the previous one by
+adding the needed amount of smoothing. In this manner, the size of the
+FIR filters remains small, which makes them efficient; at the same
+time, for what discussed, excessively small filters are not
+represented properly.
+
+*/
+
+#include "scalespace.h"
+#include "mathop.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdio.h>
+
+/** @file scalespace.h
+ ** @struct VlScaleSpace
+ ** @brief Scale space class
+ **
+ ** This is an opaque class used to compute the scale space of an
+ ** image.
+ **/
+
+struct _VlScaleSpace
+{
+  VlScaleSpaceGeometry geom ; /**< Geometry of the scale space */
+  float **octaves ; /**< Data */
+} ;
+
+/* ---------------------------------------------------------------- */
+/** @brief Get the default geometry for a given image size.
+ ** @param width image width.
+ ** @param height image height.
+ ** @return the default scale space geometry.
+ **
+ ** Both @a width and @a height must be at least one pixel wide.
+ **/
+
+VlScaleSpaceGeometry
+vl_scalespace_get_default_geometry (vl_size width, vl_size height)
+{
+  VlScaleSpaceGeometry geom ;
+  assert(width >= 1) ;
+  assert(height >= 1) ;
+  geom.width = width ;
+  geom.height = height ;
+  geom.firstOctave = 0 ;
+  geom.lastOctave = VL_MAX(floor(vl_log2_d(VL_MIN(width, height))) - 3, 0) ;
+  geom.octaveResolution= 3 ;
+  geom.octaveFirstSubdivision = 0 ;
+  geom.octaveLastSubdivision = geom.octaveResolution - 1 ;
+  geom.baseScale = 1.6 * pow(2.0, 1.0 / geom.octaveResolution) ;
+  geom.nominalScale = 0.5 ;
+  return geom ;
+}
+
+#define is_valid_geometry(geom) (\
+geom.firstOctave <= geom.lastOctave && \
+geom.octaveResolution >= 1 && \
+geom.octaveFirstSubdivision <= geom.octaveLastSubdivision && \
+geom.baseScale >= 0.0 && \
+geom.nominalScale >= 0.0)
+
+/** @brief Check scale space geometries for equality
+ ** @param a first geometry.
+ ** @param b second geometry.
+ ** @return true if equal.
+ **/
+
+vl_bool
+vl_scalespacegeometry_is_equal (VlScaleSpaceGeometry a,
+                                VlScaleSpaceGeometry b)
+{
+  return
+  a.width == b.width &&
+  a.height == b.height &&
+  a.firstOctave == b.firstOctave &&
+  a.lastOctave == b.lastOctave &&
+  a.octaveResolution == b.octaveResolution &&
+  a.octaveFirstSubdivision == b.octaveLastSubdivision &&
+  a.baseScale == b.baseScale &&
+  a.nominalScale == b.nominalScale ;
+}
+
+/** @brief Get the geometry of the scale space.
+ ** @param self object.
+ ** @return the scale space geometry.
+ **/
+
+VlScaleSpaceGeometry
+vl_scalespace_get_geometry (VlScaleSpace const * self)
+{
+  return self->geom ;
+}
+
+/** @brief Get the geometry of an octave of the scalespace.
+ ** @param self object.
+ ** @param o octave index.
+ ** @return the geometry of octave @a o.
+ **/
+
+VlScaleSpaceOctaveGeometry
+vl_scalespace_get_octave_geometry (VlScaleSpace const * self, vl_index o)
+{
+  VlScaleSpaceOctaveGeometry ogeom ;
+  ogeom.width = VL_SHIFT_LEFT(self->geom.width, -o) ;
+  ogeom.height = VL_SHIFT_LEFT(self->geom.height, -o) ;
+  ogeom.step = pow(2.0, o) ;
+  return ogeom ;
+}
+
+/** @brief Get the data of a scale space level
+ ** @param self object.
+ ** @param o octave index.
+ ** @param s level index.
+ ** @return pointer to the data for octave @a o, level @a s.
+ **
+ ** The octave index @a o must be in the range @c firstOctave
+ ** to @c lastOctave and the scale index @a s must be in the
+ ** range @c octaveFirstSubdivision to @c octaveLastSubdivision.
+ **/
+
+float *
+vl_scalespace_get_level (VlScaleSpace *self, vl_index o, vl_index s)
+{
+  VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(self,o) ;
+  float * octave ;
+  assert(self) ;
+  assert(o >= self->geom.firstOctave) ;
+  assert(o <= self->geom.lastOctave) ;
+  assert(s >= self->geom.octaveFirstSubdivision) ;
+  assert(s <= self->geom.octaveLastSubdivision) ;
+
+  octave = self->octaves[o - self->geom.firstOctave] ;
+  return octave + ogeom.width * ogeom.height * (s - self->geom.octaveFirstSubdivision) ;
+}
+
+/** @brief Get the data of a scale space level (const)
+ ** @param self object.
+ ** @param o octave index.
+ ** @param s level index.
+ ** @return pointer to the data for octave @a o, level @a s.
+ **
+ ** This function is the same as ::vl_scalespace_get_level but reutrns
+ ** a @c const pointer to the data.
+ **/
+
+float const *
+vl_scalespace_get_level_const (VlScaleSpace const * self, vl_index o, vl_index s)
+{
+  return vl_scalespace_get_level((VlScaleSpace*)self, o, s) ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Get the scale of a given octave and sublevel
+ ** @param self object.
+ ** @param o octave index.
+ ** @param s sublevel index.
+ **
+ ** The function returns the scale $\sigma(o,s)$ as a function of the
+ ** octave index @a o and sublevel @a s.
+ **/
+
+double
+vl_scalespace_get_level_sigma (VlScaleSpace const *self, vl_index o, vl_index s)
+{
+  return self->geom.baseScale * pow(2.0, o + (double) s / self->geom.octaveResolution) ;
+}
+
+/** ------------------------------------------------------------------
+ ** @internal @brief Upsample the rows and take the transpose
+ ** @param destination output image.
+ ** @param source input image.
+ ** @param width input image width.
+ ** @param height input image height.
+ **
+ ** The output image has dimensions @a height by 2 @a width (so the
+ ** destination buffer must be at least as big as two times the
+ ** input buffer).
+ **
+ ** Upsampling is performed by linear interpolation.
+ **/
+
+static void
+copy_and_upsample
+(float *destination,
+ float const *source, vl_size width, vl_size height)
+{
+  vl_index x, y, ox, oy ;
+  float v00, v10, v01, v11 ;
+
+  assert(destination) ;
+  assert(source) ;
+
+  for(y = 0 ; y < (signed)height ; ++y) {
+    oy = (y < ((signed)height - 1)) * width ;
+    v10 = source[0] ;
+    v11 = source[oy] ;
+    for(x = 0 ; x < (signed)width ; ++x) {
+      ox = x < ((signed)width - 1) ;
+      v00 = v10 ;
+      v01 = v11 ;
+      v10 = source[ox] ;
+      v11 = source[ox + oy] ;
+      destination[0] = v00 ;
+      destination[1] = 0.5f * (v00 + v10) ;
+      destination[2*width] = 0.5f * (v00 + v01) ;
+      destination[2*width+1] = 0.25f * (v00 + v01 + v10 + v11) ;
+      destination += 2 ;
+      source ++;
+    }
+    destination += 2*width ;
+  }
+}
+
+/** ------------------------------------------------------------------
+ ** @internal @brief Downsample
+ ** @param destination output imgae buffer.
+ ** @param source input image buffer.
+ ** @param width input image width.
+ ** @param height input image height.
+ ** @param numOctaves octaves (non negative).
+ **
+ ** The function downsamples the image @a d times, reducing it to @c
+ ** 1/2^d of its original size. The parameters @a width and @a height
+ ** are the size of the input image. The destination image @a dst is
+ ** assumed to be <code>floor(width/2^d)</code> pixels wide and
+ ** <code>floor(height/2^d)</code> pixels high.
+ **/
+
+static void
+copy_and_downsample
+(float *destination,
+ float const *source,
+ vl_size width, vl_size height, vl_size numOctaves)
+{
+  vl_index x, y ;
+  vl_size step = 1 << numOctaves ; /* step = 2^numOctaves */
+
+  assert(destination) ;
+  assert(source) ;
+
+  if (numOctaves == 0) {
+    memcpy(destination, source, sizeof(float) * width * height) ;
+  } else {
+    for(y = 0 ; y < (signed)height ; y += step) {
+      float const *p = source + y * width ;
+      for(x = 0 ; x < (signed)width - ((signed)step - 1) ; x += step) {
+        *destination++ = *p ;
+        p += step ;
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Create a new scale space object
+ ** @param width image width.
+ ** @param height image height.
+ ** @return new scale space object.
+ **
+ ** This function is the same as ::vl_scalespace_new_with_geometry()
+ ** but it uses ::vl_scalespace_get_default_geometry to initialise
+ ** the geometry of the scale space from the image size.
+ **
+ ** @sa ::vl_scalespace_new_with_geometry(), ::vl_scalespace_delete().
+ **/
+
+VlScaleSpace *
+vl_scalespace_new (vl_size width, vl_size height)
+{
+  VlScaleSpaceGeometry geom ;
+  geom = vl_scalespace_get_default_geometry(width, height) ;
+  return vl_scalespace_new_with_geometry(geom) ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Create a new scale space with the specified geometry
+ ** @param geom scale space geomerty.
+ ** @return new scale space object.
+ **
+ ** If the geometry is not valid (see ::VlScaleSpaceGeometry), the
+ ** result is unpredictable.
+ **
+ ** The function returns `NULL` if it was not possible to allocate the
+ ** object because of an out-of-memory condition.
+ **
+ ** @sa ::VlScaleSpaceGeometry, ::vl_scalespace_delete().
+ **/
+
+VlScaleSpace *
+vl_scalespace_new_with_geometry (VlScaleSpaceGeometry geom)
+{
+
+  vl_index o ;
+  vl_size numSublevels = geom.octaveLastSubdivision - geom.octaveFirstSubdivision + 1 ;
+  vl_size numOctaves = geom.lastOctave - geom.firstOctave + 1 ;
+  VlScaleSpace *self ;
+
+  assert(is_valid_geometry(geom)) ;
+  numOctaves = geom.lastOctave - geom.firstOctave + 1 ;
+  numSublevels = geom.octaveLastSubdivision - geom.octaveFirstSubdivision + 1 ;
+
+  self = vl_calloc(1, sizeof(VlScaleSpace)) ;
+  if (self == NULL) goto err_alloc_self ;
+  self->geom = geom ;
+  self->octaves = vl_calloc(numOctaves, sizeof(float*)) ;
+  if (self->octaves == NULL) goto err_alloc_octave_list ;
+  for (o = self->geom.firstOctave ; o <= self->geom.lastOctave ; ++o) {
+    VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(self,o) ;
+    vl_size octaveSize = ogeom.width * ogeom.height * numSublevels ;
+    self->octaves[o - self->geom.firstOctave] = vl_malloc(octaveSize * sizeof(float)) ;
+    if (self->octaves[o - self->geom.firstOctave] == NULL) goto err_alloc_octaves;
+  }
+  return self ;
+
+err_alloc_octaves:
+  for (o = self->geom.firstOctave ; o <= self->geom.lastOctave ; ++o) {
+    if (self->octaves[o - self->geom.firstOctave]) {
+      vl_free(self->octaves[o - self->geom.firstOctave]) ;
+    }
+  }
+err_alloc_octave_list:
+  vl_free(self) ;
+err_alloc_self:
+  return NULL ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Create a new copy of the object
+ ** @param self object to copy from.
+ **
+ ** The function returns `NULL` if the copy cannot be made due to an
+ ** out-of-memory condition.
+ **/
+
+VlScaleSpace *
+vl_scalespace_new_copy (VlScaleSpace* self)
+{
+  vl_index o  ;
+  VlScaleSpace * copy = vl_scalespace_new_shallow_copy(self) ;
+  if (copy == NULL) return NULL ;
+
+  for (o = self->geom.firstOctave ; o <= self->geom.lastOctave ; ++o) {
+    VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(self,o) ;
+    vl_size numSubevels = self->geom.octaveLastSubdivision - self->geom.octaveFirstSubdivision + 1;
+    memcpy(copy->octaves[o - self->geom.firstOctave],
+           self->octaves[o - self->geom.firstOctave],
+           ogeom.width * ogeom.height * numSubevels * sizeof(float)) ;
+  }
+  return copy ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Create a new shallow copy of the object
+ ** @param self object to copy from.
+ **
+ ** The function works like ::vl_scalespace_new_copy() but only allocates
+ ** the scale space, without actually copying the data.
+ **/
+
+VlScaleSpace *
+vl_scalespace_new_shallow_copy (VlScaleSpace* self)
+{
+  return vl_scalespace_new_with_geometry (self->geom) ;
+}
+
+/* ---------------------------------------------------------------- */
+/** @brief Delete object
+ ** @param self object to delete.
+ ** @sa ::vl_scalespace_new()
+ **/
+
+void
+vl_scalespace_delete (VlScaleSpace * self)
+{
+  if (self) {
+    if (self->octaves) {
+      vl_index o ;
+      for (o = self->geom.firstOctave ; o <= self->geom.lastOctave ; ++o) {
+        if (self->octaves[o - self->geom.firstOctave]) {
+          vl_free(self->octaves[o - self->geom.firstOctave]) ;
+        }
+      }
+      vl_free(self->octaves) ;
+    }
+    vl_free(self) ;
+  }
+}
+
+/* ---------------------------------------------------------------- */
+
+/** @internal @brief Fill octave starting from the first level
+ ** @param self object instance.
+ ** @param o octave to process.
+ **
+ ** The function takes the first sublevel of octave @a o (the one at
+ ** sublevel `octaveFirstLevel` and iteratively
+ ** smoothes it to obtain the other octave levels.
+ **/
+
+void
+_vl_scalespace_fill_octave (VlScaleSpace *self, vl_index o)
+{
+  vl_index s ;
+  VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(self, o) ;
+
+  for(s = self->geom.octaveFirstSubdivision + 1 ;
+      s <= self->geom.octaveLastSubdivision ; ++s) {
+    double sigma = vl_scalespace_get_level_sigma(self, o, s) ;
+    double previousSigma = vl_scalespace_get_level_sigma(self, o, s - 1) ;
+    double deltaSigma = sqrtf(sigma*sigma - previousSigma*previousSigma) ;
+
+    float* level = vl_scalespace_get_level (self, o, s) ;
+    float* previous = vl_scalespace_get_level (self, o, s-1) ;
+    vl_imsmooth_f (level, ogeom.width,
+                   previous, ogeom.width, ogeom.height, ogeom.width,
+                   deltaSigma / ogeom.step, deltaSigma / ogeom.step) ;
+  }
+}
+
+/** ------------------------------------------------------------------
+ ** @internal @brief Initialize the first level of an octave from an image
+ ** @param self ::VlScaleSpace object instance.
+ ** @param image image data.
+ ** @param o octave to start.
+ **
+ ** The function initializes the first level of octave @a o from
+ ** image @a image. The dimensions of the image are the ones set
+ ** during the creation of the ::VlScaleSpace object instance.
+ **/
+
+static void
+_vl_scalespace_start_octave_from_image (VlScaleSpace *self,
+                                        float const *image,
+                                        vl_index o)
+{
+  float *level ;
+  double sigma, imageSigma ;
+  vl_index op ;
+
+  assert(self) ;
+  assert(image) ;
+  assert(o >= self->geom.firstOctave) ;
+  assert(o <= self->geom.lastOctave) ;
+
+  /*
+   * Copy the image to self->geom.octaveFirstSubdivision of octave o, upscaling or
+   * downscaling as needed.
+   */
+
+  level = vl_scalespace_get_level(self, VL_MAX(0, o), self->geom.octaveFirstSubdivision) ;
+  copy_and_downsample(level, image, self->geom.width, self->geom.height, VL_MAX(0, o)) ;
+
+  for (op = -1 ; op >= o ; --op) {
+    VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(self, op + 1) ;
+    float *succLevel = vl_scalespace_get_level(self, op + 1, self->geom.octaveFirstSubdivision) ;
+    level = vl_scalespace_get_level(self, op, self->geom.octaveFirstSubdivision) ;
+    copy_and_upsample(level, succLevel, ogeom.width, ogeom.height) ;
+  }
+
+  /*
+   * Adjust the smoothing of the first level just initialised, accounting
+   * for the fact that the input image is assumed to be a nominal scale
+   * level.
+   */
+
+  sigma = vl_scalespace_get_level_sigma(self, o, self->geom.octaveFirstSubdivision) ;
+  imageSigma = self->geom.nominalScale ;
+
+  if (sigma > imageSigma) {
+    VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(self, o) ;
+    double deltaSigma = sqrt (sigma*sigma - imageSigma*imageSigma) ;
+    level = vl_scalespace_get_level (self, o, self->geom.octaveFirstSubdivision) ;
+    vl_imsmooth_f (level, ogeom.width,
+                   level, ogeom.width, ogeom.height, ogeom.width,
+                   deltaSigma / ogeom.step, deltaSigma / ogeom.step) ;
+  }
+}
+
+/** @internal @brief Initialize the first level of an octave from the previous octave
+ ** @param self object.
+ ** @param o octave to initialize.
+ **
+ ** The function initializes the first level of octave @a o from the
+ ** content of octave <code>o - 1</code>.
+ **/
+
+static void
+_vl_scalespace_start_octave_from_previous_octave (VlScaleSpace *self, vl_index o)
+{
+  double sigma, prevSigma ;
+  float *level, *prevLevel ;
+  vl_index prevLevelIndex ;
+  VlScaleSpaceOctaveGeometry ogeom ;
+
+  assert(self) ;
+  assert(o > self->geom.firstOctave) ; /* must not be the first octave */
+  assert(o <= self->geom.lastOctave) ;
+
+  /*
+   * From the previous octave pick the level which is closer to
+   * self->geom.octaveFirstSubdivision in this octave.
+   * The is self->geom.octaveFirstSubdivision + self->numLevels since there are
+   * self->geom.octaveResolution levels in an octave, provided that
+   * this value does not exceed self->geom.octaveLastSubdivision.
+   */
+
+  prevLevelIndex = VL_MIN(self->geom.octaveFirstSubdivision
+                          + (signed)self->geom.octaveResolution,
+                          self->geom.octaveLastSubdivision) ;
+  prevLevel = vl_scalespace_get_level (self, o - 1, prevLevelIndex) ;
+  level = vl_scalespace_get_level (self, o, self->geom.octaveFirstSubdivision) ;
+  ogeom = vl_scalespace_get_octave_geometry(self, o - 1) ;
+
+  copy_and_downsample (level, prevLevel, ogeom.width, ogeom.height, 1) ;
+
+  /*
+   * Add remaining smoothing, if any.
+   */
+
+  sigma = vl_scalespace_get_level_sigma(self, o, self->geom.octaveFirstSubdivision) ;
+  prevSigma = vl_scalespace_get_level_sigma(self, o - 1, prevLevelIndex) ;
+
+  if (sigma > prevSigma) {
+    VlScaleSpaceOctaveGeometry ogeom = vl_scalespace_get_octave_geometry(self, o) ;
+    double deltaSigma = sqrt (sigma*sigma - prevSigma*prevSigma) ;
+    level = vl_scalespace_get_level (self, o, self->geom.octaveFirstSubdivision) ;
+
+    /* todo: this may fail due to an out-of-memory condition */
+    vl_imsmooth_f (level, ogeom.width,
+                   level, ogeom.width, ogeom.height, ogeom.width,
+                   deltaSigma / ogeom.step, deltaSigma / ogeom.step) ;
+  }
+}
+
+/** @brief Initialise Scale space with new image
+ ** @param self ::VlScaleSpace object instance.
+ ** @param image image to process.
+ **
+ ** Compute the data of all the defined octaves and scales of the scale
+ ** space @a self.
+ **/
+
+void
+vl_scalespace_put_image (VlScaleSpace *self, float const *image)
+{
+  vl_index o ;
+  _vl_scalespace_start_octave_from_image(self, image, self->geom.firstOctave) ;
+  _vl_scalespace_fill_octave(self, self->geom.firstOctave) ;
+  for (o = self->geom.firstOctave + 1 ; o <= self->geom.lastOctave ; ++o) {
+    _vl_scalespace_start_octave_from_previous_octave(self, o) ;
+    _vl_scalespace_fill_octave(self, o) ;
+  }
+}

--- a/src/nonFree/sift/vl/scalespace.h
+++ b/src/nonFree/sift/vl/scalespace.h
@@ -1,0 +1,99 @@
+/** @file scalespace.h
+ ** @brief Scale Space (@ref scalespace)
+ ** @author Andrea Vedaldi
+ ** @author Karel Lenc
+ ** @author Michal Perdoch
+ **/
+
+/*
+Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+#ifndef VL_SCALESPACE_H
+#define VL_SCALESPACE_H
+
+#include "generic.h"
+#include "imopv.h"
+#include "mathop.h"
+
+/* ---------------------------------------------------------------- */
+/*                                             VlScaleSpaceGeometry */
+/* ---------------------------------------------------------------- */
+
+/** @brief Geometry of a scale space
+ **
+ ** There are a few restrictions on the valid geometrties.
+ */
+typedef struct _VlScaleSpaceGeometry
+{
+  vl_size width ; /**< Image width */
+  vl_size height ; /**< Image height */
+  vl_index firstOctave ; /**< Index of the fisrt octave */
+  vl_index lastOctave ; /**< Index of the last octave */
+  vl_size octaveResolution ; /**< Number of octave subdivisions */
+  vl_index octaveFirstSubdivision ; /**< Index of the first octave subdivision */
+  vl_index octaveLastSubdivision ; /**< Index of the last octave subdivision */
+  double baseScale ; /**< Base smoothing (smoothing of octave 0, level 0) */
+  double nominalScale ; /**< Nominal smoothing of the original image */
+} VlScaleSpaceGeometry ;
+
+VL_EXPORT
+vl_bool vl_scalespacegeometry_is_equal (VlScaleSpaceGeometry a,
+                                        VlScaleSpaceGeometry b) ;
+
+/* ---------------------------------------------------------------- */
+/*                                       VlScaleSpaceOctaveGeometry */
+/* ---------------------------------------------------------------- */
+
+/** @brief Geometry of one octave of a scale space */
+typedef struct _VlScaleSpaceOctaveGeometry
+{
+  vl_size width ; /**< Width (number of pixels) */
+  vl_size height ; /**< Height (number of pixels) */
+  double step ; /**< Sampling step (size of a pixel) */
+} VlScaleSpaceOctaveGeometry ;
+
+/* ---------------------------------------------------------------- */
+/*                                                     VlScaleSpace */
+/* ---------------------------------------------------------------- */
+
+typedef struct _VlScaleSpace VlScaleSpace ;
+
+/** @name Create and destroy
+ ** @{
+ **/
+VL_EXPORT VlScaleSpaceGeometry vl_scalespace_get_default_geometry(vl_size width, vl_size height) ;
+VL_EXPORT VlScaleSpace * vl_scalespace_new (vl_size width, vl_size height) ;
+VL_EXPORT VlScaleSpace * vl_scalespace_new_with_geometry (VlScaleSpaceGeometry geom) ;
+VL_EXPORT VlScaleSpace * vl_scalespace_new_copy (VlScaleSpace* src);
+VL_EXPORT VlScaleSpace * vl_scalespace_new_shallow_copy (VlScaleSpace* src);
+VL_EXPORT void vl_scalespace_delete (VlScaleSpace *self) ;
+/** @} */
+
+/** @name Process data
+ ** @{
+ **/
+VL_EXPORT void
+vl_scalespace_put_image (VlScaleSpace *self, float const* image);
+/** @} */
+
+/** @name Retrieve data and parameters
+ ** @{
+ **/
+VL_EXPORT VlScaleSpaceGeometry vl_scalespace_get_geometry (VlScaleSpace const * self) ;
+VL_EXPORT VlScaleSpaceOctaveGeometry vl_scalespace_get_octave_geometry (VlScaleSpace const * self, vl_index o) ;
+VL_EXPORT float *
+vl_scalespace_get_level (VlScaleSpace * self, vl_index o, vl_index s) ;
+VL_EXPORT float const *
+vl_scalespace_get_level_const (VlScaleSpace const * self, vl_index o, vl_index s) ;
+VL_EXPORT double
+vl_scalespace_get_level_sigma (VlScaleSpace const *self, vl_index o, vl_index s) ;
+/** @} */
+
+/* VL_SCALESPACE_H */
+#endif
+

--- a/src/nonFree/sift/vl/sift.c
+++ b/src/nonFree/sift/vl/sift.c
@@ -19,27 +19,17 @@ the terms of the BSD license (see the COPYING file).
 reports. Although the following list is certainly incomplete, we would
 like to thank: Wei Dong, Loic, Giuseppe, Liu, Erwin, P. Ivanov, and
 Q. S. Luo.
+@tableofcontents
 <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
 
 @ref sift.h implements a @ref sift-usage "SIFT filter object", a
 reusable object to extract SIFT features @cite{lowe99object} from one
 or multiple images.
 
-- @ref sift-intro
-  - @ref sift-intro-detector
-  - @ref sift-intro-descriptor
-  - @ref sift-intro-extensions
-- @ref sift-usage
-- @ref sift-tech
-  - @ref sift-tech-ss
-  - @ref sift-tech-detector
-    -  @ref sift-tech-detector-peak
-    -  @ref sift-tech-detector-edge
-    -  @ref sift-tech-detector-orientation
-  - @ref sift-tech-descriptor
-    - @ref sift-tech-descriptor-can
-    - @ref sift-tech-descriptor-image
-    - @ref sift-tech-descriptor-std
+This is the original VLFeat implementation of SIFT, designed to be
+compatible with Lowe's original SIFT. See @ref covdet for a different
+version of SIFT integrated in the more general covariant feature
+detector engine.
 
 <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
 @section sift-intro Overview
@@ -57,10 +47,6 @@ descriptors of custom keypoints).
 @subsection sift-intro-detector SIFT detector
 <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  -->
 
-@sa
-@ref sift-tech-ss "Scale space technical details",
-@ref sift-tech-detector "Detector technical details"
-
 A SIFT <em>keypoint</em> is a circular image region with an
 orientation. It is described by a geometric <em>frame</em> of four
 parameters: the keypoint center coordinates @e x and @e y, its @e
@@ -68,7 +54,7 @@ scale (the radius of the region), and its @e orientation (an angle
 expressed in radians). The SIFT detector uses as keypoints image
 structures which resemble &ldquo;blobs&rdquo;. By searching for blobs
 at multiple scales and positions, the SIFT detector is invariant (or,
-more accurately, covariant) to translation, rotations, and rescaling
+more accurately, covariant) to translation, rotations, and re scaling
 of the image.
 
 The keypoint orientation is also determined from the local image
@@ -448,7 +434,7 @@ center.
 
 Denote the gradient vector field computed at the scale @f$ \sigma @f$ by
 @f[
-  J(x,y) = \nalba I_\sigma(x,y)
+  J(x,y) = \nabla I_\sigma(x,y)
   =
   \left[\begin{array}{cc}
   \frac{\partial I_\sigma}{\partial x} &
@@ -533,19 +519,19 @@ the image frame). Assume that canonical and image frame are
 related by an affinity:
 
 @f[
-  \mathbf{x} = A \hat\mathbf{x} + T,
+  \mathbf{x} = A \hat{\mathbf{x}} + T,
   \qquad
   \mathbf{x} =
-  \left[\begin{array}{cc}
+  \begin{bmatrix}{c}
     x \\
     y
-  \end{arraty}\right],
+  \end{bmatrix},
   \quad
-  \hat\mathbf{x} =
-  \left[\begin{array}{cc}
+  \mathbf{x} =
+  \begin{bmatrix}{c}
     \hat x \\
     \hat y
-  \end{arraty}\right].
+  \end{bmatrix}.
 @f]
 
 @image html sift-image-frame.png

--- a/src/nonFree/sift/vl/sift.c
+++ b/src/nonFree/sift/vl/sift.c
@@ -1434,6 +1434,7 @@ vl_sift_detect (VlSiftFilt * f)
         k-> x     = xn * xper ;
         k-> y     = yn * xper ;
         k-> sigma = f->sigma0 * pow (2.0, sn/f->S) * xper ;
+        k-> peak_value = vl_abs_d(val);
         ++ k ;
       }
 

--- a/src/nonFree/sift/vl/sift.h
+++ b/src/nonFree/sift/vl/sift.h
@@ -39,6 +39,7 @@ typedef struct _VlSiftKeypoint
   float y ;     /**< y coordinate. */
   float s ;     /**< s coordinate. */
   float sigma ; /**< scale. */
+  float peak_value;
 } VlSiftKeypoint ;
 
 /** ------------------------------------------------------------------

--- a/src/nonFree/sift/vl/stringop.c
+++ b/src/nonFree/sift/vl/stringop.c
@@ -1,0 +1,462 @@
+/** @file stringop.c
+ ** @brief String operations - Definition
+ ** @author Andrea Vedaldi
+ **/
+
+/*
+Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+/**
+@file stringop.h
+@brief String operations
+@author Andrea Vedaldi
+@tableofcontents
+
+@ref stringop.h implements basic string operations. All functions that
+write to strings use range checking, which makes them safer than some
+standard POSIX equivalent (see @ref vl-stringop-err).
+
+@section vl-stringop-enumeration Enumerations
+
+@ref stringop.h defines a simple enumeration data type. This is given
+by an array of enumeration members, represented by
+instances of the ::VlEnumerator strucutre, each storing a
+name-value pair. The enumeration must end by a member whose
+name is set to @c NULL.
+
+Use ::vl_enumeration_get and ::vl_enumeration_get_casei
+to retrieve an enumeration member by name.
+
+@section vl-stringop-file-protocols File protocols
+
+@ref stringop.h defines a few file "protocols" and helps parsing them
+from URL-like formatted strings. The supported protocols are:
+
+<table>
+<caption>File protocols</caption>
+<tr><td>Protocol</td><td>Code</td><td>URL prefix</td></tr>
+<tr><td>ASCII</td><td>::VL_PROT_ASCII</td><td><code>ascii://</code></td></tr>
+<tr><td>BINARY</td><td>::VL_PROT_BINARY</td><td><code>binary://</code></td></tr>
+</table>
+
+@section vl-stringop-err Detecting overflow
+
+@ref stringop.h functions that write a string to a character buffer take
+both the buffer and its size @c n as input. If @c n is not large
+enough, the output may be truncated but it is always a null terminated
+string (provided that @c n &gt;= 1). Such functions also return the
+length of the string that would have been written @c r (which does not
+include the terminating null character) had the buffer been large
+enough.  Hence an <em>overflow</em> can be detected by testing if @c r
+&gt;= @c n, @c r can be used to re-allocate a buffer large enough to
+contain the result, and the operation can be repeated.
+**/
+
+#include "stringop.h"
+
+#include <string.h>
+#include <ctype.h>
+
+/** ------------------------------------------------------------------
+ ** @brief Extract the protocol prefix from a string
+ ** @param string string.
+ ** @param protocol protocol code (output).
+ ** @return pointer to the first character after the protocol prefix.
+ **
+ ** The function extracts the prefix of the string @a string
+ ** terminated by the first occurrence of the @c :// substring (if
+ ** any). It then matches the suffix terminated by @c :// to the
+ ** supported @ref vl-stringop-file-protocols protocols. If @c protocol is not
+ ** @c NULL, the corresponding protocol code is written to @a protocol
+ **
+ ** The function writes to @a protocol the value ::VL_PROT_NONE if no
+ ** suffix is detected and ::VL_PROT_UNKNOWN if there is a suffix but
+ ** it cannot be matched to any of the supported protocols.
+ **/
+
+VL_EXPORT char *
+vl_string_parse_protocol (char const *string, int *protocol)
+{
+  char const * cpt ;
+  int dummy ;
+
+  /* handle the case prot = 0 */
+  if (protocol == 0)
+    protocol = &dummy ;
+
+  /* look for :// */
+  cpt = strstr(string, "://") ;
+
+  if (cpt == 0) {
+    *protocol = VL_PROT_NONE ;
+    cpt = string ;
+  }
+  else {
+    if (strncmp(string, "ascii", cpt - string) == 0) {
+      *protocol = VL_PROT_ASCII ;
+    }
+    else if (strncmp(string, "bin",   cpt - string) == 0) {
+      *protocol = VL_PROT_BINARY ;
+    }
+    else {
+      *protocol = VL_PROT_UNKNOWN ;
+    }
+    cpt += 3 ;
+  }
+  return (char*) cpt ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Get protocol name
+ ** @param protocol protocol code.
+ ** @return pointer protocol name string.
+ **
+ ** The function returns a pointer to a string containing the name of
+ ** the protocol @a protocol (see the @a vl-file-protocols protocols
+ ** list).  If the protocol is unknown the function returns the empty
+ ** string.
+ **/
+
+VL_EXPORT char const *
+vl_string_protocol_name (int protocol)
+{
+  switch (protocol) {
+  case VL_PROT_ASCII:
+    return "ascii" ;
+  case VL_PROT_BINARY:
+    return "bin" ;
+  case VL_PROT_NONE :
+    return "" ;
+  default:
+    return 0 ;
+  }
+}
+
+
+/** ------------------------------------------------------------------
+ ** @brief Extract base of file name
+ ** @param destination destination buffer.
+ ** @param destinationSize size of destination buffer.
+ ** @param source input string.
+ ** @param maxNumStrippedExtensions maximum number of extensions to strip.
+ ** @return length of the destination string.
+ **
+ ** The function removes the leading path and up to @c
+ ** maxNumStrippedExtensions trailing extensions from the string @a
+ ** source and writes the result to the buffer @a destination.
+ **
+ ** The leading path is the longest suffix that ends with either the
+ ** @c \ or @c / characters. An extension is a string starting with
+ ** the <code>.</code> character not containing it. For instance, the string @c
+ ** file.png contains the extension <code>.png</code> and the string @c
+ ** file.tar.gz contains two extensions (<code>.tar</code> and @c <code>.gz</code>).
+ **
+ ** @sa @ref vl-stringop-err.
+ **/
+
+VL_EXPORT vl_size
+vl_string_basename (char * destination,
+                    vl_size destinationSize,
+                    char const * source,
+                    vl_size maxNumStrippedExtensions)
+{
+  char c ;
+  vl_uindex k = 0, beg, end ;
+
+  /* find beginning */
+  beg = 0 ;
+  for (k = 0 ; (c = source[k]) ; ++ k) {
+    if (c == '\\' || c == '/') beg = k + 1 ;
+  }
+
+  /* find ending */
+  end = strlen (source) ;
+  for (k = end ; k > beg ; --k) {
+    if (source[k - 1] == '.' && maxNumStrippedExtensions > 0) {
+      -- maxNumStrippedExtensions ;
+      end = k - 1 ;
+    }
+  }
+
+  return vl_string_copy_sub (destination, destinationSize,
+                             source + beg, source + end) ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Replace wildcard characters by a string
+ ** @param destination output buffer.
+ ** @param destinationSize size of the output buffer.
+ ** @param source input string.
+ ** @param wildcardChar wildcard character.
+ ** @param escapeChar escape character.
+ ** @param replacement replacement string.
+ **
+ ** The function replaces the occurrence of the specified wildcard
+ ** character @a wildcardChar by the string @a replacement. The result
+ ** is written to the buffer @a destination of size @a
+ ** destinationSize.
+ **
+ ** Wildcard characters may be escaped by preceding them by the @a esc
+ ** character. More in general, anything following an occurrence of @a
+ ** esc character is copied verbatim. To disable the escape characters
+ ** simply set @a esc to 0.
+ **
+ ** @return length of the result.
+ ** @sa @ref vl-stringop-err.
+ **/
+
+VL_EXPORT vl_size
+vl_string_replace_wildcard (char * destination,
+                            vl_size destinationSize,
+                            char const * source,
+                            char wildcardChar,
+                            char escapeChar,
+                            char const * replacement)
+{
+  char c ;
+  vl_uindex k = 0 ;
+  vl_bool escape = 0 ;
+
+  while ((c = *source++)) {
+
+    /* enter escape mode ? */
+    if (! escape && c == escapeChar) {
+      escape = 1 ;
+      continue ;
+    }
+
+    /* wildcard or regular? */
+    if (! escape && c == wildcardChar) {
+      char const * repl = replacement ;
+      while ((c = *repl++)) {
+        if (destination && k + 1 < destinationSize) {
+          destination[k] = c ;
+        }
+        ++ k ;
+      }
+    }
+    /* regular character */
+    else {
+      if (destination && k + 1 < destinationSize) {
+        destination[k] = c ;
+      }
+      ++ k ;
+    }
+    escape = 0 ;
+  }
+
+  /* add trailing 0 */
+  if (destinationSize > 0) {
+    destination[VL_MIN(k, destinationSize - 1)] = 0 ;
+  }
+  return  k ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Copy string
+ ** @param destination output buffer.
+ ** @param destinationSize size of the output buffer.
+ ** @param source string to copy.
+ ** @return length of the source string.
+ **
+ ** The function copies the string @a source to the buffer @a
+ ** destination of size @a destinationSize.
+ **
+ ** @sa @ref vl-stringop-err.
+ **/
+
+VL_EXPORT vl_size
+vl_string_copy (char * destination, vl_size destinationSize,
+                char const * source)
+{
+  char c ;
+  vl_uindex k = 0 ;
+
+  while ((c = *source++)) {
+    if (destination && k + 1 < destinationSize) {
+      destination[k] = c ;
+    }
+    ++ k ;
+  }
+
+  /* finalize */
+  if (destinationSize > 0) {
+    destination[VL_MIN(k, destinationSize - 1)] = 0 ;
+  }
+  return  k ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Copy substring
+ ** @param destination output buffer.
+ ** @param destinationSize  size of output buffer.
+ ** @param beginning start of the substring.
+ ** @param end end of the substring.
+ ** @return length of the destination string.
+ **
+ ** The function copies the substring from at @a beginning to @a end
+ ** (not included) to the buffer @a destination of size @a
+ ** destinationSize. If, however, the null character is found before
+ ** @a end, the substring terminates there.
+ **
+ ** @sa @ref vl-stringop-err.
+ **/
+
+VL_EXPORT vl_size
+vl_string_copy_sub (char * destination,
+                    vl_size destinationSize,
+                    char const * beginning,
+                    char const * end)
+{
+  char c ;
+  vl_uindex k = 0 ;
+
+  while (beginning < end && (c = *beginning++)) {
+    if (destination && k + 1 < destinationSize) {
+      destination[k] = c ;
+    }
+    ++ k ;
+  }
+
+  /* finalize */
+  if (destinationSize > 0) {
+    destination[VL_MIN(k, destinationSize - 1)] = 0 ;
+  }
+  return  k ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Search character in reversed order
+ ** @param beginning pointer to the substring beginning.
+ ** @param end pointer to the substring end.
+ ** @param c character to search for.
+ ** @return pointer to last occurrence of @a c, or 0 if none.
+ **
+ ** The function searches for the last occurrence of the character @a c
+ ** in the substring from @a beg to @a end (the latter not being included).
+ **/
+
+VL_EXPORT char *
+vl_string_find_char_rev (char const *beginning, char const* end, char c)
+{
+  while (end -- != beginning) {
+    if (*end == c) {
+      return (char*) end ;
+    }
+  }
+  return 0 ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Calculate string length
+ ** @param string string.
+ ** @return string length.
+ **/
+
+VL_EXPORT vl_size
+vl_string_length (char const *string)
+{
+  vl_uindex i ;
+  for (i = 0 ; string[i] ; ++i) ;
+  return i ;
+}
+
+/** ------------------------------------------------------------------
+ ** @brief Compare strings case-insensitive
+ ** @param string1 fisrt string.
+ ** @param string2 second string.
+ ** @return an integer =,<,> 0 if @c string1 =,<,> @c string2
+ **/
+
+VL_EXPORT int
+vl_string_casei_cmp (const char * string1, const char * string2)
+{
+  while (tolower((char unsigned)*string1) ==
+         tolower((char unsigned)*string2))
+  {
+    if (*string1 == 0) {
+      return 0 ;
+    }
+    string1 ++ ;
+    string2 ++ ;
+  }
+  return
+    (int)tolower((char unsigned)*string1) -
+    (int)tolower((char unsigned)*string2) ;
+}
+
+/* -------------------------------------------------------------------
+ *                                                       VlEnumeration
+ * ---------------------------------------------------------------- */
+
+/** @brief Get a member of an enumeration by name
+ ** @param enumeration array of ::VlEnumerator objects.
+ ** @param name the name of the desired member.
+ ** @return enumerator matching @a name.
+ **
+ ** If @a name is not found in the enumeration, then the value
+ ** @c NULL is returned.
+ **
+ ** @sa vl-stringop-enumeration
+ **/
+
+VL_EXPORT VlEnumerator *
+vl_enumeration_get (VlEnumerator const *enumeration, char const *name)
+{
+  assert(enumeration) ;
+  while (enumeration->name) {
+    if (strcmp(name, enumeration->name) == 0) return (VlEnumerator*)enumeration ;
+    enumeration ++ ;
+  }
+  return NULL ;
+}
+
+/** @brief Get a member of an enumeration by name (case insensitive)
+ ** @param enumeration array of ::VlEnumerator objects.
+ ** @param name the name of the desired member.
+ ** @return enumerator matching @a name.
+ **
+ ** If @a name is not found in the enumeration, then the value
+ ** @c NULL is returned. @a string is matched case insensitive.
+ **
+ **  @sa vl-stringop-enumeration
+ **/
+
+VL_EXPORT VlEnumerator *
+vl_enumeration_get_casei (VlEnumerator const *enumeration, char const *name)
+{
+  assert(enumeration) ;
+  while (enumeration->name) {
+    if (vl_string_casei_cmp(name, enumeration->name) == 0) return (VlEnumerator*)enumeration ;
+    enumeration ++ ;
+  }
+  return NULL ;
+}
+
+/** @brief Get a member of an enumeration by value
+ ** @param enumeration array of ::VlEnumerator objects.
+ ** @param value value of the desired member.
+ ** @return enumerator matching @a value.
+ **
+ ** If @a value is not found in the enumeration, then the value
+ ** @c NULL is returned.
+ **
+ ** @sa vl-stringop-enumeration
+ **/
+
+VL_EXPORT VlEnumerator *
+vl_enumeration_get_by_value (VlEnumerator const *enumeration, vl_index value)
+{
+  assert(enumeration) ;
+  while (enumeration->name) {
+    if (enumeration->value == value) return (VlEnumerator*)enumeration ;
+    enumeration ++ ;
+  }
+  return NULL ;
+}
+

--- a/src/nonFree/sift/vl/stringop.h
+++ b/src/nonFree/sift/vl/stringop.h
@@ -1,0 +1,58 @@
+/** @file stringop.h
+ ** @brief String operations
+ ** @author Andrea Vedaldi
+ **/
+
+/*
+Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+All rights reserved.
+
+This file is part of the VLFeat library and is made available under
+the terms of the BSD license (see the COPYING file).
+*/
+
+#ifndef VL_STRINGOP_H
+#define VL_STRINGOP_H
+
+#include "generic.h"
+
+/** @brief File protocols */
+enum {
+  VL_PROT_UNKNOWN = -1, /**< unknown protocol */
+  VL_PROT_NONE    =  0, /**< no protocol      */
+  VL_PROT_ASCII,        /**< ASCII protocol   */
+  VL_PROT_BINARY        /**< Binary protocol  */
+} ;
+
+
+VL_EXPORT vl_size vl_string_copy (char *destination, vl_size destinationSize, char const *source) ;
+VL_EXPORT vl_size vl_string_copy_sub (char *destination, vl_size destinationSize,
+                                      char const *beginning, char const *end) ;
+VL_EXPORT char *vl_string_parse_protocol (char const *string, int *protocol) ;
+VL_EXPORT char const *vl_string_protocol_name (int prot) ;
+VL_EXPORT vl_size vl_string_basename (char *destination, vl_size destinationSize,
+                                      char const *source, vl_size maxNumStrippedExtension) ;
+VL_EXPORT vl_size vl_string_replace_wildcard (char * destination, vl_size destinationSize,
+                                              char const *src, char wildcardChar, char escapeChar,
+                                              char const *replacement) ;
+VL_EXPORT char *vl_string_find_char_rev (char const *beginning, char const *end, char c) ;
+VL_EXPORT vl_size vl_string_length (char const *string) ;
+VL_EXPORT int vl_string_casei_cmp (const char *string1, const char *string2) ;
+
+/** @name String enumerations
+ ** @{ */
+
+/** @brief Member of an enumeration */
+typedef struct _VlEnumerator
+{
+  char const *name ; /**< enumeration member name. */
+  vl_index value ;   /**< enumeration member value. */
+} VlEnumerator ;
+
+VL_EXPORT VlEnumerator *vl_enumeration_get (VlEnumerator const *enumeration, char const *name) ;
+VL_EXPORT VlEnumerator *vl_enumeration_get_casei (VlEnumerator const *enumeration, char const *name) ;
+VL_EXPORT VlEnumerator *vl_enumeration_get_by_value (VlEnumerator const *enumeration, vl_index value) ;
+/** @} */
+
+/* VL_STRINGOP_H */
+#endif

--- a/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
+++ b/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
@@ -13,6 +13,9 @@
 #include <aliceVision/multiview/relativePose/HomographyKernel.hpp>
 #include <aliceVision/matching/RegionsMatcher.hpp>
 
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/system/cmdline.hpp>
+
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 
 #include <boost/regex.hpp>
@@ -42,183 +45,182 @@ namespace fs = boost::filesystem;
 class RepeatabilityDataset
 {
 public:
-  RepeatabilityDataset
-    (const std::string& folderPath)
-    : folderPath_(folderPath)
-  {
-    loadImages();
-    loadGroundTruthHs();
-  }
+    RepeatabilityDataset(const std::string& folderPath)
+        : folderPath_(folderPath)
+    {
+        loadImages();
+        loadGroundTruthHs();
+    }
 
-  bool check() const {
-    std::cout << "Dataset: " << folderPath_ << std::endl
-     << "#images: " << vec_image_.size() << "\n"
-     << "#homographies: " << vec_H_.size() << std::endl;
-    return !vec_H_.empty() && !vec_image_.empty() && vec_H_.size() == vec_image_.size();
-  }
+    bool check() const
+    {
+        ALICEVISION_LOG_INFO("Dataset: " << folderPath_ << std::endl
+                  << "#images: " << vec_image_.size() << "\n"
+                  << "#homographies: " << vec_H_.size());
+        return !vec_H_.empty() && !vec_image_.empty() && vec_H_.size() == vec_image_.size();
+    }
 
-  const image::Image<RGBColor>& image(size_t i) const { return vec_image_[i]; }
-  const Mat3& H(size_t i) const { return vec_H_[i]; }
-  const size_t size() const { return vec_image_.size(); }
+    const image::Image<RGBColor>& image(size_t i) const { return vec_image_[i]; }
+    const Mat3& H(size_t i) const { return vec_H_[i]; }
+    const size_t size() const { return vec_image_.size(); }
 
 private:
-  /// Load the images of a folder
-  bool loadImages()
-  {
-    std::cout << "Loading images of the dataset: " << folderPath_ << std::endl;
-
-    const boost::regex ppmFilter(".*.ppm");
-    const boost::regex pgmFilter(".*.pgm");
-
-    std::vector<std::string> ppmFiles;
-    std::vector<std::string> pgmFiles;
-
-    boost::filesystem::directory_iterator endItr;
-    for(boost::filesystem::directory_iterator i(folderPath_); i != endItr; ++i)
+    /// Load the images of a folder
+    bool loadImages()
     {
-      if(!boost::filesystem::is_regular_file(i->status()))
-        continue;
+        ALICEVISION_LOG_INFO("Loading images of the dataset: " << folderPath_);
 
-      boost::smatch what;
+        const boost::regex ppmFilter(".*.ppm");
+        const boost::regex pgmFilter(".*.pgm");
 
-      if(boost::regex_match(i->path().filename().string(), what, ppmFilter))
-      {
-        ppmFiles.push_back(i->path().filename().string());
-        continue;
-      }
+        std::vector<std::string> ppmFiles;
+        std::vector<std::string> pgmFiles;
 
-      if(boost::regex_match(i->path().filename().string(), what, pgmFilter))
-      {
-        pgmFiles.push_back(i->path().filename().string());
-      }
+        boost::filesystem::directory_iterator endItr;
+        for(boost::filesystem::directory_iterator i(folderPath_); i != endItr; ++i)
+        {
+            if(!boost::filesystem::is_regular_file(i->status()))
+                continue;
+
+            boost::smatch what;
+
+            if(boost::regex_match(i->path().filename().string(), what, ppmFilter))
+            {
+                ppmFiles.push_back(i->path().filename().string());
+                continue;
+            }
+
+            if(boost::regex_match(i->path().filename().string(), what, pgmFilter))
+            {
+                pgmFiles.push_back(i->path().filename().string());
+            }
+        }
+
+        std::vector<std::string>& vec_image_basename = ppmFiles;
+
+        if(!ppmFiles.empty())
+            vec_image_basename = ppmFiles;
+        else if(!pgmFiles.empty())
+            vec_image_basename = pgmFiles;
+        else
+            return false;
+
+        sort(vec_image_basename.begin(), vec_image_basename.end());
+        vec_image_.resize(vec_image_basename.size());
+        for(int i = 0; i < vec_image_basename.size(); ++i)
+        {
+            const std::string path = (fs::path(folderPath_) / vec_image_basename[i]).string();
+            image::Image<RGBColor> imageRGB;
+            try
+            {
+                image::readImage(path, imageRGB, image::EImageColorSpace::NO_CONVERSION);
+                vec_image_[i] = imageRGB;
+            }
+            catch(std::invalid_argument& e)
+            {
+                image::Image<unsigned char> imageGray;
+                image::readImage(path, imageGray, image::EImageColorSpace::NO_CONVERSION);
+                image::ConvertPixelType(imageGray, &imageRGB);
+                vec_image_[i] = imageRGB;
+            }
+        }
+        return true;
     }
 
-    std::vector<std::string>& vec_image_basename = ppmFiles;
-
-    if(!ppmFiles.empty())
-      vec_image_basename = ppmFiles;
-    else if (!pgmFiles.empty())
-      vec_image_basename = pgmFiles;
-    else
-      return false;
-
-    sort(vec_image_basename.begin(), vec_image_basename.end());
-    vec_image_.resize(vec_image_basename.size());
-    for (int i = 0; i < vec_image_basename.size(); ++i)
+    /// Load the Homography related to each read images:
+    ///  0-> Identity,
+    ///  1-> H1to1p,
+    ///  2-> H1to2p, ...
+    bool loadGroundTruthHs()
     {
-      const std::string path = (fs::path(folderPath_) / vec_image_basename[i]).string();
-      image::Image<RGBColor> imageRGB;
-      try
-      {
-        image::readImage(path, imageRGB, image::EImageColorSpace::NO_CONVERSION);
-        vec_image_[i] = imageRGB;
-      }
-      catch(std::invalid_argument& e)
-      {
-        image::Image<unsigned char> imageGray;
-        image::readImage(path, imageGray, image::EImageColorSpace::NO_CONVERSION);
-        image::ConvertPixelType(imageGray, &imageRGB);
-        vec_image_[i] = imageRGB;
-      }
+        ALICEVISION_LOG_INFO("ground truth homographies of dataset: " << folderPath_);
+        vec_H_.resize(6);
+        for(int i = 0; i < 6; ++i)
+        {
+            if(i == 0)
+            {
+                vec_H_[i] = Mat3::Identity();
+                continue;
+            }
 
+            const std::string path = folderPath_ + "/H1to" + std::to_string(i + 1) + "p";
+            std::ifstream f(path.c_str());
+            if(!f.is_open())
+            {
+                ALICEVISION_LOG_ERROR("Unable to load ground truth homography:\n" << path);
+                return false;
+            }
+            for(int k = 0; k < 9; ++k)
+                f >> vec_H_[i].data()[k];
+
+            vec_H_[i] /= vec_H_[i](2, 2);
+
+            // Display
+            ALICEVISION_LOG_INFO("\nGroundTruthH:\n" << vec_H_[i]);
+        }
+        return true;
     }
-    return true;
-  }
-
-  /// Load the Homography related to each read images:
-  ///  0-> Identity,
-  ///  1-> H1to1p,
-  ///  2-> H1to2p, ...
-  bool loadGroundTruthHs()
-  {
-    std::cout << "ground truth homographies of dataset: " << folderPath_ << std::endl;
-    vec_H_.resize(6);
-    for (int i = 0; i < 6; ++i)
-    {
-      if (i == 0)
-      {
-        vec_H_[i] = Mat3::Identity();
-        continue;
-      }
-
-      const std::string path = folderPath_ + "/H1to" + std::to_string(i+1) + "p";
-      std::ifstream f(path.c_str());
-      if (!f.is_open())
-      {
-        std::cerr << "Error: unable to load ground truth homography:\n"
-             << path << std::endl;
-        return false;
-      }
-      for (int k=0; k<9; ++k)
-        f >> vec_H_[i].data()[k];
-
-      vec_H_[i] /= vec_H_[i](2,2);
-
-      // Display
-      std::cout << "\n\n" << vec_H_[i] << std::endl;
-    }
-    return true;
-  }
 
 private:
-  std::string folderPath_;
+    std::string folderPath_;
 
-  std::vector<image::Image<RGBColor> > vec_image_;
-  std::vector<Mat3> vec_H_;
+    std::vector<image::Image<RGBColor>> vec_image_;
+    std::vector<Mat3> vec_H_;
 };
 
-
-
 /// Export point features based vector to matrices [(x,y)'T, (x,y)'T]
-template< typename FeaturesT, typename MatT >
-void PointsToMat(
-  const IndMatches & matches,
-  const FeaturesT & vec_feats0,
-  const FeaturesT & vec_feats1,
-  MatT & m0,
-  MatT & m1)
+template <typename FeaturesT, typename MatT>
+void PointsToMat(const IndMatches& matches, const FeaturesT& vec_feats0, const FeaturesT& vec_feats1, MatT& m0,
+                 MatT& m1)
 {
-  typedef typename FeaturesT::value_type ValueT; // Container type
-  typedef typename MatT::Scalar Scalar; // Output matrix type
+    typedef typename FeaturesT::value_type ValueT; // Container type
+    typedef typename MatT::Scalar Scalar;          // Output matrix type
 
-  m0.resize(2, matches.size());
-  m1.resize(2, matches.size());
+    m0.resize(2, matches.size());
+    m1.resize(2, matches.size());
 
-  for( size_t i = 0; i < matches.size(); ++i)
-  {
-    const ValueT & feat0 = vec_feats0[matches[i]._i];
-    m0.col(i) << feat0.x(), feat0.y();
-    const ValueT & feat1 = vec_feats1[matches[i]._j];
-    m1.col(i) << feat1.x(), feat1.y();
-  }
+    for(size_t i = 0; i < matches.size(); ++i)
+    {
+        const ValueT& feat0 = vec_feats0[matches[i]._i];
+        m0.col(i) << feat0.x(), feat0.y();
+        const ValueT& feat1 = vec_feats1[matches[i]._j];
+        m1.col(i) << feat1.x(), feat1.y();
+    }
 }
 
 struct RepeatabilityResults_Matching
 {
-  std::map< std::string, std::vector<double> > results;
+    std::map<std::string, std::vector<double>> results;
 
-  bool exportToFile(const std::string & sFile, const std::string & sdatasetName) const
-  {
-    std::ofstream ofs(sFile, std::ofstream::out | std::ofstream::app);
-
-    if( ! ofs.good() )
+    bool exportToFile(const std::string& sFile, const std::string& sdatasetName) const
     {
-        return false ;
-    }
+        std::ofstream ofs(sFile, std::ofstream::out | std::ofstream::app);
+        if(!ofs.good())
+        {
+            return false;
+        }
 
-    ofs << sdatasetName << "\n";
-    for ( const auto & val : results)
-    {
-      const std::string sParam = val.first;
-      const std::vector<double> & vec = val.second;
-      ofs << sParam << ";";
-      std::copy(vec.begin(), vec.end(), std::ostream_iterator<double>(ofs, ";"));
-      ofs << "\n";
-    }
-    ofs.close();
+        ofs << sdatasetName;
+        if(!results.empty())
+        {
+            for(const auto a : results.begin()->second)
+            {
+                ofs << ";";
+            }
+            ofs << "\n";
+            for(const auto& val : results)
+            {
+                const std::string sParam = val.first;
+                const std::vector<double>& vec = val.second;
+                ofs << sParam << ";";
+                std::copy(vec.begin(), vec.end(), std::ostream_iterator<double>(ofs, ";"));
+                ofs << "\n";
+            }
+        }
+        ofs.close();
 
-    return true ;
-  }
+        return true;
+    }
 };
 
 //--
@@ -227,216 +229,272 @@ struct RepeatabilityResults_Matching
 // Must be run one of the dataset contained here:
 //  https://github.com/aliceVision/Features_Repeatability
 //
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char** argv)
 {
-  std::string datasetPath;
-  std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
-  std::string describerPreset = "NORMAL";
-  bool featureRepeatability = false;
-  bool matchingRepeatability = false;
+    std::string datasetPath;
+    std::string outputFolder;
+    std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
+    feature::ConfigurationPreset featDescConfig;
+    bool featureRepeatability = true;
+    bool matchingRepeatability = true;
+    bool forceCpuExtraction = false;
+    int randomSeed = std::mt19937::default_seed;
+    system::EVerboseLevel verboseLevel = system::Logger::getDefaultVerboseLevel();
 
-  po::options_description allParams("AliceVision Sample repeatabilityDataset");
-  allParams.add_options()
-    ("datasetPath", po::value<std::string>(&datasetPath)->required(),
-      "Path to the datasets.")
-    ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
-      feature::EImageDescriberType_informations().c_str())
-    ("describerPreset,p", po::value<std::string>(&describerPreset)->default_value(describerPreset),
-      "Control the ImageDescriber configuration (low, medium, normal, high, ultra).\n"
-      "Configuration 'ultra' can take long time !")
-    ("featureRepeatability", po::value<bool>(&featureRepeatability)->default_value(featureRepeatability),
-      "Feature repeatability.")
-    ("matchingRepeatability", po::value<bool>(&matchingRepeatability)->default_value(matchingRepeatability),
-      "MatchingRepeatability.");
+    po::options_description allParams("AliceVision Sample repeatabilityDataset");
 
-  po::variables_map vm;
-  try
-  {
-    po::store(po::parse_command_line(argc, argv, allParams), vm);
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input", po::value<std::string>(&datasetPath)->required(), "Path to the datasets.")
+        ("output", po::value<std::string>(&outputFolder)->required(), "Output folder");
 
-    if(vm.count("help") || (argc == 1))
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
+        feature::EImageDescriberType_informations().c_str())
+
+        ("describerPreset,p", po::value<feature::EImageDescriberPreset>(&featDescConfig.descPreset)->default_value(featDescConfig.descPreset),
+        "Control the ImageDescriber configuration (low, medium, normal, high, ultra).\n"
+        "Configuration 'ultra' can take long time !")
+        ("describerQuality", po::value<feature::EFeatureQuality>(&featDescConfig.quality)->default_value(featDescConfig.quality),
+        feature::EFeatureQuality_information().c_str())
+        ("gridFiltering", po::value<bool>(&featDescConfig.gridFiltering)->default_value(featDescConfig.gridFiltering),
+        "Enable grid filtering. Highly recommended to ensure usable number of features.")
+        ("contrastFiltering", po::value<feature::EFeatureConstrastFiltering>(&featDescConfig.contrastFiltering)->default_value(featDescConfig.contrastFiltering),
+        feature::EFeatureConstrastFiltering_information().c_str())
+        ("relativePeakThreshold", po::value<float>(&featDescConfig.relativePeakThreshold)->default_value(featDescConfig.relativePeakThreshold),
+        "Peak Threshold relative to median of gradiants.")
+        ("forceCpuExtraction", po::value<bool>(&forceCpuExtraction)->default_value(forceCpuExtraction),
+         "Use only CPU feature extraction methods.")
+
+        ("featureRepeatability", po::value<bool>(&featureRepeatability)->default_value(featureRepeatability),
+        "Feature repeatability.")
+        ("matchingRepeatability", po::value<bool>(&matchingRepeatability)->default_value(matchingRepeatability),
+        "MatchingRepeatability.")
+        ("randomSeed", po::value<int>(&randomSeed)->default_value(randomSeed),
+          "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
+        ;
+
+    po::options_description logParams("Log parameters");
+    logParams.add_options()("verboseLevel,v",
+                            po::value<system::EVerboseLevel>(&verboseLevel)->default_value(verboseLevel),
+                            "verbosity level (fatal, error, warning, info, debug, trace).");
+
+    allParams.add(requiredParams).add(optionalParams).add(logParams);
+
+    po::variables_map vm;
+    try
     {
-      ALICEVISION_COUT(allParams);
-      return EXIT_SUCCESS;
+        po::store(po::parse_command_line(argc, argv, allParams), vm);
+
+        if(vm.count("help") || (argc == 1))
+        {
+            ALICEVISION_COUT(allParams);
+            return EXIT_SUCCESS;
+        }
+        po::notify(vm);
     }
-    po::notify(vm);
-  }
-  catch(boost::program_options::required_option& e)
-  {
-    ALICEVISION_CERR("ERROR: " << e.what());
-    ALICEVISION_COUT("Usage:\n\n" << allParams);
-    return EXIT_FAILURE;
-  }
-  catch(boost::program_options::error& e)
-  {
-    ALICEVISION_CERR("ERROR: " << e.what());
-    ALICEVISION_COUT("Usage:\n\n" << allParams);
-    return EXIT_FAILURE;
-  }
-
-
-  if (featureRepeatability && matchingRepeatability)
-  {
-    std::cerr << "Only one repeatability test can be performed at a time." << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  std::mt19937 randomNumberGenerator;
-
-  //--------------------------
-  // Evaluation parameters
-  //--------------------------
-  // - Precision radius to accept a point as a valid correspondence
-  const double m_dPrecision_robust = 2.5;
-  // - Nearest neighbor distance ratio to accept a photometric match between some descriptor
-  const double nndr = 0.8;
-
-  // List all subdirectories and for each one compute the repeatability
-  std::vector<std::string> vec_dataset_path;
-
-  boost::filesystem::directory_iterator endItr;
-  for(boost::filesystem::directory_iterator i(datasetPath); i != endItr; ++i)
-  {
-    if(boost::filesystem::is_directory(i->status()))
+    catch(boost::program_options::required_option& e)
     {
-      vec_dataset_path.push_back(i->path().string());
-    }
-  }
-
-  for (auto const& dataset_path : vec_dataset_path)
-  {
-    const std::string sPath = (fs::path(datasetPath) / dataset_path).string();
-    if (fs::is_regular_file(sPath))
-      continue;
-
-    RepeatabilityDataset dataset(sPath);
-    if (dataset.check())
-    {
-      // 1. Compute regions
-      // 2. Test the repeatability (localization/overlap (accuracy))
-      // 3. Export data
-
-      using namespace aliceVision::feature;
-      std::unique_ptr<ImageDescriber> image_describer;
-      if (describerTypesName == "SIFT")
-      {
-        image_describer.reset(new ImageDescriber_SIFT(SiftParams()));
-      }
-      else
-      if (describerTypesName == "AKAZE_FLOAT")
-      {
-        image_describer.reset(new ImageDescriber_AKAZE(AKAZEParams(AKAZEOptions(), AKAZE_MSURF)));
-      }
-
-      if (!image_describer)
-      {
-        std::cerr << "Cannot create the designed ImageDescriber:"
-          << describerTypesName << "." << std::endl;
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
         return EXIT_FAILURE;
-      }
-      else
-      {
-        image_describer->setConfigurationPreset(describerPreset);
-      }
-
-      // For each image computes the regions:
-      image::Image<unsigned char> imageGray;
-      HashMap<IndexT, std::unique_ptr<Regions> > map_regions;
-      for (size_t i = 0; i < dataset.size(); ++i)
-      {
-        image::ConvertPixelType(dataset.image(i), &imageGray);
-        image_describer->describe(imageGray, map_regions[i]);
-        std::cout << "image: " << i << "\t #found features: " << map_regions[i]->RegionCount() << std::endl;
-      }
-
-      // Repeatability evaluation to the first image
-      // Evaluate the feature positions accuracy (descriptors are ignored)
-      if (featureRepeatability)
-      {
-        for (size_t i = 1; i < dataset.size(); ++i)
-        {
-          if (map_regions.count(0) == 0 || map_regions.count(i) == 0)
-            continue;
-
-          const Regions * regions_0 = map_regions[0].get();
-          const Regions * regions_I = map_regions[i].get();
-          const PointFeatures pointsFeatures0 = regions_0->GetRegionsPositions();
-          const PointFeatures pointsFeaturesI = regions_I->GetRegionsPositions();
-
-          Mat x0, xI;
-          PointsToMat(pointsFeatures0, x0);
-          PointsToMat(pointsFeaturesI, xI);
-
-          IndMatches matches_0I;
-          matching::guidedMatching<robustEstimation::Mat3Model, multiview::relativePose::HomographyAsymmetricError>(
-            robustEstimation::Mat3Model(dataset.H(i).transpose()), x0, xI, Square(m_dPrecision_robust), matches_0I);
-
-          std::cout << "Feature repeatablity Results" << "\n"
-           << "*******************************" << "\n"
-           << "# Keypoints 1:                        \t" << map_regions[0]->RegionCount() << "\n"
-           << "# Keypoints N:                        \t" << map_regions[i]->RegionCount() << "\n"
-           << "# Inliers:                            \t" << matches_0I.size() << "\n"
-           << "Inliers Ratio (%):                    \t" << matches_0I.size() / (float) map_regions[0]->RegionCount() << "\n"
-           << std::endl;
-        }
-      }
-
-      if (matchingRepeatability)
-      {
-        // Test the repeatability (matching (descriptor))
-        RepeatabilityResults_Matching image_results;
-        for (size_t i = 1; i < dataset.size(); ++i)
-        {
-          if (map_regions.count(0) == 0 || map_regions.count(i) == 0)
-            continue;
-
-          const Regions * regions_0 = map_regions[0].get();
-          const Regions * regions_I = map_regions[i].get();
-          const PointFeatures pointsFeatures0 = regions_0->GetRegionsPositions();
-          const PointFeatures pointsFeaturesI = regions_I->GetRegionsPositions();
-
-          matching::IndMatches putativesMatches;
-          matching::DistanceRatioMatch(
-            randomNumberGenerator,
-            nndr, matching::BRUTE_FORCE_L2,
-            *regions_0, *regions_I,
-            putativesMatches);
-
-          Mat x0, xI;
-          PointsToMat(putativesMatches, pointsFeatures0, pointsFeaturesI, x0, xI);
-
-          IndMatches matches_0I;
-          matching::guidedMatching<robustEstimation::Mat3Model, multiview::relativePose::HomographyAsymmetricError>(
-            robustEstimation::Mat3Model(dataset.H(i).transpose()), x0, xI, Square(m_dPrecision_robust), matches_0I);
-
-          std::cout << "Feature matching repeatability Results" << "\n"
-           << "*******************************" << "\n"
-           << "** " << fs::path(sPath).stem().string() << " **" << "\n"
-           << "*******************************" << "\n"
-           << "# Keypoints 1:                        \t" << map_regions[0]->RegionCount() << "\n"
-           << "# Keypoints N:                        \t" << map_regions[i]->RegionCount() << "\n"
-           << "# Matches:                            \t" << putativesMatches.size() << "\n"
-           << "# Inliers:                            \t" << matches_0I.size() << "\n"
-           << "Inliers Ratio (%):                    \t" << matches_0I.size() / (float) putativesMatches.size() << "\n"
-           << std::endl;
-
-          const std::vector<double> results = {
-            static_cast<double>( map_regions[0]->RegionCount() ) ,
-            static_cast<double>( map_regions[i]->RegionCount() ) ,
-            static_cast<double>( putativesMatches.size() ) ,
-            static_cast<double>( matches_0I.size() ) ,
-            static_cast<double>( matches_0I.size() / (double) putativesMatches.size())
-            };
-          image_results.results[std::to_string(i)] = results;
-        }
-        image_results.exportToFile("repeatability_results.xls", fs::path(sPath).stem().string());
-      }
     }
-    else
+    catch(boost::program_options::error& e)
     {
-      std::cerr << "Invalid dataset folder: " << dataset_path << std::endl;
-      return EXIT_FAILURE;
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
+        return EXIT_FAILURE;
     }
-  }
-  return EXIT_SUCCESS;
+
+    ALICEVISION_COUT("Program called with the following parameters:");
+    ALICEVISION_COUT(vm);
+
+    // set verbose level
+    system::Logger::get()->setLogLevel(verboseLevel);
+
+    std::mt19937 randomNumberGenerator(randomSeed == -1 ? std::random_device()() : randomSeed);
+
+    //--------------------------
+    // Evaluation parameters
+    //--------------------------
+    // - Precision radius to accept a point as a valid correspondence
+    const double m_dPrecision_robust = 2.5;
+    // - Nearest neighbor distance ratio to accept a photometric match between some descriptor
+    const double nndr = 0.8;
+
+    // List all subdirectories and for each one compute the repeatability
+    std::vector<std::string> vec_dataset_path;
+
+    boost::filesystem::directory_iterator endItr;
+    for(boost::filesystem::directory_iterator i(datasetPath); i != endItr; ++i)
+    {
+        if(boost::filesystem::is_directory(i->status()))
+        {
+            vec_dataset_path.push_back(i->path().string());
+        }
+    }
+
+    std::vector<std::shared_ptr<feature::ImageDescriber>> imageDescribers;
+
+    // initialize feature extractor imageDescribers
+    {
+        std::vector<feature::EImageDescriberType> imageDescriberTypes =
+            feature::EImageDescriberType_stringToEnums(describerTypesName);
+
+        for(const auto& imageDescriberType : imageDescriberTypes)
+        {
+            std::shared_ptr<feature::ImageDescriber> imageDescriber = feature::createImageDescriber(imageDescriberType);
+            imageDescriber->setConfigurationPreset(featDescConfig);
+            if(forceCpuExtraction)
+                imageDescriber->setUseCuda(false);
+
+            imageDescribers.push_back(imageDescriber);
+        }
+    }
+
+    for(const auto& imageDescriber : imageDescribers)
+    {
+        const std::string descName = EImageDescriberType_enumToString(imageDescriber->getDescriberType());
+        ALICEVISION_LOG_INFO("Start descName: " << descName);
+        for(auto const& sPath : vec_dataset_path)
+        {
+            ALICEVISION_LOG_INFO("Start dataset: " << sPath);
+
+            if(fs::is_regular_file(sPath))
+                continue;
+
+            RepeatabilityDataset dataset(sPath);
+
+            if(!dataset.check())
+            {
+                ALICEVISION_LOG_WARNING("Invalid dataset folder: " << sPath);
+                continue;
+            }
+
+            // 1. Compute regions
+            // 2. Test the repeatability (localization/overlap (accuracy))
+            // 3. Export data
+
+            using namespace aliceVision::feature;
+
+            // For each image computes the regions:
+            image::Image<float> imageGray;
+            HashMap<IndexT, std::unique_ptr<Regions>> map_regions;
+            for(size_t i = 0; i < dataset.size(); ++i)
+            {
+                image::ConvertPixelType(dataset.image(i), &imageGray);
+                imageDescriber->describe(imageGray, map_regions[i]);
+                ALICEVISION_LOG_INFO("image: " << i << "\t #found features: " << map_regions[i]->RegionCount());
+            }
+
+            // Repeatability evaluation to the first image
+            // Evaluate the feature positions accuracy (descriptors are ignored)
+            if(featureRepeatability)
+            {
+                RepeatabilityResults_Matching featResults;
+                for(size_t i = 1; i < dataset.size(); ++i)
+                {
+                    if(map_regions.count(0) == 0 || map_regions.count(i) == 0)
+                        continue;
+
+                    const Regions* regions_0 = map_regions[0].get();
+                    const Regions* regions_I = map_regions[i].get();
+                    const PointFeatures pointsFeatures0 = regions_0->GetRegionsPositions();
+                    const PointFeatures pointsFeaturesI = regions_I->GetRegionsPositions();
+
+                    Mat x0, xI;
+                    PointsToMat(pointsFeatures0, x0);
+                    PointsToMat(pointsFeaturesI, xI);
+
+                    IndMatches matches_0I;
+                    matching::guidedMatching<robustEstimation::Mat3Model,
+                                                multiview::relativePose::HomographyAsymmetricError>(
+                        robustEstimation::Mat3Model(dataset.H(i).transpose()), x0, xI, Square(m_dPrecision_robust),
+                        matches_0I);
+
+                    ALICEVISION_LOG_INFO("Feature repeatablity Results"
+                                << "\n"
+                                << "*******************************"
+                                << "\n"
+                                << "# Keypoints 1:                        \t" << map_regions[0]->RegionCount() << "\n"
+                                << "# Keypoints N:                        \t" << map_regions[i]->RegionCount() << "\n"
+                                << "# Inliers:                            \t" << matches_0I.size() << "\n"
+                                << "Inliers Ratio (%):                    \t"
+                                << matches_0I.size() / float(map_regions[0]->RegionCount()) << "\n"
+                                );
+
+                    const std::vector<double> results = {
+                        static_cast<double>(map_regions[0]->RegionCount()),
+                        static_cast<double>(map_regions[i]->RegionCount()),
+                        static_cast<double>(matches_0I.size()),
+                        static_cast<double>(matches_0I.size() / float(map_regions[0]->RegionCount()))};
+                    featResults.results[std::to_string(i)] = results;
+                }
+                const std::string outputFilepath =
+                    (fs::path(outputFolder) / (descName + "_featureRepeatability.csv")).string();
+                ALICEVISION_LOG_INFO("Export file: " << outputFilepath);
+                featResults.exportToFile(outputFilepath, fs::path(sPath).stem().string());
+            }
+
+            if(matchingRepeatability)
+            {
+                RepeatabilityResults_Matching matchResults;
+                // Test the repeatability (matching (descriptor))
+                for(size_t i = 1; i < dataset.size(); ++i)
+                {
+                    if(map_regions.count(0) == 0 || map_regions.count(i) == 0)
+                        continue;
+
+                    const Regions* regions_0 = map_regions[0].get();
+                    const Regions* regions_I = map_regions[i].get();
+                    const PointFeatures pointsFeatures0 = regions_0->GetRegionsPositions();
+                    const PointFeatures pointsFeaturesI = regions_I->GetRegionsPositions();
+
+                    matching::IndMatches putativesMatches;
+                    matching::DistanceRatioMatch(
+                            randomNumberGenerator,
+                            nndr, matching::BRUTE_FORCE_L2, *regions_0, *regions_I,
+                            putativesMatches);
+
+                    Mat x0, xI;
+                    PointsToMat(putativesMatches, pointsFeatures0, pointsFeaturesI, x0, xI);
+
+                    IndMatches matches_0I;
+                    matching::guidedMatching<robustEstimation::Mat3Model,
+                                                multiview::relativePose::HomographyAsymmetricError>(
+                        robustEstimation::Mat3Model(dataset.H(i).transpose()), x0, xI, Square(m_dPrecision_robust),
+                        matches_0I);
+
+                    ALICEVISION_LOG_INFO("Feature matching repeatability Results"
+                                << "\n"
+                                << "*******************************"
+                                << "\n"
+                                << "** " << fs::path(sPath).stem().string() << " **"
+                                << "\n"
+                                << "*******************************"
+                                << "\n"
+                                << "# Keypoints 1:                        \t" << map_regions[0]->RegionCount() << "\n"
+                                << "# Keypoints N:                        \t" << map_regions[i]->RegionCount() << "\n"
+                                << "# Matches:                            \t" << putativesMatches.size() << "\n"
+                                << "# Inliers:                            \t" << matches_0I.size() << "\n"
+                                << "Inliers Ratio (%):                    \t"
+                                << matches_0I.size() / (float)putativesMatches.size() << "\n"
+                                );
+
+                    const std::vector<double> results = {
+                        static_cast<double>(map_regions[0]->RegionCount()),
+                        static_cast<double>(map_regions[i]->RegionCount()),
+                        static_cast<double>(putativesMatches.size()),
+                        static_cast<double>(matches_0I.size()),
+                        static_cast<double>(matches_0I.size() / (double)putativesMatches.size())};
+                    matchResults.results[std::to_string(i)] = results;
+                }
+                const std::string outputFilepath = (fs::path(outputFolder) / (descName + "_matchingRepeatability.csv")).string();
+                ALICEVISION_LOG_INFO("Export file: " << outputFilepath);
+                matchResults.exportToFile(outputFilepath, fs::path(sPath).stem().string());
+            }
+        }
+    }
+    return EXIT_SUCCESS;
 }

--- a/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
+++ b/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
   std::string jpgFilenameL;
   std::string jpgFilenameR;
   std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
-  std::string describerPreset = "NORMAL";
+  feature::ConfigurationPreset featDescPreset;
 
   po::options_description allParams("AliceVision Sample describeAndMatch");
   allParams.add_options()
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
       "Right image.")
     ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
       feature::EImageDescriberType_informations().c_str())
-    ("describerPreset,p", po::value<std::string>(&describerPreset)->default_value(describerPreset),
+    ("describerPreset,p", po::value<feature::EImageDescriberPreset>(&featDescPreset.descPreset)->default_value(featDescPreset.descPreset),
       "Control the ImageDescriber configuration (low, medium, normal, high, ultra).\n"
       "Configuration 'ultra' can take long time !");
 
@@ -97,10 +97,7 @@ int main(int argc, char **argv)
     std::cerr << "Invalid ImageDescriber type" << std::endl;
     return EXIT_FAILURE;
   }
-  if(!describerPreset.empty())
-  {
-    image_describer->setConfigurationPreset(describerPreset);
-  }
+  image_describer->setConfigurationPreset(featDescPreset);
 
   //--
   // Detect regions thanks to the image_describer

--- a/src/samples/kvldFilter/main_kvldFilter.cpp
+++ b/src/samples/kvldFilter/main_kvldFilter.cpp
@@ -108,7 +108,9 @@ int main(int argc, char **argv)
   // Detect regions thanks to an image_describer
   //--
   using namespace aliceVision::feature;
-  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(SiftParams(-1)));
+  SiftParams siftParams;
+  siftParams._firstOctave = -1;
+  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(siftParams));
   std::map<IndexT, std::unique_ptr<feature::Regions> > regions_perImage;
   image_describer->describe(imageL, regions_perImage[0]);
   image_describer->describe(imageR, regions_perImage[1]);

--- a/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
+++ b/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
@@ -55,7 +55,9 @@ int main() {
   // Detect regions thanks to an image_describer
   //--
   using namespace aliceVision::feature;
-  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(SiftParams(-1)));
+  SiftParams siftParams;
+  siftParams._firstOctave = -1;
+  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(siftParams));
   std::map<IndexT, std::unique_ptr<feature::Regions> > regions_perImage;
   image_describer->describe(imageL, regions_perImage[0]);
   image_describer->describe(imageR, regions_perImage[1]);

--- a/src/samples/robustFundamental/main_robustFundamental.cpp
+++ b/src/samples/robustFundamental/main_robustFundamental.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 {
   std::string jpgFilenameL;
   std::string jpgFilenameR;
-  std::string describerPreset;
+  feature::ConfigurationPreset featDescPreset;
   
   po::options_description allParams("AliceVision Sample robustFundamental");
   allParams.add_options()
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
       "Left image.")
     ("jpgFilenameR,r", po::value<std::string>(&jpgFilenameR)->required(),
       "Right image.")
-    ("describerPreset,p", po::value<std::string>(&describerPreset)->default_value(describerPreset),
+    ("describerPreset,p", po::value<feature::EImageDescriberPreset>(&featDescPreset.descPreset)->default_value(featDescPreset.descPreset),
       "Control the ImageDescriber configuration (low, medium, normal, high, ultra).\n"
       "Configuration 'ultra' can take long time !");
 
@@ -87,10 +87,7 @@ int main(int argc, char **argv)
   //--
   using namespace aliceVision::feature;
   std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT);
-  if (!describerPreset.empty())
-  {
-    image_describer->setConfigurationPreset(describerPreset);
-  }
+  image_describer->setConfigurationPreset(featDescPreset);
  
   std::map<IndexT, std::unique_ptr<feature::Regions> > regions_perImage;
   image_describer->describe(imageL, regions_perImage[0]);

--- a/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
+++ b/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
@@ -43,8 +43,8 @@ int main(int argc, char **argv)
 {
   std::string filenameLeft;
   std::string filenameRight;
-  std::string describerPreset = feature::EImageDescriberPreset_enumToString(feature::EImageDescriberPreset::NORMAL);
   std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
+  feature::ConfigurationPreset featDescPreset;
   
   po::options_description allParams("AliceVision Sample robustFundamental");
   allParams.add_options()
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
       "Right image.")
     ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
          feature::EImageDescriberType_informations().c_str())
-    ("describerPreset,p", po::value<std::string>(&describerPreset)->default_value(describerPreset),
+    ("describerPreset,p", po::value<feature::EImageDescriberPreset>(&featDescPreset.descPreset)->default_value(featDescPreset.descPreset),
       "Control the ImageDescriber configuration (low, medium, normal, high, ultra).\n"
       "Configuration 'ultra' can take long time !");
 
@@ -96,10 +96,7 @@ int main(int argc, char **argv)
   //--
   using namespace aliceVision::feature;
   std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT);
-  if (!describerPreset.empty())
-  {
-    image_describer->setConfigurationPreset(describerPreset);
-  }
+  image_describer->setConfigurationPreset(featDescPreset);
  
   std::map<IndexT, std::unique_ptr<feature::Regions> > regions_perImage;
   image_describer->describe(imageLeft, regions_perImage[0]);

--- a/src/samples/robustHomography/main_robustHomography.cpp
+++ b/src/samples/robustHomography/main_robustHomography.cpp
@@ -48,7 +48,9 @@ int main() {
   // Detect regions thanks to an image_describer
   //--
   using namespace aliceVision::feature;
-  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(SiftParams(-1)));
+  SiftParams siftParams;
+  siftParams._firstOctave = -1;
+  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(siftParams));
   std::map<IndexT, std::unique_ptr<feature::Regions> > regions_perImage;
   image_describer->describe(imageL, regions_perImage[0]);
   image_describer->describe(imageR, regions_perImage[1]);

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -127,9 +127,8 @@ int main(int argc, char **argv)
   std::string filenameLeft;
   std::string filenameRight;
   std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
-  std::string describerPreset = "NORMAL";
+  feature::ConfigurationPreset featDescPreset;
   float ratioThreshold{0.8f};
-
 
   po::options_description allParams("AliceVision Sample robustHomographyGrowing: it shows how "
                                     "to match the feature robustly using the growing homography algorithm.");
@@ -140,7 +139,7 @@ int main(int argc, char **argv)
            "Right image.")
           ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
            feature::EImageDescriberType_informations().c_str())
-          ("describerPreset,p", po::value<std::string>(&describerPreset)->default_value(describerPreset),
+          ("describerPreset,p", po::value<feature::EImageDescriberPreset>(&featDescPreset.descPreset)->default_value(featDescPreset.descPreset),
            "Control the ImageDescriber configuration (low, medium, normal, high, ultra).\n"
            "Configuration 'ultra' can take long time !")
           ("distanceRatio", po::value<float>(&ratioThreshold)->default_value(ratioThreshold),
@@ -192,10 +191,7 @@ int main(int argc, char **argv)
     std::cerr << "Invalid ImageDescriber type" << std::endl;
     return EXIT_FAILURE;
   }
-  if(!describerPreset.empty())
-  {
-    imageDescriber->setConfigurationPreset(describerPreset);
-  }
+  imageDescriber->setConfigurationPreset(featDescPreset);
 
   //--
   // Detect regions thanks to the imageDescriber

--- a/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
+++ b/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
@@ -46,7 +46,9 @@ int main() {
   // Detect regions thanks to an image_describer
   //--
   using namespace aliceVision::feature;
-  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(SiftParams(-1)));
+  SiftParams siftParams;
+  siftParams._firstOctave = -1;
+  std::unique_ptr<ImageDescriber> image_describer(new ImageDescriber_SIFT(siftParams));
   std::map<IndexT, std::unique_ptr<feature::Regions> > regions_perImage;
   image_describer->describe(imageL, regions_perImage[0]);
   image_describer->describe(imageR, regions_perImage[1]);

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -75,7 +75,7 @@ int aliceVision_main(int argc, char** argv)
   /// the describer types name to use for the matching
   std::string matchDescTypeNames = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
   /// the preset for the feature extractor
-  feature::EImageDescriberPreset featurePreset = feature::EImageDescriberPreset::NORMAL;
+  feature::ConfigurationPreset featDescPreset;
   /// the describer types to use for the matching
   std::vector<feature::EImageDescriberType> matchDescTypes;
   /// the estimator to use for resection
@@ -153,7 +153,7 @@ int aliceVision_main(int argc, char** argv)
           "Folder containing the descriptors for all the images (ie the *.desc.)")
       ("matchDescTypes", po::value<std::string>(&matchDescTypeNames)->default_value(matchDescTypeNames),
           "The describer types to use for the matching")
-      ("preset", po::value<feature::EImageDescriberPreset>(&featurePreset)->default_value(featurePreset), 
+      ("preset", po::value<feature::EImageDescriberPreset>(&featDescPreset.descPreset)->default_value(featDescPreset.descPreset),
           "Preset for the feature extractor when localizing a new image "
           "{LOW,MEDIUM,NORMAL,HIGH,ULTRA}")
       ("resectionEstimator", po::value<robustEstimation::ERobustEstimator>(&resectionEstimator)->default_value(resectionEstimator),
@@ -368,7 +368,7 @@ int aliceVision_main(int argc, char** argv)
   assert(param);
   
   // set other common parameters
-  param->_featurePreset = featurePreset;
+  param->_featurePreset = featDescPreset;
   param->_refineIntrinsics = refineIntrinsics;
   param->_visualDebug = visualDebug;
   param->_errorMax = resectionErrorMax;

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -297,7 +297,7 @@ int aliceVision_main(int argc, char **argv)
   // user optional parameters
 
   std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
-  std::string describerPreset = feature::EImageDescriberPreset_enumToString(feature::EImageDescriberPreset::NORMAL);
+  feature::ConfigurationPreset featDescConfig;
   int rangeStart = -1;
   int rangeSize = 1;
   int maxThreads = 0;
@@ -316,9 +316,17 @@ int aliceVision_main(int argc, char **argv)
   optionalParams.add_options()
     ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
       feature::EImageDescriberType_informations().c_str())
-    ("describerPreset,p", po::value<std::string>(&describerPreset)->default_value(describerPreset),
+    ("describerPreset,p", po::value<feature::EImageDescriberPreset>(&featDescConfig.descPreset)->default_value(featDescConfig.descPreset),
       "Control the ImageDescriber configuration (low, medium, normal, high, ultra).\n"
       "Configuration 'ultra' can take long time !")
+    ("describerQuality", po::value<feature::EFeatureQuality>(&featDescConfig.quality)->default_value(featDescConfig.quality),
+      feature::EFeatureQuality_information().c_str())
+    ("gridFiltering", po::value<bool>(&featDescConfig.gridFiltering)->default_value(featDescConfig.gridFiltering),
+      "Enable grid filtering. Highly recommended to ensure usable number of features.")
+    ("contrastFiltering", po::value<feature::EFeatureConstrastFiltering>(&featDescConfig.contrastFiltering)->default_value(featDescConfig.contrastFiltering),
+      feature::EFeatureConstrastFiltering_information().c_str())
+    ("relativePeakThreshold", po::value<float>(&featDescConfig.relativePeakThreshold)->default_value(featDescConfig.relativePeakThreshold),
+       "Peak Threshold relative to median of gradiants.")
     ("forceCpuExtraction", po::value<bool>(&forceCpuExtraction)->default_value(forceCpuExtraction),
       "Use only CPU feature extraction methods.")
     ("rangeStart", po::value<int>(&rangeStart)->default_value(rangeStart),
@@ -426,7 +434,7 @@ int aliceVision_main(int argc, char **argv)
     for(const auto& imageDescriberType: imageDescriberTypes)
     {
       std::shared_ptr<feature::ImageDescriber> imageDescriber = feature::createImageDescriber(imageDescriberType);
-      imageDescriber->setConfigurationPreset(describerPreset);
+      imageDescriber->setConfigurationPreset(featDescConfig);
       if(forceCpuExtraction)
         imageDescriber->setUseCuda(false);
 

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -323,6 +323,8 @@ int aliceVision_main(int argc, char **argv)
       feature::EFeatureQuality_information().c_str())
     ("gridFiltering", po::value<bool>(&featDescConfig.gridFiltering)->default_value(featDescConfig.gridFiltering),
       "Enable grid filtering. Highly recommended to ensure usable number of features.")
+    ("maxNbFeatures", po::value<int>(&featDescConfig.maxNbFeatures)->default_value(featDescConfig.maxNbFeatures),
+      "Max number of features extracted (0 means default value based on describerPreset).")
     ("contrastFiltering", po::value<feature::EFeatureConstrastFiltering>(&featDescConfig.contrastFiltering)->default_value(featDescConfig.contrastFiltering),
       feature::EFeatureConstrastFiltering_information().c_str())
     ("relativePeakThreshold", po::value<float>(&featDescConfig.relativePeakThreshold)->default_value(featDescConfig.relativePeakThreshold),

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -725,28 +725,17 @@ int aliceVision_main(int argc, char** argv)
     }
   }
 
-  OrderedPairList selectedPairs;
-
-  std::map<IndexT, std::string> descriptorsFilesA, descriptorsFilesB;
-
-  if(method != EImageMatchingMethod::EXHAUSTIVE)
-  {
-      // load descriptor filenames
-      aliceVision::voctree::getListOfDescriptorFiles(sfmDataA, featuresFolders, descriptorsFilesA);
-
-      if(useMultiSfM)
-          aliceVision::voctree::getListOfDescriptorFiles(sfmDataB, featuresFolders, descriptorsFilesB);
-  }
-
   if(method == EImageMatchingMethod::FRUSTUM_OR_VOCABULARYTREE)
   {
       // Frustum intersection is only implemented for pinhole cameras
       bool onlyPinhole = true;
-      for (auto & cam : sfmDataA.getIntrinsics()) {
-        if (!camera::isPinhole(cam.second->getType())) {
-          onlyPinhole = false;
-          break;
-        }
+      for(auto& cam : sfmDataA.getIntrinsics())
+      {
+          if(!camera::isPinhole(cam.second->getType()))
+          {
+              onlyPinhole = false;
+              break;
+          }
       }
 
       const std::size_t reconstructedViews = sfmDataA.getValidViews().size();
@@ -757,7 +746,8 @@ int aliceVision_main(int argc, char** argv)
       }
       else if(!onlyPinhole)
       {
-          ALICEVISION_LOG_INFO("FRUSTUM_OR_VOCABULARYTREE: Use VOCABULARYTREE matching, as the scene contains non-pinhole cameras.");
+          ALICEVISION_LOG_INFO(
+              "FRUSTUM_OR_VOCABULARYTREE: Use VOCABULARYTREE matching, as the scene contains non-pinhole cameras.");
           method = EImageMatchingMethod::VOCABULARYTREE;
       }
       else if(reconstructedViews == sfmDataA.getViews().size())
@@ -776,12 +766,25 @@ int aliceVision_main(int argc, char** argv)
   // if not enough images to use the VOCABULARYTREE use the EXHAUSTIVE method
   if(method == EImageMatchingMethod::VOCABULARYTREE || method == EImageMatchingMethod::SEQUENTIAL_AND_VOCABULARYTREE)
   {
-    if((descriptorsFilesA.size() + descriptorsFilesB.size()) < minNbImages)
-    {
-      ALICEVISION_LOG_DEBUG("Use EXHAUSTIVE method instead of VOCABULARYTREE (less images than minNbImages).");
-      method = EImageMatchingMethod::EXHAUSTIVE;
-    }
+      if((sfmDataA.getViews().size() + sfmDataB.getViews().size()) < minNbImages)
+      {
+          ALICEVISION_LOG_DEBUG("Use EXHAUSTIVE method instead of VOCABULARYTREE (less images than minNbImages).");
+          method = EImageMatchingMethod::EXHAUSTIVE;
+      }
   }
+
+  std::map<IndexT, std::string> descriptorsFilesA, descriptorsFilesB;
+
+  if(method != EImageMatchingMethod::EXHAUSTIVE)
+  {
+      // load descriptor filenames
+      aliceVision::voctree::getListOfDescriptorFiles(sfmDataA, featuresFolders, descriptorsFilesA);
+
+      if(useMultiSfM)
+          aliceVision::voctree::getListOfDescriptorFiles(sfmDataB, featuresFolders, descriptorsFilesB);
+  }
+
+  OrderedPairList selectedPairs;
 
   switch(method)
   {

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -53,6 +53,8 @@ int aliceVision_main(int argc, char **argv)
   float offsetLongitude = 0.0f;
   float offsetLatitude = 0.0f;
 
+  int randomSeed = std::mt19937::default_seed;
+
   sfm::ReconstructionEngine_panorama::Params params;
 
   po::options_description allParams(
@@ -98,7 +100,10 @@ int aliceVision_main(int argc, char **argv)
     ("intermediateRefineWithFocalDist", po::value<bool>(&params.intermediateRefineWithFocalDist)->default_value(params.intermediateRefineWithFocalDist),
       "Add an intermediate refine with rotation+focal+distortion in the different BA steps.")
     ("outputViewsAndPoses", po::value<std::string>(&outputViewsAndPosesFilepath),
-      "Path of the output SfMData file.");
+      "Path of the output SfMData file.")
+    ("randomSeed", po::value<int>(&randomSeed)->default_value(randomSeed),
+      "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
+    ;
 
   po::options_description logParams("Log parameters");
   logParams.add_options()
@@ -216,6 +221,8 @@ int aliceVision_main(int argc, char **argv)
     params,
     outDirectory,
     (fs::path(outDirectory) / "sfm_log.html").string());
+
+  sfmEngine.initRandomSeed(randomSeed);
 
   // configure the featuresPerView & the matches_provider
   sfmEngine.SetFeaturesProvider(&featuresPerView);

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -75,7 +75,7 @@ int aliceVision_main(int argc, char** argv)
   /// the describer types name to use for the matching
   std::string matchDescTypeNames = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
   /// the preset for the feature extractor
-  feature::EImageDescriberPreset featurePreset = feature::EImageDescriberPreset::NORMAL;
+  feature::ConfigurationPreset featDescPreset;
   /// the describer types to use for the matching
   std::vector<feature::EImageDescriberType> matchDescTypes;
   /// the estimator to use for resection
@@ -143,7 +143,7 @@ int aliceVision_main(int argc, char** argv)
           "Folder containing the .desc.")
       ("matchDescTypes", po::value<std::string>(&matchDescTypeNames)->default_value(matchDescTypeNames),
           "The describer types to use for the matching")
-      ("preset", po::value<feature::EImageDescriberPreset>(&featurePreset)->default_value(featurePreset), 
+      ("preset", po::value<feature::EImageDescriberPreset>(&featDescPreset.descPreset)->default_value(featDescPreset.descPreset), 
           "Preset for the feature extractor when localizing a new image "
           "{LOW,MEDIUM,NORMAL,HIGH,ULTRA}")
       ("resectionEstimator", po::value<robustEstimation::ERobustEstimator>(&resectionEstimator)->default_value(resectionEstimator),
@@ -308,7 +308,7 @@ int aliceVision_main(int argc, char** argv)
   assert(param);
   
   // set other common parameters
-  param->_featurePreset = featurePreset;
+  param->_featurePreset = featDescPreset;
   param->_refineIntrinsics = refineIntrinsics;
   param->_errorMax = resectionErrorMax;
   param->_resectionEstimator = resectionEstimator;

--- a/src/software/pipeline/main_rigLocalization.cpp
+++ b/src/software/pipeline/main_rigLocalization.cpp
@@ -78,7 +78,7 @@ int aliceVision_main(int argc, char** argv)
   /// the describer types name to use for the matching
   std::string matchDescTypeNames = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
   /// the preset for the feature extractor
-  feature::EImageDescriberPreset featurePreset = feature::EImageDescriberPreset::NORMAL;
+  feature::ConfigurationPreset featDescPreset;
   /// the describer types to use for the matching
   std::vector<feature::EImageDescriberType> matchDescTypes;
   /// the estimator to use for resection
@@ -145,7 +145,7 @@ int aliceVision_main(int argc, char** argv)
           "Folder containing the .desc.")
       ("matchDescTypes", po::value<std::string>(&matchDescTypeNames)->default_value(matchDescTypeNames),
           "The describer types to use for the matching")
-      ("preset", po::value<feature::EImageDescriberPreset>(&featurePreset)->default_value(featurePreset), 
+      ("preset", po::value<feature::EImageDescriberPreset>(&featDescPreset.descPreset)->default_value(featDescPreset.descPreset),
           "Preset for the feature extractor when localizing a new image "
           "{LOW,MEDIUM,NORMAL,HIGH,ULTRA}")
       ("resectionEstimator", po::value<robustEstimation::ERobustEstimator>(&resectionEstimator)->default_value(resectionEstimator),
@@ -314,7 +314,7 @@ int aliceVision_main(int argc, char** argv)
   assert(param);
   
   // set other common parameters
-  param->_featurePreset = featurePreset;
+  param->_featurePreset = featDescPreset;
   param->_refineIntrinsics = refineIntrinsics;
   param->_errorMax = resectionErrorMax;
   param->_resectionEstimator = resectionEstimator;


### PR DESCRIPTION
## Description

Feature point quality has a critical impact on SfM and Panorama pipelines.
This PR re-evaluate the default parameters and add new filtering strategies to be less impacted by the peak threshold in standard sift. This parameter is critical in particular on HDR images.

## Features list

- [X] Update default sift thresholds
- [X] Add new feature points filtering
- [X] Add dsp-sift variation

## Implementation remarks

 - [X] Update vlfeat to 0.9.21
 - [X] vlfeat: build as shared library and remove init/uninit on dll load
 - [X] vlfeat: remove vlcov internal buffer to allow multi-threading (use an explicit parameter instead)
