### PR TITLE
[cmake] update flags for Intel i9-10900K

### DIFF
--- a/src/cmake/OptimizeForArchitecture.cmake
+++ b/src/cmake/OptimizeForArchitecture.cmake
@@ -141,7 +141,7 @@ macro(OFA_AutodetectX86)
             set(TARGET_ARCHITECTURE "kaby-lake")
          elseif(_cpu_model EQUAL 85) # 55
             set(TARGET_ARCHITECTURE "skylake-avx512")
-         elseif(_cpu_model EQUAL 78 OR _cpu_model EQUAL 94) # 4E, 5E
+         elseif(_cpu_model EQUAL 78 OR _cpu_model EQUAL 94 OR _cpu_model EQUAL 165) # 4E, 5E
             set(TARGET_ARCHITECTURE "skylake")
          elseif(_cpu_model EQUAL 61 OR _cpu_model EQUAL 71 OR _cpu_model EQUAL 79 OR _cpu_model EQUAL 86) # 3D, 47, 4F, 56
             set(TARGET_ARCHITECTURE "broadwell")


### PR DESCRIPTION
Update the OptimizeForArchitecture so that Intel i9-10900K is recognized.

(do we really need this? the whole file is quite outdated...)


Info from here https://en.wikichip.org/wiki/intel/microarchitectures/comet_lake#Compiler_support