### PR TITLE
Update cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5789,6 +5789,9 @@ Sony;A7SM2;35.6;usercontribution
 Sony;DSC-HX60V;7.76;usercontribution
 Sony;DSC-P200;7.11;usercontribution
 Sony;DSC-RX100M4;13.2;usercontribution
+Sony;DSC-RX100M5;13.2;usercontribution
+Sony;DSC-RX100M6;13.2;usercontribution
+Sony;DSC-RX100M7;13.2;usercontribution
 Sony;DSC-RX10M2;13.2;usercontribution
 Sony;DSC-RX10M3;25.4;usercontribution
 Sony;DSC-RX1RM2;35.9;usercontribution


### PR DESCRIPTION
Add Sony RX100-M5, RX100-M6 and RX100-M7: all 1'' sensors. See https://www.digicamdb.com/sensor-sizes/
Test with meshroom: estimated focal length without camera recognision = 13.21. So 13.2 for the added camera's seems ok.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

