### PR TITLE
[software] incrementalSfM: Add option computeStructureColor

### DIFF
--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -92,6 +92,7 @@ int aliceVision_main(int argc, char **argv)
   int maxNbMatches = 0;
   int minNbMatches = 0;
   bool useOnlyMatchesFromInputFolder = false;
+  bool computeStructureColor = true;
 
   int randomSeed = std::mt19937::default_seed;
 
@@ -178,6 +179,8 @@ int aliceVision_main(int argc, char **argv)
       "Lock/Unlock scene previously reconstructed.\n")
     ("observationConstraint", po::value<EFeatureConstraint>(&sfmParams.featureConstraint)->default_value(sfmParams.featureConstraint),
       "Use of an observation constraint : basic, scale the observation or use of the covariance.\n")
+    ("computeStructureColor", po::value<bool>(&computeStructureColor)->default_value(computeStructureColor),
+      "Compute each 3D point color.\n")
     ("randomSeed", po::value<int>(&randomSeed)->default_value(randomSeed),
       "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
     ;
@@ -331,7 +334,9 @@ int aliceVision_main(int argc, char **argv)
   }
 
   // get the color for the 3D points
-  sfmEngine.colorize();
+  if(computeStructureColor)
+    sfmEngine.colorize();
+
   sfmEngine.retrieveMarkersId();
 
   ALICEVISION_LOG_INFO("Structure from motion took (s): " + std::to_string(timer.elapsed()));


### PR DESCRIPTION
## Description

Add `computeStructureColor` option to `incrementalSfM` software to enable/disable color computation of each 3D point.

