### PR TITLE
[sensorDB] Create camera sensor for Galaxy S8 (Model SM-G950W)

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5620,6 +5620,7 @@ Samsung;Samsung SM-G930F;5.76;usercontribution
 Samsung;Samsung SM-G935F;3.2;devicespecifications
 Samsung;Samsung SM-G950F;5.76;usercontribution
 Samsung;Samsung SM-G950U;2.68;usercontribution
+Samsung;Samsung SM-G950W;5.66;usercontribution
 Samsung;Samsung SM-G955F;5.76;usercontribution
 Samsung;Samsung SM-G965F;5.64;usercontribution
 Samsung;Samsung SM-G975U;5.66;devicespecifications


### PR DESCRIPTION
added Galaxy S8 Model SM-G950W with sensor width of 5.66

