### PR TITLE
Add ca-certificates update to Ubuntu docker build.

### DIFF
--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -23,6 +23,7 @@ LABEL maintainer="AliceVision Team alicevision-team@googlegroups.com"
 RUN . ./etc/os-release && \
 	apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		ca-certificates \
 		wget \
 		software-properties-common && \
 	wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - > /etc/apt/trusted.gpg.d/kitware.gpg && \


### PR DESCRIPTION
Add ca-certificates update to Ubuntu docker build - this is needed for the Kitware CMake repository, as existing certificates in the chain from the base image have expired as of the time of this commit. Installing fresh root certificates should prevent certificate chain-based issues from happening in the future.


## Description

- Building the docker image for Focal, I encountered an issue in the certificate chain for the kitware repository (for CMake), preventing the build from progressin nay further
- The issue was simply a stale root certificate, and was resolved by updating the `ca-certificates` package
* As an aside, I use snaps myself for getting a recent build of CMake, this may be easier, although if it ain't broke, don't fix it ;)

## Features list

- Update the certificates before adding the kitware PPA.


## Implementation remarks


