### PR TITLE
[sw] middlebury import

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -201,6 +201,12 @@ void readImageMetadata(const std::string& path, int& width, int& height, std::ma
     metadata.emplace(param.name().string(), param.get_string());
 }
 
+void readImageSize(const std::string& path, int& width, int& height)
+{
+    std::map<std::string, std::string> metadata;
+    readImageMetadata(path, width, height, metadata);
+}
+
 template<typename T>
 void getBufferFromImage(Image<T>& image,
                         oiio::TypeDesc format,

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -163,6 +163,14 @@ oiio::ParamValueList readImageMetadata(const std::string& path);
 void readImageMetadata(const std::string& path, int& width, int& height, std::map<std::string, std::string>& metadata);
 
 /**
+ * @brief return the size of the image for a given path
+ * @param path The given path to the image
+ * @param[out] width The image header width
+ * @param[out] height The image header height
+ */
+void readImageSize(const std::string& path, int& width, int& height);
+
+/**
  * @brief get OIIO buffer from an AliceVision image
  * @param[in] image Image class
  * @param[out] buffer OIIO buffer

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sfmDataIO_files_headers
   bafIO.hpp
   gtIO.hpp
   jsonIO.hpp
+  middlebury.hpp
   plyIO.hpp
   viewIO.hpp
 )
@@ -14,6 +15,7 @@ set(sfmDataIO_files_sources
   bafIO.cpp
   gtIO.cpp
   jsonIO.cpp
+  middlebury.cpp
   plyIO.cpp
   viewIO.cpp
 )
@@ -35,6 +37,8 @@ alicevision_add_library(aliceVision_sfmDataIO
     aliceVision_sfmData
     Boost::filesystem
   PRIVATE_LINKS
+    aliceVision_image
+    Boost::filesystem
     Boost::regex
     Boost::boost
 )
@@ -63,3 +67,11 @@ alicevision_add_test(sfmDataIO_test.cpp
 if(ALICEVISION_HAVE_ALEMBIC)
   alicevision_add_test(alembicIO_test.cpp NAME "sfmDataIO_alembic" LINKS aliceVision_sfmDataIO Alembic::Alembic)
 endif()
+
+
+alicevision_add_test(middlebury_test.cpp
+        NAME "middlebury"
+        LINKS aliceVision_sfmData
+        aliceVision_numeric
+        aliceVision_sfmDataIO
+        )

--- a/src/aliceVision/sfmDataIO/middlebury.cpp
+++ b/src/aliceVision/sfmDataIO/middlebury.cpp
@@ -1,0 +1,160 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2021 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "middlebury.hpp"
+#include <aliceVision/numeric/numeric.hpp>
+#include <aliceVision/image/io.hpp>
+
+#include <boost/filesystem.hpp>
+
+namespace aliceVision {
+namespace sfmDataIO {
+
+namespace bfs = boost::filesystem;
+
+Mat3 extractMat3FromVec(const std::vector<std::string>& entries, std::size_t offset)
+{
+    // we are supposed to read 9 elements, so the offset must be coherent with the vector size
+    if(offset + 9 > entries.size())
+    {
+        ALICEVISION_LOG_ERROR("The vector has " << entries.size()
+                                                << " elements, tried to read out of bounds (offset: " << offset);
+        throw std::out_of_range("Trying to read out of the bounds of the vector");
+    }
+    Mat3 rotation;
+    const auto lastIdx{offset + 8};
+    for(std::size_t i = offset; i <= lastIdx; ++i)
+    {
+        const double val = std::stod(entries[i]);
+        const auto row = (i - offset) / 3;
+        const auto col = (i - offset) % 3;
+        rotation(row, col) = val;
+    }
+    return rotation;
+}
+
+void parseMiddleburyCamera(const std::string& line, std::string& imageName, Mat3& matK, Mat3& rotation,
+                           Vec3& translation)
+{
+    std::vector<std::string> entries{};
+
+    std::stringstream sstream(line);
+    std::string entry;
+    const char spaceChar{' '};
+    // tokenize the line extracting all the entries separated by a space
+    while(std::getline(sstream, entry, spaceChar))
+    {
+        entries.push_back(entry);
+        ALICEVISION_LOG_TRACE(entry);
+    }
+    if(entries.size() != 22)
+    {
+        ALICEVISION_LOG_ERROR("read " << entries.size() << " entries, expected " << 22 << ". Incorrect file format");
+        throw std::runtime_error("Error while reading the camera parameters, incorrect number of entries");
+    }
+    ALICEVISION_LOG_DEBUG("read " << entries.size() << " entries");
+
+    // first entry is the image name
+    imageName = entries[0];
+    // next 9 elements are the calibration entries
+    matK = extractMat3FromVec(entries, 1);
+    // next 9 elements are the pose rotation
+    rotation = extractMat3FromVec(entries, 10);
+    // next and last 3 elements are the translation
+    translation(0) = std::stod(entries[19]);
+    translation(1) = std::stod(entries[20]);
+    translation(2) = std::stod(entries[21]);
+}
+
+sfmData::SfMData middleburySceneToSfmData(const std::string& filename, const std::string& basePath,
+                                          bool uniqueIntrinsics, bool importPoses, bool lockIntrinsics, bool lockPoses)
+{
+    std::ifstream infile(filename);
+    if(!infile.is_open())
+    {
+        ALICEVISION_LOG_ERROR("Unable to open " << filename);
+        throw std::runtime_error("Unable to open " + filename);
+    }
+
+    sfmData::SfMData scene;
+
+    std::string line;
+
+    // the first one is the number of cameras
+    std::getline(infile, line);
+    const size_t numViews = std::stoul(line);
+    ALICEVISION_LOG_INFO("Found " << numViews << " cameras to read");
+
+    // init the ids, we use incremental ids
+    IndexT intrinsicsId{0};
+    IndexT viewId{0};
+    IndexT poseId = importPoses ? 0 : UndefinedIndexT;
+
+    // parse all the other lines
+    while(std::getline(infile, line))
+    {
+        std::string imageName;
+        Mat3 matK;
+        Mat3 rotation;
+        Vec3 translation;
+        parseMiddleburyCamera(line, imageName, matK, rotation, translation);
+
+        const auto imagePath = (bfs::path(basePath) / bfs::path(imageName)).string();
+        int imageWidth{};
+        int imageHeight{};
+        image::readImageSize(imagePath, imageWidth, imageHeight);
+
+        // if uniqueIntrinsics do it once, otherwise always
+        if((uniqueIntrinsics && scene.intrinsics.empty()) || !uniqueIntrinsics)
+        {
+            ALICEVISION_LOG_DEBUG("matK " << matK);
+            // add the intrinsics
+            scene.intrinsics.insert({intrinsicsId, std::make_shared<camera::Pinhole>(imageWidth, imageHeight, matK)});
+            if(lockIntrinsics)
+            {
+                scene.intrinsics[intrinsicsId]->lock();
+            }
+        }
+        ALICEVISION_LOG_DEBUG("rotation " << rotation);
+        ALICEVISION_LOG_DEBUG("translation " << translation);
+
+        if(importPoses)
+        {
+            // add the pose entry
+            const auto pose = geometry::poseFromRT(rotation, translation);
+            scene.getPoses().insert({poseId, sfmData::CameraPose(pose, lockPoses)});
+        }
+
+        // add view
+        scene.getViews().insert({viewId, std::make_shared<sfmData::View>(imagePath, viewId, intrinsicsId, poseId,
+                                                                         imageWidth, imageHeight)});
+
+        // update the intrinsics id only if not unique
+        if(!uniqueIntrinsics)
+        {
+            ++intrinsicsId;
+        }
+        ++viewId;
+        if(importPoses)
+        {
+            ++poseId;
+        }
+    }
+    // just a safe guard
+    if(scene.getViews().size() != numViews)
+    {
+        ALICEVISION_LOG_ERROR("Read " << scene.getViews().size() << " views, expected " << numViews);
+        throw std::runtime_error("Unexpected number of cameras read");
+    }
+    ALICEVISION_LOG_INFO("Scene contains: " << scene.getIntrinsics().size() << " intrinsics, "
+                                            << scene.getViews().size() << " views, " << scene.getPoses().size()
+                                            << " poses");
+
+    return scene;
+}
+
+}
+}

--- a/src/aliceVision/sfmDataIO/middlebury.hpp
+++ b/src/aliceVision/sfmDataIO/middlebury.hpp
@@ -1,0 +1,51 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2021 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfmData/SfMData.hpp>
+
+#include <string>
+#include <vector>
+
+namespace aliceVision {
+namespace sfmDataIO {
+
+
+/**
+ * @brief Read the file containing the cameras (intrinsics and pose) in the middlebury format
+ * @param[in] filename middlebury file (e.g. temple_par.txt)
+ * @param[in] basePath the base path where the images can be found
+ * @param[in] uniqueIntrinsics whether to consider all the intrinsics of the cameras the same (those of the first camera)
+ * @param[in] importPoses whether or not to import the poses
+ * @param[in] lockIntrinsics set the intrinsics to locked (i.e. they cannot change during e.g. structure from motion)
+ * @param[in] lockPoses set the poses to locked (i.e. they cannot change during e.g. structure from motion)
+ * @return the corresponding SfMData representation of the scene
+ */
+sfmData::SfMData middleburySceneToSfmData(const std::string& filename, const std::string& basePath,
+                                          bool uniqueIntrinsics, bool importPoses, bool lockIntrinsics, bool lockPoses);
+
+/**
+ * @brief Parse a line of the middlebury file containing the calibration, the pose and the image name
+ * @param[in] line the string containing all the information separated by space
+ * @param[out] imageName the image name
+ * @param[out] matK the calibration matrix
+ * @param[out] rotation the rotation matrix of the pose
+ * @param[out] translation the translation vector of the pose
+ */
+void parseMiddleburyCamera(const std::string& line, std::string& imageName, Mat3& matK, Mat3& rotation,
+                           Vec3& translation);
+
+/**
+ * @brief Helper function to parse the list of entries parsed from the file.
+ * @param[in] entries the list of entries parsed from the file, containing the string representation of the different matrices
+ * @param[in] offset the index of the first element to add to the matrix (row-wise)
+ * @return the 3x3 matrix
+ */
+Mat3 extractMat3FromVec(const std::vector<std::string>& entries, std::size_t offset);
+
+}
+}

