### PR TITLE
[sensorDB] Update Maker of K-S2 and other DSLRs of Ricoh Imaging

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4779,7 +4779,6 @@ Pentax;Pentax K-70;23.5;dpreview,digicamdb,imaging-resource,dxomark
 Pentax;Pentax K-m;23.5;dpreview,digicamdb
 Pentax;Pentax K-r;23.6;dpreview,digicamdb,imaging-resource
 Pentax;Pentax K-S1;23.5;dpreview,digicamdb,imaging-resource,dxomark
-RICOH IMAGING COMPANY, LTD.;Pentax K-S2;23.5;dpreview,digicamdb,imaging-resource,dxomark
 Pentax;Pentax K-x;23.6;dpreview,digicamdb,imaging-resource
 Pentax;Pentax K100D;23.5;dpreview,digicamdb
 Pentax;Pentax K100D Super;23.5;dpreview,digicamdb
@@ -5087,6 +5086,15 @@ Red;Epic Dragon;30.7;usercontribution
 Red;Red Dragon 4K HD;19.19;usercontribution
 Red;Red Helium 8K S35;29.90;usercontribution
 Red;Red Mysterium-X 4K HD;20.74;usercontribution
+Ricoh;Pentax K-1;35.9;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax K-1 II;35.9;imaging-resource
+Ricoh;Pentax K-1 Mark II;35.9;dpreview,digicamdb,dxomark
+Ricoh;Pentax K-3;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax K-3 II;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax K-70;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax KP;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax K-S1;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax K-S2;23.5;dpreview,digicamdb,imaging-resource,dxomark
 Ricoh;Ricoh Caplio 400G Wide;5.33;digicamdb
 Ricoh;Ricoh Caplio 500G;7.144;dpreview,digicamdb
 Ricoh;Ricoh Caplio 500G Wide;7.11;digicamdb

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4779,7 +4779,7 @@ Pentax;Pentax K-70;23.5;dpreview,digicamdb,imaging-resource,dxomark
 Pentax;Pentax K-m;23.5;dpreview,digicamdb
 Pentax;Pentax K-r;23.6;dpreview,digicamdb,imaging-resource
 Pentax;Pentax K-S1;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-S2;23.5;dpreview,digicamdb,imaging-resource,dxomark
+RICOH IMAGING COMPANY, LTD.;Pentax K-S2;23.5;dpreview,digicamdb,imaging-resource,dxomark
 Pentax;Pentax K-x;23.6;dpreview,digicamdb,imaging-resource
 Pentax;Pentax K100D;23.5;dpreview,digicamdb
 Pentax;Pentax K100D Super;23.5;dpreview,digicamdb


### PR DESCRIPTION
**EN**

Updated cameraSensors.db. I found Actual Metadata of the Maker of K-S2 was RICOH IMAGING COMPANY, LTD. So I updated the corresponding line.

Maker value of newer Models of PENTAX must be same as K-S2, but I can't verify because I don't have them.
Also, Once maker of PENTAX cameras was HOYA corporation(since 2008) and later PENTAX RICOH IMAGING COMPANY, LTD.(since 2011) so I suppose models made in that period may have other metadata value of maker but I'm not sure.

Please review the change and tell me whether you think I should update information of other cameras.

**JA(for reader side machine translation)**
cameraSensors.dbを更新しました。K-S2のメーカーが実際にはRICOH IMAGING COMPANY, LTD.だったので、該当行を更新しました。

より新しいモデルのカメラのメーカー情報も同様にRICOH IMAGING COMPANY, LTD.になっていると思われすが、私はそのようなカメラを持っていないので確かめることができません。
また、PENTAXのカメラは2008年からはHOYA株式会社、そして2011年からはペンタックスリコーイメージング株式会社が製造しているので、その時期のモデルはまた違ったメーカー情報をメタデータに持っている可能性があります。しかし、やはりそれも確信が持てません。

fix #1113 