### PR TITLE
Update cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1369,6 +1369,7 @@ DJI;FC300X;6.16;usercontribution
 DJI;FC300X;6.16;usercontribution
 DJI;FC300XW;6.17;usercontribution
 DJI;FC330;6.17;usercontribution
+DJI;FC3411;13.13;usercontribution
 DJI;FC350;6.17;usercontribution
 DJI;FC350;6.17;usercontribution
 DJI;FC550;17.3;usercontribution


### PR DESCRIPTION
DJI Air 2S Sensor - Calculated from Pixel Size*X-Resolution: https://www.dji.com/ca/air-2s/specs
