### PR TITLE
Update cameraSensors.db with Xiaomi Mi A2

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -6872,6 +6872,7 @@ Xiaomi;Xiaomi Mi 5X;5.11;devicespecifications
 Xiaomi;Xiaomi Mi 6;4.96;devicespecifications
 Xiaomi;Xiaomi Mi 8;5.64;usercontribution,kimovil
 Xiaomi;Xiaomi Mi A2 Lite;2.98;devicespecifications
+Xiaomi;Xiaomi Mi A2;4.96;devicespecifications
 Xiaomi;Xiaomi Mi Max;4.74;devicespecifications
 Xiaomi;Xiaomi Mi Max 2;4.96;devicespecifications
 Xiaomi;Xiaomi Mi Max SD650;4.74;devicespecifications


### PR DESCRIPTION
Xiaomi;Xiaomi Mi A2;4.96;devicespecifications

Xiaomi Mi A2 has rear camera with a sensor (Sony IMX486 Exmor RS ) format of 1/2.9'' meaning (~ 4.96 x 3.72 mm)

sources:
https://www.devicespecifications.com/en/model/00354b63
https://www.digicamdb.com/sensor-sizes/

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

