### PR TITLE
Export distortion map in exr format

### DIFF
--- a/src/aliceVision/camera/cameraUndistortImage.hpp
+++ b/src/aliceVision/camera/cameraUndistortImage.hpp
@@ -14,6 +14,7 @@
 #include <aliceVision/camera/cameraCommon.hpp>
 #include <aliceVision/camera/IntrinsicBase.hpp>
 #include <aliceVision/camera/Pinhole.hpp>
+#include <aliceVision/image/io.hpp>
 
 #include <memory>
 
@@ -49,20 +50,21 @@ void UndistortImage(
 
     image_ud.resize(imageIn.Width(), imageIn.Height(), true, fillcolor);
     const image::Sampler2d<image::SamplerLinear> sampler;
-
+    int width = imageIn.Width();
+    int height = imageIn.Height();
+    
     #pragma omp parallel for
-    for (int j = 0; j < imageIn.Height(); ++j)
-      for (int i = 0; i < imageIn.Width(); ++i)
-      {
-        const Vec2 undisto_pix(i,j);
-
-        // compute coordinates with distortion
-        const Vec2 disto_pix = intrinsicPtr->get_d_pixel(undisto_pix) + ppCorrection;
-
-        // pick pixel if it is in the image domain
-        if ( imageIn.Contains(disto_pix(1), disto_pix(0)) )
-          image_ud( j, i ) = sampler(imageIn, disto_pix(1), disto_pix(0));
-      }
+    for(int j = 0; j < height; ++j)
+        for(int i = 0; i < width; ++i)
+        {       
+            const Vec2 undisto_pix(i,j); 
+            // compute coordinates with distortion
+            const Vec2 disto_pix = intrinsicPtr->get_d_pixel(undisto_pix) + ppCorrection;
+           
+            // pick pixel if it is in the image domain
+            if(imageIn.Contains(disto_pix(1), disto_pix(0)))
+                image_ud(j,i) = sampler(imageIn, disto_pix(1), disto_pix(0));
+        }
   }
 }
 

