### PR TITLE
Update INSTALL.md to suggest installing Mosek 6 instead of Mosek 5

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ AliceVision depends on:
 Other optional libraries can enable specific features (check "CMake Options" for enabling them):
 
 * OpenMP (enable multi-threading)
-* Mosek 5 (linear programming)
+* Mosek 6 (linear programming)
 * OpenCV >= 3.4.11 (feature extraction, calibration module, video IO), >= 4.5 for colorchecker (mcc)
 * Alembic (data I/O)
 * CCTag (feature extraction/matching and localization on CPU or GPU)


### PR DESCRIPTION
## Description

The `INSTALL.md` installation steps assume you have Mosek 6 installed, but the list of dependencies at the top of the document list Mosek 5.

I installed Mosek 5 and later ran into cmake errors which seem to suggest AliceVision prefers Mosek 6. [This comment from a GitHub issue](https://github.com/alicevision/AliceVision/issues/411#issuecomment-403173355) references an identical cmake error when using Mosek 8 intead of Mosek 6. Installing Mosek 5 instead of 6 seems to cause a similar problem.

## Features list

- [X] Update documentation


