### PR TITLE
[fuseCut] adjustments to the tetrahedral vote

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1473,7 +1473,7 @@ DelaunayGraphCut::GeometryIntersection DelaunayGraphCut::rayIntersectTriangle(co
     const double v = triangleUv.y; // A to B
 
     // If we find invalid uv coordinate
-    if (!std::isfinite(u) && !std::isfinite(v))
+    if (!std::isfinite(u) || !std::isfinite(v))
         return GeometryIntersection();
 
     // Ouside the triangle with marginEpsilon margin

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1409,6 +1409,17 @@ DelaunayGraphCut::intersectNextGeom(const DelaunayGraphCut::GeometryIntersection
             {
                 bool ambiguous = false;
                 const GeometryIntersection result = rayIntersectTriangle(originPt, dirVect, facet, intersectPt, epsilonFactor, ambiguous, &lastIntersectPt);
+
+                if (result.type == EGeometryType::Edge)
+                {
+                    if(result.edge.isSameUndirectionalEdge(inGeometry.edge))
+                    {
+                        ALICEVISION_LOG_ERROR("[intersectNextGeom] intersect the input edge itself, ignore intersection: inGeometry: " << inGeometry << ", intersected geo: " << result);
+                        // do not intersect the input edge itself
+                        continue;
+                    }
+                    // ALICEVISION_LOG_WARNING("[intersectNextGeom] intersect a new edge from an edge: inGeometry: " << inGeometry << ", intersected geo: " << result << ", intersectPt: " << intersectPt << ", lastIntersectPt: " << lastIntersectPt);
+                }
                 if (result.type != EGeometryType::None)
                 {
                     if (!ambiguous)
@@ -1769,7 +1780,7 @@ void DelaunayGraphCut::fillGraph(bool fixesSigma, float nPixelSizeBehind,
     ALICEVISION_LOG_DEBUG("totalStepsBehind//totalRayBehind = " << totalStepsBehind << " // " << totalRayBehind);
     ALICEVISION_LOG_DEBUG("totalCamHaveVisibilityOnVertex//totalOfVertex = " << totalCamHaveVisibilityOnVertex << " // " << totalOfVertex);
 
-    ALICEVISION_LOG_DEBUG("\n - Geometries Intersected count -");
+    ALICEVISION_LOG_DEBUG("- Geometries Intersected count -");
     ALICEVISION_LOG_DEBUG("Front: " << totalGeometriesIntersectedFrontCount);
     ALICEVISION_LOG_DEBUG("Behind: " << totalGeometriesIntersectedBehindCount);
     totalGeometriesIntersectedFrontCount /= totalCamHaveVisibilityOnVertex;
@@ -1879,7 +1890,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                 lastIntersectedFacet = mFacet;
                 if(previousGeometry.type == EGeometryType::Facet && outFrontCount.facets > 10000)
                 {
-                    ALICEVISION_LOG_WARNING("fillGraphPartPtRc front: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                    ALICEVISION_LOG_WARNING("fillGraphPartPtRc front: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam << ", outFrontCount: " << outFrontCount);
                     break;
                 }
             }
@@ -1899,7 +1910,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                     lastGeoIsVertex = true;
                     if(previousGeometry.type == EGeometryType::Vertex && outFrontCount.vertices > 1000)
                     {
-                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc front: loop on vertices. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc front: loop on vertices. Current landmark index: " << vertexIndex << ", camera: " << cam << ", outFrontCount: " << outFrontCount);
                         break;
                     }
                 }
@@ -1908,7 +1919,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                     ++outFrontCount.edges;
                     if(previousGeometry.type == EGeometryType::Edge && outFrontCount.edges > 1000)
                     {
-                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc front: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc front: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam << ", outFrontCount: " << outFrontCount);
                         break;
                     }
                 }
@@ -2024,7 +2035,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                 }
                 if(previousGeometry.type == EGeometryType::Facet && outBehindCount.facets > 1000)
                 {
-                    ALICEVISION_LOG_WARNING("fillGraphPartPtRc behind: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                    ALICEVISION_LOG_WARNING("fillGraphPartPtRc behind: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam << ", outBehindCount: " << outBehindCount);
                     break;
                 }
             }
@@ -2067,7 +2078,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                     ++outBehindCount.vertices;
                     if(previousGeometry.type == EGeometryType::Vertex && outBehindCount.vertices > 1000)
                     {
-                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc behind: loop on vertices. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc behind: loop on vertices. Current landmark index: " << vertexIndex << ", camera: " << cam << ", outBehindCount: " << outBehindCount);
                         break;
                     }
                 }
@@ -2076,7 +2087,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                     ++outBehindCount.edges;
                     if(previousGeometry.type == EGeometryType::Edge && outBehindCount.edges > 1000)
                     {
-                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc behind: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                        ALICEVISION_LOG_WARNING("fillGraphPartPtRc behind: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam << ", outBehindCount: " << outBehindCount);
                         break;
                     }
                 }
@@ -2244,7 +2255,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                         geometry.facet = mFacet;
                         if(previousGeometry.type == EGeometryType::Facet && geometriesIntersectedFrontCount.facets > 10000)
                         {
-                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam << ", intersectPt: " << intersectPt << ", lastIntersectPt: " << lastIntersectPt);
+                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam << ", intersectPt: " << intersectPt << ", lastIntersectPt: " << lastIntersectPt << ", geometriesIntersectedFrontCount: " << geometriesIntersectedFrontCount);
                             break;
                         }
                     }
@@ -2253,7 +2264,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                         ++geometriesIntersectedFrontCount.vertices;
                         if(previousGeometry.type == EGeometryType::Vertex && geometriesIntersectedFrontCount.vertices > 1000)
                         {
-                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam << ", geometriesIntersectedFrontCount: " << geometriesIntersectedFrontCount);
                             break;
                         }
                     }
@@ -2262,7 +2273,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                         ++geometriesIntersectedFrontCount.edges;
                         if(previousGeometry.type == EGeometryType::Edge && geometriesIntersectedFrontCount.edges > 1000)
                         {
-                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam << ", geometriesIntersectedFrontCount: " << geometriesIntersectedFrontCount);
                             break;
                         }
                     }
@@ -2344,7 +2355,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                         }
                         if(previousGeometry.type == EGeometryType::Facet && geometriesIntersectedBehindCount.facets > 1000)
                         {
-                            ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                            ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on facets. Current landmark index: " << vertexIndex << ", camera: " << cam << ", geometriesIntersectedBehindCount: " << geometriesIntersectedBehindCount);
                             break;
                         }
                     }
@@ -2379,7 +2390,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                             ++geometriesIntersectedBehindCount.vertices;
                             if(previousGeometry.type == EGeometryType::Vertex && geometriesIntersectedBehindCount.vertices > 1000)
                             {
-                                ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on vertices. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                                ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on vertices. Current landmark index: " << vertexIndex << ", camera: " << cam << ", geometriesIntersectedBehindCount: " << geometriesIntersectedBehindCount);
                                 break;
                             }
                         }
@@ -2388,7 +2399,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                             ++geometriesIntersectedBehindCount.edges;
                             if(previousGeometry.type == EGeometryType::Edge && geometriesIntersectedBehindCount.edges > 1000)
                             {
-                                ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam);
+                                ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on edges. Current landmark index: " << vertexIndex << ", camera: " << cam << ", geometriesIntersectedBehindCount: " << geometriesIntersectedBehindCount);
                                 break;
                             }
                         }
@@ -2447,7 +2458,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
     ALICEVISION_LOG_DEBUG("totalStepsBehind//totalRayBehind = " << totalStepsBehind << " // " << totalRayBehind);
     ALICEVISION_LOG_DEBUG("totalCamHaveVisibilityOnVertex//totalOfVertex = " << totalCamHaveVisibilityOnVertex << " // " << totalOfVertex);
 
-    ALICEVISION_LOG_DEBUG("\n - Geometries Intersected count -");
+    ALICEVISION_LOG_DEBUG("- Geometries Intersected count -");
     ALICEVISION_LOG_DEBUG("Front: " << totalGeometriesIntersectedFrontCount);
     ALICEVISION_LOG_DEBUG("Behind: " << totalGeometriesIntersectedBehindCount);
     totalGeometriesIntersectedFrontCount /= totalRayFront;

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1490,12 +1490,9 @@ DelaunayGraphCut::GeometryIntersection DelaunayGraphCut::rayIntersectTriangle(co
         {
             ambiguous = true;
         }
-        else
+        else if(dotValue < marginEpsilon)
         {
-            if (dotValue <= 0)
-            {
-               return GeometryIntersection();
-            }
+            return GeometryIntersection();
         }
     }
 

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1823,6 +1823,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                 ALICEVISION_LOG_DEBUG(
                     "[Error]: fillGraph(toTheCam) cause: geometry cannot be found."
                     << "Current vertex index: " << vertexIndex
+                    << ", Previous geometry type: " << previousGeometry.type
                     << ", outFrontCount:" << outFrontCount);
                 break;
             }
@@ -1862,7 +1863,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
 #ifdef ALICEVISION_DEBUG_VOTE
                     // exportBackPropagationMesh("fillGraph_ToCam_invalidMirorFacet", history.geometries, originPt, mp->CArr[cam]);
 #endif
