### PR TITLE
[MOD] Added new DJI FC7303 camera to src/aliceVision/sensorDB/cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1380,6 +1380,7 @@ DJI;FC6510;13.2;usercontribution
 DJI;FC6520;17.3;usercontribution
 DJI;FC6540;23.5;usercontribution
 DJI;FC7203;6.16;usercontribution
+DJI;FC7303;6.16;usercontribution
 DJI;Phantom 4;6.3;dxomark
 DJI;Phantom 4 Pro;13.2;dxomark
 DJI;Phantom Vision FC200;6.17;usercontribution


### PR DESCRIPTION
Simple user contribution do the sensorDatabase by adding the DJI Mavic Mini 2  camera info.
Tested using a 36 image dataset taken by a DJI Mavic Mini 2 for aerial photogrammetry.