--- a/src/aliceVision/sfmDataIO/middlebury_test.cpp
+++ b/src/aliceVision/sfmDataIO/middlebury_test.cpp
@@ -1,0 +1,50 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2021 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE middlebury
+
+#include <aliceVision/numeric/numeric.hpp>
+#include <aliceVision/sfmDataIO/middlebury.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+#include <aliceVision/unitTest.hpp>
+
+using namespace aliceVision;
+
+BOOST_AUTO_TEST_CASE(middlebury_parse)
+{
+    const std::string line{"temple0299.png "
+                           "1520.400000 0.000000 302.320000 "
+                           "0.000000 1525.900000 246.870000 "
+                           "0.000000 0.000000 1.000000 "
+                           "0.10793659924390045000 -0.99055951509200579000 0.08450761861721302300 "
+                           "-0.32994878599451571000 0.04449292035991074500 0.94294972223262863000 "
+                           "-0.93780781035583538000 -0.12966197244580752000 -0.32203149494584499000 "
+                           "0.06997376920479636600 -0.01263011688236693700 0.56781167778967301000"};
+    const std::string imageNameGT{"temple0299.png"};
+    const auto matKGT = (Mat3() << 1520.400000, 0.000000, 302.320000,
+                         0.000000, 1525.900000, 246.870000,
+                         0.000000, 0.000000, 1.000000).finished();
+    const auto rotationGT= (Mat3() << 0.10793659924390045000, -0.99055951509200579000, 0.08450761861721302300,
+                        -0.32994878599451571000, 0.04449292035991074500, 0.94294972223262863000,
+                        -0.93780781035583538000, -0.12966197244580752000, -0.32203149494584499000).finished();;
+    const auto translationGT= (Vec3() << 0.06997376920479636600, -0.01263011688236693700, 0.56781167778967301000).finished();;
+
+    std::string imageName;
+    Mat3 matK;
+    Mat3 rotation;
+    Vec3 translation;
+    sfmDataIO::parseMiddleburyCamera(line, imageName, matK, rotation, translation);
+
+    const auto threshold{1e-4};
+    BOOST_CHECK(imageName == imageNameGT);
+    EXPECT_MATRIX_CLOSE_FRACTION(matK, matKGT, threshold);
+    EXPECT_MATRIX_CLOSE_FRACTION(rotation, rotationGT, threshold);
+    EXPECT_MATRIX_CLOSE_FRACTION(translation, translationGT, threshold);
+
+
+}

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -51,6 +51,18 @@ if(ALICEVISION_HAVE_OPENCV)
   target_link_libraries(aliceVision_utils_imageProcessing PRIVATE ${OpenCV_LIBS})
 endif()
 
