### PR TITLE
[image] io: use zips compression for exr

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -445,8 +445,7 @@ void writeImage(const std::string& path,
   imageSpec.extra_attribs = metadata; // add custom metadata
 
   imageSpec.attribute("jpeg:subsampling", "4:4:4");           // if possible, always subsampling 4:4:4 for jpeg
-  imageSpec.attribute("CompressionQuality", 100);             // if possible, best compression quality
-  imageSpec.attribute("compression", isEXR ? "piz" : "none"); // if possible, set compression (piz for EXR, none for the other)
+  imageSpec.attribute("compression", isEXR ? "zips" : "none"); // if possible, set compression (zips for EXR, none for the other)
   if(roi.defined() && isEXR)
   {
       imageSpec.set_roi_full(roi);
@@ -530,8 +529,7 @@ void writeImageNoFloat(const std::string& path,
   imageSpec.extra_attribs = metadata; // add custom metadata
 
   imageSpec.attribute("jpeg:subsampling", "4:4:4");           // if possible, always subsampling 4:4:4 for jpeg
-  imageSpec.attribute("CompressionQuality", 100);             // if possible, best compression quality
-  imageSpec.attribute("compression", isEXR ? "none" : "none"); // if possible, set compression (piz for EXR, none for the other)
+  imageSpec.attribute("compression", isEXR ? "zips" : "none"); // if possible, set compression (zips for EXR, none for the other)
 
   const oiio::ImageBuf imgBuf = oiio::ImageBuf(imageSpec, const_cast<T*>(image.data())); // original image buffer
   const oiio::ImageBuf* outBuf = &imgBuf;  // buffer to write

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -158,7 +158,6 @@ void KeyframeSelector::process()
     mediaInfo.tileHeight = (image.Height() / 2) / _nbTileSide;
     mediaInfo.tileWidth = (image.Width() / 2) / _nbTileSide;
     mediaInfo.spec = oiio::ImageSpec(image.Width(), image.Height(), 3, oiio::TypeDesc::UINT8); // always jpeg
-    mediaInfo.spec.attribute("CompressionQuality", 100);   // always best compression quality
     mediaInfo.spec.attribute("jpeg:subsampling", "4:4:4"); // always subsampling 4:4:4
     mediaInfo.spec.attribute("oiio:ColorSpace", "sRGB");   // always sRGB
     mediaInfo.spec.attribute("Make",  _cameraInfos[mediaIndex].brand);

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -385,8 +385,7 @@ void writeImage(const std::string& path,
     imageSpec.extra_attribs = metadata; // add custom metadata
 
     imageSpec.attribute("jpeg:subsampling", "4:4:4");           // if possible, always subsampling 4:4:4 for jpeg
-    imageSpec.attribute("CompressionQuality", 100);             // if possible, best compression quality
-    imageSpec.attribute("compression", isEXR ? "piz" : "none"); // if possible, set compression (piz for EXR, none for the other)
+    imageSpec.attribute("compression", isEXR ? "zips" : "none"); // if possible, set compression (zips for EXR, none for the other)
 
     const oiio::ImageBuf imgBuf = oiio::ImageBuf(imageSpec, const_cast<T*>(buffer.data())); // original image buffer
     const oiio::ImageBuf* outBuf = &imgBuf;  // buffer to write

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -393,9 +393,9 @@ int aliceVision_main(int argc, char** argv)
 				spec_mask.tile_height = tileSize;
 				spec_weights.tile_width = tileSize;
 				spec_weights.tile_height = tileSize;
-				spec_view.attribute("compression", "piz");
-				spec_weights.attribute("compression", "piz");
-				spec_mask.attribute("compression", "piz");
+				spec_view.attribute("compression", "zips");
+				spec_weights.attribute("compression", "zips");
+				spec_mask.attribute("compression", "zips");
 				spec_view.extra_attribs = metadata;
 				spec_mask.extra_attribs = metadata;
 				spec_weights.extra_attribs = metadata;


### PR DESCRIPTION
CompressionQuality is deprecated in oiio.
Use "zips" compression instead of "piz" as loading exr in piz create issues in Nuke for large images.
