### PR TITLE
Fix small typo in cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -7094,7 +7094,7 @@ Winnovo;Winnovo K54;2.65;devicespecifications
 Winnovo;Winnovo K56;2.65;devicespecifications
 Wolder;Wolder Wiam #65;5.99;devicespecifications
 Xgody;Xgody Y20;3.68;devicespecifications
-Xiaomi,Black Shark 2 Pro;6.4;kimovil
+Xiaomi;Black Shark 2 Pro;6.4;kimovil
 Xiaomi;CC9;6.4;kimovil
 Xiaomi;POCOPHONE F1;5.64;deviceranks
 Xiaomi;POCOPHONE F2 Pro;7.27;usercontribution


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

There is a small typo (comma instead of semicolon) in cameraSensors.db: https://github.com/alicevision/AliceVision/blob/0372bca9895fd4574d5875a365f2a60d7283304f/src/aliceVision/sensorDB/cameraSensors.db#L7097

This PR is related to issue [#1175](https://github.com/alicevision/AliceVision/issues/1175)

## Features list

Fixes [#1175](https://github.com/alicevision/AliceVision/issues/1175)

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->

## Implementation remarks

None
<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

