### PR TITLE
New node to import known poses for various file formats

### DIFF
--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -791,8 +791,7 @@ void Mesh::getDepthMap(StaticVector<float>& depthMap, StaticVector<StaticVector<
                     int idTri = ti[i];
                     OrientedPoint tri;
                     tri.p = pts[tris[idTri].v[0]];
-                    tri.n = cross((pts[tris[idTri].v[1]] - pts[tris[idTri].v[0]]).normalize(),
-                                  (pts[tris[idTri].v[2]] - pts[tris[idTri].v[0]]).normalize());
+                    tri.n = computeTriangleNormal(idTri);
 
                     Mesh::rectangle re = Mesh::rectangle(pix, 1);
                     triangle_proj tp = getTriangleProjection(idTri, mp, rc, w, h);

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -25,14 +25,15 @@ namespace mesh {
 using PointVisibility = StaticVector<int>;
 using PointsVisibility = StaticVector<PointVisibility>;
 
-
 /**
  * @brief Method to remap visibilities from the reconstruction onto an other mesh.
  */
-enum EVisibilityRemappingMethod {
-    Pull = 1,    //< For each vertex of the input mesh, pull the visibilities from the closest vertex in the reconstruction.
-    Push = 2,    //< For each vertex of the reconstruction, push the visibilities to the closest triangle in the input mesh.
-    PullPush = Pull | Push  //< Combine results from Pull and Push results.
+enum EVisibilityRemappingMethod
+{
+    Pull = 1, //< For each vertex of the input mesh, pull the visibilities from the closest vertex in the reconstruction.
+    Push = 2, //< For each vertex of the reconstruction, push the visibilities to the closest triangle in the input mesh.
+    MeshItself = 4,        //< For each vertex of the mesh, test the reprojection in each camera
+    PullPush = Pull | Push //< Combine results from Pull and Push results.
 };
 
 ALICEVISION_BITMASK(EVisibilityRemappingMethod);

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -72,6 +72,8 @@ EVisibilityRemappingMethod EVisibilityRemappingMethod_stringToEnum(const std::st
         return EVisibilityRemappingMethod::Push;
     if (method == "PullPush")
         return EVisibilityRemappingMethod::PullPush;
+    if(method == "MeshItself")
+        return EVisibilityRemappingMethod::MeshItself;
     throw std::out_of_range("Invalid visibilities remapping method " + method);
 }
 
@@ -85,6 +87,8 @@ std::string EVisibilityRemappingMethod_enumToString(EVisibilityRemappingMethod m
         return "Pull";
     case EVisibilityRemappingMethod::PullPush:
         return "PullPush";
+    case EVisibilityRemappingMethod::MeshItself:
+        return "MeshItself";
     }
     throw std::out_of_range("Unrecognized EVisibilityRemappingMethod");
 }
@@ -860,6 +864,35 @@ void Texturing::loadOBJWithAtlas(const std::string& filename, bool flipNormals)
     {
         unsigned int atlasID = mesh->nmtls ? mesh->trisMtlIds()[triangleID] : 0;
         _atlases[atlasID].push_back(triangleID);
+    }
+}
+
+void Texturing::remapVisibilities(EVisibilityRemappingMethod remappingMethod,
+                                  const mvsUtils::MultiViewParams& mp, const Mesh& refMesh)
+{
+    if(refMesh.pointsVisibilities.empty() &&
+       (remappingMethod & mesh::EVisibilityRemappingMethod::Pull ||
+        remappingMethod & mesh::EVisibilityRemappingMethod::Push))
+    {
+        throw std::runtime_error("Texturing: Cannot remap visibilities as there is no reference points.");
+    }
+
+    // remap visibilities from the reference onto the mesh
+    if(remappingMethod & mesh::EVisibilityRemappingMethod::Pull)
+    {
+        remapMeshVisibilities_pullVerticesVisibility(refMesh, *mesh);
+    }
+    if(remappingMethod & mesh::EVisibilityRemappingMethod::Push)
+    {
+        remapMeshVisibilities_pushVerticesVisibilityToTriangles(refMesh, *mesh);
+    }
+    if(remappingMethod & EVisibilityRemappingMethod::MeshItself)
+    {
+        remapMeshVisibilities_meshItself(mp, *mesh);
+    }
+    if(mesh->pointsVisibilities.empty())
+    {
+        throw std::runtime_error("No visibility after visibility remapping.");
     }
 }
 

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -47,7 +47,6 @@ EUnwrapMethod EUnwrapMethod_stringToEnum(const std::string& method);
 std::string EUnwrapMethod_enumToString(EUnwrapMethod method);
 
 
-
 struct TexturingParams
 {
     unsigned int textureSide = 8192;
@@ -94,6 +93,17 @@ public:
 
     /// Load a mesh from a .obj file and initialize internal structures
     void loadOBJWithAtlas(const std::string& filename, bool flipNormals=false);
+
+    /**
+     * @brief Remap visibilities
+     *
+     * @param[in] remappingMethod the remapping method
+     * @param[in] mp multiview scene params
+     * @param[in] refMesh the reference mesh
+     * @param[in] refPointsVisibilities the reference visibilities
+     */
+    void remapVisibilities(EVisibilityRemappingMethod remappingMethod, const mvsUtils::MultiViewParams& mp,
+                           const Mesh& refMesh);
 
     /**
      * @brief Replace inner mesh with the mesh loaded from 'otherMeshPath'

--- a/src/aliceVision/mesh/meshVisibility.hpp
+++ b/src/aliceVision/mesh/meshVisibility.hpp
@@ -41,6 +41,7 @@ void remapMeshVisibilities_pullVerticesVisibility(const Mesh& refMesh, Mesh &mes
 */
 void remapMeshVisibilities_pushVerticesVisibilityToTriangles(const Mesh& refMesh, Mesh& mesh);
 
+void remapMeshVisibilities_meshItself(const mvsUtils::MultiViewParams& mp, Mesh& mesh);
 
 } // namespace mesh
 } // namespace aliceVision

