### PR TITLE
[matching] export and import distanceRatio

### DIFF
--- a/src/aliceVision/matching/IndMatch.hpp
+++ b/src/aliceVision/matching/IndMatch.hpp
@@ -70,11 +70,11 @@ struct IndMatch
 };
 
 inline std::ostream& operator<<(std::ostream & out, const IndMatch & obj) {
-  return out << obj._i << " " << obj._j;
+  return out << obj._i << " " << obj._j << " " << obj._distanceRatio;
 }
 
 inline std::istream& operator>>(std::istream & in, IndMatch & obj) {
-  return in >> obj._i >> obj._j;
+  return in >> obj._i >> obj._j >> obj._distanceRatio;
 }
 
 typedef std::vector<matching::IndMatch> IndMatches;


### PR DESCRIPTION
Currently, distanceRatio is ignored after matching. Should be used for further filtering in sfm ?