### PR TITLE
[camera] Allow PINHOLE_CAMERA to be chosen as default model

### DIFF
--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -219,7 +219,8 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(
         camera::EINTRINSIC::PINHOLE_CAMERA_BROWN,
         camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL1,
         camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE,
-        camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE1
+        camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE1,
+        camera::EINTRINSIC::PINHOLE_CAMERA
     };
 
     for(const auto& e : intrinsicsPriorities)


### PR DESCRIPTION
This PR adds the camera model `PINHOLE_CAMERA` to the list of possible default camera models that can be chosen in `getViewIntrinsic()`. This change avoids the current error that is thrown when the user specifies "pinhole" as the only allowable camera model, yet this model cannot be chosen.
