### PR TITLE
[meshing] Digging using shape from silhouette principle

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -394,6 +394,14 @@ void createVerticesWithVisibilities(const StaticVector<int>& cams, std::vector<P
     for(auto& lock: locks)
         omp_destroy_lock(&lock);
 
+    // compute pixSize
+    #pragma omp parallel for
+    for(int vi = 0; vi < verticesAttrPrepare.size(); ++vi)
+    {
+        GC_vertexInfo& v = verticesAttrPrepare[vi];
+        v.pixSize = mp->getCamsMinPixelSize(verticesCoordsPrepare[vi], v.cams);
+    }
+
 //    verticesCoordsPrepare.swap(newVerticesCoordsPrepare);
 //    simScorePrepare.swap(newSimScorePrepare);
 //    pixSizePrepare.swap(newPixSizePrepare);
@@ -503,22 +511,6 @@ std::vector<DelaunayGraphCut::CellIndex> DelaunayGraphCut::getNeighboringCellsBy
     std::set_intersection(v0ci.begin(), v0ci.end(), v1ci.begin(), v1ci.end(), std::back_inserter(neighboringCells));
     
     return neighboringCells;
-}
-
-void DelaunayGraphCut::initVertices()
-{
-    ALICEVISION_LOG_DEBUG("initVertices ...\n");
-
-    // Re-assign ids to the vertices to go one after another
-    for(int vi = 0; vi < _verticesAttr.size(); ++vi)
-    {
-        GC_vertexInfo& v = _verticesAttr[vi];
-        // fit->info().point = convertPointToPoint3d(fit->point());
-        // v.id = nVertices;
-        v.pixSize = mp->getCamsMinPixelSize(_verticesCoords[vi], v.cams);
-    }
-
-    ALICEVISION_LOG_DEBUG("initVertices done\n");
 }
 
 void DelaunayGraphCut::computeDelaunay()
@@ -747,6 +739,8 @@ void DelaunayGraphCut::addPointsFromSfM(const Point3d hexah[8], const StaticVect
 
       for(const auto& observationPair : landmark.observations)
         vAttrIt->cams.push_back(mp->getIndexFromViewId(observationPair.first));
+
+      vAttrIt->pixSize = mp->getCamsMinPixelSize(p, vAttrIt->cams);
 
       ++vCoordsIt;
       ++vAttrIt;
@@ -1315,7 +1309,6 @@ void DelaunayGraphCut::removeSmallSegs(const std::vector<GC_Seg>& segments, int 
         // T.remove(fit); // TODO GEOGRAM
     }
 
-    initVertices();
 }
 
 DelaunayGraphCut::GeometryIntersection
@@ -2865,6 +2858,10 @@ void DelaunayGraphCut::createDensePointCloud(const Point3d hexah[8], const Stati
     Point3d hexahExt[8];
     mvsUtils::inflateHexahedron(hexah, hexahExt, 1.1);
     addHelperPoints(nGridHelperVolumePointsDim, hexahExt, minDist);
+
+    // add point for shape from silhouette
+    if(mp->userParams.get<bool>("delaunaycut.addMaskHelperPoints", false))
+      addMaskHelperPoints(hexahExt, cams, *depthMapsFuseParams);
   }
 
   _verticesCoords.shrink_to_fit();
