### PR TITLE
[sensorDB] Add Asus Zenfone 8

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -249,6 +249,7 @@ Asus;Asus ZenFone Zoom ZX551ML;4.7;devicespecifications
 Asus;Asus ZenPad S 8.0 Z580CA;3.6;devicespecifications
 Asus;Asus ZenPad S 8.0 Z580CA 16GB;3.6;devicespecifications
 Asus;ASUS_I001DC;12.7;devicespecifications
+ASUS;ASUS_I006D;7.53;devicespecifications
 Asus;ASUS_Z00ED;4.69;devicespecifications
 Axgio;Axgio N3;4.69;devicespecifications
 BenQ;BenQ AC100;6.16;digicamdb


### PR DESCRIPTION

## Description

Following the tech spec from Asus:
https://www.asus.com/Mobile/Phones/ZenFone/Zenfone-8/techspec/
Sony IMX686 64 MP image sensor - 1/1.7" large sensor size, 0.8 µm pixel size.


## Features list
For Asus Zenfone 8 - ZS590KS

## Implementation remarks
I've tested it for me phone.

