### PR TITLE
Add Parrot Anafi to sensor database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4705,6 +4705,7 @@ Panasonic;Panasonic Lumix Smart Camera CM1;13.2;devicespecifications
 Panasonic;Panasonic P9;3.68;devicespecifications
 Panasonic;Panasonic PV DC3000;7.11;digicamdb
 Panasonic;Panasonic T44;2.95;devicespecifications
+Parrot;Anafi;5.9;devicespecifications
 Parrot;Bebop;8.4;usercontribution
 PENTAX;Optio330RS;7.176;usercontribution
 Pentax;Pentax *ist D;23.5;dpreview,digicamdb


### PR DESCRIPTION
I've tried it by myself and it seems to work out fine.

Source:
https://www.parrot.com/us/drones/anafi/technical-specifications --> Sensor: 1/2.4’’ CMOS
https://www.digicamdb.com/sensor-sizes/ -->1/2.4" (~ **5.90** x 4.43 mm)