@@ -2875,8 +2872,6 @@ void DelaunayGraphCut::createDensePointCloud(const Point3d hexah[8], const Stati
 
 void DelaunayGraphCut::createGraphCut(const Point3d hexah[8], const StaticVector<int>& cams, const std::string& folderName, const std::string& tmpCamsPtsFolderName, bool removeSmallSegments)
 {
-  initVertices();
-
   // Create tetrahedralization
   computeDelaunay();
   displayStatistics();

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -881,6 +881,9 @@ void DelaunayGraphCut::addMaskHelperPoints(const Point3d voxel[8], const StaticV
 {
     ALICEVISION_LOG_INFO("Add Mask Helper Points.");
 
+    Point3d inflatedVoxel[8];
+    mvsUtils::inflateHexahedron(voxel, inflatedVoxel, 1.01f);
+
     std::size_t nbPixels = 0;
     for(const auto& imgParams : mp->getImagesParams())
     {
@@ -963,7 +966,7 @@ void DelaunayGraphCut::addMaskHelperPoints(const Point3d voxel[8], const StaticV
                     {
                         const Point3d& cam = mp->CArr[c];
                         Point3d maxP = cam + (mp->iCamArr[c] * Point2d((float)bestX, (float)bestY)).normalize() * 10000000.0; 
-                        StaticVector<Point3d>* intersectionsPtr = mvsUtils::lineSegmentHexahedronIntersection(cam, maxP, voxel);
+                        StaticVector<Point3d>* intersectionsPtr = mvsUtils::lineSegmentHexahedronIntersection(cam, maxP, inflatedVoxel);
 
                         if(intersectionsPtr->size() <= 0)
                             continue;
@@ -979,17 +982,14 @@ void DelaunayGraphCut::addMaskHelperPoints(const Point3d voxel[8], const StaticV
                                 maxDepth = depth;
                             }
                         }
-                        if(voxel == nullptr || mvsUtils::isPointInHexahedron(p, voxel))
-                        {
-                            GC_vertexInfo newv;
-                            newv.nrc = 1;
-                            newv.pixSize = 0.0f;
-                            newv.cams.push_back_distinct(c);
+                        GC_vertexInfo newv;
+                        newv.nrc = 1;
+                        newv.pixSize = 0.0f;
+                        newv.cams.push_back_distinct(c);
 
-                            _verticesAttr.push_back(newv);
-                            _verticesCoords.emplace_back(p);
-                            ++nbAddedPoints;
-                        }
+                        _verticesAttr.push_back(newv);
+                        _verticesCoords.emplace_back(p);
+                        ++nbAddedPoints;
                     }
                 }
             }

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1796,7 +1796,7 @@ float DelaunayGraphCut::weightFcn(float nrc, bool labatutWeights, int  /*ncams*/
 }
 
 void DelaunayGraphCut::fillGraph(bool fixesSigma, float nPixelSizeBehind,
-                               bool labatutWeights, bool fillOut, float distFcnHeight) // fixesSigma=true nPixelSizeBehind=2*spaceSteps allPoints=1 behind=0 labatutWeights=0 fillOut=1 distFcnHeight=0
+                               bool labatutWeights, bool fillOut, float distFcnHeight) // fixesSigma=false nPixelSizeBehind=2*spaceSteps allPoints=1 behind=0 labatutWeights=0 fillOut=1 distFcnHeight=0
 {
     ALICEVISION_LOG_INFO("Computing s-t graph weights.");
     long t1 = clock();
@@ -1907,13 +1907,13 @@ void DelaunayGraphCut::fillGraph(bool fixesSigma, float nPixelSizeBehind,
 
 void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalStepsBehind, GeometriesCount& outFrontCount, GeometriesCount& outBehindCount, int vertexIndex, int cam,
                                        float weight, bool fixesSigma, float nPixelSizeBehind,
-                                       bool fillOut, float distFcnHeight)  // fixesSigma=true nPixelSizeBehind=2*spaceSteps allPoints=1 behind=0 fillOut=1 distFcnHeight=0
+                                       bool fillOut, float distFcnHeight)  // fixesSigma=false nPixelSizeBehind=2*spaceSteps allPoints=1 behind=0 fillOut=1 distFcnHeight=0
 {
     const int maxint = 1000000; // std::numeric_limits<int>::std::max()
     const double marginEpsilonFactor = 1.0e-4;
 
     const Point3d& originPt = _verticesCoords[vertexIndex];
-    const float pixSize = mp->getCamPixelSize(originPt, cam);
+    const float pixSize = _verticesAttr[vertexIndex].pixSize; // use computed pixSize,  mp->getCamPixelSize(originPt, cam);
     float maxDist = nPixelSizeBehind * pixSize;
     if(fixesSigma)
         maxDist = nPixelSizeBehind;
@@ -2074,6 +2074,8 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
         //                           << "Current vertex index: " << vertexIndex << ", outFrontCount:" << outFrontCount);
         // }
     }
+
+    if(pixSize > 0.0f) // fillIn
     {
         // Initialisation
         GeometryIntersection geometry(vertexIndex); // Starting on global vertex index

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
@@ -416,7 +416,6 @@ public:
      */
     std::vector<CellIndex> getNeighboringCellsByEdge(const Edge& e) const;
 
-    void initVertices();
     void computeDelaunay();
     void initCells();
     void displayStatistics();

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
@@ -439,6 +439,8 @@ public:
      */
     void addHelperPoints(int nGridHelperVolumePointsDim, const Point3d Voxel[8], float minDist);
 
+    void addMaskHelperPoints(const Point3d voxel[8], const StaticVector<int>& cams, const FuseParams& params);
+
     void fuseFromDepthMaps(const StaticVector<int>& cams, const Point3d voxel[8], const FuseParams& params);
 
     /**

--- a/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
@@ -97,7 +97,6 @@ BOOST_AUTO_TEST_CASE(fuseCut_delaunayGraphCut)
 
     delaunayGC.createGraphCut(&hexah[0], cams, tempDirPath + "/", tempDirPath + "/SpaceCamsTracks/", false);
     /*
-    delaunayGC.initVertices();
     delaunayGC.computeDelaunay();
     delaunayGC.displayStatistics();
     delaunayGC.computeVerticesSegSize(true, 0.0f);

--- a/src/aliceVision/mvsUtils/common.cpp
+++ b/src/aliceVision/mvsUtils/common.cpp
@@ -384,7 +384,7 @@ StaticVector<Point3d>* triangleHexahedronIntersection(Point3d& A, Point3d& B, Po
     return out;
 }
 
-StaticVector<Point3d>* lineSegmentHexahedronIntersection(Point3d& linePoint1, Point3d& linePoint2, Point3d hexah[8])
+StaticVector<Point3d>* lineSegmentHexahedronIntersection(const Point3d& linePoint1, const Point3d& linePoint2, const Point3d hexah[8])
 {
     Point3d tris[12][3];
     getHexahedronTriangles(tris, hexah);

--- a/src/aliceVision/mvsUtils/common.hpp
+++ b/src/aliceVision/mvsUtils/common.hpp
@@ -45,7 +45,7 @@ bool checkCamPairAngle(int rc, int tc, const MultiViewParams* mp, float minAng, 
 void getHexahedronTriangles(Point3d tris[12][3], const Point3d hexah[8]);
 void getCamHexahedron(const Point3d& position, const Matrix3x3& iCam, int width, int height, float minDepth, float maxDepth, Point3d hexah[8]);
 bool intersectsHexahedronHexahedron(const Point3d rchex[8], const Point3d tchex[8]);
-StaticVector<Point3d>* lineSegmentHexahedronIntersection(Point3d& linePoint1, Point3d& linePoint2, Point3d hexah[8]);
+StaticVector<Point3d>* lineSegmentHexahedronIntersection(const Point3d& linePoint1, const Point3d& linePoint2, const Point3d hexah[8]);
 StaticVector<Point3d>* triangleHexahedronIntersection(Point3d& A, Point3d& B, Point3d& C, Point3d hexah[8]);
 void triangleRectangleIntersection(Point3d& A, Point3d& B, Point3d& C, const MultiViewParams& mp, int rc,
                                                Point2d P[4], StaticVector<Point3d>& out);

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -265,6 +265,7 @@ int aliceVision_main(int argc, char* argv[])
     bool meshingFromDepthMaps = true;
     bool estimateSpaceFromSfM = true;
     bool addLandmarksToTheDensePointCloud = false;
+    bool addMaskHelperPoints = false;
     bool saveRawDensePointCloud = false;
     bool colorizeOutput = false;
     bool voteFilteringForWeaklySupportedSurfaces = true;
@@ -342,6 +343,8 @@ int aliceVision_main(int argc, char* argv[])
             "minAngleThreshold")
         ("refineFuse", po::value<bool>(&fuseParams.refineFuse)->default_value(fuseParams.refineFuse),
             "refineFuse")
+        ("addMaskHelperPoints", po::value<bool>(&addMaskHelperPoints)->default_value(addMaskHelperPoints),
+            "Add Helper points on the outline of the depth maps masks.")
         ("saveRawDensePointCloud", po::value<bool>(&saveRawDensePointCloud)->default_value(saveRawDensePointCloud),
             "Save dense point cloud before cut and filtering.")
         ("voteFilteringForWeaklySupportedSurfaces", po::value<bool>(&voteFilteringForWeaklySupportedSurfaces)->default_value(voteFilteringForWeaklySupportedSurfaces),
@@ -427,6 +430,7 @@ int aliceVision_main(int argc, char* argv[])
     mp.userParams.put("delaunaycut.voteFilteringForWeaklySupportedSurfaces", voteFilteringForWeaklySupportedSurfaces);
     mp.userParams.put("hallucinationsFiltering.minSolidAngleRatio", minSolidAngleRatio);
     mp.userParams.put("hallucinationsFiltering.nbSolidAngleFilteringIterations", nbSolidAngleFilteringIterations);
+    mp.userParams.put("delaunaycut.addMaskHelperPoints", addMaskHelperPoints);
 
     int ocTreeDim = mp.userParams.get<int>("LargeScale.gridLevel0", 1024);
     const auto baseDir = mp.userParams.get<std::string>("LargeScale.baseDirName", "root01024");


### PR DESCRIPTION
## Description

Add option in Meshing, for digging using shape from silhouette principle.

Warning: may have an impact on the tetrahedral vote due to the change in the usage of a global `pixSize` per vertex (for all observations/cameras) instead of a value per view.

## Features list

- [x] Remove `initVertices()` function
- [x] Use already computed `pixSize` in `fillGraph`
- [x] Add shape from silhouette option.

