### PR TITLE
Add frameId from image path & new function for feature loading

### DIFF
--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -128,6 +128,58 @@ std::unique_ptr<feature::Regions> loadFeatures(const std::vector<std::string>& f
   return regionsPtr;
 }
 
+bool loadFeaturesPerDescPerView(std::vector<std::vector<std::unique_ptr<feature::Regions>>>& featuresPerDescPerView,
+                                const std::vector<IndexT>& viewIds, const std::vector<std::string>& folders,
+                                const std::vector<feature::EImageDescriberType>& imageDescriberTypes)
+{
+  if(folders.empty())
+  {
+    ALICEVISION_LOG_ERROR("Can't load features, no folders provided");
+    return false;
+  }
+  if(viewIds.empty())
+  {
+    ALICEVISION_LOG_ERROR("Can't load features, no view ids provided");
+    return false;
+  }
+  if(imageDescriberTypes.empty())
+  {
+    ALICEVISION_LOG_ERROR("Can't load features, no image desciber types provided");
+    return false;
+  }
+
+  std::vector<std::unique_ptr<feature::ImageDescriber>> imageDescribers;
+  imageDescribers.resize(imageDescriberTypes.size());
+
+  for(std::size_t i = 0; i < imageDescriberTypes.size(); ++i)
+      imageDescribers.at(i) = createImageDescriber(imageDescriberTypes.at(i));
+
+  featuresPerDescPerView.resize(imageDescribers.size());
+
+  std::atomic_bool loadingSuccess(true);
+
+  for(int descIdx = 0; descIdx < imageDescribers.size(); ++descIdx)
+  {
+    std::vector<std::unique_ptr<feature::Regions>>& featuresPerView = featuresPerDescPerView.at(descIdx);
+    featuresPerView.resize(viewIds.size());
+
+#pragma omp parallel for
+    for(int viewIdx = 0; viewIdx < viewIds.size(); ++viewIdx)
+    {
+      try
+      {
+        featuresPerView.at(viewIdx) = loadFeatures(folders, viewIds.at(viewIdx), *imageDescribers.at(descIdx));
+      }
+      catch(const std::exception& e)
+      {
+        loadingSuccess = false;
+      }
+    }
+  }
+
+  return loadingSuccess;
+}
+
 bool loadRegionsPerView(feature::RegionsPerView& regionsPerView,
             const SfMData& sfmData,
             const std::vector<std::string>& folders,

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -134,17 +134,17 @@ bool loadFeaturesPerDescPerView(std::vector<std::vector<std::unique_ptr<feature:
 {
   if(folders.empty())
   {
-    ALICEVISION_LOG_ERROR("Can't load features, no folders provided");
+    ALICEVISION_LOG_ERROR("Cannot load features, no folders provided");
     return false;
   }
   if(viewIds.empty())
   {
-    ALICEVISION_LOG_ERROR("Can't load features, no view ids provided");
+    ALICEVISION_LOG_ERROR("Cannot load features, no view ids provided");
     return false;
   }
   if(imageDescriberTypes.empty())
   {
-    ALICEVISION_LOG_ERROR("Can't load features, no image desciber types provided");
+    ALICEVISION_LOG_ERROR("Cannot load features, no image desciber types provided");
     return false;
   }
 

--- a/src/aliceVision/sfm/pipeline/regionsIO.hpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.hpp
@@ -38,6 +38,18 @@ std::unique_ptr<feature::Regions> loadRegions(const std::vector<std::string>& fo
 std::unique_ptr<feature::Regions> loadFeatures(const std::vector<std::string>& folders, IndexT viewId, const feature::ImageDescriber& imageDescriber);
 
 /**
+ * @brief Load Features for each given view.
+ * @param[in,out] featuresPerDescPerView
+ * @param[in] viewIds The given view list
+ * @param[in] folders The feature Folders
+ * @param[in] imageDescriberTypes The imageDescriber types
+ * @return true if the features are correctlty loaded
+ */
+bool loadFeaturesPerDescPerView(std::vector<std::vector<std::unique_ptr<feature::Regions>>>& featuresPerDescPerView,
+                                const std::vector<IndexT>& viewIds, const std::vector<std::string>& folders,
+                                const std::vector<feature::EImageDescriberType>& imageDescriberTypes);
+
+/**
  * @brief Load Regions (Features & Descriptors) for each view of the provided SfMData container.
  * @param[in,out] regionsPerView
  * @param[in] sfmData The provided SfMData container

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -279,5 +279,30 @@ std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const s
     });
 }
 
+bool detectImageSequenceFromImagePath(const std::string& imagePathStem, IndexT& frameId, std::string& prefix, std::string& suffix)
+{
+    bool isSequence = false;
+
+    // check if the image is in a sequence
+    // regexFrame: ^(.*\D)?([0-9]+)([\-_\.].*[[:alpha:]].*)?$
+    std::regex regexFrame("^(.*\\D)?"       // the optional prefix which end with a non digit character
+                          "([0-9]+)"        // the sequence frame number
+                          "([\\-_\\.]"      // the suffix start with a separator
+                          ".*[[:alpha:]].*" // at least one letter in the suffix
+                          ")?$"             // suffix is optional
+    );
+
+    std::smatch matches;
+    if(std::regex_search(imagePathStem, matches, regexFrame))
+    {
+        prefix = matches[1];
+        suffix = matches[3];
+        frameId = static_cast<IndexT>(std::stoi(matches[2]));
+        isSequence = true;
+    }
+
+    return isSequence;
+}
+
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -279,28 +279,28 @@ std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const s
     });
 }
 
-bool detectImageSequenceFromImagePath(const std::string& imagePathStem, IndexT& frameId, std::string& prefix, std::string& suffix)
+bool extractNumberFromFileStem(const std::string& imagePathStem, IndexT& number, std::string& prefix, std::string& suffix)
 {
-    // check if the image is in a sequence
+    // check if the image stem contains a number
     // regexFrame: ^(.*\D)?([0-9]+)([\-_\.].*[[:alpha:]].*)?$
-    std::regex regexFrame("^(.*\\D)?"       // the optional prefix which end with a non digit character
-                          "([0-9]+)"        // the sequence frame number
-                          "([\\-_\\.]"      // the suffix start with a separator
+    std::regex regexFrame("^(.*\\D)?"       // the optional prefix which ends with a non digit character
+                          "([0-9]+)"        // the number
+                          "([\\-_\\.]"      // the suffix starts with a separator
                           ".*[[:alpha:]].*" // at least one letter in the suffix
                           ")?$"             // suffix is optional
     );
 
     std::smatch matches;
-    const bool isSequence = std::regex_search(imagePathStem, matches, regexFrame);
+    const bool containsNumber = std::regex_search(imagePathStem, matches, regexFrame);
 
-    if(isSequence)
+    if(containsNumber)
     {
         prefix = matches[1];
         suffix = matches[3];
-        frameId = static_cast<IndexT>(std::stoi(matches[2]));
+        number = static_cast<IndexT>(std::stoi(matches[2]));
     }
 
-    return isSequence;
+    return containsNumber;
 }
 
 } // namespace sfmDataIO

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -281,8 +281,6 @@ std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const s
 
 bool detectImageSequenceFromImagePath(const std::string& imagePathStem, IndexT& frameId, std::string& prefix, std::string& suffix)
 {
-    bool isSequence = false;
-
     // check if the image is in a sequence
     // regexFrame: ^(.*\D)?([0-9]+)([\-_\.].*[[:alpha:]].*)?$
     std::regex regexFrame("^(.*\\D)?"       // the optional prefix which end with a non digit character
@@ -293,12 +291,13 @@ bool detectImageSequenceFromImagePath(const std::string& imagePathStem, IndexT& 
     );
 
     std::smatch matches;
-    if(std::regex_search(imagePathStem, matches, regexFrame))
+    const bool isSequence = std::regex_search(imagePathStem, matches, regexFrame);
+
+    if(isSequence)
     {
         prefix = matches[1];
         suffix = matches[3];
         frameId = static_cast<IndexT>(std::stoi(matches[2]));
-        isSequence = true;
     }
 
     return isSequence;

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -91,5 +91,16 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(
 */
 std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const std::vector<std::string>& folders);
 
+
+/*
+* @brief Allows to detect if an image is part of an image sequence from the analysis of its filename
+* @param[in] imagePathStem The image path
+* @param[out] frameId the detected frameId (or UndefinedIndexT)
+* @param[out] prefix the detected sequence prefix (or empty)
+* @param[out] suffix the detected sequence suffix (or empty)
+* @return true if the image is part of an image sequence
+*/
+bool detectImageSequenceFromImagePath(const std::string& imagePathStem, IndexT& frameId, std::string& prefix, std::string& suffix);
+
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -93,7 +93,8 @@ std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const s
 
 
 /*
-* @brief Allows to detect if an image is part of an image sequence from the analysis of its filename
+* @brief Allows to detect if an image is part of an image sequence from the analysis of its filename.
+*        Expected pattern: (optional prefix which end with a non digit character)(the sequence frame number)(optional suffix with at least one letter which start with a separator)
 * @param[in] imagePathStem The image path
 * @param[out] frameId the detected frameId (or UndefinedIndexT)
 * @param[out] prefix the detected sequence prefix (or empty)

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -94,7 +94,12 @@ std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const s
 
 /*
 * @brief Allows to detect if an image is part of an image sequence from the analysis of its filename.
-*        Expected pattern: (optional prefix which end with a non digit character)(the sequence frame number)(optional suffix with at least one letter which start with a separator)
+*        Expected pattern: (optional prefix which end with a non digit character)(the sequence frame number)(optional suffix with at least one letter which start with a separator ('.', '-', '_'))
+          Examples:
+          IMG01234
+          IMG_01234.cam
+          C4M0123-A
+          01234
 * @param[in] imagePathStem The image path
 * @param[out] frameId the detected frameId (or UndefinedIndexT)
 * @param[out] prefix the detected sequence prefix (or empty)

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -93,20 +93,21 @@ std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const s
 
 
 /*
-* @brief Allows to detect if an image is part of an image sequence from the analysis of its filename.
-*        Expected pattern: (optional prefix which end with a non digit character)(the sequence frame number)(optional suffix with at least one letter which start with a separator ('.', '-', '_'))
-          Examples:
-          IMG01234
-          IMG_01234.cam
-          C4M0123-A
-          01234
-* @param[in] imagePathStem The image path
-* @param[out] frameId the detected frameId (or UndefinedIndexT)
-* @param[out] prefix the detected sequence prefix (or empty)
-* @param[out] suffix the detected sequence suffix (or empty)
-* @return true if the image is part of an image sequence
+* @brief Allows to detect if an image filename (stripped of its extension) contains a number.
+*        This function can be used to detect if an image is part of an image sequence from the analysis of its filename.
+*        Expected pattern: (optional prefix which ends with a non digit character)(a number)(optional suffix with at least one letter which starts with a separator ('.', '-', '_'))
+*          Examples:
+*          IMG01234
+*          IMG_01234.cam
+*          C4M0123-A
+*          01234
+* @param[in] imagePathStem the image filename stripped of its extension
+* @param[out] number the detected number (or UndefinedIndexT)
+* @param[out] prefix the detected prefix (or empty)
+* @param[out] suffix the detected suffix (or empty)
+* @return true if the image filename (stripped of its extension) contains a number
 */
-bool detectImageSequenceFromImagePath(const std::string& imagePathStem, IndexT& frameId, std::string& prefix, std::string& suffix);
+bool extractNumberFromFileStem(const std::string& imagePathStem, IndexT& number, std::string& prefix, std::string& suffix);
 
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/AlembicExporter.hpp>
-#include <aliceVision/sfmDataIO/ViewIO.hpp>
+#include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/utils/regexFilter.hpp>
 

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/AlembicExporter.hpp>
+#include <aliceVision/sfmDataIO/ViewIO.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/utils/regexFilter.hpp>
 
@@ -35,7 +36,7 @@ namespace fs = boost::filesystem;
 
 
 oiio::ROI computeRod(const camera::IntrinsicBase* intrinsic, bool correctPrincipalPoint)
-               
+
 {
     std::vector<Vec2> pointToBeChecked;
     pointToBeChecked.push_back(Vec2(0, 0));
@@ -394,34 +395,25 @@ int aliceVision_main(int argc, char** argv)
       continue;
 
     std::string cameraName =  view.getMetadataMake() + "_" + view.getMetadataModel();
-    std::size_t frameN = 0;
+    IndexT frameN = 0;
     bool isSequence = false;
 
     if(view.isPartOfRig())
       cameraName += std::string("_") + std::to_string(view.getSubPoseId());
 
-    // check if the image is in a sequence
-    // regexFrame: ^(.*\D)?([0-9]+)([\-_\.].*[[:alpha:]].*)?$
-    std::regex regexFrame("^(.*\\D)?"    // the optional prefix which end with a non digit character
-                      "([0-9]+)"         // the sequence frame number
-                      "([\\-_\\.]"       // the suffix start with a separator
-                      ".*[[:alpha:]].*"  // at least one letter in the suffix
-                      ")?$"              // suffix is optional
-                      );
-
-    std::smatch matches;
-    if(std::regex_search(imagePathStem, matches, regexFrame))
     {
-        const std::string prefix = matches[1];
-        const std::string suffix = matches[3];
-        frameN = std::stoi(matches[2]);
+      std::string prefix;
+      std::string suffix;
 
+      if(sfmDataIO::detectImageSequenceFromImagePath(imagePathStem, frameN, prefix, suffix))
+      {
         if(prefix.empty() && suffix.empty())
             cameraName = std::string("Undefined") + "_" + cameraName;
         else
             cameraName = prefix + "frame" + suffix + "_" + cameraName;
 
         isSequence = true;
+      }
     }
 
     ALICEVISION_LOG_TRACE("imagePathStem: " << imagePathStem << ", frameN: " << frameN << ", isSequence: " << isSequence << ", cameraName: " << cameraName);

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -405,7 +405,7 @@ int aliceVision_main(int argc, char** argv)
       std::string prefix;
       std::string suffix;
 
-      if(sfmDataIO::detectImageSequenceFromImagePath(imagePathStem, frameN, prefix, suffix))
+      if(sfmDataIO::extractNumberFromFileStem(imagePathStem, frameN, prefix, suffix))
       {
         if(prefix.empty() && suffix.empty())
             cameraName = std::string("Undefined") + "_" + cameraName;

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 #include <cstdlib>
+#include <stdexcept>
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
@@ -445,7 +446,7 @@ int aliceVision_main(int argc, char **argv)
         std::string suffix;
         if(!sfmDataIO::extractNumberFromFileStem(fs::path(view.getImagePath()).stem().string(), subPoseId, prefix, suffix))
         {
-          throw std::exception("Cannot find sub-pose id from image path.");
+          throw std::runtime_error("Cannot find sub-pose id from image path.");
         }
 
         std::hash<std::string> hash; // TODO use boost::hash_combine

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -446,7 +446,7 @@ int aliceVision_main(int argc, char **argv)
         std::string suffix;
         if(!sfmDataIO::extractNumberFromFileStem(fs::path(view.getImagePath()).stem().string(), subPoseId, prefix, suffix))
         {
-          throw std::runtime_error("Cannot find sub-pose id from image path.");
+          ALICEVISION_THROW_ERROR("Cannot find sub-pose id from image path: " << parentPath);
         }
 
         std::hash<std::string> hash; // TODO use boost::hash_combine

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -458,11 +458,10 @@ int aliceVision_main(int argc, char **argv)
         IndexT frameId;
         std::string prefix;
         std::string suffix;
-        if(sfmDataIO::detectImageSequenceFromImagePath(fs::path(view.getImagePath()).stem().string(), frameId, prefix, suffix))
+        if(sfmDataIO::extractNumberFromFileStem(fs::path(view.getImagePath()).stem().string(), frameId, prefix, suffix))
         {
           view.setFrameId(frameId);
         }
-          
     }
     
     if(boost::algorithm::starts_with(parentPath.stem().string(), "ps_") ||

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -440,11 +440,9 @@ int aliceVision_main(int argc, char **argv)
     {
       try
       {
-        const int frameId = std::stoi(fs::path(view.getImagePath()).stem().string());
         const int subPoseId = std::stoi(parentPath.stem().string());
         std::hash<std::string> hash; // TODO use boost::hash_combine
         view.setRigAndSubPoseId(hash(parentPath.parent_path().string()), subPoseId);
-        view.setFrameId(static_cast<IndexT>(frameId));
 
         #pragma omp critical
         detectedRigs[view.getRigId()][view.getSubPoseId()]++;

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -444,7 +444,7 @@ int aliceVision_main(int argc, char **argv)
         IndexT subPoseId;
         std::string prefix;
         std::string suffix;
-        if(!sfmDataIO::extractNumberFromFileStem(fs::path(view.getImagePath()).stem().string(), subPoseId, prefix, suffix))
+        if(!sfmDataIO::extractNumberFromFileStem(parentPath.stem().string(), subPoseId, prefix, suffix))
         {
           ALICEVISION_THROW_ERROR("Cannot find sub-pose id from image path: " << parentPath);
         }

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -454,6 +454,18 @@ int aliceVision_main(int argc, char **argv)
         ALICEVISION_LOG_WARNING("Invalid rig structure for view: " << view.getImagePath() << std::endl << "Used as single image.");
       }
     }
+
+    // try to detect image sequence
+    {
+        IndexT frameId;
+        std::string prefix;
+        std::string suffix;
+        if(sfmDataIO::detectImageSequenceFromImagePath(fs::path(view.getImagePath()).stem().string(), frameId, prefix, suffix))
+        {
+          view.setFrameId(frameId);
+        }
+          
+    }
     
     if(boost::algorithm::starts_with(parentPath.stem().string(), "ps_") ||
        boost::algorithm::starts_with(parentPath.stem().string(), "hdr_"))

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -440,7 +440,14 @@ int aliceVision_main(int argc, char **argv)
     {
       try
       {
-        const int subPoseId = std::stoi(parentPath.stem().string());
+        IndexT subPoseId;
+        std::string prefix;
+        std::string suffix;
+        if(!sfmDataIO::extractNumberFromFileStem(fs::path(view.getImagePath()).stem().string(), subPoseId, prefix, suffix))
+        {
+          throw std::exception("Cannot find sub-pose id from image path.");
+        }
+
         std::hash<std::string> hash; // TODO use boost::hash_combine
         view.setRigAndSubPoseId(hash(parentPath.parent_path().string()), subPoseId);
 
@@ -449,7 +456,7 @@ int aliceVision_main(int argc, char **argv)
       }
       catch(std::exception& e)
       {
-        ALICEVISION_LOG_WARNING("Invalid rig structure for view: " << view.getImagePath() << std::endl << "Used as single image.");
+        ALICEVISION_LOG_WARNING("Invalid rig structure for view: " << view.getImagePath() << std::endl << e.what() << std::endl << "Used as single image.");
       }
     }
 


### PR DESCRIPTION
## Description

This PR adds required features for the `QtAliceVision` plugin development.


## Features list

- [x] New function in `ViewIO` to detect image sequence from image path
- [x] Try to detect `frameId` from image path in `CameraInit` software
- [x] New function for feature loading in `RegionsIO` (for outside library use)
