### PR TITLE
[software] MeshFiltering: smoothing and filtering options on subset of the geometry

### DIFF
--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -1803,6 +1803,23 @@ void Mesh::letJustTringlesIdsInMesh(StaticVector<int>& trisIdsToStay)
     tris.swap(trisTmp);
 }
 
+void Mesh::letJustTringlesIdsInMesh(const StaticVectorBool& trisToStay)
+{
+    int nbTris = 0;
+    for(int i = 0; i < trisToStay.size(); ++i)
+        if(trisToStay[i])
+            ++nbTris;
+
+    StaticVector<Mesh::triangle> trisTmp;
+    trisTmp.reserve(nbTris);
+
+    for(int i = 0; i < trisToStay.size(); ++i)
+        if(trisToStay[i])
+            trisTmp.push_back(tris[i]);
+
+    tris.swap(trisTmp);
+}
+
 void Mesh::computeTrisCams(StaticVector<StaticVector<int>>& trisCams, const mvsUtils::MultiViewParams& mp, const std::string tmpDir)
 {
     if(mp.verbose)
@@ -2037,23 +2054,46 @@ void Mesh::removeTrianglesOutsideHexahedron(Point3d* hexah)
     letJustTringlesIdsInMesh(trisIdsToStay);
 }
 
-void Mesh::filterLargeEdgeTriangles(double cutAverageEdgeLengthFactor)
+void Mesh::filterLargeEdgeTriangles(double cutAverageEdgeLengthFactor, const StaticVectorBool& trisToConsider, StaticVectorBool& trisToStay) const
 {
-    double averageEdgeLength = computeAverageEdgeLength();
-    double avelthr = averageEdgeLength * cutAverageEdgeLengthFactor;
+    ALICEVISION_LOG_INFO("Filtering large triangles.");
 
-    StaticVector<int> trisIdsToStay;
-    trisIdsToStay.reserve(tris.size());
+    const double averageEdgeLength = computeAverageEdgeLength();
+    const double avelthr = averageEdgeLength * cutAverageEdgeLengthFactor;
 
-    for(int i = 0; i < tris.size(); i++)
+    #pragma omp parallel for
+    for(int i = 0; i < tris.size(); ++i)
     {
-        double triMaxEdgelength = computeTriangleMaxEdgeLength(i);
-        if(triMaxEdgelength < avelthr)
+        if(trisToConsider.empty() || trisToConsider[i])
         {
-            trisIdsToStay.push_back(i);
+          const double triMaxEdgelength = computeTriangleMaxEdgeLength(i);
+
+          if(triMaxEdgelength >= avelthr)
+              trisToStay[i] = false;
         }
     }
-    letJustTringlesIdsInMesh(trisIdsToStay);
+
+    ALICEVISION_LOG_INFO("Filtering large triangles, done.");
+}
+
+void Mesh::filterTrianglesByRatio(double ratio, const StaticVectorBool& trisToConsider, StaticVectorBool& trisToStay) const
+{
+    ALICEVISION_LOG_INFO("Filtering triangles by ratio " << ratio << ".");
+
+    #pragma omp parallel for
+    for(int i = 0; i < tris.size(); ++i)
+    {
+        if(trisToConsider.empty() || trisToConsider[i])
+        {
+          const double minEdge = computeTriangleMinEdgeLength(i);
+          const double maxEdge = computeTriangleMaxEdgeLength(i);
+          
+          if((minEdge == 0) || ((maxEdge/minEdge) > ratio))
+              trisToStay[i] = false;
+        }
+    }
+
+    ALICEVISION_LOG_INFO("Filtering triangles by ratio, done.");
 }
 
 void Mesh::invertTriangleOrientations()
@@ -2509,6 +2549,234 @@ bool Mesh::getEdgeNeighTrisInterval(Pixel& itr, Pixel& edge, StaticVector<Voxel>
         return false;
     }
 
