### PR TITLE
Add Canon Eos M50 Mark II to sensor database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -630,6 +630,7 @@ Canon;Canon EOS M2;22.3;dxomark
 Canon;Canon EOS M3;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS M5;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS M50;22.3;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon EOS M50m2;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS M6;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS M6 Mark II;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS R;36.0;dpreview,digicamdb,imaging-resource


### PR DESCRIPTION
Adds the canon eos m50 Mark II to the sensor database. It has the same sensor as the previous version.