### PR TITLE
Add Xiaomi A3 to cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -6879,6 +6879,7 @@ Wolder;Wolder Wiam #65;5.99;devicespecifications
 Xgody;Xgody Y20;3.68;devicespecifications
 Xiaomi;POCOPHONE F1;5.64;deviceranks
 Xiaomi;Mi A1;5.11;devicespecifications
+Xiaomi;Mi A3;6.4;devicespecifications
 Xiaomi;Xiaomi Mi 3;4.69;devicespecifications
 Xiaomi;Xiaomi Mi 3 TD;4.69;devicespecifications
 Xiaomi;Xiaomi Mi 4;4.69;devicespecifications


### PR DESCRIPTION
Sensor is 1/2" as per:
- https://www.devicespecifications.com/en/model/51c75175
- https://www.gsmarena.com/xiaomi_mi_a3-9769.php