+    return true;
+}
+
+bool Mesh::lockSurfaceBoundaries(int neighbourIterations, StaticVectorBool& out_ptsCanMove, bool invert) const
+{
+    using Edge = std::pair<int, int>;  // min vertex index, max vertex index
+ 
+    // qSort lambda for Edge structure
+    auto qSortCompareEdgeAsc = [] (const void* ia, const void* ib)
+    {
+        const Edge a = *(Edge*)ia;
+        const Edge b = *(Edge*)ib;
+
+        if(a.first < b.first)
+            return -1;
+        else if(a.first == b.first)
+            return (a.second < b.second) ? -1 : 1;
+        return 1;
+    };
+
+    ALICEVISION_LOG_INFO("Lock surface " << (invert? "inner part" : "boundaries") << ".");
+
+    StaticVectorBool boundariesVertices(pts.size(), false);
+
+    // Get all edges
+    StaticVector<Edge> edges(tris.size() * 3);
+
+    #pragma omp parallel for
+    for(int i = 0; i < tris.size(); ++i)
+    {
+      const int edgeStartIndex = i * 3;
+      const Mesh::triangle& t = tris[i];
+
+      edges[edgeStartIndex] = std::make_pair(std::min(t.v[0], t.v[1]), std::max(t.v[0], t.v[1]));
+      edges[edgeStartIndex + 1] = std::make_pair(std::min(t.v[1], t.v[2]), std::max(t.v[1], t.v[2]));
+      edges[edgeStartIndex + 2] = std::make_pair(std::min(t.v[2], t.v[0]), std::max(t.v[2], t.v[0]));
+    }
+
+    // Sort edges by vertex indexes
+    qsort(&edges[0], edges.size(), sizeof(Edge), qSortCompareEdgeAsc);
+
+    // Count edge, set is on boundary
+    int lastEdgeFirst = edges[0].first;
+    int lastEdgeSecond = edges[0].second;
+    int edgeCount = 0;
+    bool boundary = false;
+
+    for(int i = 0; i < edges.size(); ++i)
+    {
+      const Edge& edge = edges[i];
+
+      if((edge.first == lastEdgeFirst) && (edge.second == lastEdgeSecond))
+      {
+         ++edgeCount;
+      }
+      else
+      {
+         if(edgeCount < 2)
+         {
+           boundariesVertices[lastEdgeFirst] = true;
+           boundariesVertices[lastEdgeSecond] = true;
+           boundary = true;
+         }
+
+         lastEdgeFirst = edge.first;
+         lastEdgeSecond = edge.second;
+         edgeCount = 1;
+      }
+    }
+
+    // Return false if no boundary
+    if(!boundary)
+    {
+      ALICEVISION_LOG_INFO("No vertex on surface boundary, done.");
+      return false;
+    }
+
+    // Set is on boundary for neighbours
+    for(int n = 0; n < neighbourIterations; ++n)
+    {
+        StaticVectorBool boundariesVerticesCurrent = boundariesVertices;
+        
+        #pragma omp parallel for
+        for(int i = 0; i < edges.size(); ++i)
+        {
+            Edge& edge = edges[i];
+
+            if(boundariesVertices[edge.first] && 
+               boundariesVertices[edge.second]) // 2 vertices on boundary, skip
+                continue;
+
+            if(boundariesVertices[edge.first])
+            {
+                #pragma OMP_ATOMIC_WRITE
+                boundariesVerticesCurrent[edge.second] = true;
+            }
+
+            if(boundariesVertices[edge.second])
+            {
+                #pragma OMP_ATOMIC_WRITE
+                boundariesVerticesCurrent[edge.first] = true;
+            }
+        }
+        std::swap(boundariesVertices, boundariesVerticesCurrent);
+    }
+
+    // Create output vectors
+    if(out_ptsCanMove.empty())
+       out_ptsCanMove.resize(pts.size(), true);
+    
+    #pragma omp parallel for
+    for(int i = 0; i < boundariesVertices.size(); ++i)
+    {
+        if(boundariesVertices[i] == !invert)
+            out_ptsCanMove[i] = false;
+    }
+    
+    ALICEVISION_LOG_INFO("Lock surface " << (invert? "inner part" : "boundaries") << ", done.");
+    return true;
+}
+
+bool Mesh::getSurfaceBoundaries(StaticVectorBool& out_trisToConsider, bool invert) const
+{
+    // Edge struct
+    struct Edge
+    {
+      int first;  // min vertex index
+      int second; // max vertex index
+      int triId;  // triangle index
+
+      Edge() : first(0), second(0), triId(0)
+      {}
+
+      Edge(int vertexId1, int vertexId2, int triangleId) : triId(triangleId)
+      {
+        first  = std::min(vertexId1, vertexId2);
+        second = std::max(vertexId1, vertexId2);
+      }
+    };
+
+    // qSort lambda for Edge structure
+    auto qSortCompareEdgeAsc = [] (const void* ia, const void* ib)
+    {
+        const Edge a = *(Edge*)ia;
+        const Edge b = *(Edge*)ib;
+
+        if(a.first < b.first)
+            return -1;
+        else if(a.first == b.first)
+            return (a.second < b.second) ? -1 : 1;
+        return 1;
+    };
+
+    ALICEVISION_LOG_INFO("Get surface " << (invert? "inner part" : "boundaries") << ".");
+
+    StaticVectorBool boundariesVertices(pts.size(), false);
+
+    // Get all edges
+    StaticVector<Edge> edges(tris.size() * 3);
+
+    #pragma omp parallel for
+    for(int i = 0; i < tris.size(); ++i)
+    {
+      const int edgeStartIndex = i * 3;
+      const Mesh::triangle& t = tris[i];
+
+      edges[edgeStartIndex] = Edge(t.v[0], t.v[1], i);
+      edges[edgeStartIndex + 1] = Edge(t.v[1], t.v[2], i);
+      edges[edgeStartIndex + 2] = Edge(t.v[2], t.v[0], i);
+    }
+
+    // Sort edges by vertex indexes
+    qsort(&edges[0], edges.size(), sizeof(Edge), qSortCompareEdgeAsc);
+
+    // Count edge, set is on boundary
+    int lastEdgeFirst = edges[0].first;
+    int lastEdgeSecond = edges[0].second;
+    int edgeCount = 0;
+    bool boundary = false;
+
+    for(int i = 0; i < edges.size(); ++i)
+    {
+      const Edge& edge = edges[i];
+
+      if((edge.first == lastEdgeFirst) && (edge.second == lastEdgeSecond))
+      {
+         ++edgeCount;
+      }
+      else
+      {
+         if(edgeCount < 2)
+         {
+           boundariesVertices[lastEdgeFirst] = true;
+           boundariesVertices[lastEdgeSecond] = true;
+           boundary = true;
+         }
+
+         lastEdgeFirst = edge.first;
+         lastEdgeSecond = edge.second;
+         edgeCount = 1;
+      }
+    }
+
+    // Return false if no boundary
+    if(!boundary)
+    {
+      ALICEVISION_LOG_INFO("No vertex on surface boundary, done.");
+      return false;
+    }
+
+    // Create output vectors
+    out_trisToConsider.resize(tris.size(), false);
+
+    // Surface triangles
+    #pragma omp parallel for
+    for(int i = 0; i < edges.size(); ++i)
+    {
+        Edge& edge = edges[i];
+
+        if((boundariesVertices[edge.first] == !invert) && 
+           (boundariesVertices[edge.second] == !invert))
+        {
+            #pragma OMP_ATOMIC_WRITE
+            out_trisToConsider[edge.triId] = true;
+        }
+    }
+
+    ALICEVISION_LOG_INFO("Get surface " << (invert? "inner part" : "boundaries") << ", done.");
     return true;
 }
 

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -2704,7 +2704,7 @@ bool Mesh::getSurfaceBoundaries(StaticVectorBool& out_trisToConsider, bool inver
 
     ALICEVISION_LOG_INFO("Get surface " << (invert? "inner part" : "boundaries") << ".");
 
-    StaticVectorBool boundariesVertices(pts.size(), false);
+    StaticVectorBool boundariesEdges(tris.size() * 3, false);
 
     // Get all edges
     StaticVector<Edge> edges(tris.size() * 3);
@@ -2741,8 +2741,7 @@ bool Mesh::getSurfaceBoundaries(StaticVectorBool& out_trisToConsider, bool inver
       {
          if(edgeCount < 2)
          {
-           boundariesVertices[lastEdgeFirst] = true;
-           boundariesVertices[lastEdgeSecond] = true;
+           boundariesEdges[i-1] = true;
            boundary = true;
          }
 
@@ -2768,8 +2767,7 @@ bool Mesh::getSurfaceBoundaries(StaticVectorBool& out_trisToConsider, bool inver
     {
         Edge& edge = edges[i];
 
-        if((boundariesVertices[edge.first] == !invert) && 
-           (boundariesVertices[edge.second] == !invert))
+        if(boundariesEdges[i] == !invert)
         {
             #pragma OMP_ATOMIC_WRITE
             out_trisToConsider[edge.triId] = true;

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -185,6 +185,7 @@ public:
     void removeFreePointsFromMesh(StaticVector<int>& out_ptIdToNewPtId);
 
     void letJustTringlesIdsInMesh(StaticVector<int>& trisIdsToStay);
+    void letJustTringlesIdsInMesh(const StaticVectorBool& trisToStay);
 
     double computeAverageEdgeLength() const;
     double computeLocalAverageEdgeLength(const std::vector<std::vector<int>>& ptsNeighbors, int ptId) const;
@@ -218,7 +219,25 @@ public:
                           float alpha);
     void removeTrianglesInHexahedrons(StaticVector<Point3d>* hexahsToExcludeFromResultingMesh);
     void removeTrianglesOutsideHexahedron(Point3d* hexah);
-    void filterLargeEdgeTriangles(double cutAverageEdgeLengthFactor);
+
+   /**
+    * @brief Find all triangles with an edge length higher than the average in order to be removed.
+    * @param[in] cutAverageEdgeLengthFactor The average edge length filtering factor.
+    * @param[in] trisToConsider The input triangle group. if empty, all triangles of the mesh.
+    * @param[out] trisIdsToStay For each triangle set to true if the triangle should stay.
+    * @return false if no boundaries.
+    */
+    void filterLargeEdgeTriangles(double cutAverageEdgeLengthFactor, const StaticVectorBool& trisToConsider, StaticVectorBool& trisIdsToStay) const;
+
+   /**
+    * @brief Find all triangles with [maxEdge/minEdge > ratio] in order to be removed.
+    * @param[in] ratio The filtering ratio.
+    * @param[in] trisToConsider The input triangle group. if empty, all triangles of the mesh.
+    * @param[out] trisIdsToStay For each triangle set to true if the triangle should stay.
+    * @return false if no boundaries.
+    */
+    void filterTrianglesByRatio(double ratio, const StaticVectorBool& trisToConsider, StaticVectorBool& trisIdsToStay) const;
+
     void invertTriangleOrientations();
     void changeTriPtId(int triId, int oldPtId, int newPtId);
     int getTriPtIndex(int triId, int ptId, bool failIfDoesNotExists = true) const;
@@ -228,6 +247,25 @@ public:
 
     bool getEdgeNeighTrisInterval(Pixel& itr, Pixel& edge, StaticVector<Voxel>& edgesXStat,
                                   StaticVector<Voxel>& edgesXYStat);
+
+   /**
+    * @brief Lock mesh vertices on the surface boundaries.
+    * @param[in] neighbourIterations Number of boudary neighbours.
+    * @param[out] out_ptsCanMove For each mesh vertices set to true if locked. Initialized if empty.
+    * @param[in] invert if true lock all vertices not on the surface boundaries.
+    * @return false if no boundaries.
+    */
+    bool lockSurfaceBoundaries(int neighbourIterations, StaticVectorBool& out_ptsCanMove, bool invert = false) const;
+
+   /**
+    * @brief Get mesh triangles on the surface boundaries.
+    * @param[out] out_trisToConsider For each mesh triangle set to true if on surface.
+    * @param[in] invert If true get all triangles not on the surface boundaries.
+    * @return false if no boundaries.
+    */
+    bool getSurfaceBoundaries(StaticVectorBool& out_trisToConsider, bool invert = false) const;
+
+
 };
 
 } // namespace mesh

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -17,7 +17,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 4
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;
@@ -25,19 +25,98 @@ using namespace aliceVision;
 namespace bfs = boost::filesystem;
 namespace po = boost::program_options;
 
+enum class ESubsetType : unsigned char
+{
+    ALL = 0,
+    SURFACE_BOUNDARIES = 1,
+    SURFACE_INNER_PART = 2
+};
+
+/**
+ * @brief get informations about each subset type
+ * @return String
+ */
+std::string ESubsetType_informations()
+{
+    return "Subset types used:\n"
+           "* all: the entire mesh.\n"
+           "* surface_boundaries: mesh surface boundaries.\n"
+           "* surface_inner_part: mesh surface inner part.\n";
+}
+
+/**
+ * @brief convert an enum ESubsetType to its corresponding string
+ * @param ESubsetType
+ * @return String
+ */
+std::string ESubsetType_enumToString(ESubsetType subsetType)
+{
+  switch(subsetType)
+  {
+      case ESubsetType::ALL:                 return "all";
+      case ESubsetType::SURFACE_BOUNDARIES:  return "surface_boundaries";
+      case ESubsetType::SURFACE_INNER_PART:  return "surface_inner_part";
+  }
+  throw std::out_of_range("Invalid SubsetType enum: " + std::to_string(int(subsetType)));
+}
+
+/**
+ * @brief convert a string subsetType to its corresponding enum ESubsetType
+ * @param String
+ * @return ESubsetType
+ */
+ESubsetType ESubsetType_stringToEnum(const std::string& subsetType)
+{
+  std::string type = subsetType;
+  std::transform(type.begin(), type.end(), type.begin(), ::tolower); // tolower
+
+  if(type == "all")                 return ESubsetType::ALL;
+  if(type == "surface_boundaries")  return ESubsetType::SURFACE_BOUNDARIES;
+  if(type == "surface_inner_part")  return ESubsetType::SURFACE_INNER_PART;
+  throw std::out_of_range("Invalid filterType: " + subsetType);
+}
+
+std::ostream& operator<<(std::ostream& os, const ESubsetType subsetType)
+{
+    os << ESubsetType_enumToString(subsetType);
+    return os;
+}
+
+std::istream& operator>>(std::istream& in, ESubsetType& subsetType)
+{
+    std::string token;
+    in >> token;
+    subsetType = ESubsetType_stringToEnum(token);
+    return in;
+}
+
 int aliceVision_main(int argc, char* argv[])
 {
+    // timer initialization
+
     system::Timer timer;
+
+    // command-line required parameters
 
     std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
     std::string inputMeshPath;
     std::string outputMeshPath;
 
     bool keepLargestMeshOnly = false;
-    double removeLargeTrianglesFactor = 60.0;
 
+    // command-line smoothing parameters
+
+    std::string smoothingSubsetTypeName = ESubsetType_enumToString(ESubsetType::ALL);
+    int smoothingBoundariesNeighbours = 0;
     int smoothNIter = 10;
     float lambda = 1.0f;
+
+    // command-line filtering parameters
+
+    std::string filteringSubsetTypeName = ESubsetType_enumToString(ESubsetType::ALL);
+    int filteringIterations = 1;
+    double filterLargeTrianglesFactor = 60.0;
+    double filterTrianglesRatio = 0.0;
 
     po::options_description allParams("AliceVision meshFiltering");
 
@@ -52,12 +131,22 @@ int aliceVision_main(int argc, char* argv[])
     optionalParams.add_options()
         ("keepLargestMeshOnly", po::value<bool>(&keepLargestMeshOnly)->default_value(keepLargestMeshOnly),
             "Keep only the largest connected triangles group.")
-        ("removeLargeTrianglesFactor", po::value<double>(&removeLargeTrianglesFactor)->default_value(removeLargeTrianglesFactor),
-            "Remove all large triangles. We consider a triangle as large if one edge is bigger than N times the average edge length. Put zero to disable it.")
-        ("iterations", po::value<int>(&smoothNIter)->default_value(smoothNIter),
+        ("smoothingSubset",po::value<std::string>(&smoothingSubsetTypeName)->default_value(smoothingSubsetTypeName),
+            ESubsetType_informations().c_str())
+        ("smoothingBoundariesNeighbours", po::value<int>(&smoothingBoundariesNeighbours)->default_value(smoothingBoundariesNeighbours),
+            "Neighbours of the boudaries to consider.")
+        ("smoothingIterations", po::value<int>(&smoothNIter)->default_value(smoothNIter),
             "Number of smoothing iterations.")
-        ("lambda", po::value<float>(&lambda)->default_value(lambda),
-            "Smoothing size.");
+        ("smoothingLambda", po::value<float>(&lambda)->default_value(lambda),
+            "Smoothing size.")
+        ("filteringSubset",po::value<std::string>(&filteringSubsetTypeName)->default_value(filteringSubsetTypeName),
+            ESubsetType_informations().c_str())
+        ("filteringIterations", po::value<int>(&filteringIterations)->default_value(filteringIterations),
+            "Number of mesh filtering iterations.")
+        ("filterLargeTrianglesFactor", po::value<double>(&filterLargeTrianglesFactor)->default_value(filterLargeTrianglesFactor),
+            "Remove all large triangles. We consider a triangle as large if one edge is bigger than N times the average edge length. Put zero to disable it.")
+        ("filterTrianglesRatio", po::value<double>(&filterTrianglesRatio)->default_value(filterTrianglesRatio),
+            "Remove all triangles by ratio (largest edge /smallest edge). Put zero to disable it.");
 
     po::options_description logParams("Log parameters");
     logParams.add_options()
@@ -99,6 +188,12 @@ int aliceVision_main(int argc, char* argv[])
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
+    // check and set smoothing subset type
+    const ESubsetType smoothingSubsetType = ESubsetType_stringToEnum(smoothingSubsetTypeName);
+
+    // check and set filtering subset type
+    const ESubsetType filteringSubsetType = ESubsetType_stringToEnum(filteringSubsetTypeName);
+
     bfs::path outDirectory = bfs::path(outputMeshPath).parent_path();
     if(!bfs::is_directory(outDirectory))
         bfs::create_directory(outDirectory);
@@ -123,23 +218,68 @@ int aliceVision_main(int argc, char* argv[])
     ALICEVISION_LOG_INFO("Mesh file: \"" << inputMeshPath << "\" loaded.");
     ALICEVISION_LOG_INFO("Input mesh: " << mesh->pts.size() << " vertices and " << mesh->tris.size() << " facets.");
 
-    if(removeLargeTrianglesFactor != 0.0)
-    {
-        mesh->filterLargeEdgeTriangles(removeLargeTrianglesFactor);
-        ALICEVISION_LOG_INFO("Mesh after large triangles removal: " << mesh->pts.size() << " vertices and " << mesh->tris.size() << " facets.");
-    }
+    StaticVectorBool ptsCanMove; // empty if smoothingSubsetType is ALL
 
-    mesh::MeshEnergyOpt meOpt(nullptr);
+    // lock filter subset vertices
+    switch(smoothingSubsetType)
+    {
+        case ESubsetType::ALL: break; // nothing to lock
+
+        case ESubsetType::SURFACE_BOUNDARIES:
+        mesh->lockSurfaceBoundaries(smoothingBoundariesNeighbours, ptsCanMove, true); // invert = true (lock surface inner part)
+        break;
+
+        case ESubsetType::SURFACE_INNER_PART:
+        mesh->lockSurfaceBoundaries(smoothingBoundariesNeighbours, ptsCanMove, false); // invert = false (lock surface boundaries)
+        break;
+    }
+    
+
+    // filtering
+    if((filterLargeTrianglesFactor != 0.0) || (filterTrianglesRatio != 0.0))
     {
         ALICEVISION_LOG_INFO("Start mesh filtering.");
+
+        for(int i = 0; i < filteringIterations; ++i)
+        {
+          ALICEVISION_LOG_INFO("Mesh filtering: iteration " << i);
+
+          StaticVectorBool trisToStay(mesh->tris.size(), true);
+          StaticVectorBool trisInFilterSubset; // empty if filteringSubsetType is ALL
+
+          switch(filteringSubsetType)
+          {
+              case ESubsetType::ALL: break; // nothing to do 
+
+              case ESubsetType::SURFACE_BOUNDARIES:
+              mesh->getSurfaceBoundaries(trisInFilterSubset); // invert = false (get surface boundaries)
+              break;
+
+              case ESubsetType::SURFACE_INNER_PART:
+              mesh->getSurfaceBoundaries(trisInFilterSubset, true); // invert = true (get surface inner part)
+              break;
+          }
+
+          if(filterLargeTrianglesFactor != 0.0)
+              mesh->filterLargeEdgeTriangles(filterLargeTrianglesFactor, trisInFilterSubset, trisToStay);
+
+          if(filterTrianglesRatio != 0.0)
+              mesh->filterTrianglesByRatio(filterTrianglesRatio, trisInFilterSubset, trisToStay);
+
+          mesh->letJustTringlesIdsInMesh(trisToStay);
+        }
+        ALICEVISION_LOG_INFO("Mesh filtering done: " << mesh->pts.size() << " vertices and " << mesh->tris.size() << " facets.");
+    }
+
+    // smoothing
+    mesh::MeshEnergyOpt meOpt(nullptr);
+    {
+        ALICEVISION_LOG_INFO("Start mesh smoothing.");
         meOpt.addMesh(*mesh);
         meOpt.init();
         meOpt.cleanMesh(10);
-
-        StaticVectorBool ptsCanMove;
         meOpt.optimizeSmooth(lambda, smoothNIter, ptsCanMove);
-
-        ALICEVISION_LOG_INFO("Mesh filtering done: " << meOpt.pts.size() << " vertices and " << meOpt.tris.size() << " facets.");
+        ALICEVISION_LOG_INFO("Mesh smoothing done: " << meOpt.pts.size() << " vertices and " << meOpt.tris.size() << " facets.");
     }
 
     if(keepLargestMeshOnly)


### PR DESCRIPTION
## Description

Add smoothing and filtering options for MeshFiltering software.

## Features list

- [x] Smoothing and filtering can now be applied on a subset of the geometry (all, surface boundaries, surface inner part).
- [x] New `TrianglesByRatioFiltering` parameter.

