### PR TITLE
Add entry to cameraSensors.db for Canon EOS R6

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -633,6 +633,7 @@ Canon;Canon EOS M50;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS M6;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS M6 Mark II;22.3;dpreview,digicamdb,imaging-resource,dxomark
 Canon;Canon EOS R;36.0;dpreview,digicamdb,imaging-resource
+Canon;Canon EOS R6;35.9;devicespecifications,digicamdb
 Canon;Canon EOS Rebel SL1;22.3;dpreview,digicamdb,imaging-resource
 Canon;Canon EOS Rebel SL2;22.3;dpreview,digicamdb,imaging-resource
 Canon;Canon EOS Rebel T1i;22.3;dpreview,digicamdb,imaging-resource


### PR DESCRIPTION
Adding an entry for the Canon EOS R6 to the camera sensor database, based on the sensor size data from the Canon product "Advanced User Guide" manual, and from digicamdb.com.