-                    ALICEVISION_LOG_DEBUG("[Error]: fillGraph(toTheCam) cause: invalidOrInfinite miror facet.");
+                    //ALICEVISION_LOG_DEBUG("[Error]: fillGraph(toTheCam) cause: invalidOrInfinite miror facet.");
                     break;
                 }
                 lastIntersectedFacet = mFacet;
@@ -1883,9 +1884,8 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                     lastGeoIsVertex = true;
                     if(previousGeometry.type == EGeometryType::Vertex && outFrontCount.vertices > 1000)
                     {
-                        ALICEVISION_LOG_DEBUG("[Error]: loop on vertices. Current landmark index: " << vertexIndex);
-                        if(outFrontCount.vertices > 1010)
-                            break;
+                        ALICEVISION_LOG_DEBUG("fillGraphPartPtRc front: loop on vertices. Current landmark index: " << vertexIndex);
+                        break;
                     }
                 }
                 else if (geometry.type == EGeometryType::Edge)
@@ -1893,9 +1893,8 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                     ++outFrontCount.edges;
                     if(previousGeometry.type == EGeometryType::Edge && outFrontCount.edges > 1000)
                     {
-                        ALICEVISION_LOG_DEBUG("[Error]: loop on edges. Current landmark index: " << vertexIndex);
-                        if(outFrontCount.edges > 1010)
-                            break;
+                        ALICEVISION_LOG_DEBUG("fillGraphPartPtRc front: loop on edges. Current landmark index: " << vertexIndex);
+                        break;
                     }
                 }
             }
