### PR TITLE
[depthMap] Sgm: Fix no result with a single Tc

### DIFF
--- a/src/aliceVision/depthMap/Sgm.cpp
+++ b/src/aliceVision/depthMap/Sgm.cpp
@@ -89,6 +89,13 @@ bool Sgm::sgmRc()
 
     _cps.computeDepthSimMapVolume(_rc, volumeBestSim_dmp, volumeSecBestSim_dmp, volDim, _tCams.getData(), _depthsTcamsLimits.getData(), _depths.getData(), _sgmParams);
 
+    // particular case with only one tc
+    if(_tCams.size() < 2)
+    {
+        // the second best volume has no valid similarity values
+        volumeSecBestSim_dmp.copyFrom(volumeBestSim_dmp);
+    }
+
     if (_sgmParams.exportIntermediateResults)
     {
         CudaHostMemoryHeap<TSim, 3> volumeSecBestSim_h(volumeSecBestSim_dmp.getSize());


### PR DESCRIPTION
## Description

Fixes the particular case of 2 cameras in the depth map estimation.