### PR TITLE
Added Realme 7 Pro to sensor database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5040,6 +5040,7 @@ RaspberryPi;RP_imx219;3.6736;devicespecifications
 RaspberryPi;RP_imx477;6.287;devicespecifications
 RaspberryPi;RP_OV5647;3.6288;devicespecifications
 Realme;Realme 2 Pro;5.22;devicespecifications
+Realme;Realme 7 Pro;7.4;usercontribution
 Red;Epic Dragon;30.7;usercontribution
 Red;Red Dragon 4K HD;19.19;usercontribution
 Red;Red Helium 8K S35;29.90;usercontribution


### PR DESCRIPTION
## Description

Added Realme 7 Pro to the database. The sensor is a Sony IMX 682, and although hard to find the sensor size I found it on one website as 7.4, and checked it lines up with the calculated size from it's resolution etc.