@@ -2046,10 +2045,20 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                 if (geometry.type == EGeometryType::Vertex)
                 {
                     ++outBehindCount.vertices;
+                    if(previousGeometry.type == EGeometryType::Vertex && outBehindCount.vertices > 1000)
+                    {
+                        ALICEVISION_LOG_DEBUG("fillGraphPartPtRc behind: loop on vertices. Current landmark index: " << vertexIndex);
+                        break;
+                    }
                 }
                 else if (geometry.type == EGeometryType::Edge)
                 {
                     ++outBehindCount.edges;
+                    if(previousGeometry.type == EGeometryType::Edge && outBehindCount.edges > 1000)
+                    {
+                        ALICEVISION_LOG_DEBUG("fillGraphPartPtRc behind: loop on edges. Current landmark index: " << vertexIndex);
+                        break;
+                    }
                 }
             }
         }

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2915,7 +2915,7 @@ void DelaunayGraphCut::maxflow()
 void DelaunayGraphCut::voteFullEmptyScore(const StaticVector<int>& cams, const std::string& folderName)
 {
     ALICEVISION_LOG_INFO("DelaunayGraphCut::voteFullEmptyScore");
-    int maxint = 1000000.0f;
+    const int maxint = 1000000.0f;
 
     long t1;
 
@@ -2924,19 +2924,15 @@ void DelaunayGraphCut::voteFullEmptyScore(const StaticVector<int>& cams, const s
     ALICEVISION_LOG_INFO("sigma: " << sigma);
 
     // 0 for distFcn equals 1 all the time
-    float distFcnHeight = (float)mp->userParams.get<double>("delaunaycut.distFcnHeight", 0.0f);
+    const float distFcnHeight = (float)mp->userParams.get<double>("delaunaycut.distFcnHeight", 0.0f);
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    bool labatutCFG09 = mp->userParams.get<bool>("global.LabatutCFG09", false);
+    const bool labatutCFG09 = mp->userParams.get<bool>("global.LabatutCFG09", false);
     // jancosekIJCV: "Exploiting Visibility Information in Surface Reconstruction to Preserve Weakly Supported Surfaces", Michal Jancosek and Tomas Pajdla, 2014
-    bool jancosekIJCV = mp->userParams.get<bool>("global.JancosekIJCV", true);
+    const bool jancosekIJCV = mp->userParams.get<bool>("global.JancosekIJCV", true);
 
     if(jancosekIJCV) // true by default
     {
-        bool forceTEdge = mp->userParams.get<bool>("delaunaycut.forceTEdge", true);
+        const bool forceTEdge = mp->userParams.get<bool>("delaunaycut.voteFilteringForWeaklySupportedSurfaces", true);
 
         displayCellsStats();
 

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2811,10 +2811,16 @@ void DelaunayGraphCut::voteFullEmptyScore(const StaticVector<int>& cams, const s
 
         ALICEVISION_LOG_INFO("Jancosek IJCV method ( forceTEdgeDelta*100 = " << static_cast<int>(forceTEdgeDelta * 100.0f) << " ): ");
 
+        displayCellsStats();
+
         // compute weights on edge between tetrahedra
         fillGraph(false, sigma, false, true, distFcnHeight);
 
+        displayCellsStats();
+
         addToInfiniteSw((float)maxint);
+
+        displayCellsStats();
 
         if(saveTemporaryBinFiles)
             saveDhInfo(folderName + "delaunayTriangulationInfoInit.bin");
@@ -2829,6 +2835,8 @@ void DelaunayGraphCut::voteFullEmptyScore(const StaticVector<int>& cams, const s
         {
             forceTedgesByGradientIJCV(false, sigma);
         }
+
+        displayCellsStats();
 
         if(saveTemporaryBinFiles)
             saveDhInfo(folderName + "delaunayTriangulationInfoAfterForce.bin");

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -3134,9 +3134,11 @@ void DelaunayGraphCut::displayCellsStats() const
         Accumulator acc_fullnessScore;
         Accumulator acc_emptinessScore;
         Accumulator acc_on;
+        int64_t countPositiveSWeight = 0;
 
         for(const GC_cellInfo& cellAttr : _cellsAttr)
         {
+            countPositiveSWeight += (cellAttr.cellSWeight > 0);
             acc_cellScore(cellAttr.cellSWeight - cellAttr.cellTWeight);
             acc_cellSWeight(cellAttr.cellSWeight);
             acc_cellTWeight(cellAttr.cellTWeight);
@@ -3158,6 +3160,7 @@ void DelaunayGraphCut::displayCellsStats() const
         displayAcc("fullnessScore", acc_fullnessScore);
         displayAcc("emptinessScore", acc_emptinessScore);
         displayAcc("on", acc_on);
+        ALICEVISION_LOG_INFO("countPositiveSWeight: " << countPositiveSWeight);
     }
 }
 

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2087,7 +2087,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
     const float maxSilentPartRange = (float)mp->userParams.get<double>("delaunaycut.maxSilentPartRange", 100.0f);
     ALICEVISION_LOG_DEBUG("maxSilentPartRange: " << maxSilentPartRange);
 
-    float nsigmaJumpPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaJumpPart", 2.0f);
+    const float nsigmaJumpPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaJumpPart", 4.0f);
     ALICEVISION_LOG_DEBUG("nsigmaJumpPart: " << nsigmaJumpPart);
 
     const float nsigmaFrontSilentPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaFrontSilentPart", 2.0f);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2106,8 +2106,8 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                 // As long as we find a next geometry
                 Point3d lastIntersectPt = originPt;
                 // Iterate on geometries in the direction of camera's vertex within margin defined by maxDist (as long as we find a next geometry)
-                while ((geometry.type != EGeometryType::Vertex || (mp->CArr[cam] - intersectPt).size() < 1.0e-3) // We reach our camera vertex
-                && (lastIntersectPt - originPt).size() <= (nsigmaJumpPart + nsigmaFrontSilentPart) * maxDist) // We to far from the originPt
+                while ((geometry.type != EGeometryType::Vertex || (mp->CArr[cam] - intersectPt).size() > 1.0e-3) // We reach our camera vertex
+                    && (lastIntersectPt - originPt).size() <= (nsigmaJumpPart + nsigmaFrontSilentPart) * maxDist) // We are to far from the originPt
                 {
                     // Keep previous informations
                     const GeometryIntersection previousGeometry = geometry;

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1482,7 +1482,8 @@ DelaunayGraphCut::GeometryIntersection DelaunayGraphCut::rayIntersectTriangle(co
 
     // In case intersectPt is provided, check if intersectPt is in front of lastIntersectionPt 
     // in the DirVec direction to ensure that we are moving forward in the right direction
-    if (lastIntersectPt != nullptr) {
+    if (lastIntersectPt != nullptr)
+    {
         const Point3d diff = tempIntersectPt - *lastIntersectPt;
         const double dotValue = dot(DirVec, diff.normalize());
 
@@ -1759,8 +1760,12 @@ void DelaunayGraphCut::fillGraph(bool fixesSigma, float nPixelSizeBehind,
     ALICEVISION_LOG_DEBUG("totalCamHaveVisibilityOnVertex//totalOfVertex = " << totalCamHaveVisibilityOnVertex << " // " << totalOfVertex);
 
     ALICEVISION_LOG_DEBUG("\n - Geometries Intersected count -");
-    ALICEVISION_LOG_DEBUG("Front: edges " << totalGeometriesIntersectedFrontCount.edges << ", vertices: " << totalGeometriesIntersectedFrontCount.vertices << ", facets: " << totalGeometriesIntersectedFrontCount.facets);
-    ALICEVISION_LOG_DEBUG("Behind: edges " << totalGeometriesIntersectedBehindCount.edges << ", vertices: " << totalGeometriesIntersectedBehindCount.vertices << ", facets: " << totalGeometriesIntersectedBehindCount.facets);
+    ALICEVISION_LOG_DEBUG("Front: " << totalGeometriesIntersectedFrontCount);
+    ALICEVISION_LOG_DEBUG("Behind: " << totalGeometriesIntersectedBehindCount);
+    totalGeometriesIntersectedFrontCount /= totalCamHaveVisibilityOnVertex;
+    totalGeometriesIntersectedBehindCount /= totalCamHaveVisibilityOnVertex;
+    ALICEVISION_LOG_DEBUG("Front per vertex: " << totalGeometriesIntersectedFrontCount);
+    ALICEVISION_LOG_DEBUG("Behind per vertex: " << totalGeometriesIntersectedBehindCount);
     mvsUtils::printfElapsedTime(t1, "s-t graph weights computed : ");
 }
 

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -3121,28 +3121,9 @@ mesh::Mesh* DelaunayGraphCut::createMesh(bool filterHelperPointsTriangles)
             const Point3d N = cross((points[1] - points[0]).normalize(), (points[2] - points[0]).normalize()).normalize();
 
             const double dd1 = orientedPointPlaneDistance(D1, points[0], N);
-            const double dd2 = orientedPointPlaneDistance(D2, points[0], N);
+            // const double dd2 = orientedPointPlaneDistance(D2, points[0], N);
 
-            bool clockwise = false; // std::signbit(dd1)
-            if(dd1 == 0.0f)
-            {
-                if(dd2 == 0.0f)
-                {
-                    ALICEVISION_LOG_WARNING("createMesh: bad triangle orientation.");
-                }
-                else if(dd2 > 0.0f)
-                {
-                    clockwise = true;
-                }
-            }
-            else if(dd1 < 0.0f)
-            {
-                clockwise = true;
-            }
-            if(std::signbit(dd1) == std::signbit(dd2))
-            {
-                ALICEVISION_LOG_WARNING("createMesh: bad triangle signbit.");
-            }
+            const bool clockwise = std::signbit(dd1);
 
             if(clockwise)
             {

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -3029,7 +3029,7 @@ mesh::Mesh* DelaunayGraphCut::createMesh(bool filterHelperPointsTriangles)
             {
                 clockwise = true;
             }
-            if(std::signbit(dd1) != std::signbit(dd2))
+            if(std::signbit(dd1) == std::signbit(dd2))
             {
                 ALICEVISION_LOG_WARNING("createMesh: bad triangle signbit.");
             }

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1457,7 +1457,7 @@ DelaunayGraphCut::GeometryIntersection DelaunayGraphCut::rayIntersectTriangle(co
     const double ACSize = (*A - *C).size();
 
     const double marginEpsilon = std::min(std::min(ABSize, BCSize), ACSize) * epsilonFactor;
-    const double ambiguityEpsilon = (ABSize + BCSize + ACSize) / 3.0 * 1.0e-5;
+    const double ambiguityEpsilon = (ABSize + BCSize + ACSize) / 3.0 * 1.0e-2;
 
     Point3d tempIntersectPt;
     const Point2d triangleUv = getLineTriangleIntersectBarycCoords(&tempIntersectPt, A, B, C, &originPt, &DirVec);
@@ -1486,14 +1486,14 @@ DelaunayGraphCut::GeometryIntersection DelaunayGraphCut::rayIntersectTriangle(co
     {
         const Point3d diff = tempIntersectPt - *lastIntersectPt;
         const double dotValue = dot(DirVec, diff.normalize());
+        if(dotValue < marginEpsilon)
+        {
+            return GeometryIntersection();
+        }
 
         if (diff.size() < ambiguityEpsilon)
         {
             ambiguous = true;
-        }
-        else if(dotValue < marginEpsilon)
-        {
-            return GeometryIntersection();
         }
     }
 

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2945,15 +2945,23 @@ mesh::Mesh* DelaunayGraphCut::createMesh(bool filterHelperPointsTriangles)
             Facet f1(ci, k);
             bool uo = _cellIsFull[f1.cellIndex]; // get if it is occupied
             if(!uo)
+            {
+                // "f1" is in an EMPTY cell, skip it
                 continue;
+            }
 
             Facet f2 = mirrorFacet(f1);
             if(isInvalidOrInfiniteCell(f2.cellIndex))
                 continue;
             bool vo = _cellIsFull[f2.cellIndex]; // get if it is occupied
 
-            if(uo == vo)
+            if(vo)
+            {
+                // "f2" is in a FULL cell, skip it
                 continue;
+            }
+
+            // "f1" is in a FULL cell and "f2" is in an EMPTY cell
 
             VertexIndex vertices[3];
             vertices[0] = getVertexIndex(f1, 0);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1875,10 +1875,22 @@ void DelaunayGraphCut::fillGraphPartPtRc(int& outTotalStepsFront, int& outTotalS
                 {
                     ++outFrontCount.vertices;
                     lastGeoIsVertex = true;
+                    if(previousGeometry.type == EGeometryType::Vertex && outFrontCount.vertices > 1000)
+                    {
+                        ALICEVISION_LOG_DEBUG("[Error]: loop on vertices. Current landmark index: " << vertexIndex);
+                        if(outFrontCount.vertices > 1010)
+                            break;
+                    }
                 }
                 else if (geometry.type == EGeometryType::Edge)
                 {
                     ++outFrontCount.edges;
+                    if(previousGeometry.type == EGeometryType::Edge && outFrontCount.edges > 1000)
+                    {
+                        ALICEVISION_LOG_DEBUG("[Error]: loop on edges. Current landmark index: " << vertexIndex);
+                        if(outFrontCount.edges > 1010)
+                            break;
+                    }
                 }
             }
         }

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2833,9 +2833,7 @@ void DelaunayGraphCut::voteFullEmptyScore(const StaticVector<int>& cams, const s
 
     if(jancosekIJCV) // true by default
     {
-        float forceTEdgeDelta = (float)mp->userParams.get<double>("delaunaycut.forceTEdgeDelta", 0.1f);
-
-        ALICEVISION_LOG_INFO("Jancosek IJCV method ( forceTEdgeDelta*100 = " << static_cast<int>(forceTEdgeDelta * 100.0f) << " ): ");
+        bool forceTEdge = mp->userParams.get<bool>("delaunaycut.forceTEdge", true);
 
         displayCellsStats();
 
@@ -2857,7 +2855,7 @@ void DelaunayGraphCut::voteFullEmptyScore(const StaticVector<int>& cams, const s
             meshf->saveToObj(folderName + "tetrahedralMesh_beforeForceTEdge_emptiness.obj");
         }
 
-        if((forceTEdgeDelta > 0.0f) && (forceTEdgeDelta < 1.0f))
+        if(forceTEdge)
         {
             forceTedgesByGradientIJCV(false, sigma);
         }

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1363,7 +1363,7 @@ DelaunayGraphCut::intersectNextGeom(const DelaunayGraphCut::GeometryIntersection
     {
         for (CellIndex adjCellIndex : getNeighboringCellsByVertexIndex(inGeometry.vertexIndex))
         {
-            if (isInfiniteCell(adjCellIndex))
+            if(isInvalidOrInfiniteCell(adjCellIndex))
                 continue;
 
             // Get local vertex index
@@ -1396,7 +1396,7 @@ DelaunayGraphCut::intersectNextGeom(const DelaunayGraphCut::GeometryIntersection
 
         for (CellIndex adjCellIndex : getNeighboringCellsByEdge(inGeometry.edge))
         {
-            if (isInfiniteCell(adjCellIndex))
+            if(isInvalidOrInfiniteCell(adjCellIndex))
                 continue;
             // Local vertices indices
             const VertexIndex lvi0 = _tetrahedralization->index(adjCellIndex, inGeometry.edge.v0);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2078,23 +2078,23 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
     ALICEVISION_LOG_INFO("Forcing t-edges");
     long t2 = clock();
 
-    float forceTEdgeDelta = (float)mp->userParams.get<double>("delaunaycut.forceTEdgeDelta", 0.1f);
+    const float forceTEdgeDelta = (float)mp->userParams.get<double>("delaunaycut.forceTEdgeDelta", 0.1f);
     ALICEVISION_LOG_DEBUG("forceTEdgeDelta: " << forceTEdgeDelta);
 
-    float minJumpPartRange = (float)mp->userParams.get<double>("delaunaycut.minJumpPartRange", 10000.0f);
+    const float minJumpPartRange = (float)mp->userParams.get<double>("delaunaycut.minJumpPartRange", 10000.0f);
     ALICEVISION_LOG_DEBUG("minJumpPartRange: " << minJumpPartRange);
 
-    float maxSilentPartRange = (float)mp->userParams.get<double>("delaunaycut.maxSilentPartRange", 100.0f);
+    const float maxSilentPartRange = (float)mp->userParams.get<double>("delaunaycut.maxSilentPartRange", 100.0f);
     ALICEVISION_LOG_DEBUG("maxSilentPartRange: " << maxSilentPartRange);
 
     float nsigmaJumpPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaJumpPart", 2.0f);
     ALICEVISION_LOG_DEBUG("nsigmaJumpPart: " << nsigmaJumpPart);
 
-    float nsigmaFrontSilentPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaFrontSilentPart", 2.0f);
+    const float nsigmaFrontSilentPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaFrontSilentPart", 2.0f);
     ALICEVISION_LOG_DEBUG("nsigmaFrontSilentPart: " << nsigmaFrontSilentPart);
 
     // This parameter allows to enlage the surface margin behind the point
-    float nsigmaBackSilentPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaBackSilentPart", 2.0f);
+    const float nsigmaBackSilentPart = (float)mp->userParams.get<double>("delaunaycut.nsigmaBackSilentPart", 2.0f);
     ALICEVISION_LOG_DEBUG("nsigmaBackSilentPart: " << nsigmaBackSilentPart);
 
     for(GC_cellInfo& c: _cellsAttr)
@@ -2138,8 +2138,8 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
         {
             const float maxDist = nPixelSizeBehind * (fixesSigma ? 1.0f : mp->getCamPixelSize(originPt, cam));
 
-            float minJump = 10000000.0f;
-            float minSilent = 10000000.0f;
+            // float minJump = 10000000.0f;
+            // float minSilent = 10000000.0f;
             float maxJump = 0.0f;
             float maxSilent = 0.0f;
             float midSilent = 10000000.0f;
@@ -2176,7 +2176,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
 #ifdef ALICEVISION_DEBUG_VOTE
                         // exportBackPropagationMesh("forceTedges_ToCam_typeNone", history.geometries, originPt, mp->CArr[cam]);
 #endif
-                        ALICEVISION_LOG_DEBUG("[Error]: forceTedges(toTheCam) cause: geometry cannot be found.");
+                        // ALICEVISION_LOG_DEBUG("[Error]: forceTedges(toTheCam) cause: geometry cannot be found.");
                         break;
                     }
 
@@ -2199,12 +2199,12 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                         const GC_cellInfo& c = _cellsAttr[geometry.facet.cellIndex];
                         if ((lastIntersectPt - originPt).size() > nsigmaFrontSilentPart * maxDist) // (p-originPt).size() > 2 * sigma
                         {
-                            minJump = std::min(minJump, c.emptinessScore);
+                            // minJump = std::min(minJump, c.emptinessScore);
                             maxJump = std::max(maxJump, c.emptinessScore);
                         }
                         else
                         {
-                            minSilent = std::min(minSilent, c.emptinessScore);
+                            // minSilent = std::min(minSilent, c.emptinessScore);
                             maxSilent = std::max(maxSilent, c.emptinessScore);
                         }
 
@@ -2215,7 +2215,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
 #ifdef ALICEVISION_DEBUG_VOTE
                             // exportBackPropagationMesh("forceTedges_ToCam_invalidMirorFacet", history.geometries, originPt, mp->CArr[cam]);
 #endif
-                            ALICEVISION_LOG_DEBUG("[Error]: forceTedges(toTheCam) cause: invalidOrInfinite miror facet.");
+                            // ALICEVISION_LOG_DEBUG("[Error]: forceTedges(toTheCam) cause: invalidOrInfinite miror facet.");
                             break;
                         }
                         geometry.facet = mFacet;
@@ -2223,10 +2223,20 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                     else if (geometry.type == EGeometryType::Vertex)
                     {
                         ++totalGeometriesIntersectedFrontCount.vertices;
+                        if(previousGeometry.type == EGeometryType::Vertex && totalGeometriesIntersectedFrontCount.vertices > 1000)
+                        {
+                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on edges. Current landmark index: " << vertexIndex);
+                            break;
+                        }
                     }
                     else if (geometry.type == EGeometryType::Edge)
                     {
                         ++totalGeometriesIntersectedFrontCount.edges;
+                        if(previousGeometry.type == EGeometryType::Edge && totalGeometriesIntersectedFrontCount.edges > 1000)
+                        {
+                            ALICEVISION_LOG_WARNING("forceTedgesByGradient front: loop on edges. Current landmark index: " << vertexIndex);
+                            break;
+                        }
                     }
                 }
                 ++totalRayFront;
@@ -2262,14 +2272,14 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
 
                     if(geometry.type == EGeometryType::None)
                     {
-                        // If we come from a facet, the next intersection must exist (even if the mirror facet is invalid, which is verified later) 
-                        if (previousGeometry.type == EGeometryType::Facet)
-                        {
-#ifdef ALICEVISION_DEBUG_VOTE
-                            // exportBackPropagationMesh("forceTedges_behindThePoint_NoneButPreviousIsFacet", history.geometries, originPt, mp->CArr[cam]);
-#endif
-                            ALICEVISION_LOG_DEBUG("[Error]: forceTedges(behindThePoint) cause: None geometry but previous is Facet.");
-                        }
+//                         // If we come from a facet, the next intersection must exist (even if the mirror facet is invalid, which is verified later) 
+//                         if (previousGeometry.type == EGeometryType::Facet)
+//                         {
+// #ifdef ALICEVISION_DEBUG_VOTE
+//                             // exportBackPropagationMesh("forceTedges_behindThePoint_NoneButPreviousIsFacet", history.geometries, originPt, mp->CArr[cam]);
+// #endif
+//                             ALICEVISION_LOG_DEBUG("[Error]: forceTedges(behindThePoint) cause: None geometry but previous is Facet.");
+//                         }
                         // Break if we reach the end of the tetrahedralization volume
                         break;
                     }
@@ -2286,7 +2296,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                         }
 
                         const GC_cellInfo& c = _cellsAttr[geometry.facet.cellIndex];
-                        minSilent = std::min(minSilent, c.emptinessScore);
+                        // minSilent = std::min(minSilent, c.emptinessScore);
                         maxSilent = std::max(maxSilent, c.emptinessScore);
 
                         // Take the mirror facet to iterate over the next cell
@@ -2328,10 +2338,20 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                         if (geometry.type == EGeometryType::Vertex)
                         {
                             ++totalGeometriesIntersectedFrontCount.vertices;
+                            if(previousGeometry.type == EGeometryType::Vertex && totalGeometriesIntersectedFrontCount.vertices > 1000)
+                            {
+                                ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on vertices. Current landmark index: " << vertexIndex);
+                                break;
+                            }
                         }
                         else if (geometry.type == EGeometryType::Edge)
                         {
                             ++totalGeometriesIntersectedFrontCount.edges;
+                            if(previousGeometry.type == EGeometryType::Edge && totalGeometriesIntersectedFrontCount.edges > 1000)
+                            {
+                                ALICEVISION_LOG_WARNING("forceTedgesByGradient behind: loop on edges. Current landmark index: " << vertexIndex);
+                                break;
+                            }
                         }
                     }
                 }
@@ -2352,8 +2372,7 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
                     // midSilent: score of the next tetrahedron directly after p (called T1 in the paper)
                     // maxSilent: max score of emptiness for the tetrahedron around the point p (+/- 2*sigma around p)
 
-                    if(
-                       (midSilent / maxJump < forceTEdgeDelta) && // (g / B) < k_rel    //// k_rel=0.1
+                    if((midSilent / maxJump < forceTEdgeDelta) && // (g / B) < k_rel    //// k_rel=0.1
                        (maxJump - midSilent > minJumpPartRange) && // (B - g) > k_abs   //// k_abs=10000 // 1000 in the paper
                        (maxSilent < maxSilentPartRange)) // g < k_outl                  //// k_outl=100  // 400 in the paper
                         //(maxSilent-minSilent<maxSilentPartRange))
@@ -2371,11 +2390,10 @@ void DelaunayGraphCut::forceTedgesByGradientIJCV(bool fixesSigma, float nPixelSi
 
     for(GC_cellInfo& c: _cellsAttr)
     {
-        float w = std::max(1.0f, c.cellTWeight);
+        const float w = std::max(1.0f, c.cellTWeight) * c.on;
 
-        // cellTWeight = clamp(w * c.on, cellTWeight, 1000000.0f);
-        c.cellTWeight = std::max(c.cellTWeight, std::min(1000000.0f, w * c.on));
-        // c.cellTWeight = std::max(c.cellTWeight,fit->info().on);
+        // cellTWeight = clamp(w, cellTWeight, 1000000.0f);
+        c.cellTWeight = std::max(c.cellTWeight, std::min(1000000.0f, w));
     }
 
     ALICEVISION_LOG_DEBUG("_verticesAttr.size(): " << _verticesAttr.size() << "(" << verticesRandIds.size() << ")");
@@ -2755,9 +2773,9 @@ void DelaunayGraphCut::maxflow()
     int nbTCells = 0;
     for(CellIndex ci = 0; ci < nbCells; ++ci)
     {
-        GC_cellInfo& c = _cellsAttr[ci];
-        float ws = c.cellSWeight;
-        float wt = c.cellTWeight;
+        const GC_cellInfo& c = _cellsAttr[ci];
+        const float ws = c.cellSWeight;
+        const float wt = c.cellTWeight;
 
         assert(ws >= 0.0f);
         assert(wt >= 0.0f);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -3015,24 +3015,25 @@ mesh::Mesh* DelaunayGraphCut::createMesh(bool filterHelperPointsTriangles)
             const double dd1 = orientedPointPlaneDistance(D1, points[0], N);
             const double dd2 = orientedPointPlaneDistance(D2, points[0], N);
 
-            bool clockwise = false;
+            bool clockwise = false; // std::signbit(dd1)
             if(dd1 == 0.0f)
             {
                 if(dd2 == 0.0f)
                 {
                     ALICEVISION_LOG_WARNING("createMesh: bad triangle orientation.");
                 }
-                if(dd2 > 0.0f)
+                else if(dd2 > 0.0f)
                 {
                     clockwise = true;
                 }
             }
-            else
+            else if(dd1 < 0.0f)
             {
-                if(dd1 < 0.0f)
-                {
-                    clockwise = true;
-                }
+                clockwise = true;
+            }
+            if(std::signbit(dd1) != std::signbit(dd2))
+            {
+                ALICEVISION_LOG_WARNING("createMesh: bad triangle signbit.");
             }
 
             if(clockwise)

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
@@ -186,7 +186,13 @@ public:
             edges += gc.edges;
             vertices += gc.vertices;
             facets += gc.facets;
-
+            return *this;
+        }
+        GeometriesCount& operator/=(const size_t v)
+        {
+            edges /= v;
+            vertices /= v;
+            facets /= v;
             return *this;
         }
     };

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
@@ -97,7 +97,11 @@ public:
         {
             return v0 == e.v0 && v1 == e.v1;
         }
-
+        bool isSameUndirectionalEdge(const Edge& e) const
+        {
+            return (v0 == e.v0 && v1 == e.v1) ||
+                   (v0 == e.v1 && v1 == e.v0);
+        }
     };
 
     enum class EGeometryType

--- a/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
@@ -64,13 +64,15 @@ BOOST_AUTO_TEST_CASE(fuseCut_delaunayGraphCut)
     for (size_t i = 0; i < delaunayGC._verticesCoords.size(); i++)
         ALICEVISION_LOG_TRACE("[" << i << "]: " << delaunayGC._verticesCoords[i].x << ", " << delaunayGC._verticesCoords[i].y << ", " << delaunayGC._verticesCoords[i].z);
 
-    // delaunayGC.createGraphCut(&hexah[0], cams, tempDirPath + "/", tempDirPath + "/SpaceCamsTracks/", false);
+    delaunayGC.createGraphCut(&hexah[0], cams, tempDirPath + "/", tempDirPath + "/SpaceCamsTracks/", false);
+    /*
     delaunayGC.initVertices();
     delaunayGC.computeDelaunay();
     delaunayGC.displayStatistics();
     delaunayGC.computeVerticesSegSize(true, 0.0f);
     delaunayGC.voteFullEmptyScore(cams, tempDirPath);
     delaunayGC.reconstructGC(&hexah[0]);
+    */
 
     ALICEVISION_LOG_TRACE("CreateGraphCut Done.");
 }

--- a/src/aliceVision/fuseCut/delaunayGraphCutTypes.hpp
+++ b/src/aliceVision/fuseCut/delaunayGraphCutTypes.hpp
@@ -55,14 +55,17 @@ struct GC_cellInfo
     }
 };
 
+struct GC_Seg
+{
+    int segSize = 0;
+    int segId = -1;
+};
+
 struct GC_vertexInfo
 {
     float pixSize = 0.0f;
     /// Number of cameras which have contributed to the refinement of the vertex position, so nrc >= cams.size().
     int nrc = 0;
-    int segSize = 0;
-    int segId = -1;
-    bool isOnSurface = false;
     /// All cameras having a visibility of this vertex. Some of them may not have contributed to the vertex position
     StaticVector<int> cams;
 
@@ -86,9 +89,6 @@ struct GC_vertexInfo
     {
         fwrite(&pixSize, sizeof(float), 1, f);
         fwrite(&nrc, sizeof(int), 1, f);
-        fwrite(&segSize, sizeof(int), 1, f);
-        fwrite(&segId, sizeof(int), 1, f);
-        fwrite(&isOnSurface, sizeof(bool), 1, f);
         int n = cams.size();
         fwrite(&n, sizeof(int), 1, f);
         if(n > 0)
@@ -101,9 +101,6 @@ struct GC_vertexInfo
     {
         fread(&pixSize, sizeof(float), 1, f);
         fread(&nrc, sizeof(int), 1, f);
-        fread(&segSize, sizeof(int), 1, f);
-        fread(&segId, sizeof(int), 1, f);
-        fread(&isOnSurface, sizeof(bool), 1, f);
         int n;
         fread(&n, sizeof(int), 1, f);
         if(n > 0)

--- a/src/aliceVision/mesh/MeshAnalyze.cpp
+++ b/src/aliceVision/mesh/MeshAnalyze.cpp
@@ -150,7 +150,7 @@ void MeshAnalyze::getVertexPrincipalCurvatures(double Kh, double Kg, double& K1,
     K2 = Kh - temp;
 }
 
-bool MeshAnalyze::applyLaplacianOperator(int ptId, StaticVector<Point3d>& ptsToApplyLaplacianOp, Point3d& ln)
+bool MeshAnalyze::applyLaplacianOperator(int ptId, const StaticVector<Point3d>& ptsToApplyLaplacianOp, Point3d& ln)
 {
     StaticVector<int>& ptNeighPtsOrdered = ptsNeighPtsOrdered[ptId];
     if(ptNeighPtsOrdered.empty())
@@ -181,12 +181,6 @@ bool MeshAnalyze::applyLaplacianOperator(int ptId, StaticVector<Point3d>& ptsToA
         return false;
     }
 
-    if(std::isnan(d) || std::isnan(n.x) || std::isnan(n.y) || std::isnan(n.z)) // check if is not NaN
-    {
-        ALICEVISION_LOG_WARNING("MeshAnalyze::applyLaplacianOperator: nan");
-        return false;
-    }
-
     return true;
 }
 
@@ -198,9 +192,10 @@ bool MeshAnalyze::getLaplacianSmoothingVector(int ptId, Point3d& ln)
 }
 
 // kobbelt kampagna 98 Interactive Multi-Resolution Modeling on Arbitrary Meshes
-// page 5 - U1 - laplacian is obtained when apply to origina pts , U2 - bi-laplacian is obtained when apply to laplacian
-// pts
-bool MeshAnalyze::getBiLaplacianSmoothingVector(int ptId, StaticVector<Point3d>& ptsLaplacian, Point3d& tp)
+// page 5:
+// U1 - laplacian is obtained when apply to original points,
+// U2 - bi-laplacian is obtained when apply to laplacian points
+bool MeshAnalyze::getBiLaplacianSmoothingVector(int ptId, const StaticVector<Point3d>& ptsLaplacian, Point3d& tp)
 {
     if(applyLaplacianOperator(ptId, ptsLaplacian, tp))
     {

--- a/src/aliceVision/mesh/MeshAnalyze.hpp
+++ b/src/aliceVision/mesh/MeshAnalyze.hpp
@@ -25,9 +25,9 @@ public:
     int getVertexIdInTriangleForPtId(int ptId, int triId);
     bool getVertexMeanCurvatureNormal(int ptId, Point3d& Kh);
     void getVertexPrincipalCurvatures(double Kh, double Kg, double& K1, double& K2);
-    bool applyLaplacianOperator(int ptId, StaticVector<Point3d>& ptsToApplyLaplacianOp, Point3d& ln);
+    bool applyLaplacianOperator(int ptId, const StaticVector<Point3d>& ptsToApplyLaplacianOp, Point3d& ln);
     bool getLaplacianSmoothingVector(int ptId, Point3d& ln);
-    bool getBiLaplacianSmoothingVector(int ptId, StaticVector<Point3d>& ptsLaplacian, Point3d& tp);
+    bool getBiLaplacianSmoothingVector(int ptId, const StaticVector<Point3d>& ptsLaplacian, Point3d& tp);
     bool getMeanCurvAndLaplacianSmoothing(int ptId, Point3d& F, float epsilon);
     bool getVertexSurfaceNormal(int ptId, Point3d& N);
 };

--- a/src/aliceVision/mvsData/Point2d.hpp
+++ b/src/aliceVision/mvsData/Point2d.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cmath>
+#include <ostream>
 
 namespace aliceVision {
 
@@ -88,6 +89,12 @@ public:
 inline double dot(const Point2d& p1, const Point2d& p2)
 {
     return p1.x * p2.x + p1.y * p2.y;
+}
+
+inline std::ostream& operator<<(std::ostream& stream, const Point2d& p)
+{
+    stream << p.x << "," << p.y;
+    return stream;
 }
 
 } // namespace aliceVision

--- a/src/aliceVision/mvsData/Point3d.hpp
+++ b/src/aliceVision/mvsData/Point3d.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <cmath>
+#include <ostream>
 
 namespace aliceVision {
 
@@ -107,7 +108,7 @@ public:
 
     friend double dot(const Point3d& p1, const Point3d& p2);
     friend Point3d cross(const Point3d& a, const Point3d& b);
-    friend Point3d proj(Point3d& e, Point3d& a);
+    friend Point3d proj(const Point3d& e, const Point3d& a);
 };
 
 inline double dist(const Point3d& p1, const Point3d& p2)
@@ -130,9 +131,15 @@ inline Point3d cross(const Point3d& a, const Point3d& b)
     return vc;
 }
 
-inline Point3d proj(Point3d& e, Point3d& a)
+inline Point3d proj(const Point3d& e, const Point3d& a)
 {
     return e * (dot(e, a) / dot(e, e));
+}
+
+inline std::ostream& operator<<(std::ostream& stream, const Point3d& p)
+{
+    stream << p.x << "," << p.y << "," << p.z;
+    return stream;
 }
 
 } // namespace aliceVision

--- a/src/aliceVision/mvsData/Point4d.hpp
+++ b/src/aliceVision/mvsData/Point4d.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <ostream>
+
 namespace aliceVision {
 
 class Point4d
@@ -98,5 +100,11 @@ public:
         return e * (dot(e, a) / dot(e, e));
     }
 };
+
+inline std::ostream& operator<<(std::ostream& stream, const Point4d& p)
+{
+    stream << p.x << "," << p.y << "," << p.z << "," << p.w;
+    return stream;
+}
 
 } // namespace aliceVision

--- a/src/aliceVision/mvsData/geometry.cpp
+++ b/src/aliceVision/mvsData/geometry.cpp
@@ -47,7 +47,7 @@ void computeRotCS(Point3d* xax, Point3d* yax, const Point3d* n)
     *yax = cross(*n, *xax);
 }
 
-bool lineLineIntersect(float* k, float* l, Point3d* llis, Point3d* lli1, Point3d* lli2, const Point3d& p1,
+bool lineLineIntersect(double* k, double* l, Point3d* llis, Point3d* lli1, Point3d* lli2, const Point3d& p1,
                        const Point3d& p2, const Point3d& p3, const Point3d& p4)
 {
     /*
@@ -68,7 +68,7 @@ bool lineLineIntersect(float* k, float* l, Point3d* llis, Point3d* lli1, Point3d
     %   (csd@cmu.edu)
     */
 
-    float d1343, d4321, d1321, d4343, d2121, denom, numer, p13[3], p43[3], p21[3], pa[3], pb[3], muab[2];
+    double d1343, d4321, d1321, d4343, d2121, denom, numer, p13[3], p43[3], p21[3], pa[3], pb[3], muab[2];
 
     p13[0] = p1.x - p3.x;
     p13[1] = p1.y - p3.y;
@@ -139,7 +139,7 @@ bool lineLineIntersect(float* k, float* l, Point3d* llis, Point3d* lli1, Point3d
 
 bool lineLineIntersect(Point3d& out, const Point3d& p1, const Point3d& v1, const Point3d& p2, const Point3d& v2)
 {
-    float k, l;
+    double k, l;
     Point3d lli1, lli2;
     Point3d p1v1 = p1 + v1;
     Point3d p2v2 = p2 + v2;
@@ -149,44 +149,44 @@ bool lineLineIntersect(Point3d& out, const Point3d& p1, const Point3d& v1, const
 Point3d linePlaneIntersect(const Point3d& linePoint, const Point3d& lineVect, const Point3d& planePoint,
                            const Point3d& planeNormal)
 {
-    float planePoint_x = planePoint.x;
-    float planePoint_y = planePoint.y;
-    float planePoint_z = planePoint.z;
-    float planeNormal_x = planeNormal.x;
-    float planeNormal_y = planeNormal.y;
-    float planeNormal_z = planeNormal.z;
-    float linePoint_x = linePoint.x;
-    float linePoint_y = linePoint.y;
-    float linePoint_z = linePoint.z;
-    float lineVect_x = lineVect.x;
-    float lineVect_y = lineVect.y;
-    float lineVect_z = lineVect.z;
-    float k = ((planePoint_x * planeNormal_x + planePoint_y * planeNormal_y + planePoint_z * planeNormal_z) - (planeNormal_x * linePoint_x + planeNormal_y * linePoint_y + planeNormal_z * linePoint_z)) / (planeNormal_x * lineVect_x + planeNormal_y * lineVect_y + planeNormal_z * lineVect_z);
+    const double planePoint_x = planePoint.x;
+    const double planePoint_y = planePoint.y;
+    const double planePoint_z = planePoint.z;
+    const double planeNormal_x = planeNormal.x;
+    const double planeNormal_y = planeNormal.y;
+    const double planeNormal_z = planeNormal.z;
+    const double linePoint_x = linePoint.x;
+    const double linePoint_y = linePoint.y;
+    const double linePoint_z = linePoint.z;
+    const double lineVect_x = lineVect.x;
+    const double lineVect_y = lineVect.y;
+    const double lineVect_z = lineVect.z;
+    const double k = ((planePoint_x * planeNormal_x + planePoint_y * planeNormal_y + planePoint_z * planeNormal_z) - (planeNormal_x * linePoint_x + planeNormal_y * linePoint_y + planeNormal_z * linePoint_z)) / (planeNormal_x * lineVect_x + planeNormal_y * lineVect_y + planeNormal_z * lineVect_z);
     return linePoint + lineVect * k;
-    //---KP---float k = (dot(planePoint, planeNormal) - dot(planeNormal, linePoint)) / dot(planeNormal, lineVect);
+    //---KP---double k = (dot(planePoint, planeNormal) - dot(planeNormal, linePoint)) / dot(planeNormal, lineVect);
     //---KP---return linePoint + lineVect * k;
 }
 
 void linePlaneIntersect(Point3d* out, const Point3d* linePoint, const Point3d* lineVect, const Point3d* planePoint,
                         const Point3d* planeNormal)
 {
-    float planePoint_x = planePoint->x;
-    float planePoint_y = planePoint->y;
-    float planePoint_z = planePoint->z;
-    float planeNormal_x = planeNormal->x;
-    float planeNormal_y = planeNormal->y;
-    float planeNormal_z = planeNormal->z;
-    float linePoint_x = linePoint->x;
-    float linePoint_y = linePoint->y;
-    float linePoint_z = linePoint->z;
-    float lineVect_x = lineVect->x;
-    float lineVect_y = lineVect->y;
-    float lineVect_z = lineVect->z;
-    float k = ((planePoint_x * planeNormal_x + planePoint_y * planeNormal_y + planePoint_z * planeNormal_z) - (planeNormal_x * linePoint_x + planeNormal_y * linePoint_y + planeNormal_z * linePoint_z)) / (planeNormal_x * lineVect_x + planeNormal_y * lineVect_y + planeNormal_z * lineVect_z);
+    const double planePoint_x = planePoint->x;
+    const double planePoint_y = planePoint->y;
+    const double planePoint_z = planePoint->z;
+    const double planeNormal_x = planeNormal->x;
+    const double planeNormal_y = planeNormal->y;
+    const double planeNormal_z = planeNormal->z;
+    const double linePoint_x = linePoint->x;
+    const double linePoint_y = linePoint->y;
+    const double linePoint_z = linePoint->z;
+    const double lineVect_x = lineVect->x;
+    const double lineVect_y = lineVect->y;
+    const double lineVect_z = lineVect->z;
+    const double k = ((planePoint_x * planeNormal_x + planePoint_y * planeNormal_y + planePoint_z * planeNormal_z) - (planeNormal_x * linePoint_x + planeNormal_y * linePoint_y + planeNormal_z * linePoint_z)) / (planeNormal_x * lineVect_x + planeNormal_y * lineVect_y + planeNormal_z * lineVect_z);
     out->x = linePoint_x + (lineVect_x) * k;
     out->y = linePoint_y + (lineVect_y) * k;
     out->z = linePoint_z + (lineVect_z) * k;
-    //---KP---float k = (dot(*planePoint, *planeNormal) - dot(*planeNormal, *linePoint)) / dot(*planeNormal, *lineVect);
+    //---KP---double k = (dot(*planePoint, *planeNormal) - dot(*planeNormal, *linePoint)) / dot(*planeNormal, *lineVect);
     //---KP---*out = *linePoint + (*lineVect) * k;
 }
 
@@ -249,7 +249,7 @@ void rotPointAroundVect(double* out, const double* X, const double* vect, const 
     out[2] = z * sizeX;
 }
 
-void rotPointAroundVect(Point3d* out, const Point3d* X, const Point3d* vect, const float angle)
+void rotPointAroundVect(Point3d* out, const Point3d* X, const Point3d* vect, const double angle)
 {
     double o[3];
     double dX[3] = {(double)X->x, (double)X->y, (double)X->z};
@@ -263,6 +263,7 @@ void rotPointAroundVect(Point3d* out, const Point3d* X, const Point3d* vect, con
 Point2d getLineTriangleIntersectBarycCoords(Point3d* P, const Point3d* A, const Point3d* B, const Point3d* C,
                                             const Point3d* linePoint, const Point3d* lineVect)
 {
+    // flat code instead of all functions calls to improve performances
     const double A_x = A->x;
     const double A_y = A->y;
     const double A_z = A->z;
@@ -303,26 +304,24 @@ Point2d getLineTriangleIntersectBarycCoords(Point3d* P, const Point3d* A, const 
     P->y = P_y;
     P->z = P_z;
 
-    //---KP---Point3d v0 = *C - *A;
-    //---KP---Point3d v1 = *B - *A;
-    //---KP---Point3d n = cross(v0.normalize(), v1.normalize()).normalize();
-    //---KP---linePlaneIntersect(P, linePoint, lineVect, A, &n);
-    //---KP---// Compute vectors
-    //---KP---Point3d v2 = *P - *A;
-    //---KP---// Compute dot products
-    //---KP---float dot00 = dot(v0, v0);
-    //---KP---float dot01 = dot(v0, v1);
-    //---KP---float dot02 = dot(v0, v2);
-    //---KP---float dot11 = dot(v1, v1);
-    //---KP---float dot12 = dot(v1, v2);
-    //---KP---// Compute barycentric coordinates
-    //---KP---float invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
-    //---KP---float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
-    //---KP---float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
-
-    // if ((u==0.0f)||(v==0.0f)||(u+v==1.0f)) {
-    //	printf("WARNNG : isLineInTriangle - is on border! \n");
-    //};
+/*
+    const Point3d v0 = *C - *A;
+    const Point3d v1 = *B - *A;
+    const Point3d n = cross(v0.normalize(), v1.normalize()).normalize();
+    linePlaneIntersect(P, linePoint, lineVect, A, &n);
+    // Compute vectors
+    const Point3d v2 = *P - *A;
+    // Compute dot products
+    const double dot00 = dot(v0, v0);
+    const double dot01 = dot(v0, v1);
+    const double dot02 = dot(v0, v2);
+    const double dot11 = dot(v1, v1);
+    const double dot12 = dot(v1, v2);
+    // Compute barycentric coordinates
+    const double invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
+    const double u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    const double v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+*/
 
     // Check if point is in triangle
     return Point2d(u, v);
@@ -345,23 +344,23 @@ bool isLineSegmentInTriangle(Point3d& lpi, const Point3d& A, const Point3d& B, c
     Point3d lineVect = linePoint2 - linePoint1;
 
     // linePlaneIntersect(&P, linePoint, lineVect, A, &n);
-    float k = (dot(A, n) - dot(n, linePoint1)) / dot(n, lineVect);
+    const double k = (dot(A, n) - dot(n, linePoint1)) / dot(n, lineVect);
     lpi = linePoint1 + lineVect * k;
 
     // Compute vectors
-    Point3d v2 = lpi - A;
+    const Point3d v2 = lpi - A;
 
     // Compute dot products
-    float dot00 = dot(v0, v0);
-    float dot01 = dot(v0, v1);
-    float dot02 = dot(v0, v2);
-    float dot11 = dot(v1, v1);
-    float dot12 = dot(v1, v2);
+    const double dot00 = dot(v0, v0);
+    const double dot01 = dot(v0, v1);
+    const double dot02 = dot(v0, v2);
+    const double dot11 = dot(v1, v1);
+    const double dot12 = dot(v1, v2);
 
     // Compute barycentric coordinates
-    float invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
-    float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
-    float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+    const double invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
+    const double u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    const double v = (dot00 * dot12 - dot01 * dot02) * invDenom;
 
     // Check if point is in triangle
     return (k >= 0.0) && (k <= 1.0) && (u > 0.0) && (v > 0.0) && (u + v < 1.0);
@@ -372,21 +371,21 @@ Point2d computeBarycentricCoordinates(const Point2d& A, const Point2d& B, const 
 {
     // http://www.blackpawn.com/texts/pointinpoly/default.html
 
-    Point2d v0 = C - A;
-    Point2d v1 = B - A;
-    Point2d v2 = P - A;
+    const Point2d v0 = C - A;
+    const Point2d v1 = B - A;
+    const Point2d v2 = P - A;
 
     // Compute dot products
-    float dot00 = dot(v0, v0);
-    float dot01 = dot(v0, v1);
-    float dot02 = dot(v0, v2);
-    float dot11 = dot(v1, v1);
-    float dot12 = dot(v1, v2);
+    const double dot00 = dot(v0, v0);
+    const double dot01 = dot(v0, v1);
+    const double dot02 = dot(v0, v2);
+    const double dot11 = dot(v1, v1);
+    const double dot12 = dot(v1, v2);
 
     // Compute barycentric coordinates
-    float invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
-    float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
-    float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+    const double invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
+    const double u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    const double v = (dot00 * dot12 - dot01 * dot02) * invDenom;
 
     return Point2d(u, v);
 }
@@ -405,18 +404,18 @@ bool isPointInTriangle(const Point2d& A, const Point2d& B, const Point2d& C, con
 
 bool lineSegmentsIntersect2DTest(const Point2d& A, const Point2d& B, const Point2d& C, const Point2d& D)
 {
-    float r = ((A.y - C.y) * (D.x - C.x) - (A.x - C.x) * (D.y - C.y)) /
+    const double r = ((A.y - C.y) * (D.x - C.x) - (A.x - C.x) * (D.y - C.y)) /
               ((B.x - A.x) * (D.y - C.y) - (B.y - A.y) * (D.x - C.x));
-    float s = ((A.y - C.y) * (B.x - A.x) - (A.x - C.x) * (B.y - A.y)) /
+    const double s = ((A.y - C.y) * (B.x - A.x) - (A.x - C.x) * (B.y - A.y)) /
               ((B.x - A.x) * (D.y - C.y) - (B.y - A.y) * (D.x - C.x));
     return ((r >= 0.0) && (r <= 1.0) && (s >= 0.0) && (s <= 1.0));
 }
 
 bool lineSegmentsIntersect2DTest(Point2d& S, const Point2d& A, const Point2d& B, const Point2d& C, const Point2d& D)
 {
-    float r = ((A.y - C.y) * (D.x - C.x) - (A.x - C.x) * (D.y - C.y)) /
+    const double r = ((A.y - C.y) * (D.x - C.x) - (A.x - C.x) * (D.y - C.y)) /
               ((B.x - A.x) * (D.y - C.y) - (B.y - A.y) * (D.x - C.x));
-    float s = ((A.y - C.y) * (B.x - A.x) - (A.x - C.x) * (B.y - A.y)) /
+    const double s = ((A.y - C.y) * (B.x - A.x) - (A.x - C.x) * (B.y - A.y)) /
               ((B.x - A.x) * (D.y - C.y) - (B.y - A.y) * (D.x - C.x));
     S = A + (B - A) * r;
     return ((r >= 0.0) && (r <= 1.0) && (s >= 0.0) && (s <= 1.0));

--- a/src/aliceVision/mvsData/geometry.hpp
+++ b/src/aliceVision/mvsData/geometry.hpp
@@ -126,7 +126,7 @@ double pointPlaneDistance(const Point3d& point, const Point3d& planePoint, const
 
 double orientedPointPlaneDistance(const Point3d& point, const Point3d& planePoint, const Point3d& planeNormal);
 void computeRotCS(Point3d* xax, Point3d* yax, const Point3d* n);
-bool lineLineIntersect(float* k, float* l, Point3d* llis, Point3d* lli1, Point3d* lli2, const Point3d& p1,
+bool lineLineIntersect(double* k, double* l, Point3d* llis, Point3d* lli1, Point3d* lli2, const Point3d& p1,
                        const Point3d& p2, const Point3d& p3, const Point3d& p4);
 bool lineLineIntersectLeft(Point3d& out, const Point3d& p1, const Point3d& p2, const Point3d& p3, const Point3d& p4);
 bool lineLineIntersect(Point3d& out, const Point3d& p1, const Point3d& v1, const Point3d& p2, const Point3d& v2);
@@ -139,7 +139,7 @@ double angleBetwV1andV2(const Point3d& iV1, const Point3d& iV2);
 double angleBetwABandAC(const Point3d& A, const Point3d& B, const Point3d& C);
 
 void rotPointAroundVect(double* out, const double* X, const double* vect, const double angle);
-void rotPointAroundVect(Point3d* out, const Point3d* X, const Point3d* vect, const float angle);
+void rotPointAroundVect(Point3d* out, const Point3d* X, const Point3d* vect, const double angle);
 Point2d getLineTriangleIntersectBarycCoords(Point3d* P, const Point3d* A, const Point3d* B, const Point3d* C,
                                             const Point3d* linePoint, const Point3d* lineVect);
 bool isLineInTriangle(Point3d* P, const Point3d* A, const Point3d* B, const Point3d* C, const Point3d* linePoint,

--- a/src/aliceVision/mvsUtils/common.cpp
+++ b/src/aliceVision/mvsUtils/common.cpp
@@ -32,20 +32,20 @@ bool get2dLineImageIntersection(Point2d* pFrom, Point2d* pTo, Point2d linePoint1
 
     v = v.normalize();
 
-    float a = -v.y;
-    float b = v.x;
-    float c = -a * linePoint1.x - b * linePoint1.y;
+    double a = -v.y;
+    double b = v.x;
+    double c = -a * linePoint1.x - b * linePoint1.y;
 
     int intersections = 0;
-    float rw = (float)mp->getWidth(camId);
-    float rh = (float)mp->getHeight(camId);
+    double rw = (double)mp->getWidth(camId);
+    double rh = (double)mp->getHeight(camId);
 
     // ax + by + c = 0
 
     // right epip line intersection with the left side of the right image
     // a*0 + b*y + c = 0; y = -c / b;
-    float x = 0;
-    float y = -c / b;
+    double x = 0;
+    double y = -c / b;
     if((y >= 0) && (y < rh))
     {
         *pFrom = Point2d(x, y);
@@ -159,13 +159,13 @@ bool triangulateMatch(Point3d& out, const Point2d& refpix, const Point2d& tarpix
 {
     Point3d refvect = mp->iCamArr[refCam] * refpix;
     refvect = refvect.normalize();
-    Point3d refpoint = refvect + mp->CArr[refCam];
+    const Point3d refpoint = refvect + mp->CArr[refCam];
 
     Point3d tarvect = mp->iCamArr[tarCam] * tarpix;
     tarvect = tarvect.normalize();
-    Point3d tarpoint = tarvect + mp->CArr[tarCam];
+    const Point3d tarpoint = tarvect + mp->CArr[tarCam];
 
-    float k, l;
+    double k, l;
     Point3d lli1, lli2;
 
     return lineLineIntersect(&k, &l, &out, &lli1, &lli2, mp->CArr[refCam], refpoint, mp->CArr[tarCam], tarpoint);
@@ -223,25 +223,25 @@ std::string formatElapsedTime(long t1)
     return out;
 }
 
-bool checkPair(const Point3d& p, int rc, int tc, const MultiViewParams* mp, float minAng, float maxAng)
+bool checkPair(const Point3d& p, int rc, int tc, const MultiViewParams* mp, double minAng, double maxAng)
 {
-    float ps1 = mp->getCamPixelSize(p, rc);
-    float ps2 = mp->getCamPixelSize(p, tc);
-    float ang = angleBetwABandAC(p, mp->CArr[rc], mp->CArr[tc]);
+    const double ps1 = mp->getCamPixelSize(p, rc);
+    const double ps2 = mp->getCamPixelSize(p, tc);
+    const double ang = angleBetwABandAC(p, mp->CArr[rc], mp->CArr[tc]);
 
     return ((std::min(ps1, ps2) > std::max(ps1, ps2) * 0.8) && (ang >= minAng) && (ang <= maxAng));
 }
 
-bool checkCamPairAngle(int rc, int tc, const MultiViewParams* mp, float minAng, float maxAng)
+bool checkCamPairAngle(int rc, int tc, const MultiViewParams* mp, double minAng, double maxAng)
 {
     if(rc == tc)
     {
         return false;
     }
 
-    Point3d rn = mp->iRArr[rc] * Point3d(0.0, 0.0, 1.0);
-    Point3d tn = mp->iRArr[tc] * Point3d(0.0, 0.0, 1.0);
-    float a = angleBetwV1andV2(rn, tn);
+    const Point3d rn = mp->iRArr[rc] * Point3d(0.0, 0.0, 1.0);
+    const Point3d tn = mp->iRArr[tc] * Point3d(0.0, 0.0, 1.0);
+    const double a = angleBetwV1andV2(rn, tn);
 
     return ((a >= minAng) && (a <= maxAng));
 }
@@ -410,7 +410,7 @@ StaticVector<Point3d>* lineSegmentHexahedronIntersection(Point3d& linePoint1, Po
 void triangleRectangleIntersection(Point3d& A, Point3d& B, Point3d& C, const MultiViewParams& mp, int rc,
                                                      Point2d P[4], StaticVector<Point3d>& out)
 {
-    float maxd =
+    const double maxd =
         std::max(std::max((mp.CArr[rc] - A).size(), (mp.CArr[rc] - B).size()), (mp.CArr[rc] - C).size()) * 1000.0f;
 
     out.reserve(40);
@@ -470,8 +470,8 @@ bool isPointInHexahedron(const Point3d& p, const Point3d* hexah)
     Point3d c = hexah[3];
     Point3d d = hexah[4];
     Point3d n = cross(a - b, b - c).normalize();
-    float d1 = orientedPointPlaneDistance(p, a, n);
-    float d2 = orientedPointPlaneDistance(d, a, n);
+    double d1 = orientedPointPlaneDistance(p, a, n);
+    double d2 = orientedPointPlaneDistance(d, a, n);
     if(d1 * d2 < 0.0)
         return false;
 

--- a/src/aliceVision/mvsUtils/common.hpp
+++ b/src/aliceVision/mvsUtils/common.hpp
@@ -40,7 +40,7 @@ inline void printfElapsedTime(long t1, std::string prefix = "")
 int gaussKernelVoting(StaticVector<OrientedPoint*>* pts, float sigma);
 float angularDistnace(OrientedPoint* op1, OrientedPoint* op2);
 bool arecoincident(OrientedPoint* op1, OrientedPoint* op2, float pixSize);
-bool checkPair(const Point3d& p, int rc, int tc, const MultiViewParams* mp, float minAng, float maxAng);
+bool checkPair(const Point3d& p, int rc, int tc, const MultiViewParams* mp, double minAng, double maxAng);
 bool checkCamPairAngle(int rc, int tc, const MultiViewParams* mp, float minAng, float maxAng);
 void getHexahedronTriangles(Point3d tris[12][3], const Point3d hexah[8]);
 void getCamHexahedron(const Point3d& position, const Matrix3x3& iCam, int width, int height, float minDepth, float maxDepth, Point3d hexah[8]);

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -499,7 +499,8 @@ int aliceVision_main(int argc, char* argv[])
                     }
 
                     delaunayGC.createGraphCut(&hexah[0], cams, outDirectory.string()+"/", outDirectory.string()+"/SpaceCamsTracks/", false);
-                    delaunayGC.graphCutPostProcessing();
+
+                    delaunayGC.graphCutPostProcessing(&hexah[0], outDirectory.string()+"/");
                     mesh = delaunayGC.createMesh();
                     delaunayGC.createPtsCams(ptsCams);
                     mesh::meshPostProcessing(mesh, ptsCams, mp, outDirectory.string()+"/", nullptr, &hexah[0]);

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -267,7 +267,7 @@ int aliceVision_main(int argc, char* argv[])
     bool addLandmarksToTheDensePointCloud = false;
     bool saveRawDensePointCloud = false;
     bool colorizeOutput = false;
-    float forceTEdgeDelta = 0.1f;
+    bool forceTEdge = false;
     unsigned int seed = 0;
     BoundingBox boundingBox;
 
@@ -342,8 +342,8 @@ int aliceVision_main(int argc, char* argv[])
             "refineFuse")
         ("saveRawDensePointCloud", po::value<bool>(&saveRawDensePointCloud)->default_value(saveRawDensePointCloud),
             "Save dense point cloud before cut and filtering.")
-        ("forceTEdgeDelta", po::value<float>(&forceTEdgeDelta)->default_value(forceTEdgeDelta),
-            "0 to disable force T edge in graphcut. Threshold for emptiness/fullness variation.")
+        ("forceTEdge", po::value<bool>(&forceTEdge)->default_value(forceTEdge),
+            "Enable force T edge in graphcut.")
         ("seed", po::value<unsigned int>(&seed)->default_value(seed),
          "Seed used in random processes. (0 to use a random seed)."); 
 
@@ -417,8 +417,8 @@ int aliceVision_main(int argc, char* argv[])
     mvsUtils::MultiViewParams mp(sfmData, "", "", depthMapsFolder, meshingFromDepthMaps);
 
     mp.userParams.put("LargeScale.universePercentile", universePercentile);
-    mp.userParams.put("delaunaycut.forceTEdgeDelta", forceTEdgeDelta);
     mp.userParams.put("delaunaycut.seed", seed);
+    mp.userParams.put("delaunaycut.forceTEdge", forceTEdge);
 
     int ocTreeDim = mp.userParams.get<int>("LargeScale.gridLevel0", 1024);
     const auto baseDir = mp.userParams.get<std::string>("LargeScale.baseDirName", "root01024");

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -267,7 +267,7 @@ int aliceVision_main(int argc, char* argv[])
     bool addLandmarksToTheDensePointCloud = false;
     bool saveRawDensePointCloud = false;
     bool colorizeOutput = false;
-    bool forceTEdge = false;
+    bool voteFilteringForWeaklySupportedSurfaces = true;
     unsigned int seed = 0;
     BoundingBox boundingBox;
 
@@ -342,8 +342,8 @@ int aliceVision_main(int argc, char* argv[])
             "refineFuse")
         ("saveRawDensePointCloud", po::value<bool>(&saveRawDensePointCloud)->default_value(saveRawDensePointCloud),
             "Save dense point cloud before cut and filtering.")
-        ("forceTEdge", po::value<bool>(&forceTEdge)->default_value(forceTEdge),
-            "Enable force T edge in graphcut.")
+        ("voteFilteringForWeaklySupportedSurfaces", po::value<bool>(&voteFilteringForWeaklySupportedSurfaces)->default_value(voteFilteringForWeaklySupportedSurfaces),
+            "Improve support of weakly supported surfaces with a tetrahedra fullness score filtering.")
         ("seed", po::value<unsigned int>(&seed)->default_value(seed),
          "Seed used in random processes. (0 to use a random seed)."); 
 
@@ -418,7 +418,7 @@ int aliceVision_main(int argc, char* argv[])
 
     mp.userParams.put("LargeScale.universePercentile", universePercentile);
     mp.userParams.put("delaunaycut.seed", seed);
-    mp.userParams.put("delaunaycut.forceTEdge", forceTEdge);
+    mp.userParams.put("delaunaycut.voteFilteringForWeaklySupportedSurfaces", voteFilteringForWeaklySupportedSurfaces);
 
     int ocTreeDim = mp.userParams.get<int>("LargeScale.gridLevel0", 1024);
     const auto baseDir = mp.userParams.get<std::string>("LargeScale.baseDirName", "root01024");


### PR DESCRIPTION
## Description

With the improvements of the tetrahedral intersection in https://github.com/alicevision/AliceVision/pull/848, some adjustments are needed in the next steps.

## Features list

- [X] vote on cellSWeight for more cells. Instead of voting only for the last tetrahedron, we vote for multiple
ones along the ray from the 3D vertex to the camera. The tetrahedral intersection now works fine and reach the camera almost all the time, so only the tetrahedra around the camera were voting on cellSWeight. This creates problem on some datasets, so we now vote for multiple cells.
- [X] minor reduction of the memory consumption
- [X] fix inverted condition in forceTedgesByGradient
- [X] minor code cleanup
- [X] forceTedges: change nsigmaJumpPart from 2 to 4
