### PR TITLE
GCC11: fix missing <limits> header.

### DIFF
--- a/src/aliceVision/hdr/rgbCurve.cpp
+++ b/src/aliceVision/hdr/rgbCurve.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <sstream>
 #include <numeric>
+#include <limits>
 
 #include <aliceVision/system/Logger.hpp>
 


### PR DESCRIPTION
In gcc:11 `<numeric>` header no longer yields `<limits>` header.
https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes
