### PR TITLE
[software] Texturing: improve memory usage

### DIFF
--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -285,6 +285,12 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
 
     ALICEVISION_LOG_DEBUG("nbAtlasMax: " << nbAtlasMax);
 
+    // Add rounding to have a uniform repartition between chunks (avoid a small chunk at the end)
+    const int nChunks = std::ceil(nbAtlas / double(nbAtlasMax));
+    nbAtlasMax = std::ceil(nbAtlas / double(nChunks));
+    ALICEVISION_LOG_DEBUG("nChunks: " << nChunks);
+    ALICEVISION_LOG_INFO("nbAtlasMax (after rounding): " << nbAtlasMax);
+
     if (availableMem - nbAtlasMax*atlasPyramidMaxMemSize < 1000) //keep 1 GB margin in memory
         nbAtlasMax -= 1;
     nbAtlasMax = std::max(1, nbAtlasMax); //if not enough memory, do it one by one

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -270,18 +270,28 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
     const std::size_t atlasPyramidMaxMemSize = texParams.nbBand * atlasContribMemSize;
 
     const int availableRam = int(memInfo.availableRam / std::pow(2,20));
-    const int availableMem = availableRam - 2 * imageMaxMemSize - imagePyramidMaxMemSize; // keep some memory for the 2 input images in cache and one laplacian pyramid
+    const int availableMem = availableRam - 2 * (imagePyramidMaxMemSize + imageMaxMemSize); // keep some memory for the 2 input images in cache and one laplacian pyramid
 
     const int nbAtlas = _atlases.size();
-    int nbAtlasMax = std::floor(availableMem / atlasPyramidMaxMemSize); //maximum number of textures laplacian pyramid in RAM
+    // Memory needed to process each attlas = input + input pyramid + output atlas pyramid
+    const int memoryPerAtlas = (imageMaxMemSize + imagePyramidMaxMemSize) + atlasPyramidMaxMemSize;
+    int nbAtlasMax = std::floor(availableMem / double(memoryPerAtlas)); //maximum number of textures laplacian pyramid in RAM
     nbAtlasMax = std::min(nbAtlas, nbAtlasMax); //if enough memory, do it with all atlases
+
+    ALICEVISION_LOG_INFO("nbAtlas: " << nbAtlas);
+    ALICEVISION_LOG_INFO("availableRam: " << availableRam);
+    ALICEVISION_LOG_INFO("availableMem: " << availableMem);
+    ALICEVISION_LOG_INFO("memoryPerAtlas: " << memoryPerAtlas);
+
+    ALICEVISION_LOG_DEBUG("nbAtlasMax: " << nbAtlasMax);
+
     if (availableMem - nbAtlasMax*atlasPyramidMaxMemSize < 1000) //keep 1 GB margin in memory
         nbAtlasMax -= 1;
     nbAtlasMax = std::max(1, nbAtlasMax); //if not enough memory, do it one by one
 
-    ALICEVISION_LOG_INFO("Total amount of available RAM  : " << availableRam << " MB.");
-    ALICEVISION_LOG_INFO("Total amount of memory remaining for the computation : " << availableMem << " MB.");
-    ALICEVISION_LOG_INFO("Total amount of an image in memory  : " << imageMaxMemSize << " MB.");
+    ALICEVISION_LOG_INFO("Total amount of available RAM: " << availableRam << " MB.");
+    ALICEVISION_LOG_INFO("Total amount of memory remaining for the computation: " << availableMem << " MB.");
+    ALICEVISION_LOG_INFO("Total amount of an image in memory: " << imageMaxMemSize << " MB.");
     ALICEVISION_LOG_INFO("Total amount of an atlas pyramid in memory: " << atlasPyramidMaxMemSize << " MB.");
     ALICEVISION_LOG_INFO("Processing " << nbAtlas << " atlases by chunks of " << nbAtlasMax);
 


### PR DESCRIPTION
## Description

Avoid possible crashes due to excessive memory usage.

Reaching memory limits could crash the Texturing step:
![texturing_crash](https://user-images.githubusercontent.com/153585/107857467-c2c25a00-6e2e-11eb-98f1-490c4e1df222.png)

With the modified estimation:
![texturing_a_betterEstimation](https://user-images.githubusercontent.com/153585/107857476-ceae1c00-6e2e-11eb-9760-5a67c01fd514.png)

And with uniform repartition:
![texturing_b_uniformRepartition](https://user-images.githubusercontent.com/153585/107857484-d968b100-6e2e-11eb-8d84-7e91deb8680a.png)