+alicevision_add_software(aliceVision_utils_importMiddlebury
+        SOURCE main_importMiddlebury.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS
+        aliceVision_numeric
+        aliceVision_geometry
+        aliceVision_sfmData
+        aliceVision_sfmDataIO
+        aliceVision_system
+        ${Boost_LIBRARIES}
+        )
+
 # Voctree creation
 alicevision_add_software(aliceVision_utils_voctreeCreation
   SOURCE main_voctreeCreation.cpp

--- a/src/software/utils/main_importMiddlebury.cpp
+++ b/src/software/utils/main_importMiddlebury.cpp
@@ -1,0 +1,131 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2021 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/middlebury.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+
+#include <boost/program_options.hpp>
+#include <boost/filesystem.hpp>
+
+#include <iostream>
+#include <vector>
+#include <ostream>
+#include <string>
+
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace bfs = boost::filesystem;
+
+
+/*
+ * This program generate an SfMData from the configuration files of the Middlebury dataset
+ */
+int aliceVision_main(int argc, char** argv)
+{
+    std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+    // the text file containing the cameras
+    std::string middleburyFile;
+    // the sfm data file to generate
+    std::string sfmDataFilename;
+    // whether to use shared intrinsics among all views
+    bool uniqueIntrinsics{false};
+    // whether to import or not the poses
+    bool importPoses{true};
+    // whether to lock or not the intrinsics
+    bool lockIntrinsics{true};
+    // whether to lock or not the poses
+    bool lockPoses{true};
+
+    po::options_description allParams("This program generate an SfMData from the configuration files of the Middlebury dataset.");
+
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()("input,i", po::value<std::string>(&middleburyFile)->required(), "The text file containing the cameras (e.g. temple_par.txt).")
+        ("output,o", po::value<std::string>(&sfmDataFilename)->required(), "Output sfmdata filename");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("uniqueIntrinsics", po::bool_switch(&uniqueIntrinsics),
+         "Consider all the camera having the same intrinsics (the first camera instrinsics will be used for all the others")
+        ("importPoses", po::value<bool>(&importPoses)->default_value(importPoses),
+         "Import the poses, disable this if you want, e.g. test the sfm part and assess the camera pose estimation.")
+        ("lockIntrinsics", po::value<bool>(&lockIntrinsics)->default_value(lockIntrinsics),
+         "Set the intrinsics to locked, so they will not be refined in the sfm step.")
+        ("lockPoses", po::value<bool>(&lockPoses)->default_value(lockPoses),
+         "Set the poses to locked, so they will not be refined in the sfm step")
+        ;
+
+    po::options_description logParams("Log parameters");
+    logParams.add_options()("verboseLevel,v", po::value<std::string>(&verboseLevel)->default_value(verboseLevel),
+                            "verbosity level (fatal, error, warning, info, debug, trace).");
+
+    allParams.add(requiredParams).add(optionalParams).add(logParams);
+
+    po::variables_map vm;
+    try
+    {
+        po::store(po::parse_command_line(argc, argv, allParams), vm);
+
+        if(vm.count("help") || (argc == 1))
+        {
+            ALICEVISION_COUT(allParams);
+            return EXIT_SUCCESS;
+        }
+        po::notify(vm);
+    }
+    catch(boost::program_options::required_option& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
+        return EXIT_FAILURE;
+    }
+    catch(boost::program_options::error& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_COUT("Program called with the following parameters:");
+    ALICEVISION_COUT(vm);
+
+    // set verbose level
+    system::Logger::get()->setLogLevel(verboseLevel);
+
+    // check input file exist
+    if(!exists(bfs::path(middleburyFile)))
+    {
+        ALICEVISION_LOG_ERROR("File " << middleburyFile << " does not exist");
+        return EXIT_FAILURE;
+    }
+
+    // get the base path
+    const auto basePath = bfs::path(middleburyFile).parent_path().string();
+
+    // parse file
+    const auto sfmData =
+        sfmDataIO::middleburySceneToSfmData(middleburyFile, basePath, uniqueIntrinsics, importPoses, lockIntrinsics, lockPoses);
+
+    if(!sfmDataIO::Save(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("Unable to save " << sfmDataFilename);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_importMiddlebury.cpp
+++ b/src/software/utils/main_importMiddlebury.cpp
@@ -52,7 +52,7 @@ int aliceVision_main(int argc, char** argv)
     // whether to lock or not the poses
     bool lockPoses{true};
 
-    po::options_description allParams("This program generate an SfMData from the configuration files of the Middlebury dataset.");
+    po::options_description allParams("This program generate an SfMData from the configuration files of the Middlebury dataset: https://vision.middlebury.edu/mview/data");
 
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()("input,i", po::value<std::string>(&middleburyFile)->required(), "The text file containing the cameras (e.g. temple_par.txt).")


### PR DESCRIPTION
## Description
It introduces a new application to import the [Middlebury dataset ](https://vision.middlebury.edu/mview/data/)(dino, temple) as a alicevision sfmdata format (abc, sfm..).
It parses the .txt file of the dataset and outputs the relevant data file format of choice.
The images are supposed to be in the same folder as the .txt (as they are provided by the website)


## Features list
Several options for the import
* the instrinsics (Pinhole model only as the images are already undistorted) can be locked or not, depending if one wants to benchmark the sfm part too
- Similarly the poses can be imported or not, and they can be locked or not


Example of the dense reconstruction for the temple full
![image](https://user-images.githubusercontent.com/1331744/123828845-3195e080-d902-11eb-8d5a-5ea7d89aaa47.png)