--- a/src/aliceVision/mvsData/geometry.cpp
+++ b/src/aliceVision/mvsData/geometry.cpp
@@ -193,9 +193,8 @@ void linePlaneIntersect(Point3d* out, const Point3d* linePoint, const Point3d* l
 // this angle is always between 0 and 180
 double angleBetwV1andV2(const Point3d& iV1, const Point3d& iV2)
 {
-    Point3d V1, V2;
-    V1 = iV1.normalize();
-    V2 = iV2.normalize();
+    const Point3d V1 = iV1.normalize();
+    const Point3d V2 = iV2.normalize();
 
     const double a = acos((double)(V1.x * V2.x + V1.y * V2.y + V1.z * V2.z));
     if(std::isnan(a))

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -197,9 +197,13 @@ bool ReconstructionEngine_sequentialSfM::process()
   }
   else
   {
-    // If we don't have any landmark, we need to triangulate them from the known poses.
-    // But even if we already have landmarks, we need to try to triangulate new points with the current set of parameters.
+    // Optimize input before starting adding new views
     std::set<IndexT> prevReconstructedViews = _sfmData.getValidViews();
+
+    triangulate({}, prevReconstructedViews);
+    bundleAdjustment(prevReconstructedViews);
+
+    // The optimization could allow the triangulation of new landmarks
     triangulate({}, prevReconstructedViews);
     bundleAdjustment(prevReconstructedViews);
   }

--- a/src/software/convert/CMakeLists.txt
+++ b/src/software/convert/CMakeLists.txt
@@ -29,6 +29,19 @@ alicevision_add_software(aliceVision_convertFloatDescriptorToUchar
         Boost::boost
         Boost::timer
 )
+
+alicevision_add_software(aliceVision_importKnownPoses
+  SOURCE main_importKnownPoses.cpp
+  FOLDER ${FOLDER_SOFTWARE_CONVERT}
+  LINKS aliceVision_localization
+        aliceVision_feature
+        aliceVision_sfmData
+        aliceVision_sfmDataIO
+        Boost::program_options
+        Boost::filesystem
+        Boost::boost
+        Boost::timer
+)
 endif() # ALICEVISION_BUILD_SFM
 
 # Convert image to EXR

--- a/src/software/convert/main_importKnownPoses.cpp
+++ b/src/software/convert/main_importKnownPoses.cpp
@@ -1,0 +1,404 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2021 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/config.hpp>
+#include <aliceVision/utils/regexFilter.hpp>
+
+#include <boost/program_options.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/filesystem.hpp>
+
+#include <algorithm>
+#include <string>
+#include <regex>
+
+#include <iostream>
+#include <list>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace json = boost::property_tree;
+namespace fs = boost::filesystem;
+
+
+struct XMPData
+{
+    std::vector<double> rotation;
+    std::vector<double> position;
+    std::vector<double> distortionCoefficients;
+    std::string distortionModel;
+    double focalLength = 0.0;
+    int skew = 0;
+    double aspectRatio = 1.0;
+    double principalPointU = 0.0;
+    double principalPointV = 0.0;
+    std::string calibrationPrior = "DEFAULT";
+    int calibrationGroup = 0;
+    int distortionGroup = 0;
+    int inTexturing = 0;
+    int inMeshing = 0;
+};
+
+
+XMPData read_xmp(const std::string& xmpFilepath, std::string knownPosesFilePath, std::string stem, fs::directory_entry pathIt)
+{
+    XMPData xmp;
+    const fs::path path = pathIt.path();
+    if(!is_regular_file(path))
+        ALICEVISION_THROW_ERROR("Path isn't a regulat file: " << path);
+    std::string extension = path.extension().string();
+    boost::to_lower(extension);
+    if(extension != ".xmp")
+        ALICEVISION_THROW_ERROR("Unknown extension: " << extension);
+
+    json::ptree tree;
+    read_xml(knownPosesFilePath + '/' + stem + ".xmp", tree);
+
+    xmp.distortionModel =
+        tree.get<std::string>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:DistortionModel", "DEFAULT");
+    xmp.focalLength = tree.get<double>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:FocalLength", 0.0);
+    xmp.skew = tree.get<int>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:Skew", 0);
+    xmp.aspectRatio = tree.get<double>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:AspectRatio", 1.0);
+    xmp.principalPointU = tree.get<float>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:PrincipalPointU", 0);
+    xmp.principalPointV = tree.get<float>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:PrincipalPointV", 0);
+    xmp.calibrationPrior = tree.get<std::string>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:CalibrationPrior", "DEFAULT");
+    xmp.calibrationGroup = tree.get<int>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:CalibrationGroup", 0);
+    xmp.distortionGroup = tree.get<int>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:DistortionGroup", 0);
+    xmp.inTexturing = tree.get<int>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:InTexturing", 0);
+    xmp.inMeshing = tree.get<int>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:InMeshing", 0);
+
+    std::string rotationStr = tree.get<std::string>("x:xmpmeta.rdf:RDF.rdf:Description.xcr:Rotation", "");
+    std::vector<std::string> rotationStrings;
+    boost::split(rotationStrings, rotationStr, boost::is_any_of(" \t"), boost::token_compress_on);
+    ALICEVISION_LOG_TRACE("stem: " << stem);
+    ALICEVISION_LOG_TRACE("rotation: " << rotationStrings);
+
+    for(std::string rot_val : rotationStrings)
+    {
+        xmp.rotation.push_back(std::stod(rot_val));
+    }
+
+    std::string positionStr = tree.get<std::string>("x:xmpmeta.rdf:RDF.rdf:Description.xcr:Position", "");
+    std::vector<std::string> positionStrings;
+    if(!positionStr.empty())
+    {
+        boost::split(positionStrings, positionStr, boost::is_any_of(" \t"), boost::token_compress_on);
+        ALICEVISION_LOG_TRACE("position: " << positionStrings);
+    }
+    else
+    {
+        positionStr = tree.get<std::string>("x:xmpmeta.rdf:RDF.rdf:Description.<xmlattr>.xcr:Position", "");
+        boost::split(positionStrings, positionStr, boost::is_any_of(" \t"), boost::token_compress_on);
+    }
+
+    for(std::string pos_val : positionStrings)
+    {
+        xmp.position.push_back(std::stod(pos_val));
+    }
+    std::string distortionStr =
+        tree.get<std::string>("x:xmpmeta.rdf:RDF.rdf:Description.xcr:DistortionCoeficients", "");
+    std::vector<std::string> distortionStrings;
+    boost::split(distortionStrings, distortionStr, boost::is_any_of(" \t"), boost::token_compress_on);
+    ALICEVISION_LOG_TRACE("distortion: " << distortionStrings);
+
+    for(std::string disto_val : distortionStrings)
+    {
+        xmp.distortionCoefficients.push_back(std::stod(disto_val));
+    }
+    return xmp;
+}
+
+// import from a SfMData format to another
+int aliceVision_main(int argc, char **argv)
+{
+  // command-line parameters
+  std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+  std::string knownPosesFilePath;
+  std::string sfmDataFilePath;
+  std::string outputFilename;
+
+  sfmData::SfMData sfmData;
+
+  po::options_description allParams("AliceVision importKnownPoses");
+
+  // enter the parameter
+  po::options_description requiredParams("Required parameters");
+  requiredParams.add_options()
+      ("knownPosesData", po::value<std::string>(&knownPosesFilePath)->required(), "Input path to a json file or a folder containing an XMP file per image.")
+      ("sfmData", po::value<std::string>(&sfmDataFilePath)->required(), "SfmData filepath.")
+      ("output,o", po::value<std::string>(&outputFilename)->required(), "Output sfmData filepath.");
+
+  po::options_description logParams("Log parameters");
+  logParams.add_options()("verboseLevel,v", po::value<std::string>(&verboseLevel)->default_value(verboseLevel),
+                          "verbosity level (fatal,  error, warning, info, debug, trace).");
+
+  allParams.add(requiredParams).add(logParams);
+
+  po::variables_map vm;
+
+  try
+  {
+      po::store(po::parse_command_line(argc, argv, allParams), vm);
+
+      if(vm.count("help") || (argc == 1))
+      {
+          ALICEVISION_COUT(allParams);
+          return EXIT_SUCCESS;
+      }
+
+      po::notify(vm);
+  }
+  catch(boost::program_options::required_option& e)
+  {
+      ALICEVISION_CERR("ERROR: " << e.what() << std::endl);
+      ALICEVISION_COUT("Usage:\n\n" << allParams);
+      return EXIT_FAILURE;
+  }
+  catch(boost::program_options::error& e)
+  {
+      ALICEVISION_CERR("ERROR: " << e.what() << std::endl);
+      ALICEVISION_COUT("Usage:\n\n" << allParams);
+      return EXIT_FAILURE;
+  }
+
+  ALICEVISION_COUT("Program called with the following parameters:");
+  ALICEVISION_COUT(vm);
+
+  // Loading the sfmData to modify it
+  if(!sfmDataIO::Load(sfmData, sfmDataFilePath, sfmDataIO::ESfMData::ALL))
+  {
+      ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilePath << "' cannot be read.");
+      return EXIT_FAILURE;
+  }
+  if(sfmData.getViews().empty())
+  {
+      ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilePath << "' is empty.");
+      return EXIT_FAILURE;
+  }
+
+  if(fs::is_directory(knownPosesFilePath))
+  {
+      try
+      {
+          std::map<std::string, IndexT> viewIdPerStem;
+          for(const auto viewIt : sfmData.getViews())
+          {
+              const std::string stem = fs::path(viewIt.second->getImagePath()).stem().string();
+              viewIdPerStem[stem] = viewIt.first;
+          }
+
+          for(const auto& pathIt : fs::directory_iterator(knownPosesFilePath))
+          {
+              const std::string stem = pathIt.path().stem().string();
+              const XMPData xmp = read_xmp(pathIt.path().string(), knownPosesFilePath, stem, pathIt);
+
+              const IndexT viewId = viewIdPerStem[stem];
+              aliceVision::sfmData::View& view = sfmData.getView(viewId);
+              aliceVision::sfmData::CameraPose& pose = sfmData.getPoses()[view.getPoseId()];
+
+              camera::IntrinsicBase* intrinsicBase = sfmData.getIntrinsicPtr(view.getIntrinsicId());
+
+              Mat3 rot;
+              Vec3 row_one(xmp.rotation[0], xmp.rotation[1], xmp.rotation[2]);
+              Vec3 row_two(xmp.rotation[3], xmp.rotation[4], xmp.rotation[5]);
+              Vec3 row_three(xmp.rotation[6], xmp.rotation[7], xmp.rotation[8]);
+              rot.row(0) = row_one;
+              rot.row(1) = row_two;
+              rot.row(2) = row_three;
+              Vec3 pos_vec(xmp.position[0], xmp.position[1], xmp.position[2]);
+              
+              aliceVision::geometry::Pose3 pos3(rot, pos_vec);
+              pose.setTransform(pos3);
+
+              aliceVision::camera::IntrinsicsScaleOffsetDisto* intrinsic =
+                  dynamic_cast<aliceVision::camera::IntrinsicsScaleOffsetDisto*>(intrinsicBase);
+
+              if(xmp.distortionModel == "brown3t2")
+              {
+                  if(intrinsic->getType() != camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3)//camera::EINTRINSIC::PINHOLE_CAMERA_BROWN)
+                  {
+                      ALICEVISION_THROW_ERROR("Error in: " << stem << "'s instinsics...");
+                  }
+                  else
+                  {
+                      if(xmp.distortionCoefficients.size() == 6)
+                      {
+                          // Element 4 is useless and needs to be ignored.
+                          std::vector<double> distortionCoefficients = xmp.distortionCoefficients;
+                          distortionCoefficients.erase(distortionCoefficients.begin() + 5);
+                          distortionCoefficients.erase(distortionCoefficients.begin() + 4);
+                          distortionCoefficients.erase(distortionCoefficients.begin() + 3);
+
+                          // IntrinsicsScaleOffsetDisto::setDistortionParams: wrong number of distortion parameters (expected: 3, given:5).
+                          intrinsic->setDistortionParams(
+                              distortionCoefficients); // vector of 5 elements (r1, r2, r3, t1, t2)
+                      }
+                      else
+                          ALICEVISION_THROW_ERROR(
+                              "Error in xmp file: " << stem << " the distortion coefficient doesn't have the right size.");
+                  }
+              }
+              else if(xmp.distortionModel == "brown3")
+              {
+                  if(intrinsic->getType() != camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3)
+                  {
+                      ALICEVISION_THROW_ERROR("Error in: " << stem << "'s instinsics.");
+                  }
+                  else
+                  {
+                      if(xmp.distortionCoefficients.size() == 3)
+                      {
+                          intrinsic->setDistortionParams(
+                              xmp.distortionCoefficients); // vector of 3 elements (r1, r2, r3)
+                      }
+                      else
+                          ALICEVISION_THROW_ERROR(
+                              "Error in xmp file: " << stem << " the distortion coefficient doesn't have the right size.");
+                  }
+              }
+              else
+              {
+                  ALICEVISION_THROW_ERROR("Unsupported distortion model: " << xmp.distortionModel);
+              }
+          }
+      }
+      catch(boost::program_options::error& e)
+      {
+          ALICEVISION_CERR("ERROR: " << e.what() << std::endl);
+          return EXIT_FAILURE;
+      }
+      // export the SfMData scene in the expected format
+      if(!sfmDataIO::Save(sfmData, outputFilename, sfmDataIO::ESfMData::ALL))
+      {
+          ALICEVISION_LOG_ERROR("An error occured while trying to save '" << outputFilename << "'");
+          return EXIT_FAILURE;
+      }
+      return EXIT_SUCCESS;
+  }
+  else if(is_regular_file(fs::path(knownPosesFilePath)))
+  {
+      std::ifstream jsonFile(knownPosesFilePath);
+      if(!jsonFile)
+      {
+          ALICEVISION_LOG_ERROR("Error opening file: " << knownPosesFilePath);
+          return EXIT_FAILURE;
+      }
+
+      std::string line;
+      size_t count = 0;
+      std::vector<std::pair<size_t, int>> records;
+      std::vector<std::pair<IndexT, IndexT>> frameIdToPoseId;
+
+      // Here we are making a vector that associate a frameId to a PoseId so we can access each easier
+      for(const auto& view : sfmData.getViews())
+      {
+          frameIdToPoseId.emplace_back(view.second->getFrameId(), view.second->getPoseId());
+      }
+      std::sort(frameIdToPoseId.begin(), frameIdToPoseId.end());
+
+      // ensure there is no duplicated frameId
+      auto it = std::adjacent_find(frameIdToPoseId.begin(), frameIdToPoseId.end(),
+                                   [](const auto& a, const auto& b) { return a.first == b.first; });
+      if(it != frameIdToPoseId.end())
+      {
+          ALICEVISION_THROW_ERROR("Duplicated frameId in sfmData: " << sfmDataFilePath << ", frameID: " << it->first);
+      }
+        try
+        {
+            // This is where we start to read our json line by line
+            while(getline(jsonFile, line))
+            {
+                std::stringstream linestream(line);
+                int sensor;
+                float fov;
+                long timestamp;
+                int frmcnt;
+                float expoff;
+                float expdur;
+                std::vector<float> up;
+                std::vector<float> forward;
+                std::vector<float> pose;
+                json::ptree pt;
+
+                // We put each line in a stringstream because that is what boost's parser needs
+                // THe parser turns the json into a property tree in which we access the informations and store them
+                json::json_parser::read_json(linestream, pt);
+                sensor = pt.get<int>("sensorwidth", 0);
+                fov = pt.get<float>("xFovDegrees", 0);
+                timestamp = pt.get<long>("tstamp", 0);
+                frmcnt = pt.get<int>("frmcnt", 0);
+                expoff = pt.get<float>("exposureOff", 0);
+                expdur = pt.get<float>("exposureDur", 0);
+                // These arguments are lists so we need to loop to store them properly
+                for(json::ptree::value_type& up_val : pt.get_child("up"))
+                {
+                    std::string value = up_val.second.data();
+                    up.push_back(std::stof(value));
+                }
+                for(json::ptree::value_type& for_val : pt.get_child("forward"))
+                {
+                    std::string value = for_val.second.data();
+                    forward.push_back(std::stof(value));
+                }
+                for(json::ptree::value_type& pose_val : pt.get_child("pose"))
+                {
+                    std::string value = pose_val.second.data();
+                    pose.push_back(std::stof(value));
+                }
+                // We use records to indexify our frame count this way we know which frame started the list, this will be our offset
+                records.emplace_back(count, frmcnt);
+
+                // Without surprise we store our vector pose to get our position
+                Vec3 pos_vec(pose[0], pose[1], pose[2]);
+                Mat3 rot;
+                // And we need those two vectors to calculate the rotation matrix
+                Vec3 up_vec(up[0], up[1], up[2]);
+                Vec3 forward_vec(forward[0], forward[1], forward[2]);
+
+                rot.row(0) = up_vec.cross(forward_vec);
+                rot.row(1) = -up_vec;
+                rot.row(2) = forward_vec;
+                // we store this new information into a pose3
+                aliceVision::geometry::Pose3 pos3(rot, pos_vec);
+
+                // And we set this pose into the sfmData using our frameId (which corresponds to the count) to set a new pos3 transform
+                IndexT sfmPoseId = frameIdToPoseId[count].second;
+                sfmData.getPoses()[sfmPoseId].setTransform(pos3);
+                count++;
+                // We repeat this to each line of the file which contains a json
+            }
+        }
+        catch(boost::program_options::error& e)
+        {
+            ALICEVISION_CERR("ERROR: " << e.what() << std::endl);
+            return EXIT_FAILURE;
+        }
+  }
+
+  // export the SfMData scene in the expected format
+  if(!sfmDataIO::Save(sfmData, outputFilename, sfmDataIO::ESfMData::ALL))
+  {
+      ALICEVISION_LOG_ERROR("An error occured while trying to save '" << outputFilename << "'");
+      return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -194,7 +194,7 @@ int aliceVision_main(int argc, char* argv[])
     if(!mesh.hasUVs())
     {
         // Need visibilities to compute unwrap
-        mesh.mesh->remapVisibilities(texParams.visibilityRemappingMethod, refMesh);
+        mesh.remapVisibilities(texParams.visibilityRemappingMethod, mp, refMesh);
         ALICEVISION_LOG_INFO("Input mesh has no UV coordinates, start unwrapping (" + unwrapMethod +")");
         mesh.unwrap(mp, mesh::EUnwrapMethod_stringToEnum(unwrapMethod));
         ALICEVISION_LOG_INFO("Unwrapping done.");
@@ -211,9 +211,13 @@ int aliceVision_main(int argc, char* argv[])
 
         mesh.updateAtlases();
 
-        // remap visibilities
+        // need to recompute visibilities for all vertices
         mesh.mesh->pointsVisibilities.clear();
-        mesh.mesh->remapVisibilities(texParams.visibilityRemappingMethod, refMesh);
+    }
+
+    if(mesh.mesh->pointsVisibilities.empty())
+    {
+        mesh.remapVisibilities(texParams.visibilityRemappingMethod, mp, refMesh);
 
         // DEBUG: export subdivided mesh
         // mesh.saveAsOBJ(outputFolder, "subdividedMesh", outputTextureFileType);

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -289,7 +289,7 @@ int aliceVision_main(int argc, char** argv)
   std::string dualFisheyeSplitPreset;         // dual-fisheye split type preset
   std::size_t equirectangularNbSplits;        // nb splits for equirectangular image
   std::size_t equirectangularSplitResolution; // split resolution for equirectangular image
-  bool equirectangularDemoMode;
+  bool equirectangularDemoMode = false;
   double fov = 110.0;                         // Field of View in degree
   int nbThreads = 3;
 
@@ -306,16 +306,14 @@ int aliceVision_main(int argc, char** argv)
   po::options_description optionalParams("Optional parameters");
   optionalParams.add_options()
     ("splitMode,m", po::value<std::string>(&splitMode)->default_value("equirectangular"),
-      "Split mode "
-      "(exif, equirectangular, dualfisheye)")
+      "Split mode (equirectangular, dualfisheye)")
     ("dualFisheyeSplitPreset", po::value<std::string>(&dualFisheyeSplitPreset)->default_value("center"),
-      "Dual-Fisheye split type preset "
-      "(center, top, bottom)")
+      "Dual-Fisheye split type preset (center, top, bottom)")
     ("equirectangularNbSplits", po::value<std::size_t>(&equirectangularNbSplits)->default_value(2),
       "Equirectangular number of splits")
     ("equirectangularSplitResolution", po::value<std::size_t>(&equirectangularSplitResolution)->default_value(1200),
       "Equirectangular split resolution")
-    ("equirectangularDemoMode", po::value<bool>(&equirectangularDemoMode)->default_value(false),
+    ("equirectangularDemoMode", po::value<bool>(&equirectangularDemoMode)->default_value(equirectangularDemoMode),
       "Export a SVG file that simulate the split")
     ("fov", po::value<double>(&fov)->default_value(fov),
       "Field of View to extract (in degree).")


### PR DESCRIPTION
## Features list

 - Import known poses from a JSON file (camera poses and intrinsics)
 - Import known poses from XMP (XML) files (camera poses and intrinsics)
 - Import known poses from a maya text file .ma (camera poses only).
 - [mesh] new remap visibility method without dense sfmData information. Guess visibilities from mesh orientation. It assumes that there is no occultation from non reconstructed elements.
 - [mesh] obj loader: fix material index management when combining multiple ones
 - [sfm] incremental: optimize input when starting from known poses/landmarks
