### PR TITLE
[image] Remove reference to potentially destroyed object

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -311,7 +311,7 @@ endif()
 # ==============================================================================
 # OpenImageIO
 # ==============================================================================
-find_package(OpenImageIO 1.8 REQUIRED)
+find_package(OpenImageIO 2.0.9 REQUIRED)
 if(OPENIMAGEIO_FOUND OR OpenImageIO_FOUND)
   message(STATUS "OpenImageIO found.")
   if(UNIX)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -271,33 +271,15 @@ void readImage(const std::string& path,
   if(!inBuf.initialized())
     throw std::runtime_error("Cannot find/open image file '" + path + "'.");
 
-#if OIIO_VERSION <= (10000 * 2 + 100 * 0 + 8) // OIIO_VERSION <= 2.0.8
-  // Workaround for bug in RAW colorspace management in previous versions of OIIO:
-  //     When asking sRGB we got sRGB primaries with linear gamma,
-  //     but oiio::ColorSpace was wrongly set to sRGB.
-  oiio::ImageSpec inSpec = inBuf.spec();
-  if(inSpec.get_string_attribute("oiio:ColorSpace", "") == "sRGB")
-  {
-    if(inBuf.file_format_name() == "raw")
-    {
-      // For the RAW plugin: override colorspace as linear (as the content is linear with sRGB primaries but declared as sRGB)
-      inSpec.attribute("oiio:ColorSpace", "Linear");
-      ALICEVISION_LOG_TRACE("OIIO workaround: RAW input image " << path << " is in Linear.");
-    }
-  }
-#else
-  const oiio::ImageSpec& inSpec = inBuf.spec();
-#endif
-
   // check picture channels number
-  if(inSpec.nchannels != 1 && inSpec.nchannels < 3)
+  if(inBuf.spec().nchannels != 1 && inBuf.spec().nchannels < 3)
     throw std::runtime_error("Can't load channels of image file '" + path + "'.");
 
   // color conversion
   if(imageColorSpace == EImageColorSpace::AUTO)
     throw std::runtime_error("You must specify a requested color space for image file '" + path + "'.");
 
-  const std::string& colorSpace = inSpec.get_string_attribute("oiio:ColorSpace", "sRGB"); // default image color space is sRGB
+  const std::string& colorSpace = inBuf.spec().get_string_attribute("oiio:ColorSpace", "sRGB"); // default image color space is sRGB
   ALICEVISION_LOG_TRACE("Read image " << path << " (encoded in " << colorSpace << " colorspace).");
 
   if(imageColorSpace == EImageColorSpace::SRGB) // color conversion to sRGB
@@ -318,9 +300,9 @@ void readImage(const std::string& path,
   }
 
   // convert to grayscale if needed
-  if(nchannels == 1 && inSpec.nchannels >= 3)
+  if(nchannels == 1 && inBuf.spec().nchannels >= 3)
   {
-    // convertion region of interest (for inSpec.nchannels > 3)
+    // convertion region of interest (for inBuf.spec().nchannels > 3)
     oiio::ROI convertionROI = inBuf.roi();
     convertionROI.chbegin = 0;
     convertionROI.chend = 3;
@@ -332,13 +314,13 @@ void readImage(const std::string& path,
     oiio::ImageBufAlgo::channel_sum(grayscaleBuf, inBuf, weights, convertionROI);
     inBuf.copy(grayscaleBuf);
 
-    // TODO: if inSpec.nchannels == 4: premult?
+    // TODO: if inBuf.spec().nchannels == 4: premult?
   }
 
   // duplicate first channel for RGB
-  if (nchannels >= 3 && inSpec.nchannels == 1)
+  if (nchannels >= 3 && inBuf.spec().nchannels == 1)
   {
-    oiio::ImageSpec requestedSpec(inSpec.width, inSpec.height, 3, format);
+    oiio::ImageSpec requestedSpec(inBuf.spec().width, inBuf.spec().height, 3, format);
     oiio::ImageBuf requestedBuf(requestedSpec);
     int channelOrder[] = { 0, 0, 0 };
     float channelValues[] = { 0 /*ignore*/, 0 /*ignore*/, 0 /*ignore*/ };
@@ -349,7 +331,7 @@ void readImage(const std::string& path,
   // Add an alpha channel if needed
   if (nchannels == 4 && inBuf.spec().nchannels == 3)
   {
-    oiio::ImageSpec requestedSpec(inSpec.width, inSpec.height, 3, format);
+    oiio::ImageSpec requestedSpec(inBuf.spec().width, inBuf.spec().height, 3, format);
     oiio::ImageBuf requestedBuf(requestedSpec);
     int channelOrder[] = { 0, 1, 2, -1 /*constant value*/ };
     float channelValues[] = { 0 /*ignore*/, 0 /*ignore*/, 0 /*ignore*/, 1.0 };
@@ -361,7 +343,7 @@ void readImage(const std::string& path,
   }
 
   // copy pixels from oiio to eigen
-  image.resize(inSpec.width, inSpec.height, false);
+  image.resize(inBuf.spec().width, inBuf.spec().height, false);
   {
     oiio::ROI exportROI = inBuf.roi();
     exportROI.chbegin = 0;


### PR DESCRIPTION
inSpec was a reference to a potentially destroyed object (std::swap inside the braces)