--- a/src/aliceVision/camera/cameraUndistortImage.hpp
+++ b/src/aliceVision/camera/cameraUndistortImage.hpp
@@ -29,7 +29,7 @@ void UndistortImage(
   image::Image<T>& image_ud,
   T fillcolor,
   bool correctPrincipalPoint = false, 
-  oiio::ROI & roi = oiio::ROI())
+  const oiio::ROI & roi = oiio::ROI())
 {
   if (!intrinsicPtr->hasDistortion()) // no distortion, perform a direct copy
   {

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -413,7 +413,8 @@ void writeImage(const std::string& path,
                 int nchannels,
                 const Image<T>& image,
                 EImageColorSpace imageColorSpace,
-                const oiio::ParamValueList& metadata = oiio::ParamValueList())
+                const oiio::ParamValueList& metadata = oiio::ParamValueList(),
+                const oiio::ROI& roi = oiio::ROI())
 {
   const fs::path bPath = fs::path(path);
   const std::string extension = boost::to_lower_copy(bPath.extension().string());
@@ -437,6 +438,10 @@ void writeImage(const std::string& path,
   imageSpec.attribute("jpeg:subsampling", "4:4:4");           // if possible, always subsampling 4:4:4 for jpeg
   imageSpec.attribute("CompressionQuality", 100);             // if possible, best compression quality
   imageSpec.attribute("compression", isEXR ? "piz" : "none"); // if possible, set compression (piz for EXR, none for the other)
+  if(roi.defined() && isEXR)
+  {
+      imageSpec.set_roi_full(roi);
+  }
 
   const oiio::ImageBuf imgBuf = oiio::ImageBuf(imageSpec, const_cast<T*>(image.data())); // original image buffer
   const oiio::ImageBuf* outBuf = &imgBuf;  // buffer to write
@@ -578,7 +583,7 @@ void readImage(const std::string& path, Image<RGBColor>& image, const ImageReadO
   readImage(path, oiio::TypeDesc::UINT8, 3, image, imageReadOptions);
 }
 
-void writeImage(const std::string& path, const Image<unsigned char>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata)
+void writeImage(const std::string& path, const Image<unsigned char>& image, EImageColorSpace imageColorSpace,const oiio::ParamValueList& metadata)
 {
   writeImageNoFloat(path, oiio::TypeDesc::UINT8, image, imageColorSpace, metadata);
 }
@@ -593,27 +598,27 @@ void writeImage(const std::string& path, const Image<IndexT>& image, EImageColor
   writeImageNoFloat(path, oiio::TypeDesc::UINT32, image, imageColorSpace, metadata);
 }
 
-void writeImage(const std::string& path, const Image<RGBAfColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata)
+void writeImage(const std::string& path, const Image<RGBAfColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata, const oiio::ROI& roi)
 {
-  writeImage(path, oiio::TypeDesc::FLOAT, 4, image, imageColorSpace, metadata);
+  writeImage(path, oiio::TypeDesc::FLOAT, 4, image, imageColorSpace, metadata,roi);
 }
 
-void writeImage(const std::string& path, const Image<RGBAColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata)
+void writeImage(const std::string& path, const Image<RGBAColor>& image, EImageColorSpace imageColorSpace,const oiio::ParamValueList& metadata)
 {
   writeImage(path, oiio::TypeDesc::UINT8, 4, image, imageColorSpace, metadata);
 }
 
-void writeImage(const std::string& path, const Image<RGBfColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata)
+void writeImage(const std::string& path, const Image<RGBfColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata, const oiio::ROI &roi)
 {
-  writeImage(path, oiio::TypeDesc::FLOAT, 3, image, imageColorSpace, metadata);
+  writeImage(path, oiio::TypeDesc::FLOAT, 3, image, imageColorSpace, metadata,roi);
 }
 
-void writeImage(const std::string& path, const Image<float>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata)
+void writeImage(const std::string& path, const Image<float>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata, const oiio::ROI& roi)
 {
-  writeImage(path, oiio::TypeDesc::FLOAT, 1, image, imageColorSpace, metadata);
+  writeImage(path, oiio::TypeDesc::FLOAT, 1, image, imageColorSpace, metadata,roi);
 }
 
-void writeImage(const std::string& path, const Image<RGBColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata)
+void writeImage(const std::string& path, const Image<RGBColor>& image, EImageColorSpace imageColorSpace,const oiio::ParamValueList& metadata)
 {
   writeImage(path, oiio::TypeDesc::UINT8, 3, image, imageColorSpace, metadata);
 }

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -201,13 +201,13 @@ void readImageDirect(const std::string& path, Image<unsigned char>& image);
  * @param[in] path The given path to the image
  * @param[in] image The output image buffer
  */
-void writeImage(const std::string& path, const Image<float>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
+void writeImage(const std::string& path, const Image<float>& image, EImageColorSpace imageColorSpace,const oiio::ParamValueList& metadata = oiio::ParamValueList(),const oiio::ROI& roi = oiio::ROI());
 void writeImage(const std::string& path, const Image<unsigned char>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
 void writeImage(const std::string& path, const Image<int>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
 void writeImage(const std::string& path, const Image<IndexT>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
-void writeImage(const std::string& path, const Image<RGBAfColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
+void writeImage(const std::string& path, const Image<RGBAfColor>& image, EImageColorSpace imageColorSpace,const oiio::ParamValueList& metadata = oiio::ParamValueList(),const oiio::ROI& roi = oiio::ROI());
 void writeImage(const std::string& path, const Image<RGBAColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
-void writeImage(const std::string& path, const Image<RGBfColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
+void writeImage(const std::string& path, const Image<RGBfColor>& image, EImageColorSpace imageColorSpace,const oiio::ParamValueList& metadata = oiio::ParamValueList(),const oiio::ROI& roi = oiio::ROI());
 void writeImage(const std::string& path, const Image<RGBColor>& image, EImageColorSpace imageColorSpace, const oiio::ParamValueList& metadata = oiio::ParamValueList());
 
 

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -249,13 +249,10 @@ int aliceVision_main(int argc, char** argv)
               }
           }
 
-          if(exportUVMaps)
-          {
-              const std::string dstImage =
-                  (undistortedImagesFolderPath / ("Distortion_UVMap_" + std::to_string(intrinsicPair.first) + "." +
-                                                  image::EImageFileType_enumToString(outputMapFileType))).string();
-              image::writeImage(dstImage, image_dist, image::EImageColorSpace::AUTO);
-          }
+          const std::string dstImage =
+              (undistortedImagesFolderPath / ("Distortion_UVMap_" + std::to_string(intrinsicPair.first) + "." +
+                                              image::EImageFileType_enumToString(outputMapFileType))).string();
+          image::writeImage(dstImage, image_dist, image::EImageColorSpace::AUTO);
       }
   }
 

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -248,7 +248,7 @@ int aliceVision_main(int argc, char** argv)
                   const std::string dstImage =
                       (undistortedImagesFolderPath / ("Distortion_UVMap_" + std::to_string(intrinsicPair.first) + "." +
                                                       image::EImageFileType_enumToString(outputMapFileType))).string();
-                  image::writeImage(dstImage, image_dist, image::EImageColorSpace::NO_CONVERSION);
+                  image::writeImage(dstImage, image_dist, image::EImageColorSpace::AUTO);
               }
           }
       }
@@ -285,7 +285,7 @@ int aliceVision_main(int argc, char** argv)
       const std::string dstImage = (undistortedImagesFolderPath / (std::to_string(view.getIntrinsicId()) + "_" + imagePathStem + "." + image::EImageFileType_enumToString(outputFileType))).string();
       const camera::IntrinsicBase * cam = iterIntrinsic->second.get();
 
-      image::readImage(view.getImagePath(), image, image::EImageColorSpace::NO_CONVERSION);
+      image::readImage(view.getImagePath(), image, image::EImageColorSpace::LINEAR);
       oiio::ParamValueList metadata = image::readImageMetadata(view.getImagePath());
       oiio::ROI roiNuke;
 
@@ -312,18 +312,18 @@ int aliceVision_main(int argc, char** argv)
                                   std::to_string(roi.ybegin) + ";" + std::to_string(roi.yend));
             camera::UndistortImage(image, cam, image_ud, image::FBLACK, correctPrincipalPoint,roi); 
             oiio::ROI roiNuke = computeRoiForNuke(cam, roi, correctPrincipalPoint);
-            writeImage(dstImage, image_ud, image::EImageColorSpace::NO_CONVERSION, oiio::ParamValueList(),roiNuke);
+            writeImage(dstImage, image_ud, image::EImageColorSpace::AUTO, oiio::ParamValueList(),roiNuke);
         }
         else
         {
             camera::UndistortImage(image, cam, image_ud, image::FBLACK, correctPrincipalPoint); 
-            image::writeImage(dstImage, image_ud, image::EImageColorSpace::NO_CONVERSION, metadata); 
+            image::writeImage(dstImage, image_ud, image::EImageColorSpace::AUTO, metadata); 
         }   
       }
       else // (no distortion)
       {
         // copy the image since there is no distortion
-        image::writeImage(dstImage, image, image::EImageColorSpace::NO_CONVERSION, metadata);
+        image::writeImage(dstImage, image, image::EImageColorSpace::AUTO, metadata);
       }
     }
 


### PR DESCRIPTION
- We want to export the transformation map between the origin image and the undistorted one.
- The undistorted image must contain a ROD which includes all the available pixels
