### PR TITLE
Color management for RAW images

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -185,7 +185,7 @@ jobs:
           additionalCachedPaths: ${{ env.buildDir }}/vcpkg_installed
           # This is used to unbreak cached artifacts if for some reason dependencies fail to build,
           # the action does not notice it and saves broken artifacts.
-          appendedCacheKey: cache1
+          appendedCacheKey: cache2
 
       - name: vcpkg - Display installed packages
         run:

--- a/src/aliceVision/hdr/hdrTestCommon.hpp
+++ b/src/aliceVision/hdr/hdrTestCommon.hpp
@@ -34,11 +34,14 @@ bool extractSamplesGroups(std::vector<std::vector<ImageSample>>& out_samples,
         int height = 0;
         image::readImageSize(imagePaths[idGroup][0], width, height);
 
+        image::ImageReadOptions imgReadOptions;
+        imgReadOptions.rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
+        imgReadOptions.workingColorSpace = image::EImageColorSpace::LINEAR;
+
         std::vector<ImageSample> groupSamples;
         if (!Sampling::extractSamplesFromImages(groupSamples, imagePaths[idGroup],
                                                 times[idGroup], width, height,
-                                                channelQuantization,
-                                                image::EImageColorSpace::LINEAR, image::ERawColorInterpretation::LibRawWhiteBalancing,
+                                                channelQuantization, imgReadOptions,
                                                 Sampling::Params{}))
         {
             return false;

--- a/src/aliceVision/hdr/hdrTestCommon.hpp
+++ b/src/aliceVision/hdr/hdrTestCommon.hpp
@@ -38,7 +38,7 @@ bool extractSamplesGroups(std::vector<std::vector<ImageSample>>& out_samples,
         if (!Sampling::extractSamplesFromImages(groupSamples, imagePaths[idGroup],
                                                 times[idGroup], width, height,
                                                 channelQuantization,
-                                                image::EImageColorSpace::LINEAR, true,
+                                                image::EImageColorSpace::LINEAR, image::ERawColorInterpretation::LibRawWhiteBalancing,
                                                 Sampling::Params{}))
         {
             return false;

--- a/src/aliceVision/hdr/sampling.cpp
+++ b/src/aliceVision/hdr/sampling.cpp
@@ -146,7 +146,7 @@ void square(image::Image<image::RGBfColor> & dest, const Eigen::Matrix<image::RG
     }
 }
 
-bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string>& imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const EImageColorSpace& colorspace, image::ERawColorInterpretation rawColorInterpretation, const Sampling::Params params)
+bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string>& imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Sampling::Params params)
 {
     const int radiusp1 = params.radius + 1;
     const int diameter = (params.radius * 2) + 1;
@@ -171,12 +171,8 @@ bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, c
     {
         const double exposure = times[idBracket];
 
-        image::ImageReadOptions options;
-        options.workingColorSpace = colorspace;
-        options.rawColorInterpretation = rawColorInterpretation;
-        
         // Load image
-        readImage(imagePaths[idBracket], img, options);
+        readImage(imagePaths[idBracket], img, imgReadOptions);
 
         if(img.Width() != imageWidth || img.Height() != imageHeight)
         {

--- a/src/aliceVision/hdr/sampling.cpp
+++ b/src/aliceVision/hdr/sampling.cpp
@@ -146,7 +146,7 @@ void square(image::Image<image::RGBfColor> & dest, const Eigen::Matrix<image::RG
     }
 }
 
-bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const EImageColorSpace & colorspace, bool applyWhiteBalance, const Sampling::Params params)
+bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string>& imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const EImageColorSpace& colorspace, image::ERawColorInterpretation rawColorInterpretation, const Sampling::Params params)
 {
     const int radiusp1 = params.radius + 1;
     const int diameter = (params.radius * 2) + 1;
@@ -173,8 +173,8 @@ bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, c
 
         image::ImageReadOptions options;
         options.workingColorSpace = colorspace;
-        options.rawColorInterpretation = applyWhiteBalance ? image::ERawColorInterpretation::LibRawWhiteBalancing  : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
-
+        options.rawColorInterpretation = rawColorInterpretation;
+        
         // Load image
         readImage(imagePaths[idBracket], img, options);
 

--- a/src/aliceVision/hdr/sampling.cpp
+++ b/src/aliceVision/hdr/sampling.cpp
@@ -173,7 +173,7 @@ bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, c
 
         image::ImageReadOptions options;
         options.workingColorSpace = colorspace;
-        options.applyWhiteBalance = applyWhiteBalance;
+        options.rawColorInterpretation = applyWhiteBalance ? image::ERawColorInterpretation::LibRawWhiteBalancing  : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
 
         // Load image
         readImage(imagePaths[idBracket], img, options);

--- a/src/aliceVision/hdr/sampling.hpp
+++ b/src/aliceVision/hdr/sampling.hpp
@@ -66,7 +66,7 @@ public:
     void filter(size_t maxTotalPoints);
     void extractUsefulSamples(std::vector<ImageSample> & out_samples, const std::vector<ImageSample> & samples, int imageIndex) const;
     
-    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::EImageColorSpace & colorspace, image::ERawColorInterpretation rawColorInterpretation, const Params params);
+    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Params params);
 
 private:
     MapSampleRefList _positions;

--- a/src/aliceVision/hdr/sampling.hpp
+++ b/src/aliceVision/hdr/sampling.hpp
@@ -66,7 +66,7 @@ public:
     void filter(size_t maxTotalPoints);
     void extractUsefulSamples(std::vector<ImageSample> & out_samples, const std::vector<ImageSample> & samples, int imageIndex) const;
     
-    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::EImageColorSpace & colorspace, bool applyWhiteBalance, const Params params);
+    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::EImageColorSpace & colorspace, image::ERawColorInterpretation rawColorInterpretation, const Params params);
 
 private:
     MapSampleRefList _positions;

--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -10,6 +10,7 @@ set(image_files_headers
   convertion.hpp
   convolutionBase.hpp
   convolution.hpp
+  dcp.hpp
   diffusion.hpp
   drawing.hpp
   filtering.hpp
@@ -26,6 +27,7 @@ set(image_files_headers
 set(image_files_sources
   colorspace.cpp
   convolution.cpp
+  dcp.cpp
   filtering.cpp
   io.cpp
   imageAlgo.cpp

--- a/src/aliceVision/image/all.hpp
+++ b/src/aliceVision/image/all.hpp
@@ -27,5 +27,6 @@
 #include "aliceVision/image/Rgb.hpp"
 #include "aliceVision/image/Sampler.hpp"
 #include "aliceVision/image/convertionOpenCV.hpp"
+#include "aliceVision/image/dcp.hpp"
 
 

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -1369,7 +1369,6 @@ void DCPProfile::apply(float* rgb, const DCPProfileApplyParams& params) const
 
         if (params.use_tone_curve)
         {
-            // tone_curve.Apply(ws_rgb[0], ws_rgb[1], ws_rgb[2]);
             AS_tone_curve.Apply(ws_rgb[0], ws_rgb[1], ws_rgb[2]);
         }
 

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -1,0 +1,1530 @@
+#include <iostream>
+#include <cstdio>
+#include <cstring>
+#include <functional>
+
+#include "dcp.hpp"
+
+using namespace alicevision::image;
+
+namespace
+{
+double calibrationIlluminantToTemperature(int light)
+{
+    enum class LightSource {
+        UNKNOWN = 0,
+        DAYLIGHT = 1,
+        FLUORESCENT = 2,
+        TUNGSTEN = 3,
+        FLASH = 4,
+        FINE_WEATHER = 9,
+        CLOUDY_WEATHER = 10,
+        SHADE = 11,
+        DAYLIGHT_FLUORESCENT = 12, // D  5700 - 7100K
+        DAYWHITE_FLUORESCENT = 13, // N  4600 - 5500K
+        COOL_WHITE_FLUORESCENT = 14, // W  3800 - 4500K
+        WHITE_FLUORESCENT = 15, // WW 3250 - 3800K
+        WARM_WHITE_FLUORESCENT = 16, // L  2600 - 3250K
+        STANDARD_LIGHT_A = 17,
+        STANDARD_LIGHT_B = 18,
+        STANDARD_LIGHT_C = 19,
+        D55 = 20,
+        D65 = 21,
+        D75 = 22,
+        D50 = 23,
+        ISO_STUDIO_TUNGSTEN = 24,
+        OTHER = 255
+    };
+
+    // These temperatures are those found in DNG SDK reference code
+    switch (LightSource(light)) {
+        case LightSource::STANDARD_LIGHT_A:
+        case LightSource::TUNGSTEN: {
+            return 2850.0;
+        }
+
+        case LightSource::ISO_STUDIO_TUNGSTEN: {
+            return 3200.0;
+        }
+
+        case LightSource::D50: {
+            return 5000.0;
+        }
+
+        case LightSource::D55:
+        case LightSource::DAYLIGHT:
+        case LightSource::FINE_WEATHER:
+        case LightSource::FLASH:
+        case LightSource::STANDARD_LIGHT_B: {
+            return 5500.0;
+        }
+
+        case LightSource::D65:
+        case LightSource::STANDARD_LIGHT_C:
+        case LightSource::CLOUDY_WEATHER: {
+            return 6500.0;
+        }
+
+        case LightSource::D75:
+        case LightSource::SHADE: {
+            return 7500.0;
+        }
+
+        case LightSource::DAYLIGHT_FLUORESCENT: {
+            return (5700.0 + 7100.0) * 0.5;
+        }
+
+        case LightSource::DAYWHITE_FLUORESCENT: {
+            return (4600.0 + 5500.0) * 0.5;
+        }
+
+        case LightSource::COOL_WHITE_FLUORESCENT:
+        case LightSource::FLUORESCENT: {
+            return (3800.0 + 4500.0) * 0.5;
+        }
+
+        case LightSource::WHITE_FLUORESCENT: {
+            return (3250.0 + 3800.0) * 0.5;
+        }
+
+        case LightSource::WARM_WHITE_FLUORESCENT: {
+            return (2600.0 + 3250.0) * 0.5;
+        }
+
+        default: {
+            return 0.0;
+        }
+    }
+}
+}
+
+enum class TagType : int { T_INVALID = 0, T_BYTE = 1, T_ASCII = 2, T_SHORT = 3, T_LONG = 4, T_RATIONAL = 5, T_SBYTE = 6, T_UNDEFINED = 7, T_SSHORT = 8, T_SLONG = 9, T_SRATIONAL = 10, T_FLOAT = 11, T_DOUBLE = 12, T_OLYUNDEF = 13, T_AUTO = 98, T_SUBDIR = 99 };
+enum class Endianness : int { UNKNOWN = 0, LITTLE = 0x4949, BIG = 0x4D4D };
+
+inline static int getTypeSize(TagType type)
+{
+    return (
+        (type == TagType::T_INVALID || type == TagType::T_BYTE || type == TagType::T_ASCII || type == TagType::T_SBYTE || type == TagType::T_UNDEFINED) ? 1 :
+        (type == TagType::T_SHORT || type == TagType::T_SSHORT) ? 2 :
+        (type == TagType::T_LONG || type == TagType::T_SLONG || type == TagType::T_FLOAT || type == TagType::T_OLYUNDEF) ? 4 :
+        (type == TagType::T_RATIONAL || type == TagType::T_SRATIONAL || type == TagType::T_DOUBLE) ? 8 : 0
+        );
+}
+
+enum class TagKey : int {
+    COLOR_MATRIX_1 = 50721,
+    COLOR_MATRIX_2 = 50722,
+    PROFILE_HUE_SAT_MAP_DIMS = 50937,
+    PROFILE_HUE_SAT_MAP_DATA_1 = 50938,
+    PROFILE_HUE_SAT_MAP_DATA_2 = 50939,
+    PROFILE_TONE_CURVE = 50940,
+    PROFILE_TONE_COPYRIGHT = 50942,
+    CALIBRATION_ILLUMINANT_1 = 50778,
+    CALIBRATION_ILLUMINANT_2 = 50779,
+    FORWARD_MATRIX_1 = 50964,
+    FORWARD_MATRIX_2 = 50965,
+    PROFILE_LOOK_TABLE_DIMS = 50981,
+    PROFILE_LOOK_TABLE_DATA = 50982,
+    PROFILE_HUE_SAT_MAP_ENCODING = 51107,
+    PROFILE_LOOK_TABLE_ENCODING = 51108,
+    BASELINE_EXPOSURE_OFFSET = 51109
+};
+
+//-----------------------------------------------------------------------------
+// Reading Endianness dependent data
+//-----------------------------------------------------------------------------
+unsigned short sget2(const unsigned char* s, Endianness order)
+{
+    if (order == Endianness::LITTLE) {
+        return s[0] | s[1] << 8;
+    }
+    else {
+        return s[0] << 8 | s[1];
+    }
+}
+int sget4(const unsigned char* s, Endianness order)
+{
+    if (order == Endianness::LITTLE) {
+        return s[0] | s[1] << 8 | s[2] << 16 | s[3] << 24;
+    }
+    else {
+        return s[0] << 24 | s[1] << 16 | s[2] << 8 | s[3];
+    }
+}
+inline unsigned short get2(FILE* f, Endianness order)
+{
+    unsigned char str[2] = { 0xff, 0xff };
+    fread(str, 1, 2, f);
+    return sget2(str, order);
+}
+int get4(FILE* f, Endianness order)
+{
+    unsigned char str[4] = { 0xff, 0xff, 0xff, 0xff };
+    fread(str, 1, 4, f);
+    return sget4(str, order);
+}
+short int int2_to_signed(short unsigned int i)
+{
+    union {
+        short unsigned int i;
+        short int s;
+    } u;
+    u.i = i;
+    return u.s;
+}
+
+
+/*
+ * A class representing a single TIFF tag
+ */
+class Tag
+{
+
+public:
+    unsigned short tagID{0};
+    TagType        type{TagType::T_INVALID};
+    unsigned int   datasize{0};
+    std::vector<unsigned char> v_value;
+    Endianness     order{Endianness::UNKNOWN};
+
+    Tag() = default;
+    Tag(unsigned short tag, TagType type, unsigned int datasize, Endianness order, FILE* f);
+
+    ~Tag() = default;
+
+    bool operator==(const Tag& t) const;
+
+    int    toInt(int ofs, TagType astype = TagType::T_INVALID) const;
+    double toDouble(int ofs = 0) const;
+    void   toString(char* buffer, std::size_t size, int ofs = 0) const;
+
+    std::string valueToString() const;
+};
+
+Tag::Tag(unsigned short tag, TagType type, unsigned int datasize, Endianness order, FILE* f) : // file index supposed to be at rigth location to read datasize
+    tagID(tag), type(type), datasize(datasize), order(order)
+{
+
+    // load value field (possibly seek before)
+    const int valuesize = datasize * getTypeSize(type);
+
+    if (valuesize > 4) {
+        fseek(f, get4(f, order), SEEK_SET);
+    }
+
+    // read value
+    //value = new unsigned char[valuesize + 1];
+    v_value.resize(valuesize + 1);
+    auto readSize = fread(v_value.data(), 1, valuesize, f);
+    //value[readSize] = '\0';
+    v_value[readSize] = '\0';
+}
+
+bool Tag::operator==(const Tag& t) const
+{
+    return (tagID == t.tagID);
+}
+
+int Tag::toInt(int ofs, TagType astype) const
+{
+    if (astype == TagType::T_INVALID) {
+        astype = type;
+    }
+
+    switch (astype) {
+    case TagType::T_SBYTE:
+        return int(static_cast<signed char>(v_value[ofs]));
+
+    case TagType::T_BYTE:
+        return v_value[ofs];
+
+    case TagType::T_ASCII:
+        return 0;
+
+    case TagType::T_SSHORT:
+        return (int)int2_to_signed(sget2(v_value.data() + ofs, order));
+
+    case TagType::T_SHORT:
+        return (int)sget2(v_value.data() + ofs, order);
+
+    case TagType::T_SLONG:
+    case TagType::T_LONG:
+        return (int)sget4(v_value.data() + ofs, order);
+
+    case TagType::T_SRATIONAL: {
+        int a = (int)sget4(v_value.data() + ofs + 4, order);
+        return a == 0 ? 0 : (int)sget4(v_value.data() + ofs, order) / a;
+    }
+
+    case TagType::T_RATIONAL: {
+        uint32_t a = (uint32_t)sget4(v_value.data() + ofs + 4, order);
+        return a == 0 ? 0 : (uint32_t)sget4(v_value.data() + ofs, order) / a;
+    }
+
+    case TagType::T_FLOAT:
+        return (int)toDouble(ofs);
+
+    case TagType::T_UNDEFINED:
+        return 0;
+
+    default:
+        return 0; // Quick fix for missing cases (INVALID, DOUBLE, OLYUNDEF, SUBDIR)
+    }
+
+    return 0;
+}
+
+double Tag::toDouble(int ofs) const
+{
+    union IntFloat {
+        uint32_t i;
+        float f;
+    } conv;
+
+    double ud, dd;
+
+    switch (type) {
+    case TagType::T_SBYTE:
+        return (double)(static_cast<signed char>(v_value[ofs]));
+
+    case TagType::T_BYTE:
+        return (double)((int)v_value[ofs]);
+
+    case TagType::T_ASCII:
+        return 0.0;
+
+    case TagType::T_SSHORT:
+        return (double)int2_to_signed(sget2(v_value.data() + ofs, order));
+
+    case TagType::T_SHORT:
+        return (double)((int)sget2(v_value.data() + ofs, order));
+
+    case TagType::T_SLONG:
+    case TagType::T_LONG:
+        return (double)((int)sget4(v_value.data() + ofs, order));
+
+    case TagType::T_SRATIONAL:
+        ud = (int)sget4(v_value.data() + ofs, order);
+        dd = (int)sget4(v_value.data() + ofs + 4, order);
+        return dd == 0. ? 0. : ud / dd;
+
+    case TagType::T_RATIONAL:
+        ud = (uint32_t)sget4(v_value.data() + ofs, order);
+        dd = (uint32_t)sget4(v_value.data() + ofs + 4, order);
+        return dd == 0. ? 0. : ud / dd;
+
+    case TagType::T_FLOAT:
+        conv.i = sget4(v_value.data() + ofs, order);
+        return conv.f;
+
+    case TagType::T_UNDEFINED:
+        return 0.;
+
+    default:
+        return 0.;
+    }
+
+}
+
+void Tag::toString(char* buffer, std::size_t size, int ofs) const
+{
+    if (!buffer || !size) {
+        return;
+    }
+
+    if (type == TagType::T_UNDEFINED) {
+        bool isstring = true;
+        unsigned int i = 0;
+
+        for (i = 0; i + ofs < datasize && i < 64 && v_value[i + ofs]; i++)
+            if (v_value[i + ofs] < 32 || v_value[i + ofs] > 126) {
+                isstring = false;
+            }
+
+        if (isstring) {
+            if (size < 3) {
+                return;
+            }
+
+            std::size_t j = 0;
+
+            for (i = 0; i + ofs < datasize && i < 64 && v_value[i + ofs]; i++) {
+                if (v_value[i + ofs] == '<' || v_value[i + ofs] == '>') {
+                    buffer[j++] = '\\';
+                    if (j > size - 2) {
+                        break;
+                    }
+                }
+
+                buffer[j++] = v_value[i + ofs];
+                if (j > size - 2) {
+                    break;
+                }
+            }
+
+            buffer[j++] = 0;
+            return;
+        }
+    }
+    else if (type == TagType::T_ASCII) {
+        snprintf(buffer, size, "%.64s", v_value.data() + ofs);
+        return;
+    }
+
+    size_t maxcount = std::min<size_t>(datasize, 10);
+
+    buffer[0] = 0;
+
+    for (int i = 0; i < std::min<int>(maxcount, datasize * getTypeSize(type) - ofs); i++) {
+        std::size_t len = strlen(buffer);
+
+        if (i > 0 && size - len > 2) {
+            strcat(buffer, ", ");
+            len += 2;
+        }
+
+        char* b = buffer + len;
+
+        switch (type) {
+        case TagType::T_UNDEFINED:
+        case TagType::T_BYTE:
+            snprintf(b, size - len, "%d", v_value[i + ofs]);
+            break;
+
+        case TagType::T_SSHORT:
+            snprintf(b, size - len, "%d", toInt(2 * i + ofs));
+            break;
+
+        case TagType::T_SHORT:
+            snprintf(b, size - len, "%u", toInt(2 * i + ofs));
+            break;
+
+        case TagType::T_SLONG:
+            snprintf(b, size - len, "%d", toInt(4 * i + ofs));
+            break;
+
+        case TagType::T_LONG:
+            snprintf(b, size - len, "%u", toInt(4 * i + ofs));
+            break;
+
+        case TagType::T_SRATIONAL:
+            snprintf(b, size - len, "%d/%d", (int)sget4(v_value.data() + 8 * i + ofs, order), (int)sget4(v_value.data() + 8 * i + ofs + 4, order));
+            break;
+
+        case TagType::T_RATIONAL:
+            snprintf(b, size - len, "%u/%u", (uint32_t)sget4(v_value.data() + 8 * i + ofs, order), (uint32_t)sget4(v_value.data() + 8 * i + ofs + 4, order));
+            break;
+
+        case TagType::T_FLOAT:
+            snprintf(b, size - len, "%g", toDouble(8 * i + ofs));
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    if (datasize > maxcount && size - strlen(buffer) > 3) {
+        strcat(buffer, "...");
+    }
+}
+
+std::string Tag::valueToString() const
+{
+    char buffer[1024];
+    toString(buffer, sizeof(buffer));
+    return buffer;
+}
+
+Tag* findTag(TagKey tagID, std::vector<Tag>& v_Tags)
+{
+    size_t idx = 0;
+    while (idx < v_Tags.size() && (v_Tags[idx].tagID != (unsigned short)tagID))
+    {
+        idx++;
+    }
+    return (idx == v_Tags.size()) ? nullptr : &v_Tags[idx];
+}
+
+
+void SplineToneCurve::Set(const std::vector<double>& v_xy)
+{
+    std::vector<double> v_x;
+    std::vector<double> v_y;
+    std::vector<double> v_ypp;
+
+    const size_t N = v_xy.size() / 2;
+
+    for (int i = 0; i < N; ++i)
+    {
+        v_x.push_back(v_xy[2 * i]);
+        v_y.push_back(v_xy[2 * i + 1]);
+        v_ypp.push_back(0.0);
+    }
+    std::vector<double> v_u(N - 1, 0.0);
+
+    v_ypp[0] = v_u[0] = 0.0;    /* Natural spline */
+
+    for (int i = 1; i < N - 1; ++i) {
+        const double sig = (v_x[i] - v_x[i - 1]) / (v_x[i + 1] - v_x[i - 1]);
+        const double p = sig * v_ypp[i - 1] + 2.0;
+        v_ypp[i] = (sig - 1.0) / p;
+        v_u[i] = ((v_y[i + 1] - v_y[i])
+            / (v_x[i + 1] - v_x[i]) - (v_y[i] - v_y[i - 1]) / (v_x[i] - v_x[i - 1]));
+        v_u[i] = (6.0 * v_u[i] / (v_x[i + 1] - v_x[i - 1]) - sig * v_u[i - 1]) / p;
+    }
+
+    v_ypp[N - 1] = 0.0;
+
+    for (int k = N - 2; k >= 0; --k) {
+        v_ypp[k] = v_ypp[k] * v_ypp[k + 1] + v_u[k];
+    }
+
+    int k_hi = 0;
+
+    for (int i = 0; i < 65536; ++i) {
+
+        float t = float(i) / 65535.f;
+        while ((v_x[k_hi] <= t) && (k_hi < v_x.size() - 1))
+            k_hi++;
+
+        int k_lo = k_hi - 1;
+        double h = v_x[k_hi] - v_x[k_lo];
+        const double a = (v_x[k_hi] - t) / h;
+        const double b = (t - v_x[k_lo]) / h;
+        const double r = a * v_y[k_lo] + b * v_y[k_hi] + ((a * a * a - a) * v_ypp[k_lo] + (b * b * b - b) * v_ypp[k_hi]) * (h * h) * 0.1666666666666666666666666666666;
+
+        ffffToneCurve[i] = (float)(r > 0.0 ? (r < 1.0 ? r : 1.0) : 0.0) * 65535.f;
+    }
+}
+
+void SplineToneCurve::Apply(float& ir, float& ig, float& ib) const
+{
+    float r = std::max<float>(0.0, std::min<float>(65535.0, ir));
+    float g = std::max<float>(0.0, std::min<float>(65535.0, ig));
+    float b = std::max<float>(0.0, std::min<float>(65535.0, ib));
+
+    if (r >= g) {
+        if (g > b) {
+            RGBTone(r, g, b);     // Case 1: r >= g >  b
+        }
+        else if (b > r) {
+            RGBTone(b, r, g);     // Case 2: b >  r >= g
+        }
+        else if (b > g) {
+            RGBTone(r, b, g);     // Case 3: r >= b >  g
+        }
+        else {                           // Case 4: r == g == b
+            r = getval(r);
+            g = getval(g);
+            b = g;
+        }
+    }
+    else {
+        if (r >= b) {
+            RGBTone(g, r, b);     // Case 5: g >  r >= b
+        }
+        else if (b > g) {
+            RGBTone(b, g, r);     // Case 6: b >  g >  r
+        }
+        else {
+            RGBTone(g, b, r);     // Case 7: g >= b >  r
+        }
+    }
+
+    if (!(ir < 0.0 || ir > 65535.0) || !(ig < 0.0 || ig > 65535.0) || !(ib < 0.0 || ib > 65535.0)) {
+        ir = r;
+        ig = g;
+        ib = b;
+    }
+}
+
+void SplineToneCurve::RGBTone(float& maxval, float& medval, float& minval) const
+{
+    const float minvalold = minval, medvalold = medval, maxvalold = maxval;
+
+    maxval = getval(maxval);
+    minval = getval(minval);
+    medval = minval + ((maxval - minval) * (medvalold - minvalold) / (maxvalold - minvalold));
+}
+
+float SplineToneCurve::getval(const float idx) const
+{
+    const int idx_int = (int)idx;
+    const float idx_dec = idx - idx_int;
+
+    if (idx_int < 0)
+        return ffffToneCurve.front();
+    else if (idx_int >= 65535)
+        return ffffToneCurve.back();
+    else
+        return idx_dec * ffffToneCurve[idx_int] + (1.f - idx_dec) * ffffToneCurve[idx_int + 1];
+}
+
+
+DCPProfile::DCPProfile(const std::string filename) :
+    will_interpolate(false),
+    valid(false),
+    baseline_exposure_offset(0.0)
+{
+    delta_info.hue_step = delta_info.val_step = look_info.hue_step = look_info.val_step = 0;
+    constexpr int tiff_float_size = 4;
+
+    static const float adobe_camera_raw_default_curve[] = {
+        0.00000f, 0.00078f, 0.00160f, 0.00242f,
+        0.00314f, 0.00385f, 0.00460f, 0.00539f,
+        0.00623f, 0.00712f, 0.00806f, 0.00906f,
+        0.01012f, 0.01122f, 0.01238f, 0.01359f,
+        0.01485f, 0.01616f, 0.01751f, 0.01890f,
+        0.02033f, 0.02180f, 0.02331f, 0.02485f,
+        0.02643f, 0.02804f, 0.02967f, 0.03134f,
+        0.03303f, 0.03475f, 0.03648f, 0.03824f,
+        0.04002f, 0.04181f, 0.04362f, 0.04545f,
+        0.04730f, 0.04916f, 0.05103f, 0.05292f,
+        0.05483f, 0.05675f, 0.05868f, 0.06063f,
+        0.06259f, 0.06457f, 0.06655f, 0.06856f,
+        0.07057f, 0.07259f, 0.07463f, 0.07668f,
+        0.07874f, 0.08081f, 0.08290f, 0.08499f,
+        0.08710f, 0.08921f, 0.09134f, 0.09348f,
+        0.09563f, 0.09779f, 0.09996f, 0.10214f,
+        0.10433f, 0.10652f, 0.10873f, 0.11095f,
+        0.11318f, 0.11541f, 0.11766f, 0.11991f,
+        0.12218f, 0.12445f, 0.12673f, 0.12902f,
+        0.13132f, 0.13363f, 0.13595f, 0.13827f,
+        0.14061f, 0.14295f, 0.14530f, 0.14765f,
+        0.15002f, 0.15239f, 0.15477f, 0.15716f,
+        0.15956f, 0.16197f, 0.16438f, 0.16680f,
+        0.16923f, 0.17166f, 0.17410f, 0.17655f,
+        0.17901f, 0.18148f, 0.18395f, 0.18643f,
+        0.18891f, 0.19141f, 0.19391f, 0.19641f,
+        0.19893f, 0.20145f, 0.20398f, 0.20651f,
+        0.20905f, 0.21160f, 0.21416f, 0.21672f,
+        0.21929f, 0.22185f, 0.22440f, 0.22696f,
+        0.22950f, 0.23204f, 0.23458f, 0.23711f,
+        0.23963f, 0.24215f, 0.24466f, 0.24717f,
+        0.24967f, 0.25216f, 0.25465f, 0.25713f,
+        0.25961f, 0.26208f, 0.26454f, 0.26700f,
+        0.26945f, 0.27189f, 0.27433f, 0.27676f,
+        0.27918f, 0.28160f, 0.28401f, 0.28641f,
+        0.28881f, 0.29120f, 0.29358f, 0.29596f,
+        0.29833f, 0.30069f, 0.30305f, 0.30540f,
+        0.30774f, 0.31008f, 0.31241f, 0.31473f,
+        0.31704f, 0.31935f, 0.32165f, 0.32395f,
+        0.32623f, 0.32851f, 0.33079f, 0.33305f,
+        0.33531f, 0.33756f, 0.33981f, 0.34205f,
+        0.34428f, 0.34650f, 0.34872f, 0.35093f,
+        0.35313f, 0.35532f, 0.35751f, 0.35969f,
+        0.36187f, 0.36404f, 0.36620f, 0.36835f,
+        0.37050f, 0.37264f, 0.37477f, 0.37689f,
+        0.37901f, 0.38112f, 0.38323f, 0.38533f,
+        0.38742f, 0.38950f, 0.39158f, 0.39365f,
+        0.39571f, 0.39777f, 0.39982f, 0.40186f,
+        0.40389f, 0.40592f, 0.40794f, 0.40996f,
+        0.41197f, 0.41397f, 0.41596f, 0.41795f,
+        0.41993f, 0.42191f, 0.42388f, 0.42584f,
+        0.42779f, 0.42974f, 0.43168f, 0.43362f,
+        0.43554f, 0.43747f, 0.43938f, 0.44129f,
+        0.44319f, 0.44509f, 0.44698f, 0.44886f,
+        0.45073f, 0.45260f, 0.45447f, 0.45632f,
+        0.45817f, 0.46002f, 0.46186f, 0.46369f,
+        0.46551f, 0.46733f, 0.46914f, 0.47095f,
+        0.47275f, 0.47454f, 0.47633f, 0.47811f,
+        0.47989f, 0.48166f, 0.48342f, 0.48518f,
+        0.48693f, 0.48867f, 0.49041f, 0.49214f,
+        0.49387f, 0.49559f, 0.49730f, 0.49901f,
+        0.50072f, 0.50241f, 0.50410f, 0.50579f,
+        0.50747f, 0.50914f, 0.51081f, 0.51247f,
+        0.51413f, 0.51578f, 0.51742f, 0.51906f,
+        0.52069f, 0.52232f, 0.52394f, 0.52556f,
+        0.52717f, 0.52878f, 0.53038f, 0.53197f,
+        0.53356f, 0.53514f, 0.53672f, 0.53829f,
+        0.53986f, 0.54142f, 0.54297f, 0.54452f,
+        0.54607f, 0.54761f, 0.54914f, 0.55067f,
+        0.55220f, 0.55371f, 0.55523f, 0.55673f,
+        0.55824f, 0.55973f, 0.56123f, 0.56271f,
+        0.56420f, 0.56567f, 0.56715f, 0.56861f,
+        0.57007f, 0.57153f, 0.57298f, 0.57443f,
+        0.57587f, 0.57731f, 0.57874f, 0.58017f,
+        0.58159f, 0.58301f, 0.58443f, 0.58583f,
+        0.58724f, 0.58864f, 0.59003f, 0.59142f,
+        0.59281f, 0.59419f, 0.59556f, 0.59694f,
+        0.59830f, 0.59966f, 0.60102f, 0.60238f,
+        0.60373f, 0.60507f, 0.60641f, 0.60775f,
+        0.60908f, 0.61040f, 0.61173f, 0.61305f,
+        0.61436f, 0.61567f, 0.61698f, 0.61828f,
+        0.61957f, 0.62087f, 0.62216f, 0.62344f,
+        0.62472f, 0.62600f, 0.62727f, 0.62854f,
+        0.62980f, 0.63106f, 0.63232f, 0.63357f,
+        0.63482f, 0.63606f, 0.63730f, 0.63854f,
+        0.63977f, 0.64100f, 0.64222f, 0.64344f,
+        0.64466f, 0.64587f, 0.64708f, 0.64829f,
+        0.64949f, 0.65069f, 0.65188f, 0.65307f,
+        0.65426f, 0.65544f, 0.65662f, 0.65779f,
+        0.65897f, 0.66013f, 0.66130f, 0.66246f,
+        0.66362f, 0.66477f, 0.66592f, 0.66707f,
+        0.66821f, 0.66935f, 0.67048f, 0.67162f,
+        0.67275f, 0.67387f, 0.67499f, 0.67611f,
+        0.67723f, 0.67834f, 0.67945f, 0.68055f,
+        0.68165f, 0.68275f, 0.68385f, 0.68494f,
+        0.68603f, 0.68711f, 0.68819f, 0.68927f,
+        0.69035f, 0.69142f, 0.69249f, 0.69355f,
+        0.69461f, 0.69567f, 0.69673f, 0.69778f,
+        0.69883f, 0.69988f, 0.70092f, 0.70196f,
+        0.70300f, 0.70403f, 0.70506f, 0.70609f,
+        0.70711f, 0.70813f, 0.70915f, 0.71017f,
+        0.71118f, 0.71219f, 0.71319f, 0.71420f,
+        0.71520f, 0.71620f, 0.71719f, 0.71818f,
+        0.71917f, 0.72016f, 0.72114f, 0.72212f,
+        0.72309f, 0.72407f, 0.72504f, 0.72601f,
+        0.72697f, 0.72794f, 0.72890f, 0.72985f,
+        0.73081f, 0.73176f, 0.73271f, 0.73365f,
+        0.73460f, 0.73554f, 0.73647f, 0.73741f,
+        0.73834f, 0.73927f, 0.74020f, 0.74112f,
+        0.74204f, 0.74296f, 0.74388f, 0.74479f,
+        0.74570f, 0.74661f, 0.74751f, 0.74842f,
+        0.74932f, 0.75021f, 0.75111f, 0.75200f,
+        0.75289f, 0.75378f, 0.75466f, 0.75555f,
+        0.75643f, 0.75730f, 0.75818f, 0.75905f,
+        0.75992f, 0.76079f, 0.76165f, 0.76251f,
+        0.76337f, 0.76423f, 0.76508f, 0.76594f,
+        0.76679f, 0.76763f, 0.76848f, 0.76932f,
+        0.77016f, 0.77100f, 0.77183f, 0.77267f,
+        0.77350f, 0.77432f, 0.77515f, 0.77597f,
+        0.77680f, 0.77761f, 0.77843f, 0.77924f,
+        0.78006f, 0.78087f, 0.78167f, 0.78248f,
+        0.78328f, 0.78408f, 0.78488f, 0.78568f,
+        0.78647f, 0.78726f, 0.78805f, 0.78884f,
+        0.78962f, 0.79040f, 0.79118f, 0.79196f,
+        0.79274f, 0.79351f, 0.79428f, 0.79505f,
+        0.79582f, 0.79658f, 0.79735f, 0.79811f,
+        0.79887f, 0.79962f, 0.80038f, 0.80113f,
+        0.80188f, 0.80263f, 0.80337f, 0.80412f,
+        0.80486f, 0.80560f, 0.80634f, 0.80707f,
+        0.80780f, 0.80854f, 0.80926f, 0.80999f,
+        0.81072f, 0.81144f, 0.81216f, 0.81288f,
+        0.81360f, 0.81431f, 0.81503f, 0.81574f,
+        0.81645f, 0.81715f, 0.81786f, 0.81856f,
+        0.81926f, 0.81996f, 0.82066f, 0.82135f,
+        0.82205f, 0.82274f, 0.82343f, 0.82412f,
+        0.82480f, 0.82549f, 0.82617f, 0.82685f,
+        0.82753f, 0.82820f, 0.82888f, 0.82955f,
+        0.83022f, 0.83089f, 0.83155f, 0.83222f,
+        0.83288f, 0.83354f, 0.83420f, 0.83486f,
+        0.83552f, 0.83617f, 0.83682f, 0.83747f,
+        0.83812f, 0.83877f, 0.83941f, 0.84005f,
+        0.84069f, 0.84133f, 0.84197f, 0.84261f,
+        0.84324f, 0.84387f, 0.84450f, 0.84513f,
+        0.84576f, 0.84639f, 0.84701f, 0.84763f,
+        0.84825f, 0.84887f, 0.84949f, 0.85010f,
+        0.85071f, 0.85132f, 0.85193f, 0.85254f,
+        0.85315f, 0.85375f, 0.85436f, 0.85496f,
+        0.85556f, 0.85615f, 0.85675f, 0.85735f,
+        0.85794f, 0.85853f, 0.85912f, 0.85971f,
+        0.86029f, 0.86088f, 0.86146f, 0.86204f,
+        0.86262f, 0.86320f, 0.86378f, 0.86435f,
+        0.86493f, 0.86550f, 0.86607f, 0.86664f,
+        0.86720f, 0.86777f, 0.86833f, 0.86889f,
+        0.86945f, 0.87001f, 0.87057f, 0.87113f,
+        0.87168f, 0.87223f, 0.87278f, 0.87333f,
+        0.87388f, 0.87443f, 0.87497f, 0.87552f,
+        0.87606f, 0.87660f, 0.87714f, 0.87768f,
+        0.87821f, 0.87875f, 0.87928f, 0.87981f,
+        0.88034f, 0.88087f, 0.88140f, 0.88192f,
+        0.88244f, 0.88297f, 0.88349f, 0.88401f,
+        0.88453f, 0.88504f, 0.88556f, 0.88607f,
+        0.88658f, 0.88709f, 0.88760f, 0.88811f,
+        0.88862f, 0.88912f, 0.88963f, 0.89013f,
+        0.89063f, 0.89113f, 0.89163f, 0.89212f,
+        0.89262f, 0.89311f, 0.89360f, 0.89409f,
+        0.89458f, 0.89507f, 0.89556f, 0.89604f,
+        0.89653f, 0.89701f, 0.89749f, 0.89797f,
+        0.89845f, 0.89892f, 0.89940f, 0.89987f,
+        0.90035f, 0.90082f, 0.90129f, 0.90176f,
+        0.90222f, 0.90269f, 0.90316f, 0.90362f,
+        0.90408f, 0.90454f, 0.90500f, 0.90546f,
+        0.90592f, 0.90637f, 0.90683f, 0.90728f,
+        0.90773f, 0.90818f, 0.90863f, 0.90908f,
+        0.90952f, 0.90997f, 0.91041f, 0.91085f,
+        0.91130f, 0.91173f, 0.91217f, 0.91261f,
+        0.91305f, 0.91348f, 0.91392f, 0.91435f,
+        0.91478f, 0.91521f, 0.91564f, 0.91606f,
+        0.91649f, 0.91691f, 0.91734f, 0.91776f,
+        0.91818f, 0.91860f, 0.91902f, 0.91944f,
+        0.91985f, 0.92027f, 0.92068f, 0.92109f,
+        0.92150f, 0.92191f, 0.92232f, 0.92273f,
+        0.92314f, 0.92354f, 0.92395f, 0.92435f,
+        0.92475f, 0.92515f, 0.92555f, 0.92595f,
+        0.92634f, 0.92674f, 0.92713f, 0.92753f,
+        0.92792f, 0.92831f, 0.92870f, 0.92909f,
+        0.92947f, 0.92986f, 0.93025f, 0.93063f,
+        0.93101f, 0.93139f, 0.93177f, 0.93215f,
+        0.93253f, 0.93291f, 0.93328f, 0.93366f,
+        0.93403f, 0.93440f, 0.93478f, 0.93515f,
+        0.93551f, 0.93588f, 0.93625f, 0.93661f,
+        0.93698f, 0.93734f, 0.93770f, 0.93807f,
+        0.93843f, 0.93878f, 0.93914f, 0.93950f,
+        0.93986f, 0.94021f, 0.94056f, 0.94092f,
+        0.94127f, 0.94162f, 0.94197f, 0.94231f,
+        0.94266f, 0.94301f, 0.94335f, 0.94369f,
+        0.94404f, 0.94438f, 0.94472f, 0.94506f,
+        0.94540f, 0.94573f, 0.94607f, 0.94641f,
+        0.94674f, 0.94707f, 0.94740f, 0.94774f,
+        0.94807f, 0.94839f, 0.94872f, 0.94905f,
+        0.94937f, 0.94970f, 0.95002f, 0.95035f,
+        0.95067f, 0.95099f, 0.95131f, 0.95163f,
+        0.95194f, 0.95226f, 0.95257f, 0.95289f,
+        0.95320f, 0.95351f, 0.95383f, 0.95414f,
+        0.95445f, 0.95475f, 0.95506f, 0.95537f,
+        0.95567f, 0.95598f, 0.95628f, 0.95658f,
+        0.95688f, 0.95718f, 0.95748f, 0.95778f,
+        0.95808f, 0.95838f, 0.95867f, 0.95897f,
+        0.95926f, 0.95955f, 0.95984f, 0.96013f,
+        0.96042f, 0.96071f, 0.96100f, 0.96129f,
+        0.96157f, 0.96186f, 0.96214f, 0.96242f,
+        0.96271f, 0.96299f, 0.96327f, 0.96355f,
+        0.96382f, 0.96410f, 0.96438f, 0.96465f,
+        0.96493f, 0.96520f, 0.96547f, 0.96574f,
+        0.96602f, 0.96629f, 0.96655f, 0.96682f,
+        0.96709f, 0.96735f, 0.96762f, 0.96788f,
+        0.96815f, 0.96841f, 0.96867f, 0.96893f,
+        0.96919f, 0.96945f, 0.96971f, 0.96996f,
+        0.97022f, 0.97047f, 0.97073f, 0.97098f,
+        0.97123f, 0.97149f, 0.97174f, 0.97199f,
+        0.97223f, 0.97248f, 0.97273f, 0.97297f,
+        0.97322f, 0.97346f, 0.97371f, 0.97395f,
+        0.97419f, 0.97443f, 0.97467f, 0.97491f,
+        0.97515f, 0.97539f, 0.97562f, 0.97586f,
+        0.97609f, 0.97633f, 0.97656f, 0.97679f,
+        0.97702f, 0.97725f, 0.97748f, 0.97771f,
+        0.97794f, 0.97817f, 0.97839f, 0.97862f,
+        0.97884f, 0.97907f, 0.97929f, 0.97951f,
+        0.97973f, 0.97995f, 0.98017f, 0.98039f,
+        0.98061f, 0.98082f, 0.98104f, 0.98125f,
+        0.98147f, 0.98168f, 0.98189f, 0.98211f,
+        0.98232f, 0.98253f, 0.98274f, 0.98295f,
+        0.98315f, 0.98336f, 0.98357f, 0.98377f,
+        0.98398f, 0.98418f, 0.98438f, 0.98458f,
+        0.98478f, 0.98498f, 0.98518f, 0.98538f,
+        0.98558f, 0.98578f, 0.98597f, 0.98617f,
+        0.98636f, 0.98656f, 0.98675f, 0.98694f,
+        0.98714f, 0.98733f, 0.98752f, 0.98771f,
+        0.98789f, 0.98808f, 0.98827f, 0.98845f,
+        0.98864f, 0.98882f, 0.98901f, 0.98919f,
+        0.98937f, 0.98955f, 0.98973f, 0.98991f,
+        0.99009f, 0.99027f, 0.99045f, 0.99063f,
+        0.99080f, 0.99098f, 0.99115f, 0.99133f,
+        0.99150f, 0.99167f, 0.99184f, 0.99201f,
+        0.99218f, 0.99235f, 0.99252f, 0.99269f,
+        0.99285f, 0.99302f, 0.99319f, 0.99335f,
+        0.99351f, 0.99368f, 0.99384f, 0.99400f,
+        0.99416f, 0.99432f, 0.99448f, 0.99464f,
+        0.99480f, 0.99495f, 0.99511f, 0.99527f,
+        0.99542f, 0.99558f, 0.99573f, 0.99588f,
+        0.99603f, 0.99619f, 0.99634f, 0.99649f,
+        0.99664f, 0.99678f, 0.99693f, 0.99708f,
+        0.99722f, 0.99737f, 0.99751f, 0.99766f,
+        0.99780f, 0.99794f, 0.99809f, 0.99823f,
+        0.99837f, 0.99851f, 0.99865f, 0.99879f,
+        0.99892f, 0.99906f, 0.99920f, 0.99933f,
+        0.99947f, 0.99960f, 0.99974f, 0.99987f,
+        1.00000f
+    };
+
+    FILE* const file = fopen(filename.c_str(), "rb");
+
+    if (file == nullptr) {
+        printf ("Unable to load DCP profile '%s' !", filename.c_str());
+        return;
+    }
+
+    // read tiff header
+    fseek(file, 0, SEEK_SET);
+    unsigned short bo;
+    fread(&bo, 1, 2, file);
+    Endianness order = (Endianness)((int)bo);
+    get2(file, order);
+    int ifdOffset = get4(file, order);
+
+    // read tags
+    const int numOfTags = get2(file, order);
+
+    if (numOfTags <= 0 || numOfTags > 1000) {
+        std::cerr << "ERROR : Tag number out of range !" << std::endl;
+        fclose(file);
+        return;
+    }
+
+    std::vector<Tag> v_tag;
+
+    for (int i = 0; i < numOfTags; i++) {
+
+        unsigned short tag = get2(file, order);
+        TagType type = (TagType)get2(file, order);
+        unsigned int datasize = get4(file, order);
+
+        if (!datasize) {
+            datasize = 1;
+        }
+
+        // filter out invalid tags
+        // note the large count is to be able to pass LeafData ASCII tag which can be up to almost 10 megabytes,
+        // (only a small part of it will actually be parsed though)
+        if ((int)type < 1 || (int)type > 14 || datasize > 10 * 1024 * 1024) {
+            type = TagType::T_INVALID;
+            fclose(file);
+            std::cerr << "ERROR : Invalid Tag in dcp file !" << std::endl;
+            return;
+        }
+
+        // store next Tag's position in file
+        int save = ftell(file) + 4;
+
+        Tag t(tag, type, datasize, order, file);
+
+        v_tag.push_back(t);
+
+        fseek(file, save, SEEK_SET);
+    }
+
+    fclose(file);
+
+    Tag* tag = findTag(TagKey::CALIBRATION_ILLUMINANT_1, v_tag);
+    info.light_source_1 =
+        tag
+        ? tag->toInt(0, TagType::T_SHORT)
+        : -1;
+    tag = findTag(TagKey::CALIBRATION_ILLUMINANT_2, v_tag);
+    info.light_source_2 =
+        tag
+        ? tag->toInt(0, TagType::T_SHORT)
+        : -1;
+    info.temperature_1 = calibrationIlluminantToTemperature(info.light_source_1);
+    info.temperature_2 = calibrationIlluminantToTemperature(info.light_source_2);
+
+    const bool has_second_hue_sat = findTag(TagKey::PROFILE_HUE_SAT_MAP_DATA_2, v_tag); // Some profiles have two matrices, but just one huesat
+
+    // Fetch Forward Matrices, if any
+    tag = findTag(TagKey::FORWARD_MATRIX_1, v_tag);
+
+    if (tag) {
+        info.has_forward_matrix_1 = true;
+
+        for (int row = 0; row < 3; ++row) {
+            for (int col = 0; col < 3; ++col) {
+                forward_matrix_1[row][col] = tag->toDouble((col + row * 3) * 8);
+            }
+        }
+    }
+
+    tag = findTag(TagKey::FORWARD_MATRIX_2, v_tag);
+
+    if (tag) {
+        info.has_forward_matrix_2 = true;
+
+        for (int row = 0; row < 3; ++row) {
+            for (int col = 0; col < 3; ++col) {
+                forward_matrix_2[row][col] = tag->toDouble((col + row * 3) * 8);
+            }
+        }
+    }
+
+    // Color Matrix (one is always there)
+    tag = findTag(TagKey::COLOR_MATRIX_1, v_tag);
+
+    if (!tag) {
+        std::cerr << "DCP '" << filename << "' is missing 'ColorMatrix1'. Skipped." << std::endl;
+        fclose(file);
+        return;
+    }
+
+    info.has_color_matrix_1 = true;
+
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            color_matrix_1[row][col] = tag->toDouble((col + row * 3) * 8);
+        }
+    }
+
+    tag = findTag(TagKey::PROFILE_LOOK_TABLE_DIMS, v_tag);
+
+    if (tag) {
+        look_info.hue_divisions = tag->toInt(0);
+        look_info.sat_divisions = tag->toInt(4);
+        look_info.val_divisions = tag->toInt(8);
+
+        tag = findTag(TagKey::PROFILE_LOOK_TABLE_ENCODING, v_tag);
+        look_info.srgb_gamma = tag && tag->toInt(0);
+
+        tag = findTag(TagKey::PROFILE_LOOK_TABLE_DATA, v_tag);
+        look_info.array_count = tag->datasize / 3;
+
+        look_table.resize(look_info.array_count);
+
+        for (unsigned int i = 0; i < look_info.array_count; i++) {
+            look_table[i].hue_shift = tag->toDouble((i * 3) * tiff_float_size);
+            look_table[i].sat_scale = tag->toDouble((i * 3 + 1) * tiff_float_size);
+            look_table[i].val_scale = tag->toDouble((i * 3 + 2) * tiff_float_size);
+        }
+
+        // Precalculated constants for table application
+        look_info.pc.h_scale =
+            look_info.hue_divisions < 2
+            ? 0.0f
+            : static_cast<float>(look_info.hue_divisions) / 6.0f;
+        look_info.pc.s_scale = look_info.sat_divisions - 1;
+        look_info.pc.v_scale = look_info.val_divisions - 1;
+        look_info.pc.max_hue_index0 = look_info.hue_divisions - 1;
+        look_info.pc.max_sat_index0 = look_info.sat_divisions - 2;
+        look_info.pc.max_val_index0 = look_info.val_divisions - 2;
+        look_info.pc.hue_step = look_info.sat_divisions;
+        look_info.pc.val_step = look_info.hue_divisions * look_info.pc.hue_step;
+
+        info.has_look_table = true;
+    }
+
+    tag = findTag(TagKey::PROFILE_HUE_SAT_MAP_DIMS, v_tag);
+
+    if (tag) {
+        delta_info.hue_divisions = tag->toInt(0);
+        delta_info.sat_divisions = tag->toInt(4);
+        delta_info.val_divisions = tag->toInt(8);
+
+        tag = findTag(TagKey::PROFILE_HUE_SAT_MAP_ENCODING, v_tag);
+        delta_info.srgb_gamma = tag && tag->toInt(0);
+
+        tag = findTag(TagKey::PROFILE_HUE_SAT_MAP_DATA_1, v_tag);
+        delta_info.array_count = tag->datasize / 3;
+
+        deltas_1.resize(delta_info.array_count);
+
+        for (unsigned int i = 0; i < delta_info.array_count; ++i) {
+            deltas_1[i].hue_shift = tag->toDouble((i * 3) * tiff_float_size);
+            deltas_1[i].sat_scale = tag->toDouble((i * 3 + 1) * tiff_float_size);
+            deltas_1[i].val_scale = tag->toDouble((i * 3 + 2) * tiff_float_size);
+        }
+
+        delta_info.pc.h_scale =
+            delta_info.hue_divisions < 2
+            ? 0.0f
+            : static_cast<float>(delta_info.hue_divisions) / 6.0f;
+        delta_info.pc.s_scale = delta_info.sat_divisions - 1;
+        delta_info.pc.v_scale = delta_info.val_divisions - 1;
+        delta_info.pc.max_hue_index0 = delta_info.hue_divisions - 1;
+        delta_info.pc.max_sat_index0 = delta_info.sat_divisions - 2;
+        delta_info.pc.max_val_index0 = delta_info.val_divisions - 2;
+        delta_info.pc.hue_step = delta_info.sat_divisions;
+        delta_info.pc.val_step = delta_info.hue_divisions * delta_info.pc.hue_step;
+
+        info.has_hue_sat_map = true;
+    }
+
+    if (info.light_source_2 != -1) {
+        // Second matrix
+        info.has_color_matrix_2 = true;
+
+        tag = findTag(TagKey::COLOR_MATRIX_2, v_tag);
+
+        for (int row = 0; row < 3; ++row) {
+            for (int col = 0; col < 3; ++col) {
+                color_matrix_2[row][col] =
+                    tag
+                    ? tag->toDouble((col + row * 3) * 8)
+                    : color_matrix_1[row][col];
+            }
+        }
+
+        // Second huesatmap
+        if (has_second_hue_sat) {
+            deltas_2.resize(delta_info.array_count);
+
+            // Saturation maps. Need to be unwinded.
+            tag = findTag(TagKey::PROFILE_HUE_SAT_MAP_DATA_2, v_tag);
+
+            for (unsigned int i = 0; i < delta_info.array_count; ++i) {
+                deltas_2[i].hue_shift = tag->toDouble((i * 3) * tiff_float_size);
+                deltas_2[i].sat_scale = tag->toDouble((i * 3 + 1) * tiff_float_size);
+                deltas_2[i].val_scale = tag->toDouble((i * 3 + 2) * tiff_float_size);
+            }
+        }
+    }
+
+    tag = findTag(TagKey::BASELINE_EXPOSURE_OFFSET, v_tag);
+
+    if (tag) {
+        info.has_baseline_exposure_offset = true;
+        baseline_exposure_offset = tag->toDouble();
+    }
+
+    // Read tone curve points, if any, but disable to RTs own profiles
+    tag = findTag(TagKey::PROFILE_TONE_CURVE, v_tag);
+
+    if (tag) {
+        std::vector<double> AS_curve_points;
+
+        // Push back each X/Y coordinates in a loop
+        bool curve_is_linear = true;
+
+        for (int i = 0; i < tag->datasize; i += 2) {
+            const double x = tag->toDouble((i + 0) * tiff_float_size);
+            const double y = tag->toDouble((i + 1) * tiff_float_size);
+
+            if (x != y) {
+                curve_is_linear = false;
+            }
+
+            AS_curve_points.push_back(x);
+            AS_curve_points.push_back(y);
+        }
+
+        if (!curve_is_linear) {
+            // Create the curve
+            info.has_tone_curve = true;
+            AS_tone_curve.Set(AS_curve_points);
+        }
+    } else {
+        tag = findTag(TagKey::PROFILE_TONE_COPYRIGHT, v_tag);
+
+        if (tag && tag->valueToString().find("Adobe Systems") != std::string::npos) {
+            // An Adobe profile without tone curve is expected to have the Adobe Default Curve
+            std::vector<double> AS_curve_points;
+
+            constexpr size_t tc_len = sizeof(adobe_camera_raw_default_curve) / sizeof(adobe_camera_raw_default_curve[0]);
+
+            for (size_t i = 0; i < tc_len; ++i) {
+                const double x = static_cast<double>(i) / (tc_len - 1);
+                const double y = adobe_camera_raw_default_curve[i];
+                AS_curve_points.push_back(x);
+                AS_curve_points.push_back(y);
+            }
+
+            info.has_tone_curve = true;
+            AS_tone_curve.Set(AS_curve_points);
+        }
+    }
+
+    will_interpolate = false;
+
+    if (info.has_forward_matrix_1) {
+        if (info.has_forward_matrix_2) {
+            if (forward_matrix_1 != forward_matrix_2) {
+                // Common that forward matrices are the same!
+                will_interpolate = true;
+            }
+
+            if (!deltas_1.empty() && !deltas_2.empty()) {
+                // We assume tables are different
+                will_interpolate = true;
+            }
+        }
+    }
+
+    if (info.has_color_matrix_1 && info.has_color_matrix_2) {
+        if (color_matrix_1 != color_matrix_2) {
+            will_interpolate = true;
+        }
+
+        if (!deltas_1.empty() && !deltas_2.empty()) {
+            will_interpolate = true;
+        }
+    }
+
+    if (file) {
+        fclose(file);
+    }
+
+    valid = true;
+
+    std::vector<double> gammatab_srgb_data;
+    std::vector<double> igammatab_srgb_data;
+    for (int i = 0; i < 65536; i++)
+    {
+        double x = i / 65535.0;
+        gammatab_srgb_data.push_back((x <= 0.003040) ? (x * 12.92310) : (1.055 * exp(log(x) / 2.4) - 0.055));   // from RT
+        igammatab_srgb_data.push_back((x <= 0.039286) ? (x / 12.92310) : (exp(log((x + 0.055) / 1.055) * 2.4))); // from RT
+    }
+    gammatab_srgb.Set(gammatab_srgb_data);
+    igammatab_srgb.Set(igammatab_srgb_data);
+
+}
+
+DCPProfile::~DCPProfile() = default;
+
+static inline bool rgb2hsvdcp(float r, float g, float b, float& h, float& s, float& v)
+{
+
+    const float var_Min = std::min<float>(r, std::min<float>(g, b));
+
+    if (var_Min < 0.f) {
+        return false;
+    }
+    else {
+        const float var_Max = std::max<float>(r, std::max<float>(g, b));
+        const float del_Max = var_Max - var_Min;
+        v = var_Max / 65535.f;
+
+        if (fabsf(del_Max) < 0.00001f) {
+            h = 0.f;
+            s = 0.f;
+        }
+        else {
+            s = del_Max / var_Max;
+
+            if (r == var_Max) {
+                h = (g - b) / del_Max;
+            }
+            else if (g == var_Max) {
+                h = 2.f + (b - r) / del_Max;
+            }
+            else {
+                h = 4.f + (r - g) / del_Max;
+            }
+
+            if (h < 0.f) {
+                h += 6.f;
+            }
+            else if (h > 6.f) {
+                h -= 6.f;
+            }
+        }
+
+        return true;
+    }
+}
+
+static inline void rgb2hsvtc(float r, float g, float b, float& h, float& s, float& v)
+{
+    const float var_Min = std::min<float>(r, std::min<float>(g, b));
+    const float var_Max = std::max<float>(r, std::max<float>(g, b));
+    const float del_Max = var_Max - var_Min;
+
+    v = var_Max / 65535.f;
+
+    if (del_Max < 0.00001f) {
+        h = 0.f;
+        s = 0.f;
+    }
+    else {
+        s = del_Max / var_Max;
+
+        if (r == var_Max) {
+            h = (g < b ? 6.f : 0.f) + (g - b) / del_Max;
+        }
+        else if (g == var_Max) {
+            h = 2.f + (b - r) / del_Max;
+        }
+        else {
+            h = 4.f + (r - g) / del_Max;
+        }
+    }
+}
+
+static inline void hsv2rgbdcp(float h, float s, float v, float& r, float& g, float& b)
+{
+    // special version for dcp which saves 1 division (in caller) and six multiplications (inside this function)
+    const int sector = h;  // sector 0 to 5, floor() is very slow, and h is always > 0
+    const float f = h - sector; // fractional part of h
+
+    v *= 65535.f;
+    const float vs = v * s;
+    const float p = v - vs;
+    const float q = v - f * vs;
+    const float t = p + v - q;
+
+    switch (sector) {
+    case 1:
+        r = q;
+        g = v;
+        b = p;
+        break;
+
+    case 2:
+        r = p;
+        g = v;
+        b = t;
+        break;
+
+    case 3:
+        r = p;
+        g = q;
+        b = v;
+        break;
+
+    case 4:
+        r = t;
+        g = p;
+        b = v;
+        break;
+
+    case 5:
+        r = v;
+        g = p;
+        b = q;
+        break;
+
+    default:
+        r = v;
+        g = t;
+        b = p;
+    }
+}
+
+void DCPProfile::apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& params)
+{
+    // Compute matrices to and from selected working space
+    ws_sRGB = { 1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0 };
+    sRGB_ws = { 1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0 };
+
+    if (params.working_space.compare("sRGB"))
+    {
+        if (params.working_space.compare("prophoto"))
+        {
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < 3; j++) {
+                    double to_ws = 0.0;
+                    double from_ws = 0.0;
+                    for (int k = 0; k < 3; k++) {
+                        to_ws   += prophoto_xyz[i][k] * xyz_sRGB[k][j];
+                        from_ws += sRGB_xyz[i][k] * xyz_prophoto[k][j];
+                    }
+                    ws_sRGB[i][j] = to_ws;
+                    sRGB_ws[i][j] = from_ws;
+                }
+            }
+        }
+        else if (params.working_space.compare("AdobeRGB"))
+        {
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < 3; j++) {
+                    double to_ws = 0.0;
+                    double from_ws = 0.0;
+                    for (int k = 0; k < 3; k++) {
+                        to_ws   += AdobeRGB_xyz[i][k] * xyz_sRGB[k][j];
+                        from_ws += sRGB_xyz[i][k] * xyz_AdobeRGB[k][j];
+                    }
+                    ws_sRGB[i][j] = to_ws;
+                    sRGB_ws[i][j] = from_ws;
+                }
+            }
+        }
+    }
+
+    // Apply DCP profile
+    #pragma omp parallel for
+    for (int i = 0; i < image.spec().height; ++i)
+        for (int j = 0; j < image.spec().width; ++j)
+        {
+            float rgb[3];
+            image.getpixel(j, i, rgb, 3);
+            for (int c = 0; c < 3; ++c)
+            {
+                rgb[c] *= 65535.0;
+            }
+            apply(rgb, params);
+            for (int c = 0; c < 3; ++c)
+            {
+                rgb[c] /= 65535.0;
+            }
+            image.setpixel(j, i, rgb, 3);
+        }
+}
+
+void DCPProfile::apply(float* rgb, const DCPProfileApplyParams& params) const
+{
+#define CLIPF_0_65535(a) ((a)>0.f?((a)<65535.5f?(a):65535.5f):0.f)
+#define CLIPF_0_1(a) ((a)>0?((a)<1?(a):1):0)
+
+    const float exp_scale = (params.apply_baseline_exposure_offset && info.has_baseline_exposure_offset) ? powf(2.0, baseline_exposure_offset) : 1.0;
+
+    if (!params.use_tone_curve && !params.apply_look_table) {
+        if (exp_scale == 1.f) {
+            return;
+        }
+
+        for (int c = 0; c < 3; c++) {
+            rgb[c] *= exp_scale;
+        }
+    }
+    else {
+
+        for (int c = 0; c < 3; c++) {
+            rgb[c] *= exp_scale;
+        }
+
+        float ws_rgb[3] = { 0.0, 0.0, 0.0 };
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                ws_rgb[i] += ws_sRGB[i][j] * rgb[j];
+            }
+            if (params.apply_look_table || params.use_tone_curve)
+            {
+                ws_rgb[i] = std::max<float>(ws_rgb[i], 0.f);
+            }
+        }
+
+        if (params.apply_look_table) {
+            float clipped_ws_rgb[3];
+            for (int i = 0; i < 3; i++)
+            {
+                clipped_ws_rgb[i] = CLIPF_0_65535(ws_rgb[i]);
+            }
+
+            float h, s, v;
+            rgb2hsvtc(clipped_ws_rgb[0], clipped_ws_rgb[1], clipped_ws_rgb[2], h, s, v);
+
+            hsdApply(look_info, look_table, h, s, v);
+            s = CLIPF_0_1(s);
+            v = CLIPF_0_1(v);
+
+            h += (h < 0.0f ? 6.0f : (h >= 6.0f ? -6.0f : 0.0f));
+
+            hsv2rgbdcp(h, s, v, clipped_ws_rgb[0], clipped_ws_rgb[1], clipped_ws_rgb[2]);
+
+            if (!(ws_rgb[0] < 0.0 || ws_rgb[0] > 65535.0) || !(ws_rgb[1] < 0.0 || ws_rgb[1] > 65535.0) || !(ws_rgb[2] < 0.0 || ws_rgb[2] > 65535.0)) {
+                ws_rgb[0] = clipped_ws_rgb[0];
+                ws_rgb[1] = clipped_ws_rgb[1];
+                ws_rgb[2] = clipped_ws_rgb[2];
+            }
+        }
+
+        if (params.use_tone_curve) {
+            //tone_curve.Apply(ws_rgb[0], ws_rgb[1], ws_rgb[2]);
+            AS_tone_curve.Apply(ws_rgb[0], ws_rgb[1], ws_rgb[2]);
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+            rgb[i] = 0.0;
+            for (int j = 0; j < 3; j++)
+            {
+                rgb[i] += sRGB_ws[i][j] * ws_rgb[j];
+            }
+        }
+
+    }
+}
+
+inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h, float& s, float& v) const
+{
+    // Apply the HueSatMap. Ported from Adobes reference implementation.
+    float hue_shift;
+    float sat_scale;
+    float val_scale;
+    float v_encoded = v;
+
+    if (table_info.val_divisions < 2) {
+        // Optimize most common case of "2.5D" table
+        const float h_scaled = h * table_info.pc.h_scale;
+        const float s_scaled = s * table_info.pc.s_scale;
+
+        int h_index0 = std::max<int>(h_scaled, 0);
+        const int s_index0 = std::max(std::min<int>(s_scaled, table_info.pc.max_sat_index0), 0);
+
+        int h_index1 = h_index0 + 1;
+
+        if (h_index0 >= table_info.pc.max_hue_index0) {
+            h_index0 = table_info.pc.max_hue_index0;
+            h_index1 = 0;
+        }
+
+        const float h_fract1 = h_scaled - static_cast<float>(h_index0);
+        const float s_fract1 = s_scaled - static_cast<float>(s_index0);
+
+        const float h_fract0 = 1.0f - h_fract1;
+        const float s_fract0 = 1.0f - s_fract1;
+
+        std::vector<HsbModify>::size_type e00_index = h_index0 * table_info.pc.hue_step + s_index0;
+        std::vector<HsbModify>::size_type e01_index = e00_index + (h_index1 - h_index0) * table_info.pc.hue_step;
+
+        const float hue_shift0 = h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift;
+        const float sat_scale0 = h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale;
+        const float val_scale0 = h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale;
+
+        ++e00_index;
+        ++e01_index;
+
+        const float hueShift1 = h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift;
+        const float satScale1 = h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale;
+        const float valScale1 = h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale;
+
+        hue_shift = s_fract0 * hue_shift0 + s_fract1 * hueShift1;
+        sat_scale = s_fract0 * sat_scale0 + s_fract1 * satScale1;
+        val_scale = s_fract0 * val_scale0 + s_fract1 * valScale1;
+    } else {
+        const float h_scaled = h * table_info.pc.h_scale;
+        const float s_scaled = s * table_info.pc.s_scale;
+
+        if (table_info.srgb_gamma) {
+            v_encoded = gammatab_srgb[v * 65535.f];
+        }
+
+        const float v_scaled = v_encoded * table_info.pc.v_scale;
+
+        int h_index0 = h_scaled;
+        const int s_index0 = std::max(std::min<int>(s_scaled, table_info.pc.max_sat_index0), 0);
+        const int v_index0 = std::max(std::min<int>(v_scaled, table_info.pc.max_val_index0), 0);
+
+        int h_index1 = h_index0 + 1;
+
+        if (h_index0 >= table_info.pc.max_hue_index0) {
+            h_index0 = table_info.pc.max_hue_index0;
+            h_index1 = 0;
+        }
+
+        const float h_fract1 = h_scaled - static_cast<float>(h_index0);
+        const float s_fract1 = s_scaled - static_cast<float>(s_index0);
+        const float v_fract1 = v_scaled - static_cast<float>(v_index0);
+
+        const float h_fract0 = 1.0f - h_fract1;
+        const float s_fract0 = 1.0f - s_fract1;
+        const float v_fract0 = 1.0f - v_fract1;
+
+        std::vector<HsbModify>::size_type e00_index = v_index0 * table_info.pc.val_step + h_index0 * table_info.pc.hue_step + s_index0;
+        std::vector<HsbModify>::size_type e01_index = e00_index + (h_index1 - h_index0) * table_info.pc.hue_step;
+        std::vector<HsbModify>::size_type e10_index = e00_index + table_info.pc.val_step;
+        std::vector<HsbModify>::size_type e11_index = e01_index + table_info.pc.val_step;
+
+        const float hueShift0 =
+            v_fract0 * (h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift)
+            + v_fract1 * (h_fract0 * table_base[e10_index].hue_shift + h_fract1 * table_base[e11_index].hue_shift);
+        const float satScale0 =
+            v_fract0 * (h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale)
+            + v_fract1 * (h_fract0 * table_base[e10_index].sat_scale + h_fract1 * table_base[e11_index].sat_scale);
+        const float valScale0 =
+            v_fract0 * (h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale)
+            + v_fract1 * (h_fract0 * table_base[e10_index].val_scale + h_fract1 * table_base[e11_index].val_scale);
+
+        ++e00_index;
+        ++e01_index;
+        ++e10_index;
+        ++e11_index;
+
+        const float hueShift1 =
+            v_fract0 * (h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift)
+            + v_fract1 * (h_fract0 * table_base[e10_index].hue_shift + h_fract1 * table_base[e11_index].hue_shift);
+        const float satScale1 =
+            v_fract0 * (h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale)
+            + v_fract1 * (h_fract0 * table_base[e10_index].sat_scale + h_fract1 * table_base[e11_index].sat_scale);
+        const float valScale1 =
+            v_fract0 * (h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale)
+            + v_fract1 * (h_fract0 * table_base[e10_index].val_scale + h_fract1 * table_base[e11_index].val_scale);
+
+        hue_shift = s_fract0 * hueShift0 + s_fract1 * hueShift1;
+        sat_scale = s_fract0 * satScale0 + s_fract1 * satScale1;
+        val_scale = s_fract0 * valScale0 + s_fract1 * valScale1;
+    }
+
+    hue_shift *= 6.0f / 360.0f; // Convert to internal hue range.
+
+    h += hue_shift;
+    s *= sat_scale; // No clipping here, we are RT float :-)
+
+    if (table_info.srgb_gamma) {
+        v = igammatab_srgb[v_encoded * val_scale * 65535.f];
+    } else {
+        v *= val_scale;
+    }
+}
+
+

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <functional>
 
+#include <aliceVision/system/Logger.hpp>
 #include "dcp.hpp"
 
 using namespace alicevision::image;
@@ -11,7 +12,8 @@ namespace
 {
 double calibrationIlluminantToTemperature(int light)
 {
-    enum class LightSource {
+    enum class LightSource
+    {
         UNKNOWN = 0,
         DAYLIGHT = 1,
         FLUORESCENT = 2,
@@ -20,10 +22,10 @@ double calibrationIlluminantToTemperature(int light)
         FINE_WEATHER = 9,
         CLOUDY_WEATHER = 10,
         SHADE = 11,
-        DAYLIGHT_FLUORESCENT = 12, // D  5700 - 7100K
-        DAYWHITE_FLUORESCENT = 13, // N  4600 - 5500K
+        DAYLIGHT_FLUORESCENT = 12,   // D  5700 - 7100K
+        DAYWHITE_FLUORESCENT = 13,   // N  4600 - 5500K
         COOL_WHITE_FLUORESCENT = 14, // W  3800 - 4500K
-        WHITE_FLUORESCENT = 15, // WW 3250 - 3800K
+        WHITE_FLUORESCENT = 15,      // WW 3250 - 3800K
         WARM_WHITE_FLUORESCENT = 16, // L  2600 - 3250K
         STANDARD_LIGHT_A = 17,
         STANDARD_LIGHT_B = 18,
@@ -37,17 +39,21 @@ double calibrationIlluminantToTemperature(int light)
     };
 
     // These temperatures are those found in DNG SDK reference code
-    switch (LightSource(light)) {
+    switch(LightSource(light))
+    {
         case LightSource::STANDARD_LIGHT_A:
-        case LightSource::TUNGSTEN: {
+        case LightSource::TUNGSTEN:
+        {
             return 2850.0;
         }
 
-        case LightSource::ISO_STUDIO_TUNGSTEN: {
+        case LightSource::ISO_STUDIO_TUNGSTEN:
+        {
             return 3200.0;
         }
 
-        case LightSource::D50: {
+        case LightSource::D50:
+        {
             return 5000.0;
         }
 
@@ -55,63 +61,233 @@ double calibrationIlluminantToTemperature(int light)
         case LightSource::DAYLIGHT:
         case LightSource::FINE_WEATHER:
         case LightSource::FLASH:
-        case LightSource::STANDARD_LIGHT_B: {
+        case LightSource::STANDARD_LIGHT_B:
+        {
             return 5500.0;
         }
 
         case LightSource::D65:
         case LightSource::STANDARD_LIGHT_C:
-        case LightSource::CLOUDY_WEATHER: {
+        case LightSource::CLOUDY_WEATHER:
+        {
             return 6500.0;
         }
 
         case LightSource::D75:
-        case LightSource::SHADE: {
+        case LightSource::SHADE:
+        {
             return 7500.0;
         }
 
-        case LightSource::DAYLIGHT_FLUORESCENT: {
+        case LightSource::DAYLIGHT_FLUORESCENT:
+        {
             return (5700.0 + 7100.0) * 0.5;
         }
 
-        case LightSource::DAYWHITE_FLUORESCENT: {
+        case LightSource::DAYWHITE_FLUORESCENT:
+        {
             return (4600.0 + 5500.0) * 0.5;
         }
 
         case LightSource::COOL_WHITE_FLUORESCENT:
-        case LightSource::FLUORESCENT: {
+        case LightSource::FLUORESCENT:
+        {
             return (3800.0 + 4500.0) * 0.5;
         }
 
-        case LightSource::WHITE_FLUORESCENT: {
+        case LightSource::WHITE_FLUORESCENT:
+        {
             return (3250.0 + 3800.0) * 0.5;
         }
 
-        case LightSource::WARM_WHITE_FLUORESCENT: {
+        case LightSource::WARM_WHITE_FLUORESCENT:
+        {
             return (2600.0 + 3250.0) * 0.5;
         }
 
-        default: {
+        default:
+        {
             return 0.0;
         }
     }
 }
-}
 
-enum class TagType : int { T_INVALID = 0, T_BYTE = 1, T_ASCII = 2, T_SHORT = 3, T_LONG = 4, T_RATIONAL = 5, T_SBYTE = 6, T_UNDEFINED = 7, T_SSHORT = 8, T_SLONG = 9, T_SRATIONAL = 10, T_FLOAT = 11, T_DOUBLE = 12, T_OLYUNDEF = 13, T_AUTO = 98, T_SUBDIR = 99 };
-enum class Endianness : int { UNKNOWN = 0, LITTLE = 0x4949, BIG = 0x4D4D };
+inline bool rgb2hsvdcp(float r, float g, float b, float& h, float& s, float& v)
+    {
+
+        const float var_Min = std::min<float>(r, std::min<float>(g, b));
+
+        if (var_Min < 0.f)
+        {
+            return false;
+        }
+        else
+        {
+            const float var_Max = std::max<float>(r, std::max<float>(g, b));
+            const float del_Max = var_Max - var_Min;
+            v = var_Max / 65535.f;
+
+            if (fabsf(del_Max) < 0.00001f)
+            {
+                h = 0.f;
+                s = 0.f;
+            }
+            else
+            {
+                s = del_Max / var_Max;
+
+                if (r == var_Max)
+                {
+                    h = (g - b) / del_Max;
+                }
+                else if (g == var_Max)
+                {
+                    h = 2.f + (b - r) / del_Max;
+                }
+                else
+                {
+                    h = 4.f + (r - g) / del_Max;
+                }
+
+                if (h < 0.f)
+                {
+                    h += 6.f;
+                }
+                else if (h > 6.f)
+                {
+                    h -= 6.f;
+                }
+            }
+
+            return true;
+        }
+    }
+
+inline void rgb2hsvtc(float r, float g, float b, float& h, float& s, float& v)
+    {
+        const float var_Min = std::min<float>(r, std::min<float>(g, b));
+        const float var_Max = std::max<float>(r, std::max<float>(g, b));
+        const float del_Max = var_Max - var_Min;
+
+        v = var_Max / 65535.f;
+
+        if (del_Max < 0.00001f)
+        {
+            h = 0.f;
+            s = 0.f;
+        }
+        else
+        {
+            s = del_Max / var_Max;
+
+            if (r == var_Max)
+            {
+                h = (g < b ? 6.f : 0.f) + (g - b) / del_Max;
+            }
+            else if (g == var_Max)
+            {
+                h = 2.f + (b - r) / del_Max;
+            }
+            else
+            {
+                h = 4.f + (r - g) / del_Max;
+            }
+        }
+    }
+
+inline void hsv2rgbdcp(float h, float s, float v, float& r, float& g, float& b)
+    {
+        // special version for dcp which saves 1 division (in caller) and six multiplications (inside this function)
+        const int sector = h;       // sector 0 to 5, floor() is very slow, and h is always > 0
+        const float f = h - sector; // fractional part of h
+
+        v *= 65535.f;
+        const float vs = v * s;
+        const float p = v - vs;
+        const float q = v - f * vs;
+        const float t = p + v - q;
+
+        switch (sector)
+        {
+        case 1:
+            r = q;
+            g = v;
+            b = p;
+            break;
+
+        case 2:
+            r = p;
+            g = v;
+            b = t;
+            break;
+
+        case 3:
+            r = p;
+            g = q;
+            b = v;
+            break;
+
+        case 4:
+            r = t;
+            g = p;
+            b = v;
+            break;
+
+        case 5:
+            r = v;
+            g = p;
+            b = q;
+            break;
+
+        default:
+            r = v;
+            g = t;
+            b = p;
+        }
+    }
+} // namespace
+
+enum class TagType : int
+{
+    T_INVALID = 0,
+    T_BYTE = 1,
+    T_ASCII = 2,
+    T_SHORT = 3,
+    T_LONG = 4,
+    T_RATIONAL = 5,
+    T_SBYTE = 6,
+    T_UNDEFINED = 7,
+    T_SSHORT = 8,
+    T_SLONG = 9,
+    T_SRATIONAL = 10,
+    T_FLOAT = 11,
+    T_DOUBLE = 12,
+    T_OLYUNDEF = 13,
+    T_AUTO = 98,
+    T_SUBDIR = 99
+};
+enum class Endianness : int
+{
+    UNKNOWN = 0,
+    LITTLE = 0x4949,
+    BIG = 0x4D4D
+};
 
 inline static int getTypeSize(TagType type)
 {
-    return (
-        (type == TagType::T_INVALID || type == TagType::T_BYTE || type == TagType::T_ASCII || type == TagType::T_SBYTE || type == TagType::T_UNDEFINED) ? 1 :
-        (type == TagType::T_SHORT || type == TagType::T_SSHORT) ? 2 :
-        (type == TagType::T_LONG || type == TagType::T_SLONG || type == TagType::T_FLOAT || type == TagType::T_OLYUNDEF) ? 4 :
-        (type == TagType::T_RATIONAL || type == TagType::T_SRATIONAL || type == TagType::T_DOUBLE) ? 8 : 0
-        );
+    return ((type == TagType::T_INVALID || type == TagType::T_BYTE || type == TagType::T_ASCII ||
+             type == TagType::T_SBYTE || type == TagType::T_UNDEFINED)
+                ? 1
+            : (type == TagType::T_SHORT || type == TagType::T_SSHORT) ? 2
+            : (type == TagType::T_LONG || type == TagType::T_SLONG || type == TagType::T_FLOAT ||
+               type == TagType::T_OLYUNDEF)
+                ? 4
+            : (type == TagType::T_RATIONAL || type == TagType::T_SRATIONAL || type == TagType::T_DOUBLE) ? 8
+                                                                                                         : 0);
 }
 
-enum class TagKey : int {
+enum class TagKey : int
+{
     COLOR_MATRIX_1 = 50721,
     COLOR_MATRIX_2 = 50722,
     PROFILE_HUE_SAT_MAP_DIMS = 50937,
@@ -135,44 +311,48 @@ enum class TagKey : int {
 //-----------------------------------------------------------------------------
 unsigned short sget2(const unsigned char* s, Endianness order)
 {
-    if (order == Endianness::LITTLE) {
+    if(order == Endianness::LITTLE)
+    {
         return s[0] | s[1] << 8;
     }
-    else {
+    else
+    {
         return s[0] << 8 | s[1];
     }
 }
 int sget4(const unsigned char* s, Endianness order)
 {
-    if (order == Endianness::LITTLE) {
+    if(order == Endianness::LITTLE)
+    {
         return s[0] | s[1] << 8 | s[2] << 16 | s[3] << 24;
     }
-    else {
+    else
+    {
         return s[0] << 24 | s[1] << 16 | s[2] << 8 | s[3];
     }
 }
 inline unsigned short get2(FILE* f, Endianness order)
 {
-    unsigned char str[2] = { 0xff, 0xff };
+    unsigned char str[2] = {0xff, 0xff};
     fread(str, 1, 2, f);
     return sget2(str, order);
 }
 int get4(FILE* f, Endianness order)
 {
-    unsigned char str[4] = { 0xff, 0xff, 0xff, 0xff };
+    unsigned char str[4] = {0xff, 0xff, 0xff, 0xff};
     fread(str, 1, 4, f);
     return sget4(str, order);
 }
 short int int2_to_signed(short unsigned int i)
 {
-    union {
+    union
+    {
         short unsigned int i;
         short int s;
     } u;
     u.i = i;
     return u.s;
 }
-
 
 /*
  * A class representing a single TIFF tag
@@ -182,10 +362,10 @@ class Tag
 
 public:
     unsigned short tagID{0};
-    TagType        type{TagType::T_INVALID};
-    unsigned int   datasize{0};
+    TagType type{TagType::T_INVALID};
+    unsigned int datasize{0};
     std::vector<unsigned char> v_value;
-    Endianness     order{Endianness::UNKNOWN};
+    Endianness order{Endianness::UNKNOWN};
 
     Tag() = default;
     Tag(unsigned short tag, TagType type, unsigned int datasize, Endianness order, FILE* f);
@@ -194,29 +374,34 @@ public:
 
     bool operator==(const Tag& t) const;
 
-    int    toInt(int ofs, TagType astype = TagType::T_INVALID) const;
+    int toInt(int ofs, TagType astype = TagType::T_INVALID) const;
     double toDouble(int ofs = 0) const;
-    void   toString(char* buffer, std::size_t size, int ofs = 0) const;
+    void toString(char* buffer, std::size_t size, int ofs = 0) const;
 
     std::string valueToString() const;
 };
 
-Tag::Tag(unsigned short tag, TagType type, unsigned int datasize, Endianness order, FILE* f) : // file index supposed to be at rigth location to read datasize
-    tagID(tag), type(type), datasize(datasize), order(order)
+Tag::Tag(unsigned short tag, TagType type, unsigned int datasize, Endianness order, FILE* f)
+    : // file index supposed to be at rigth location to read datasize
+    tagID(tag)
+    , type(type)
+    , datasize(datasize)
+    , order(order)
 {
 
     // load value field (possibly seek before)
     const int valuesize = datasize * getTypeSize(type);
 
-    if (valuesize > 4) {
+    if(valuesize > 4)
+    {
         fseek(f, get4(f, order), SEEK_SET);
     }
 
     // read value
-    //value = new unsigned char[valuesize + 1];
+    // value = new unsigned char[valuesize + 1];
     v_value.resize(valuesize + 1);
     auto readSize = fread(v_value.data(), 1, valuesize, f);
-    //value[readSize] = '\0';
+    // value[readSize] = '\0';
     v_value[readSize] = '\0';
 }
 
@@ -227,48 +412,52 @@ bool Tag::operator==(const Tag& t) const
 
 int Tag::toInt(int ofs, TagType astype) const
 {
-    if (astype == TagType::T_INVALID) {
+    if(astype == TagType::T_INVALID)
+    {
         astype = type;
     }
 
-    switch (astype) {
-    case TagType::T_SBYTE:
-        return int(static_cast<signed char>(v_value[ofs]));
+    switch(astype)
+    {
+        case TagType::T_SBYTE:
+            return int(static_cast<signed char>(v_value[ofs]));
 
-    case TagType::T_BYTE:
-        return v_value[ofs];
+        case TagType::T_BYTE:
+            return v_value[ofs];
 
-    case TagType::T_ASCII:
-        return 0;
+        case TagType::T_ASCII:
+            return 0;
 
-    case TagType::T_SSHORT:
-        return (int)int2_to_signed(sget2(v_value.data() + ofs, order));
+        case TagType::T_SSHORT:
+            return (int)int2_to_signed(sget2(v_value.data() + ofs, order));
 
-    case TagType::T_SHORT:
-        return (int)sget2(v_value.data() + ofs, order);
+        case TagType::T_SHORT:
+            return (int)sget2(v_value.data() + ofs, order);
 
-    case TagType::T_SLONG:
-    case TagType::T_LONG:
-        return (int)sget4(v_value.data() + ofs, order);
+        case TagType::T_SLONG:
+        case TagType::T_LONG:
+            return (int)sget4(v_value.data() + ofs, order);
 
-    case TagType::T_SRATIONAL: {
-        int a = (int)sget4(v_value.data() + ofs + 4, order);
-        return a == 0 ? 0 : (int)sget4(v_value.data() + ofs, order) / a;
-    }
+        case TagType::T_SRATIONAL:
+        {
+            int a = (int)sget4(v_value.data() + ofs + 4, order);
+            return a == 0 ? 0 : (int)sget4(v_value.data() + ofs, order) / a;
+        }
 
-    case TagType::T_RATIONAL: {
-        uint32_t a = (uint32_t)sget4(v_value.data() + ofs + 4, order);
-        return a == 0 ? 0 : (uint32_t)sget4(v_value.data() + ofs, order) / a;
-    }
+        case TagType::T_RATIONAL:
+        {
+            uint32_t a = (uint32_t)sget4(v_value.data() + ofs + 4, order);
+            return a == 0 ? 0 : (uint32_t)sget4(v_value.data() + ofs, order) / a;
+        }
 
-    case TagType::T_FLOAT:
-        return (int)toDouble(ofs);
+        case TagType::T_FLOAT:
+            return (int)toDouble(ofs);
 
-    case TagType::T_UNDEFINED:
-        return 0;
+        case TagType::T_UNDEFINED:
+            return 0;
 
-    default:
-        return 0; // Quick fix for missing cases (INVALID, DOUBLE, OLYUNDEF, SUBDIR)
+        default:
+            return 0; // Quick fix for missing cases (INVALID, DOUBLE, OLYUNDEF, SUBDIR)
     }
 
     return 0;
@@ -276,88 +465,98 @@ int Tag::toInt(int ofs, TagType astype) const
 
 double Tag::toDouble(int ofs) const
 {
-    union IntFloat {
+    union IntFloat
+    {
         uint32_t i;
         float f;
     } conv;
 
     double ud, dd;
 
-    switch (type) {
-    case TagType::T_SBYTE:
-        return (double)(static_cast<signed char>(v_value[ofs]));
+    switch(type)
+    {
+        case TagType::T_SBYTE:
+            return (double)(static_cast<signed char>(v_value[ofs]));
 
-    case TagType::T_BYTE:
-        return (double)((int)v_value[ofs]);
+        case TagType::T_BYTE:
+            return (double)((int)v_value[ofs]);
 
-    case TagType::T_ASCII:
-        return 0.0;
+        case TagType::T_ASCII:
+            return 0.0;
 
-    case TagType::T_SSHORT:
-        return (double)int2_to_signed(sget2(v_value.data() + ofs, order));
+        case TagType::T_SSHORT:
+            return (double)int2_to_signed(sget2(v_value.data() + ofs, order));
 
-    case TagType::T_SHORT:
-        return (double)((int)sget2(v_value.data() + ofs, order));
+        case TagType::T_SHORT:
+            return (double)((int)sget2(v_value.data() + ofs, order));
 
-    case TagType::T_SLONG:
-    case TagType::T_LONG:
-        return (double)((int)sget4(v_value.data() + ofs, order));
+        case TagType::T_SLONG:
+        case TagType::T_LONG:
+            return (double)((int)sget4(v_value.data() + ofs, order));
 
-    case TagType::T_SRATIONAL:
-        ud = (int)sget4(v_value.data() + ofs, order);
-        dd = (int)sget4(v_value.data() + ofs + 4, order);
-        return dd == 0. ? 0. : ud / dd;
+        case TagType::T_SRATIONAL:
+            ud = (int)sget4(v_value.data() + ofs, order);
+            dd = (int)sget4(v_value.data() + ofs + 4, order);
+            return dd == 0. ? 0. : ud / dd;
 
-    case TagType::T_RATIONAL:
-        ud = (uint32_t)sget4(v_value.data() + ofs, order);
-        dd = (uint32_t)sget4(v_value.data() + ofs + 4, order);
-        return dd == 0. ? 0. : ud / dd;
+        case TagType::T_RATIONAL:
+            ud = (uint32_t)sget4(v_value.data() + ofs, order);
+            dd = (uint32_t)sget4(v_value.data() + ofs + 4, order);
+            return dd == 0. ? 0. : ud / dd;
 
-    case TagType::T_FLOAT:
-        conv.i = sget4(v_value.data() + ofs, order);
-        return conv.f;
+        case TagType::T_FLOAT:
+            conv.i = sget4(v_value.data() + ofs, order);
+            return conv.f;
 
-    case TagType::T_UNDEFINED:
-        return 0.;
+        case TagType::T_UNDEFINED:
+            return 0.;
 
-    default:
-        return 0.;
+        default:
+            return 0.;
     }
-
 }
 
 void Tag::toString(char* buffer, std::size_t size, int ofs) const
 {
-    if (!buffer || !size) {
+    if(!buffer || !size)
+    {
         return;
     }
 
-    if (type == TagType::T_UNDEFINED) {
+    if(type == TagType::T_UNDEFINED)
+    {
         bool isstring = true;
         unsigned int i = 0;
 
-        for (i = 0; i + ofs < datasize && i < 64 && v_value[i + ofs]; i++)
-            if (v_value[i + ofs] < 32 || v_value[i + ofs] > 126) {
+        for(i = 0; i + ofs < datasize && i < 64 && v_value[i + ofs]; i++)
+            if(v_value[i + ofs] < 32 || v_value[i + ofs] > 126)
+            {
                 isstring = false;
             }
 
-        if (isstring) {
-            if (size < 3) {
+        if(isstring)
+        {
+            if(size < 3)
+            {
                 return;
             }
 
             std::size_t j = 0;
 
-            for (i = 0; i + ofs < datasize && i < 64 && v_value[i + ofs]; i++) {
-                if (v_value[i + ofs] == '<' || v_value[i + ofs] == '>') {
+            for(i = 0; i + ofs < datasize && i < 64 && v_value[i + ofs]; i++)
+            {
+                if(v_value[i + ofs] == '<' || v_value[i + ofs] == '>')
+                {
                     buffer[j++] = '\\';
-                    if (j > size - 2) {
+                    if(j > size - 2)
+                    {
                         break;
                     }
                 }
 
                 buffer[j++] = v_value[i + ofs];
-                if (j > size - 2) {
+                if(j > size - 2)
+                {
                     break;
                 }
             }
@@ -366,7 +565,8 @@ void Tag::toString(char* buffer, std::size_t size, int ofs) const
             return;
         }
     }
-    else if (type == TagType::T_ASCII) {
+    else if(type == TagType::T_ASCII)
+    {
         snprintf(buffer, size, "%.64s", v_value.data() + ofs);
         return;
     }
@@ -375,56 +575,62 @@ void Tag::toString(char* buffer, std::size_t size, int ofs) const
 
     buffer[0] = 0;
 
-    for (int i = 0; i < std::min<int>(maxcount, datasize * getTypeSize(type) - ofs); i++) {
+    for(int i = 0; i < std::min<int>(maxcount, datasize * getTypeSize(type) - ofs); i++)
+    {
         std::size_t len = strlen(buffer);
 
-        if (i > 0 && size - len > 2) {
+        if(i > 0 && size - len > 2)
+        {
             strcat(buffer, ", ");
             len += 2;
         }
 
         char* b = buffer + len;
 
-        switch (type) {
-        case TagType::T_UNDEFINED:
-        case TagType::T_BYTE:
-            snprintf(b, size - len, "%d", v_value[i + ofs]);
-            break;
+        switch(type)
+        {
+            case TagType::T_UNDEFINED:
+            case TagType::T_BYTE:
+                snprintf(b, size - len, "%d", v_value[i + ofs]);
+                break;
 
-        case TagType::T_SSHORT:
-            snprintf(b, size - len, "%d", toInt(2 * i + ofs));
-            break;
+            case TagType::T_SSHORT:
+                snprintf(b, size - len, "%d", toInt(2 * i + ofs));
+                break;
 
-        case TagType::T_SHORT:
-            snprintf(b, size - len, "%u", toInt(2 * i + ofs));
-            break;
+            case TagType::T_SHORT:
+                snprintf(b, size - len, "%u", toInt(2 * i + ofs));
+                break;
 
-        case TagType::T_SLONG:
-            snprintf(b, size - len, "%d", toInt(4 * i + ofs));
-            break;
+            case TagType::T_SLONG:
+                snprintf(b, size - len, "%d", toInt(4 * i + ofs));
+                break;
 
-        case TagType::T_LONG:
-            snprintf(b, size - len, "%u", toInt(4 * i + ofs));
-            break;
+            case TagType::T_LONG:
+                snprintf(b, size - len, "%u", toInt(4 * i + ofs));
+                break;
 
-        case TagType::T_SRATIONAL:
-            snprintf(b, size - len, "%d/%d", (int)sget4(v_value.data() + 8 * i + ofs, order), (int)sget4(v_value.data() + 8 * i + ofs + 4, order));
-            break;
+            case TagType::T_SRATIONAL:
+                snprintf(b, size - len, "%d/%d", (int)sget4(v_value.data() + 8 * i + ofs, order),
+                         (int)sget4(v_value.data() + 8 * i + ofs + 4, order));
+                break;
 
-        case TagType::T_RATIONAL:
-            snprintf(b, size - len, "%u/%u", (uint32_t)sget4(v_value.data() + 8 * i + ofs, order), (uint32_t)sget4(v_value.data() + 8 * i + ofs + 4, order));
-            break;
+            case TagType::T_RATIONAL:
+                snprintf(b, size - len, "%u/%u", (uint32_t)sget4(v_value.data() + 8 * i + ofs, order),
+                         (uint32_t)sget4(v_value.data() + 8 * i + ofs + 4, order));
+                break;
 
-        case TagType::T_FLOAT:
-            snprintf(b, size - len, "%g", toDouble(8 * i + ofs));
-            break;
+            case TagType::T_FLOAT:
+                snprintf(b, size - len, "%g", toDouble(8 * i + ofs));
+                break;
 
-        default:
-            break;
+            default:
+                break;
         }
     }
 
-    if (datasize > maxcount && size - strlen(buffer) > 3) {
+    if(datasize > maxcount && size - strlen(buffer) > 3)
+    {
         strcat(buffer, "...");
     }
 }
@@ -439,13 +645,12 @@ std::string Tag::valueToString() const
 Tag* findTag(TagKey tagID, std::vector<Tag>& v_Tags)
 {
     size_t idx = 0;
-    while (idx < v_Tags.size() && (v_Tags[idx].tagID != (unsigned short)tagID))
+    while(idx < v_Tags.size() && (v_Tags[idx].tagID != (unsigned short)tagID))
     {
         idx++;
     }
     return (idx == v_Tags.size()) ? nullptr : &v_Tags[idx];
 }
-
 
 void SplineToneCurve::Set(const std::vector<double>& v_xy)
 {
@@ -455,7 +660,7 @@ void SplineToneCurve::Set(const std::vector<double>& v_xy)
 
     const size_t N = v_xy.size() / 2;
 
-    for (int i = 0; i < N; ++i)
+    for(int i = 0; i < N; ++i)
     {
         v_x.push_back(v_xy[2 * i]);
         v_y.push_back(v_xy[2 * i + 1]);
@@ -463,36 +668,40 @@ void SplineToneCurve::Set(const std::vector<double>& v_xy)
     }
     std::vector<double> v_u(N - 1, 0.0);
 
-    v_ypp[0] = v_u[0] = 0.0;    /* Natural spline */
+    v_ypp[0] = v_u[0] = 0.0; /* Natural spline */
 
-    for (int i = 1; i < N - 1; ++i) {
+    for(int i = 1; i < N - 1; ++i)
+    {
         const double sig = (v_x[i] - v_x[i - 1]) / (v_x[i + 1] - v_x[i - 1]);
         const double p = sig * v_ypp[i - 1] + 2.0;
         v_ypp[i] = (sig - 1.0) / p;
-        v_u[i] = ((v_y[i + 1] - v_y[i])
-            / (v_x[i + 1] - v_x[i]) - (v_y[i] - v_y[i - 1]) / (v_x[i] - v_x[i - 1]));
+        v_u[i] = ((v_y[i + 1] - v_y[i]) / (v_x[i + 1] - v_x[i]) - (v_y[i] - v_y[i - 1]) / (v_x[i] - v_x[i - 1]));
         v_u[i] = (6.0 * v_u[i] / (v_x[i + 1] - v_x[i - 1]) - sig * v_u[i - 1]) / p;
     }
 
     v_ypp[N - 1] = 0.0;
 
-    for (int k = N - 2; k >= 0; --k) {
+    for(int k = N - 2; k >= 0; --k)
+    {
         v_ypp[k] = v_ypp[k] * v_ypp[k + 1] + v_u[k];
     }
 
     int k_hi = 0;
 
-    for (int i = 0; i < 65536; ++i) {
+    for(int i = 0; i < 65536; ++i)
+    {
 
         float t = float(i) / 65535.f;
-        while ((v_x[k_hi] <= t) && (k_hi < v_x.size() - 1))
+        while((v_x[k_hi] <= t) && (k_hi < v_x.size() - 1))
             k_hi++;
 
         int k_lo = k_hi - 1;
         double h = v_x[k_hi] - v_x[k_lo];
         const double a = (v_x[k_hi] - t) / h;
         const double b = (t - v_x[k_lo]) / h;
-        const double r = a * v_y[k_lo] + b * v_y[k_hi] + ((a * a * a - a) * v_ypp[k_lo] + (b * b * b - b) * v_ypp[k_hi]) * (h * h) * 0.1666666666666666666666666666666;
+        const double r = a * v_y[k_lo] + b * v_y[k_hi] +
+                         ((a * a * a - a) * v_ypp[k_lo] + (b * b * b - b) * v_ypp[k_hi]) * (h * h) *
+                             0.1666666666666666666666666666666;
 
         ffffToneCurve[i] = (float)(r > 0.0 ? (r < 1.0 ? r : 1.0) : 0.0) * 65535.f;
     }
@@ -504,35 +713,45 @@ void SplineToneCurve::Apply(float& ir, float& ig, float& ib) const
     float g = std::max<float>(0.0, std::min<float>(65535.0, ig));
     float b = std::max<float>(0.0, std::min<float>(65535.0, ib));
 
-    if (r >= g) {
-        if (g > b) {
-            RGBTone(r, g, b);     // Case 1: r >= g >  b
+    if(r >= g)
+    {
+        if(g > b)
+        {
+            RGBTone(r, g, b); // Case 1: r >= g >  b
         }
-        else if (b > r) {
-            RGBTone(b, r, g);     // Case 2: b >  r >= g
+        else if(b > r)
+        {
+            RGBTone(b, r, g); // Case 2: b >  r >= g
         }
-        else if (b > g) {
-            RGBTone(r, b, g);     // Case 3: r >= b >  g
+        else if(b > g)
+        {
+            RGBTone(r, b, g); // Case 3: r >= b >  g
         }
-        else {                           // Case 4: r == g == b
+        else
+        { // Case 4: r == g == b
             r = getval(r);
             g = getval(g);
             b = g;
         }
     }
-    else {
-        if (r >= b) {
-            RGBTone(g, r, b);     // Case 5: g >  r >= b
+    else
+    {
+        if(r >= b)
+        {
+            RGBTone(g, r, b); // Case 5: g >  r >= b
         }
-        else if (b > g) {
-            RGBTone(b, g, r);     // Case 6: b >  g >  r
+        else if(b > g)
+        {
+            RGBTone(b, g, r); // Case 6: b >  g >  r
         }
-        else {
-            RGBTone(g, b, r);     // Case 7: g >= b >  r
+        else
+        {
+            RGBTone(g, b, r); // Case 7: g >= b >  r
         }
     }
 
-    if (!(ir < 0.0 || ir > 65535.0) || !(ig < 0.0 || ig > 65535.0) || !(ib < 0.0 || ib > 65535.0)) {
+    if(!(ir < 0.0 || ir > 65535.0) || !(ig < 0.0 || ig > 65535.0) || !(ib < 0.0 || ib > 65535.0))
+    {
         ir = r;
         ig = g;
         ib = b;
@@ -553,287 +772,123 @@ float SplineToneCurve::getval(const float idx) const
     const int idx_int = (int)idx;
     const float idx_dec = idx - idx_int;
 
-    if (idx_int < 0)
+    if(idx_int < 0)
         return ffffToneCurve.front();
-    else if (idx_int >= 65535)
+    else if(idx_int >= 65535)
         return ffffToneCurve.back();
     else
         return idx_dec * ffffToneCurve[idx_int] + (1.f - idx_dec) * ffffToneCurve[idx_int + 1];
 }
 
-
-DCPProfile::DCPProfile(const std::string filename) :
-    will_interpolate(false),
-    valid(false),
-    baseline_exposure_offset(0.0)
+DCPProfile::DCPProfile(const std::string filename)
+    : will_interpolate(false)
+    , valid(false)
+    , baseline_exposure_offset(0.0)
 {
     delta_info.hue_step = delta_info.val_step = look_info.hue_step = look_info.val_step = 0;
     constexpr int tiff_float_size = 4;
 
     static const float adobe_camera_raw_default_curve[] = {
-        0.00000f, 0.00078f, 0.00160f, 0.00242f,
-        0.00314f, 0.00385f, 0.00460f, 0.00539f,
-        0.00623f, 0.00712f, 0.00806f, 0.00906f,
-        0.01012f, 0.01122f, 0.01238f, 0.01359f,
-        0.01485f, 0.01616f, 0.01751f, 0.01890f,
-        0.02033f, 0.02180f, 0.02331f, 0.02485f,
-        0.02643f, 0.02804f, 0.02967f, 0.03134f,
-        0.03303f, 0.03475f, 0.03648f, 0.03824f,
-        0.04002f, 0.04181f, 0.04362f, 0.04545f,
-        0.04730f, 0.04916f, 0.05103f, 0.05292f,
-        0.05483f, 0.05675f, 0.05868f, 0.06063f,
-        0.06259f, 0.06457f, 0.06655f, 0.06856f,
-        0.07057f, 0.07259f, 0.07463f, 0.07668f,
-        0.07874f, 0.08081f, 0.08290f, 0.08499f,
-        0.08710f, 0.08921f, 0.09134f, 0.09348f,
-        0.09563f, 0.09779f, 0.09996f, 0.10214f,
-        0.10433f, 0.10652f, 0.10873f, 0.11095f,
-        0.11318f, 0.11541f, 0.11766f, 0.11991f,
-        0.12218f, 0.12445f, 0.12673f, 0.12902f,
-        0.13132f, 0.13363f, 0.13595f, 0.13827f,
-        0.14061f, 0.14295f, 0.14530f, 0.14765f,
-        0.15002f, 0.15239f, 0.15477f, 0.15716f,
-        0.15956f, 0.16197f, 0.16438f, 0.16680f,
-        0.16923f, 0.17166f, 0.17410f, 0.17655f,
-        0.17901f, 0.18148f, 0.18395f, 0.18643f,
-        0.18891f, 0.19141f, 0.19391f, 0.19641f,
-        0.19893f, 0.20145f, 0.20398f, 0.20651f,
-        0.20905f, 0.21160f, 0.21416f, 0.21672f,
-        0.21929f, 0.22185f, 0.22440f, 0.22696f,
-        0.22950f, 0.23204f, 0.23458f, 0.23711f,
-        0.23963f, 0.24215f, 0.24466f, 0.24717f,
-        0.24967f, 0.25216f, 0.25465f, 0.25713f,
-        0.25961f, 0.26208f, 0.26454f, 0.26700f,
-        0.26945f, 0.27189f, 0.27433f, 0.27676f,
-        0.27918f, 0.28160f, 0.28401f, 0.28641f,
-        0.28881f, 0.29120f, 0.29358f, 0.29596f,
-        0.29833f, 0.30069f, 0.30305f, 0.30540f,
-        0.30774f, 0.31008f, 0.31241f, 0.31473f,
-        0.31704f, 0.31935f, 0.32165f, 0.32395f,
-        0.32623f, 0.32851f, 0.33079f, 0.33305f,
-        0.33531f, 0.33756f, 0.33981f, 0.34205f,
-        0.34428f, 0.34650f, 0.34872f, 0.35093f,
-        0.35313f, 0.35532f, 0.35751f, 0.35969f,
-        0.36187f, 0.36404f, 0.36620f, 0.36835f,
-        0.37050f, 0.37264f, 0.37477f, 0.37689f,
-        0.37901f, 0.38112f, 0.38323f, 0.38533f,
-        0.38742f, 0.38950f, 0.39158f, 0.39365f,
-        0.39571f, 0.39777f, 0.39982f, 0.40186f,
-        0.40389f, 0.40592f, 0.40794f, 0.40996f,
-        0.41197f, 0.41397f, 0.41596f, 0.41795f,
-        0.41993f, 0.42191f, 0.42388f, 0.42584f,
-        0.42779f, 0.42974f, 0.43168f, 0.43362f,
-        0.43554f, 0.43747f, 0.43938f, 0.44129f,
-        0.44319f, 0.44509f, 0.44698f, 0.44886f,
-        0.45073f, 0.45260f, 0.45447f, 0.45632f,
-        0.45817f, 0.46002f, 0.46186f, 0.46369f,
-        0.46551f, 0.46733f, 0.46914f, 0.47095f,
-        0.47275f, 0.47454f, 0.47633f, 0.47811f,
-        0.47989f, 0.48166f, 0.48342f, 0.48518f,
-        0.48693f, 0.48867f, 0.49041f, 0.49214f,
-        0.49387f, 0.49559f, 0.49730f, 0.49901f,
-        0.50072f, 0.50241f, 0.50410f, 0.50579f,
-        0.50747f, 0.50914f, 0.51081f, 0.51247f,
-        0.51413f, 0.51578f, 0.51742f, 0.51906f,
-        0.52069f, 0.52232f, 0.52394f, 0.52556f,
-        0.52717f, 0.52878f, 0.53038f, 0.53197f,
-        0.53356f, 0.53514f, 0.53672f, 0.53829f,
-        0.53986f, 0.54142f, 0.54297f, 0.54452f,
-        0.54607f, 0.54761f, 0.54914f, 0.55067f,
-        0.55220f, 0.55371f, 0.55523f, 0.55673f,
-        0.55824f, 0.55973f, 0.56123f, 0.56271f,
-        0.56420f, 0.56567f, 0.56715f, 0.56861f,
-        0.57007f, 0.57153f, 0.57298f, 0.57443f,
-        0.57587f, 0.57731f, 0.57874f, 0.58017f,
-        0.58159f, 0.58301f, 0.58443f, 0.58583f,
-        0.58724f, 0.58864f, 0.59003f, 0.59142f,
-        0.59281f, 0.59419f, 0.59556f, 0.59694f,
-        0.59830f, 0.59966f, 0.60102f, 0.60238f,
-        0.60373f, 0.60507f, 0.60641f, 0.60775f,
-        0.60908f, 0.61040f, 0.61173f, 0.61305f,
-        0.61436f, 0.61567f, 0.61698f, 0.61828f,
-        0.61957f, 0.62087f, 0.62216f, 0.62344f,
-        0.62472f, 0.62600f, 0.62727f, 0.62854f,
-        0.62980f, 0.63106f, 0.63232f, 0.63357f,
-        0.63482f, 0.63606f, 0.63730f, 0.63854f,
-        0.63977f, 0.64100f, 0.64222f, 0.64344f,
-        0.64466f, 0.64587f, 0.64708f, 0.64829f,
-        0.64949f, 0.65069f, 0.65188f, 0.65307f,
-        0.65426f, 0.65544f, 0.65662f, 0.65779f,
-        0.65897f, 0.66013f, 0.66130f, 0.66246f,
-        0.66362f, 0.66477f, 0.66592f, 0.66707f,
-        0.66821f, 0.66935f, 0.67048f, 0.67162f,
-        0.67275f, 0.67387f, 0.67499f, 0.67611f,
-        0.67723f, 0.67834f, 0.67945f, 0.68055f,
-        0.68165f, 0.68275f, 0.68385f, 0.68494f,
-        0.68603f, 0.68711f, 0.68819f, 0.68927f,
-        0.69035f, 0.69142f, 0.69249f, 0.69355f,
-        0.69461f, 0.69567f, 0.69673f, 0.69778f,
-        0.69883f, 0.69988f, 0.70092f, 0.70196f,
-        0.70300f, 0.70403f, 0.70506f, 0.70609f,
-        0.70711f, 0.70813f, 0.70915f, 0.71017f,
-        0.71118f, 0.71219f, 0.71319f, 0.71420f,
-        0.71520f, 0.71620f, 0.71719f, 0.71818f,
-        0.71917f, 0.72016f, 0.72114f, 0.72212f,
-        0.72309f, 0.72407f, 0.72504f, 0.72601f,
-        0.72697f, 0.72794f, 0.72890f, 0.72985f,
-        0.73081f, 0.73176f, 0.73271f, 0.73365f,
-        0.73460f, 0.73554f, 0.73647f, 0.73741f,
-        0.73834f, 0.73927f, 0.74020f, 0.74112f,
-        0.74204f, 0.74296f, 0.74388f, 0.74479f,
-        0.74570f, 0.74661f, 0.74751f, 0.74842f,
-        0.74932f, 0.75021f, 0.75111f, 0.75200f,
-        0.75289f, 0.75378f, 0.75466f, 0.75555f,
-        0.75643f, 0.75730f, 0.75818f, 0.75905f,
-        0.75992f, 0.76079f, 0.76165f, 0.76251f,
-        0.76337f, 0.76423f, 0.76508f, 0.76594f,
-        0.76679f, 0.76763f, 0.76848f, 0.76932f,
-        0.77016f, 0.77100f, 0.77183f, 0.77267f,
-        0.77350f, 0.77432f, 0.77515f, 0.77597f,
-        0.77680f, 0.77761f, 0.77843f, 0.77924f,
-        0.78006f, 0.78087f, 0.78167f, 0.78248f,
-        0.78328f, 0.78408f, 0.78488f, 0.78568f,
-        0.78647f, 0.78726f, 0.78805f, 0.78884f,
-        0.78962f, 0.79040f, 0.79118f, 0.79196f,
-        0.79274f, 0.79351f, 0.79428f, 0.79505f,
-        0.79582f, 0.79658f, 0.79735f, 0.79811f,
-        0.79887f, 0.79962f, 0.80038f, 0.80113f,
-        0.80188f, 0.80263f, 0.80337f, 0.80412f,
-        0.80486f, 0.80560f, 0.80634f, 0.80707f,
-        0.80780f, 0.80854f, 0.80926f, 0.80999f,
-        0.81072f, 0.81144f, 0.81216f, 0.81288f,
-        0.81360f, 0.81431f, 0.81503f, 0.81574f,
-        0.81645f, 0.81715f, 0.81786f, 0.81856f,
-        0.81926f, 0.81996f, 0.82066f, 0.82135f,
-        0.82205f, 0.82274f, 0.82343f, 0.82412f,
-        0.82480f, 0.82549f, 0.82617f, 0.82685f,
-        0.82753f, 0.82820f, 0.82888f, 0.82955f,
-        0.83022f, 0.83089f, 0.83155f, 0.83222f,
-        0.83288f, 0.83354f, 0.83420f, 0.83486f,
-        0.83552f, 0.83617f, 0.83682f, 0.83747f,
-        0.83812f, 0.83877f, 0.83941f, 0.84005f,
-        0.84069f, 0.84133f, 0.84197f, 0.84261f,
-        0.84324f, 0.84387f, 0.84450f, 0.84513f,
-        0.84576f, 0.84639f, 0.84701f, 0.84763f,
-        0.84825f, 0.84887f, 0.84949f, 0.85010f,
-        0.85071f, 0.85132f, 0.85193f, 0.85254f,
-        0.85315f, 0.85375f, 0.85436f, 0.85496f,
-        0.85556f, 0.85615f, 0.85675f, 0.85735f,
-        0.85794f, 0.85853f, 0.85912f, 0.85971f,
-        0.86029f, 0.86088f, 0.86146f, 0.86204f,
-        0.86262f, 0.86320f, 0.86378f, 0.86435f,
-        0.86493f, 0.86550f, 0.86607f, 0.86664f,
-        0.86720f, 0.86777f, 0.86833f, 0.86889f,
-        0.86945f, 0.87001f, 0.87057f, 0.87113f,
-        0.87168f, 0.87223f, 0.87278f, 0.87333f,
-        0.87388f, 0.87443f, 0.87497f, 0.87552f,
-        0.87606f, 0.87660f, 0.87714f, 0.87768f,
-        0.87821f, 0.87875f, 0.87928f, 0.87981f,
-        0.88034f, 0.88087f, 0.88140f, 0.88192f,
-        0.88244f, 0.88297f, 0.88349f, 0.88401f,
-        0.88453f, 0.88504f, 0.88556f, 0.88607f,
-        0.88658f, 0.88709f, 0.88760f, 0.88811f,
-        0.88862f, 0.88912f, 0.88963f, 0.89013f,
-        0.89063f, 0.89113f, 0.89163f, 0.89212f,
-        0.89262f, 0.89311f, 0.89360f, 0.89409f,
-        0.89458f, 0.89507f, 0.89556f, 0.89604f,
-        0.89653f, 0.89701f, 0.89749f, 0.89797f,
-        0.89845f, 0.89892f, 0.89940f, 0.89987f,
-        0.90035f, 0.90082f, 0.90129f, 0.90176f,
-        0.90222f, 0.90269f, 0.90316f, 0.90362f,
-        0.90408f, 0.90454f, 0.90500f, 0.90546f,
-        0.90592f, 0.90637f, 0.90683f, 0.90728f,
-        0.90773f, 0.90818f, 0.90863f, 0.90908f,
-        0.90952f, 0.90997f, 0.91041f, 0.91085f,
-        0.91130f, 0.91173f, 0.91217f, 0.91261f,
-        0.91305f, 0.91348f, 0.91392f, 0.91435f,
-        0.91478f, 0.91521f, 0.91564f, 0.91606f,
-        0.91649f, 0.91691f, 0.91734f, 0.91776f,
-        0.91818f, 0.91860f, 0.91902f, 0.91944f,
-        0.91985f, 0.92027f, 0.92068f, 0.92109f,
-        0.92150f, 0.92191f, 0.92232f, 0.92273f,
-        0.92314f, 0.92354f, 0.92395f, 0.92435f,
-        0.92475f, 0.92515f, 0.92555f, 0.92595f,
-        0.92634f, 0.92674f, 0.92713f, 0.92753f,
-        0.92792f, 0.92831f, 0.92870f, 0.92909f,
-        0.92947f, 0.92986f, 0.93025f, 0.93063f,
-        0.93101f, 0.93139f, 0.93177f, 0.93215f,
-        0.93253f, 0.93291f, 0.93328f, 0.93366f,
-        0.93403f, 0.93440f, 0.93478f, 0.93515f,
-        0.93551f, 0.93588f, 0.93625f, 0.93661f,
-        0.93698f, 0.93734f, 0.93770f, 0.93807f,
-        0.93843f, 0.93878f, 0.93914f, 0.93950f,
-        0.93986f, 0.94021f, 0.94056f, 0.94092f,
-        0.94127f, 0.94162f, 0.94197f, 0.94231f,
-        0.94266f, 0.94301f, 0.94335f, 0.94369f,
-        0.94404f, 0.94438f, 0.94472f, 0.94506f,
-        0.94540f, 0.94573f, 0.94607f, 0.94641f,
-        0.94674f, 0.94707f, 0.94740f, 0.94774f,
-        0.94807f, 0.94839f, 0.94872f, 0.94905f,
-        0.94937f, 0.94970f, 0.95002f, 0.95035f,
-        0.95067f, 0.95099f, 0.95131f, 0.95163f,
-        0.95194f, 0.95226f, 0.95257f, 0.95289f,
-        0.95320f, 0.95351f, 0.95383f, 0.95414f,
-        0.95445f, 0.95475f, 0.95506f, 0.95537f,
-        0.95567f, 0.95598f, 0.95628f, 0.95658f,
-        0.95688f, 0.95718f, 0.95748f, 0.95778f,
-        0.95808f, 0.95838f, 0.95867f, 0.95897f,
-        0.95926f, 0.95955f, 0.95984f, 0.96013f,
-        0.96042f, 0.96071f, 0.96100f, 0.96129f,
-        0.96157f, 0.96186f, 0.96214f, 0.96242f,
-        0.96271f, 0.96299f, 0.96327f, 0.96355f,
-        0.96382f, 0.96410f, 0.96438f, 0.96465f,
-        0.96493f, 0.96520f, 0.96547f, 0.96574f,
-        0.96602f, 0.96629f, 0.96655f, 0.96682f,
-        0.96709f, 0.96735f, 0.96762f, 0.96788f,
-        0.96815f, 0.96841f, 0.96867f, 0.96893f,
-        0.96919f, 0.96945f, 0.96971f, 0.96996f,
-        0.97022f, 0.97047f, 0.97073f, 0.97098f,
-        0.97123f, 0.97149f, 0.97174f, 0.97199f,
-        0.97223f, 0.97248f, 0.97273f, 0.97297f,
-        0.97322f, 0.97346f, 0.97371f, 0.97395f,
-        0.97419f, 0.97443f, 0.97467f, 0.97491f,
-        0.97515f, 0.97539f, 0.97562f, 0.97586f,
-        0.97609f, 0.97633f, 0.97656f, 0.97679f,
-        0.97702f, 0.97725f, 0.97748f, 0.97771f,
-        0.97794f, 0.97817f, 0.97839f, 0.97862f,
-        0.97884f, 0.97907f, 0.97929f, 0.97951f,
-        0.97973f, 0.97995f, 0.98017f, 0.98039f,
-        0.98061f, 0.98082f, 0.98104f, 0.98125f,
-        0.98147f, 0.98168f, 0.98189f, 0.98211f,
-        0.98232f, 0.98253f, 0.98274f, 0.98295f,
-        0.98315f, 0.98336f, 0.98357f, 0.98377f,
-        0.98398f, 0.98418f, 0.98438f, 0.98458f,
-        0.98478f, 0.98498f, 0.98518f, 0.98538f,
-        0.98558f, 0.98578f, 0.98597f, 0.98617f,
-        0.98636f, 0.98656f, 0.98675f, 0.98694f,
-        0.98714f, 0.98733f, 0.98752f, 0.98771f,
-        0.98789f, 0.98808f, 0.98827f, 0.98845f,
-        0.98864f, 0.98882f, 0.98901f, 0.98919f,
-        0.98937f, 0.98955f, 0.98973f, 0.98991f,
-        0.99009f, 0.99027f, 0.99045f, 0.99063f,
-        0.99080f, 0.99098f, 0.99115f, 0.99133f,
-        0.99150f, 0.99167f, 0.99184f, 0.99201f,
-        0.99218f, 0.99235f, 0.99252f, 0.99269f,
-        0.99285f, 0.99302f, 0.99319f, 0.99335f,
-        0.99351f, 0.99368f, 0.99384f, 0.99400f,
-        0.99416f, 0.99432f, 0.99448f, 0.99464f,
-        0.99480f, 0.99495f, 0.99511f, 0.99527f,
-        0.99542f, 0.99558f, 0.99573f, 0.99588f,
-        0.99603f, 0.99619f, 0.99634f, 0.99649f,
-        0.99664f, 0.99678f, 0.99693f, 0.99708f,
-        0.99722f, 0.99737f, 0.99751f, 0.99766f,
-        0.99780f, 0.99794f, 0.99809f, 0.99823f,
-        0.99837f, 0.99851f, 0.99865f, 0.99879f,
-        0.99892f, 0.99906f, 0.99920f, 0.99933f,
-        0.99947f, 0.99960f, 0.99974f, 0.99987f,
-        1.00000f
-    };
+        0.00000f, 0.00078f, 0.00160f, 0.00242f, 0.00314f, 0.00385f, 0.00460f, 0.00539f, 0.00623f, 0.00712f, 0.00806f,
+        0.00906f, 0.01012f, 0.01122f, 0.01238f, 0.01359f, 0.01485f, 0.01616f, 0.01751f, 0.01890f, 0.02033f, 0.02180f,
+        0.02331f, 0.02485f, 0.02643f, 0.02804f, 0.02967f, 0.03134f, 0.03303f, 0.03475f, 0.03648f, 0.03824f, 0.04002f,
+        0.04181f, 0.04362f, 0.04545f, 0.04730f, 0.04916f, 0.05103f, 0.05292f, 0.05483f, 0.05675f, 0.05868f, 0.06063f,
+        0.06259f, 0.06457f, 0.06655f, 0.06856f, 0.07057f, 0.07259f, 0.07463f, 0.07668f, 0.07874f, 0.08081f, 0.08290f,
+        0.08499f, 0.08710f, 0.08921f, 0.09134f, 0.09348f, 0.09563f, 0.09779f, 0.09996f, 0.10214f, 0.10433f, 0.10652f,
+        0.10873f, 0.11095f, 0.11318f, 0.11541f, 0.11766f, 0.11991f, 0.12218f, 0.12445f, 0.12673f, 0.12902f, 0.13132f,
+        0.13363f, 0.13595f, 0.13827f, 0.14061f, 0.14295f, 0.14530f, 0.14765f, 0.15002f, 0.15239f, 0.15477f, 0.15716f,
+        0.15956f, 0.16197f, 0.16438f, 0.16680f, 0.16923f, 0.17166f, 0.17410f, 0.17655f, 0.17901f, 0.18148f, 0.18395f,
+        0.18643f, 0.18891f, 0.19141f, 0.19391f, 0.19641f, 0.19893f, 0.20145f, 0.20398f, 0.20651f, 0.20905f, 0.21160f,
+        0.21416f, 0.21672f, 0.21929f, 0.22185f, 0.22440f, 0.22696f, 0.22950f, 0.23204f, 0.23458f, 0.23711f, 0.23963f,
+        0.24215f, 0.24466f, 0.24717f, 0.24967f, 0.25216f, 0.25465f, 0.25713f, 0.25961f, 0.26208f, 0.26454f, 0.26700f,
+        0.26945f, 0.27189f, 0.27433f, 0.27676f, 0.27918f, 0.28160f, 0.28401f, 0.28641f, 0.28881f, 0.29120f, 0.29358f,
+        0.29596f, 0.29833f, 0.30069f, 0.30305f, 0.30540f, 0.30774f, 0.31008f, 0.31241f, 0.31473f, 0.31704f, 0.31935f,
+        0.32165f, 0.32395f, 0.32623f, 0.32851f, 0.33079f, 0.33305f, 0.33531f, 0.33756f, 0.33981f, 0.34205f, 0.34428f,
+        0.34650f, 0.34872f, 0.35093f, 0.35313f, 0.35532f, 0.35751f, 0.35969f, 0.36187f, 0.36404f, 0.36620f, 0.36835f,
+        0.37050f, 0.37264f, 0.37477f, 0.37689f, 0.37901f, 0.38112f, 0.38323f, 0.38533f, 0.38742f, 0.38950f, 0.39158f,
+        0.39365f, 0.39571f, 0.39777f, 0.39982f, 0.40186f, 0.40389f, 0.40592f, 0.40794f, 0.40996f, 0.41197f, 0.41397f,
+        0.41596f, 0.41795f, 0.41993f, 0.42191f, 0.42388f, 0.42584f, 0.42779f, 0.42974f, 0.43168f, 0.43362f, 0.43554f,
+        0.43747f, 0.43938f, 0.44129f, 0.44319f, 0.44509f, 0.44698f, 0.44886f, 0.45073f, 0.45260f, 0.45447f, 0.45632f,
+        0.45817f, 0.46002f, 0.46186f, 0.46369f, 0.46551f, 0.46733f, 0.46914f, 0.47095f, 0.47275f, 0.47454f, 0.47633f,
+        0.47811f, 0.47989f, 0.48166f, 0.48342f, 0.48518f, 0.48693f, 0.48867f, 0.49041f, 0.49214f, 0.49387f, 0.49559f,
+        0.49730f, 0.49901f, 0.50072f, 0.50241f, 0.50410f, 0.50579f, 0.50747f, 0.50914f, 0.51081f, 0.51247f, 0.51413f,
+        0.51578f, 0.51742f, 0.51906f, 0.52069f, 0.52232f, 0.52394f, 0.52556f, 0.52717f, 0.52878f, 0.53038f, 0.53197f,
+        0.53356f, 0.53514f, 0.53672f, 0.53829f, 0.53986f, 0.54142f, 0.54297f, 0.54452f, 0.54607f, 0.54761f, 0.54914f,
+        0.55067f, 0.55220f, 0.55371f, 0.55523f, 0.55673f, 0.55824f, 0.55973f, 0.56123f, 0.56271f, 0.56420f, 0.56567f,
+        0.56715f, 0.56861f, 0.57007f, 0.57153f, 0.57298f, 0.57443f, 0.57587f, 0.57731f, 0.57874f, 0.58017f, 0.58159f,
+        0.58301f, 0.58443f, 0.58583f, 0.58724f, 0.58864f, 0.59003f, 0.59142f, 0.59281f, 0.59419f, 0.59556f, 0.59694f,
+        0.59830f, 0.59966f, 0.60102f, 0.60238f, 0.60373f, 0.60507f, 0.60641f, 0.60775f, 0.60908f, 0.61040f, 0.61173f,
+        0.61305f, 0.61436f, 0.61567f, 0.61698f, 0.61828f, 0.61957f, 0.62087f, 0.62216f, 0.62344f, 0.62472f, 0.62600f,
+        0.62727f, 0.62854f, 0.62980f, 0.63106f, 0.63232f, 0.63357f, 0.63482f, 0.63606f, 0.63730f, 0.63854f, 0.63977f,
+        0.64100f, 0.64222f, 0.64344f, 0.64466f, 0.64587f, 0.64708f, 0.64829f, 0.64949f, 0.65069f, 0.65188f, 0.65307f,
+        0.65426f, 0.65544f, 0.65662f, 0.65779f, 0.65897f, 0.66013f, 0.66130f, 0.66246f, 0.66362f, 0.66477f, 0.66592f,
+        0.66707f, 0.66821f, 0.66935f, 0.67048f, 0.67162f, 0.67275f, 0.67387f, 0.67499f, 0.67611f, 0.67723f, 0.67834f,
+        0.67945f, 0.68055f, 0.68165f, 0.68275f, 0.68385f, 0.68494f, 0.68603f, 0.68711f, 0.68819f, 0.68927f, 0.69035f,
+        0.69142f, 0.69249f, 0.69355f, 0.69461f, 0.69567f, 0.69673f, 0.69778f, 0.69883f, 0.69988f, 0.70092f, 0.70196f,
+        0.70300f, 0.70403f, 0.70506f, 0.70609f, 0.70711f, 0.70813f, 0.70915f, 0.71017f, 0.71118f, 0.71219f, 0.71319f,
+        0.71420f, 0.71520f, 0.71620f, 0.71719f, 0.71818f, 0.71917f, 0.72016f, 0.72114f, 0.72212f, 0.72309f, 0.72407f,
+        0.72504f, 0.72601f, 0.72697f, 0.72794f, 0.72890f, 0.72985f, 0.73081f, 0.73176f, 0.73271f, 0.73365f, 0.73460f,
+        0.73554f, 0.73647f, 0.73741f, 0.73834f, 0.73927f, 0.74020f, 0.74112f, 0.74204f, 0.74296f, 0.74388f, 0.74479f,
+        0.74570f, 0.74661f, 0.74751f, 0.74842f, 0.74932f, 0.75021f, 0.75111f, 0.75200f, 0.75289f, 0.75378f, 0.75466f,
+        0.75555f, 0.75643f, 0.75730f, 0.75818f, 0.75905f, 0.75992f, 0.76079f, 0.76165f, 0.76251f, 0.76337f, 0.76423f,
+        0.76508f, 0.76594f, 0.76679f, 0.76763f, 0.76848f, 0.76932f, 0.77016f, 0.77100f, 0.77183f, 0.77267f, 0.77350f,
+        0.77432f, 0.77515f, 0.77597f, 0.77680f, 0.77761f, 0.77843f, 0.77924f, 0.78006f, 0.78087f, 0.78167f, 0.78248f,
+        0.78328f, 0.78408f, 0.78488f, 0.78568f, 0.78647f, 0.78726f, 0.78805f, 0.78884f, 0.78962f, 0.79040f, 0.79118f,
+        0.79196f, 0.79274f, 0.79351f, 0.79428f, 0.79505f, 0.79582f, 0.79658f, 0.79735f, 0.79811f, 0.79887f, 0.79962f,
+        0.80038f, 0.80113f, 0.80188f, 0.80263f, 0.80337f, 0.80412f, 0.80486f, 0.80560f, 0.80634f, 0.80707f, 0.80780f,
+        0.80854f, 0.80926f, 0.80999f, 0.81072f, 0.81144f, 0.81216f, 0.81288f, 0.81360f, 0.81431f, 0.81503f, 0.81574f,
+        0.81645f, 0.81715f, 0.81786f, 0.81856f, 0.81926f, 0.81996f, 0.82066f, 0.82135f, 0.82205f, 0.82274f, 0.82343f,
+        0.82412f, 0.82480f, 0.82549f, 0.82617f, 0.82685f, 0.82753f, 0.82820f, 0.82888f, 0.82955f, 0.83022f, 0.83089f,
+        0.83155f, 0.83222f, 0.83288f, 0.83354f, 0.83420f, 0.83486f, 0.83552f, 0.83617f, 0.83682f, 0.83747f, 0.83812f,
+        0.83877f, 0.83941f, 0.84005f, 0.84069f, 0.84133f, 0.84197f, 0.84261f, 0.84324f, 0.84387f, 0.84450f, 0.84513f,
+        0.84576f, 0.84639f, 0.84701f, 0.84763f, 0.84825f, 0.84887f, 0.84949f, 0.85010f, 0.85071f, 0.85132f, 0.85193f,
+        0.85254f, 0.85315f, 0.85375f, 0.85436f, 0.85496f, 0.85556f, 0.85615f, 0.85675f, 0.85735f, 0.85794f, 0.85853f,
+        0.85912f, 0.85971f, 0.86029f, 0.86088f, 0.86146f, 0.86204f, 0.86262f, 0.86320f, 0.86378f, 0.86435f, 0.86493f,
+        0.86550f, 0.86607f, 0.86664f, 0.86720f, 0.86777f, 0.86833f, 0.86889f, 0.86945f, 0.87001f, 0.87057f, 0.87113f,
+        0.87168f, 0.87223f, 0.87278f, 0.87333f, 0.87388f, 0.87443f, 0.87497f, 0.87552f, 0.87606f, 0.87660f, 0.87714f,
+        0.87768f, 0.87821f, 0.87875f, 0.87928f, 0.87981f, 0.88034f, 0.88087f, 0.88140f, 0.88192f, 0.88244f, 0.88297f,
+        0.88349f, 0.88401f, 0.88453f, 0.88504f, 0.88556f, 0.88607f, 0.88658f, 0.88709f, 0.88760f, 0.88811f, 0.88862f,
+        0.88912f, 0.88963f, 0.89013f, 0.89063f, 0.89113f, 0.89163f, 0.89212f, 0.89262f, 0.89311f, 0.89360f, 0.89409f,
+        0.89458f, 0.89507f, 0.89556f, 0.89604f, 0.89653f, 0.89701f, 0.89749f, 0.89797f, 0.89845f, 0.89892f, 0.89940f,
+        0.89987f, 0.90035f, 0.90082f, 0.90129f, 0.90176f, 0.90222f, 0.90269f, 0.90316f, 0.90362f, 0.90408f, 0.90454f,
+        0.90500f, 0.90546f, 0.90592f, 0.90637f, 0.90683f, 0.90728f, 0.90773f, 0.90818f, 0.90863f, 0.90908f, 0.90952f,
+        0.90997f, 0.91041f, 0.91085f, 0.91130f, 0.91173f, 0.91217f, 0.91261f, 0.91305f, 0.91348f, 0.91392f, 0.91435f,
+        0.91478f, 0.91521f, 0.91564f, 0.91606f, 0.91649f, 0.91691f, 0.91734f, 0.91776f, 0.91818f, 0.91860f, 0.91902f,
+        0.91944f, 0.91985f, 0.92027f, 0.92068f, 0.92109f, 0.92150f, 0.92191f, 0.92232f, 0.92273f, 0.92314f, 0.92354f,
+        0.92395f, 0.92435f, 0.92475f, 0.92515f, 0.92555f, 0.92595f, 0.92634f, 0.92674f, 0.92713f, 0.92753f, 0.92792f,
+        0.92831f, 0.92870f, 0.92909f, 0.92947f, 0.92986f, 0.93025f, 0.93063f, 0.93101f, 0.93139f, 0.93177f, 0.93215f,
+        0.93253f, 0.93291f, 0.93328f, 0.93366f, 0.93403f, 0.93440f, 0.93478f, 0.93515f, 0.93551f, 0.93588f, 0.93625f,
+        0.93661f, 0.93698f, 0.93734f, 0.93770f, 0.93807f, 0.93843f, 0.93878f, 0.93914f, 0.93950f, 0.93986f, 0.94021f,
+        0.94056f, 0.94092f, 0.94127f, 0.94162f, 0.94197f, 0.94231f, 0.94266f, 0.94301f, 0.94335f, 0.94369f, 0.94404f,
+        0.94438f, 0.94472f, 0.94506f, 0.94540f, 0.94573f, 0.94607f, 0.94641f, 0.94674f, 0.94707f, 0.94740f, 0.94774f,
+        0.94807f, 0.94839f, 0.94872f, 0.94905f, 0.94937f, 0.94970f, 0.95002f, 0.95035f, 0.95067f, 0.95099f, 0.95131f,
+        0.95163f, 0.95194f, 0.95226f, 0.95257f, 0.95289f, 0.95320f, 0.95351f, 0.95383f, 0.95414f, 0.95445f, 0.95475f,
+        0.95506f, 0.95537f, 0.95567f, 0.95598f, 0.95628f, 0.95658f, 0.95688f, 0.95718f, 0.95748f, 0.95778f, 0.95808f,
+        0.95838f, 0.95867f, 0.95897f, 0.95926f, 0.95955f, 0.95984f, 0.96013f, 0.96042f, 0.96071f, 0.96100f, 0.96129f,
+        0.96157f, 0.96186f, 0.96214f, 0.96242f, 0.96271f, 0.96299f, 0.96327f, 0.96355f, 0.96382f, 0.96410f, 0.96438f,
+        0.96465f, 0.96493f, 0.96520f, 0.96547f, 0.96574f, 0.96602f, 0.96629f, 0.96655f, 0.96682f, 0.96709f, 0.96735f,
+        0.96762f, 0.96788f, 0.96815f, 0.96841f, 0.96867f, 0.96893f, 0.96919f, 0.96945f, 0.96971f, 0.96996f, 0.97022f,
+        0.97047f, 0.97073f, 0.97098f, 0.97123f, 0.97149f, 0.97174f, 0.97199f, 0.97223f, 0.97248f, 0.97273f, 0.97297f,
+        0.97322f, 0.97346f, 0.97371f, 0.97395f, 0.97419f, 0.97443f, 0.97467f, 0.97491f, 0.97515f, 0.97539f, 0.97562f,
+        0.97586f, 0.97609f, 0.97633f, 0.97656f, 0.97679f, 0.97702f, 0.97725f, 0.97748f, 0.97771f, 0.97794f, 0.97817f,
+        0.97839f, 0.97862f, 0.97884f, 0.97907f, 0.97929f, 0.97951f, 0.97973f, 0.97995f, 0.98017f, 0.98039f, 0.98061f,
+        0.98082f, 0.98104f, 0.98125f, 0.98147f, 0.98168f, 0.98189f, 0.98211f, 0.98232f, 0.98253f, 0.98274f, 0.98295f,
+        0.98315f, 0.98336f, 0.98357f, 0.98377f, 0.98398f, 0.98418f, 0.98438f, 0.98458f, 0.98478f, 0.98498f, 0.98518f,
+        0.98538f, 0.98558f, 0.98578f, 0.98597f, 0.98617f, 0.98636f, 0.98656f, 0.98675f, 0.98694f, 0.98714f, 0.98733f,
+        0.98752f, 0.98771f, 0.98789f, 0.98808f, 0.98827f, 0.98845f, 0.98864f, 0.98882f, 0.98901f, 0.98919f, 0.98937f,
+        0.98955f, 0.98973f, 0.98991f, 0.99009f, 0.99027f, 0.99045f, 0.99063f, 0.99080f, 0.99098f, 0.99115f, 0.99133f,
+        0.99150f, 0.99167f, 0.99184f, 0.99201f, 0.99218f, 0.99235f, 0.99252f, 0.99269f, 0.99285f, 0.99302f, 0.99319f,
+        0.99335f, 0.99351f, 0.99368f, 0.99384f, 0.99400f, 0.99416f, 0.99432f, 0.99448f, 0.99464f, 0.99480f, 0.99495f,
+        0.99511f, 0.99527f, 0.99542f, 0.99558f, 0.99573f, 0.99588f, 0.99603f, 0.99619f, 0.99634f, 0.99649f, 0.99664f,
+        0.99678f, 0.99693f, 0.99708f, 0.99722f, 0.99737f, 0.99751f, 0.99766f, 0.99780f, 0.99794f, 0.99809f, 0.99823f,
+        0.99837f, 0.99851f, 0.99865f, 0.99879f, 0.99892f, 0.99906f, 0.99920f, 0.99933f, 0.99947f, 0.99960f, 0.99974f,
+        0.99987f, 1.00000f};
 
     FILE* const file = fopen(filename.c_str(), "rb");
 
-    if (file == nullptr) {
-        printf ("Unable to load DCP profile '%s' !", filename.c_str());
+    if(file == nullptr)
+    {
+        ALICEVISION_LOG_WARNING("Unable to load DCP profile " << filename);
         return;
     }
 
@@ -848,31 +903,35 @@ DCPProfile::DCPProfile(const std::string filename) :
     // read tags
     const int numOfTags = get2(file, order);
 
-    if (numOfTags <= 0 || numOfTags > 1000) {
-        std::cerr << "ERROR : Tag number out of range !" << std::endl;
+    if(numOfTags <= 0 || numOfTags > 1000)
+    {
+        ALICEVISION_LOG_WARNING("DCP Error: Tag number out of range.");
         fclose(file);
         return;
     }
 
     std::vector<Tag> v_tag;
 
-    for (int i = 0; i < numOfTags; i++) {
+    for(int i = 0; i < numOfTags; i++)
+    {
 
         unsigned short tag = get2(file, order);
         TagType type = (TagType)get2(file, order);
         unsigned int datasize = get4(file, order);
 
-        if (!datasize) {
+        if(!datasize)
+        {
             datasize = 1;
         }
 
         // filter out invalid tags
         // note the large count is to be able to pass LeafData ASCII tag which can be up to almost 10 megabytes,
         // (only a small part of it will actually be parsed though)
-        if ((int)type < 1 || (int)type > 14 || datasize > 10 * 1024 * 1024) {
+        if((int)type < 1 || (int)type > 14 || datasize > 10 * 1024 * 1024)
+        {
             type = TagType::T_INVALID;
             fclose(file);
-            std::cerr << "ERROR : Invalid Tag in dcp file !" << std::endl;
+            ALICEVISION_LOG_WARNING("ERROR : Invalid Tag in dcp file !");
             return;
         }
 
@@ -889,28 +948,26 @@ DCPProfile::DCPProfile(const std::string filename) :
     fclose(file);
 
     Tag* tag = findTag(TagKey::CALIBRATION_ILLUMINANT_1, v_tag);
-    info.light_source_1 =
-        tag
-        ? tag->toInt(0, TagType::T_SHORT)
-        : -1;
+    info.light_source_1 = tag ? tag->toInt(0, TagType::T_SHORT) : -1;
     tag = findTag(TagKey::CALIBRATION_ILLUMINANT_2, v_tag);
-    info.light_source_2 =
-        tag
-        ? tag->toInt(0, TagType::T_SHORT)
-        : -1;
+    info.light_source_2 = tag ? tag->toInt(0, TagType::T_SHORT) : -1;
     info.temperature_1 = calibrationIlluminantToTemperature(info.light_source_1);
     info.temperature_2 = calibrationIlluminantToTemperature(info.light_source_2);
 
-    const bool has_second_hue_sat = findTag(TagKey::PROFILE_HUE_SAT_MAP_DATA_2, v_tag); // Some profiles have two matrices, but just one huesat
+    const bool has_second_hue_sat =
+        findTag(TagKey::PROFILE_HUE_SAT_MAP_DATA_2, v_tag); // Some profiles have two matrices, but just one huesat
 
     // Fetch Forward Matrices, if any
     tag = findTag(TagKey::FORWARD_MATRIX_1, v_tag);
 
-    if (tag) {
+    if(tag)
+    {
         info.has_forward_matrix_1 = true;
 
-        for (int row = 0; row < 3; ++row) {
-            for (int col = 0; col < 3; ++col) {
+        for(int row = 0; row < 3; ++row)
+        {
+            for(int col = 0; col < 3; ++col)
+            {
                 forward_matrix_1[row][col] = tag->toDouble((col + row * 3) * 8);
             }
         }
@@ -918,11 +975,14 @@ DCPProfile::DCPProfile(const std::string filename) :
 
     tag = findTag(TagKey::FORWARD_MATRIX_2, v_tag);
 
-    if (tag) {
+    if(tag)
+    {
         info.has_forward_matrix_2 = true;
 
-        for (int row = 0; row < 3; ++row) {
-            for (int col = 0; col < 3; ++col) {
+        for(int row = 0; row < 3; ++row)
+        {
+            for(int col = 0; col < 3; ++col)
+            {
                 forward_matrix_2[row][col] = tag->toDouble((col + row * 3) * 8);
             }
         }
@@ -931,23 +991,27 @@ DCPProfile::DCPProfile(const std::string filename) :
     // Color Matrix (one is always there)
     tag = findTag(TagKey::COLOR_MATRIX_1, v_tag);
 
-    if (!tag) {
-        std::cerr << "DCP '" << filename << "' is missing 'ColorMatrix1'. Skipped." << std::endl;
+    if(!tag)
+    {
+        ALICEVISION_LOG_WARNING("DCP '" << filename << "' is missing 'ColorMatrix1'. Skipped.");
         fclose(file);
         return;
     }
 
     info.has_color_matrix_1 = true;
 
-    for (int row = 0; row < 3; ++row) {
-        for (int col = 0; col < 3; ++col) {
+    for(int row = 0; row < 3; ++row)
+    {
+        for(int col = 0; col < 3; ++col)
+        {
             color_matrix_1[row][col] = tag->toDouble((col + row * 3) * 8);
         }
     }
 
     tag = findTag(TagKey::PROFILE_LOOK_TABLE_DIMS, v_tag);
 
-    if (tag) {
+    if(tag)
+    {
         look_info.hue_divisions = tag->toInt(0);
         look_info.sat_divisions = tag->toInt(4);
         look_info.val_divisions = tag->toInt(8);
@@ -960,17 +1024,15 @@ DCPProfile::DCPProfile(const std::string filename) :
 
         look_table.resize(look_info.array_count);
 
-        for (unsigned int i = 0; i < look_info.array_count; i++) {
+        for(unsigned int i = 0; i < look_info.array_count; i++)
+        {
             look_table[i].hue_shift = tag->toDouble((i * 3) * tiff_float_size);
             look_table[i].sat_scale = tag->toDouble((i * 3 + 1) * tiff_float_size);
             look_table[i].val_scale = tag->toDouble((i * 3 + 2) * tiff_float_size);
         }
 
         // Precalculated constants for table application
-        look_info.pc.h_scale =
-            look_info.hue_divisions < 2
-            ? 0.0f
-            : static_cast<float>(look_info.hue_divisions) / 6.0f;
+        look_info.pc.h_scale = look_info.hue_divisions < 2 ? 0.0f : static_cast<float>(look_info.hue_divisions) / 6.0f;
         look_info.pc.s_scale = look_info.sat_divisions - 1;
         look_info.pc.v_scale = look_info.val_divisions - 1;
         look_info.pc.max_hue_index0 = look_info.hue_divisions - 1;
@@ -984,7 +1046,8 @@ DCPProfile::DCPProfile(const std::string filename) :
 
     tag = findTag(TagKey::PROFILE_HUE_SAT_MAP_DIMS, v_tag);
 
-    if (tag) {
+    if(tag)
+    {
         delta_info.hue_divisions = tag->toInt(0);
         delta_info.sat_divisions = tag->toInt(4);
         delta_info.val_divisions = tag->toInt(8);
@@ -997,16 +1060,15 @@ DCPProfile::DCPProfile(const std::string filename) :
 
         deltas_1.resize(delta_info.array_count);
 
-        for (unsigned int i = 0; i < delta_info.array_count; ++i) {
+        for(unsigned int i = 0; i < delta_info.array_count; ++i)
+        {
             deltas_1[i].hue_shift = tag->toDouble((i * 3) * tiff_float_size);
             deltas_1[i].sat_scale = tag->toDouble((i * 3 + 1) * tiff_float_size);
             deltas_1[i].val_scale = tag->toDouble((i * 3 + 2) * tiff_float_size);
         }
 
         delta_info.pc.h_scale =
-            delta_info.hue_divisions < 2
-            ? 0.0f
-            : static_cast<float>(delta_info.hue_divisions) / 6.0f;
+            delta_info.hue_divisions < 2 ? 0.0f : static_cast<float>(delta_info.hue_divisions) / 6.0f;
         delta_info.pc.s_scale = delta_info.sat_divisions - 1;
         delta_info.pc.v_scale = delta_info.val_divisions - 1;
         delta_info.pc.max_hue_index0 = delta_info.hue_divisions - 1;
@@ -1018,29 +1080,31 @@ DCPProfile::DCPProfile(const std::string filename) :
         info.has_hue_sat_map = true;
     }
 
-    if (info.light_source_2 != -1) {
+    if(info.light_source_2 != -1)
+    {
         // Second matrix
         info.has_color_matrix_2 = true;
 
         tag = findTag(TagKey::COLOR_MATRIX_2, v_tag);
 
-        for (int row = 0; row < 3; ++row) {
-            for (int col = 0; col < 3; ++col) {
-                color_matrix_2[row][col] =
-                    tag
-                    ? tag->toDouble((col + row * 3) * 8)
-                    : color_matrix_1[row][col];
+        for(int row = 0; row < 3; ++row)
+        {
+            for(int col = 0; col < 3; ++col)
+            {
+                color_matrix_2[row][col] = tag ? tag->toDouble((col + row * 3) * 8) : color_matrix_1[row][col];
             }
         }
 
         // Second huesatmap
-        if (has_second_hue_sat) {
+        if(has_second_hue_sat)
+        {
             deltas_2.resize(delta_info.array_count);
 
             // Saturation maps. Need to be unwinded.
             tag = findTag(TagKey::PROFILE_HUE_SAT_MAP_DATA_2, v_tag);
 
-            for (unsigned int i = 0; i < delta_info.array_count; ++i) {
+            for(unsigned int i = 0; i < delta_info.array_count; ++i)
+            {
                 deltas_2[i].hue_shift = tag->toDouble((i * 3) * tiff_float_size);
                 deltas_2[i].sat_scale = tag->toDouble((i * 3 + 1) * tiff_float_size);
                 deltas_2[i].val_scale = tag->toDouble((i * 3 + 2) * tiff_float_size);
@@ -1050,7 +1114,8 @@ DCPProfile::DCPProfile(const std::string filename) :
 
     tag = findTag(TagKey::BASELINE_EXPOSURE_OFFSET, v_tag);
 
-    if (tag) {
+    if(tag)
+    {
         info.has_baseline_exposure_offset = true;
         baseline_exposure_offset = tag->toDouble();
     }
@@ -1058,17 +1123,20 @@ DCPProfile::DCPProfile(const std::string filename) :
     // Read tone curve points, if any, but disable to RTs own profiles
     tag = findTag(TagKey::PROFILE_TONE_CURVE, v_tag);
 
-    if (tag) {
+    if(tag)
+    {
         std::vector<double> AS_curve_points;
 
         // Push back each X/Y coordinates in a loop
         bool curve_is_linear = true;
 
-        for (int i = 0; i < tag->datasize; i += 2) {
+        for(int i = 0; i < tag->datasize; i += 2)
+        {
             const double x = tag->toDouble((i + 0) * tiff_float_size);
             const double y = tag->toDouble((i + 1) * tiff_float_size);
 
-            if (x != y) {
+            if(x != y)
+            {
                 curve_is_linear = false;
             }
 
@@ -1076,21 +1144,27 @@ DCPProfile::DCPProfile(const std::string filename) :
             AS_curve_points.push_back(y);
         }
 
-        if (!curve_is_linear) {
+        if(!curve_is_linear)
+        {
             // Create the curve
             info.has_tone_curve = true;
             AS_tone_curve.Set(AS_curve_points);
         }
-    } else {
+    }
+    else
+    {
         tag = findTag(TagKey::PROFILE_TONE_COPYRIGHT, v_tag);
 
-        if (tag && tag->valueToString().find("Adobe Systems") != std::string::npos) {
+        if(tag && tag->valueToString().find("Adobe Systems") != std::string::npos)
+        {
             // An Adobe profile without tone curve is expected to have the Adobe Default Curve
             std::vector<double> AS_curve_points;
 
-            constexpr size_t tc_len = sizeof(adobe_camera_raw_default_curve) / sizeof(adobe_camera_raw_default_curve[0]);
+            constexpr size_t tc_len =
+                sizeof(adobe_camera_raw_default_curve) / sizeof(adobe_camera_raw_default_curve[0]);
 
-            for (size_t i = 0; i < tc_len; ++i) {
+            for(size_t i = 0; i < tc_len; ++i)
+            {
                 const double x = static_cast<double>(i) / (tc_len - 1);
                 const double y = adobe_camera_raw_default_curve[i];
                 AS_curve_points.push_back(x);
@@ -1104,31 +1178,39 @@ DCPProfile::DCPProfile(const std::string filename) :
 
     will_interpolate = false;
 
-    if (info.has_forward_matrix_1) {
-        if (info.has_forward_matrix_2) {
-            if (forward_matrix_1 != forward_matrix_2) {
+    if(info.has_forward_matrix_1)
+    {
+        if(info.has_forward_matrix_2)
+        {
+            if(forward_matrix_1 != forward_matrix_2)
+            {
                 // Common that forward matrices are the same!
                 will_interpolate = true;
             }
 
-            if (!deltas_1.empty() && !deltas_2.empty()) {
+            if(!deltas_1.empty() && !deltas_2.empty())
+            {
                 // We assume tables are different
                 will_interpolate = true;
             }
         }
     }
 
-    if (info.has_color_matrix_1 && info.has_color_matrix_2) {
-        if (color_matrix_1 != color_matrix_2) {
+    if(info.has_color_matrix_1 && info.has_color_matrix_2)
+    {
+        if(color_matrix_1 != color_matrix_2)
+        {
             will_interpolate = true;
         }
 
-        if (!deltas_1.empty() && !deltas_2.empty()) {
+        if(!deltas_1.empty() && !deltas_2.empty())
+        {
             will_interpolate = true;
         }
     }
 
-    if (file) {
+    if(file)
+    {
         fclose(file);
     }
 
@@ -1136,154 +1218,38 @@ DCPProfile::DCPProfile(const std::string filename) :
 
     std::vector<double> gammatab_srgb_data;
     std::vector<double> igammatab_srgb_data;
-    for (int i = 0; i < 65536; i++)
+    for(int i = 0; i < 65536; i++)
     {
         double x = i / 65535.0;
-        gammatab_srgb_data.push_back((x <= 0.003040) ? (x * 12.92310) : (1.055 * exp(log(x) / 2.4) - 0.055));   // from RT
-        igammatab_srgb_data.push_back((x <= 0.039286) ? (x / 12.92310) : (exp(log((x + 0.055) / 1.055) * 2.4))); // from RT
+        gammatab_srgb_data.push_back((x <= 0.003040) ? (x * 12.92310) : (1.055 * exp(log(x) / 2.4) - 0.055)); // from RT
+        igammatab_srgb_data.push_back((x <= 0.039286) ? (x / 12.92310)
+                                                      : (exp(log((x + 0.055) / 1.055) * 2.4))); // from RT
     }
     gammatab_srgb.Set(gammatab_srgb_data);
     igammatab_srgb.Set(igammatab_srgb_data);
-
 }
 
 DCPProfile::~DCPProfile() = default;
 
-static inline bool rgb2hsvdcp(float r, float g, float b, float& h, float& s, float& v)
-{
-
-    const float var_Min = std::min<float>(r, std::min<float>(g, b));
-
-    if (var_Min < 0.f) {
-        return false;
-    }
-    else {
-        const float var_Max = std::max<float>(r, std::max<float>(g, b));
-        const float del_Max = var_Max - var_Min;
-        v = var_Max / 65535.f;
-
-        if (fabsf(del_Max) < 0.00001f) {
-            h = 0.f;
-            s = 0.f;
-        }
-        else {
-            s = del_Max / var_Max;
-
-            if (r == var_Max) {
-                h = (g - b) / del_Max;
-            }
-            else if (g == var_Max) {
-                h = 2.f + (b - r) / del_Max;
-            }
-            else {
-                h = 4.f + (r - g) / del_Max;
-            }
-
-            if (h < 0.f) {
-                h += 6.f;
-            }
-            else if (h > 6.f) {
-                h -= 6.f;
-            }
-        }
-
-        return true;
-    }
-}
-
-static inline void rgb2hsvtc(float r, float g, float b, float& h, float& s, float& v)
-{
-    const float var_Min = std::min<float>(r, std::min<float>(g, b));
-    const float var_Max = std::max<float>(r, std::max<float>(g, b));
-    const float del_Max = var_Max - var_Min;
-
-    v = var_Max / 65535.f;
-
-    if (del_Max < 0.00001f) {
-        h = 0.f;
-        s = 0.f;
-    }
-    else {
-        s = del_Max / var_Max;
-
-        if (r == var_Max) {
-            h = (g < b ? 6.f : 0.f) + (g - b) / del_Max;
-        }
-        else if (g == var_Max) {
-            h = 2.f + (b - r) / del_Max;
-        }
-        else {
-            h = 4.f + (r - g) / del_Max;
-        }
-    }
-}
-
-static inline void hsv2rgbdcp(float h, float s, float v, float& r, float& g, float& b)
-{
-    // special version for dcp which saves 1 division (in caller) and six multiplications (inside this function)
-    const int sector = h;  // sector 0 to 5, floor() is very slow, and h is always > 0
-    const float f = h - sector; // fractional part of h
-
-    v *= 65535.f;
-    const float vs = v * s;
-    const float p = v - vs;
-    const float q = v - f * vs;
-    const float t = p + v - q;
-
-    switch (sector) {
-    case 1:
-        r = q;
-        g = v;
-        b = p;
-        break;
-
-    case 2:
-        r = p;
-        g = v;
-        b = t;
-        break;
-
-    case 3:
-        r = p;
-        g = q;
-        b = v;
-        break;
-
-    case 4:
-        r = t;
-        g = p;
-        b = v;
-        break;
-
-    case 5:
-        r = v;
-        g = p;
-        b = q;
-        break;
-
-    default:
-        r = v;
-        g = t;
-        b = p;
-    }
-}
-
 void DCPProfile::apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& params)
 {
     // Compute matrices to and from selected working space
-    ws_sRGB = { 1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0 };
-    sRGB_ws = { 1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0 };
+    ws_sRGB = { 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 };
+    sRGB_ws = { 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 };
 
     if (params.working_space.compare("sRGB"))
     {
         if (params.working_space.compare("prophoto"))
         {
-            for (int i = 0; i < 3; i++) {
-                for (int j = 0; j < 3; j++) {
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < 3; j++)
+                {
                     double to_ws = 0.0;
                     double from_ws = 0.0;
-                    for (int k = 0; k < 3; k++) {
-                        to_ws   += prophoto_xyz[i][k] * xyz_sRGB[k][j];
+                    for (int k = 0; k < 3; k++)
+                    {
+                        to_ws += prophoto_xyz[i][k] * xyz_sRGB[k][j];
                         from_ws += sRGB_xyz[i][k] * xyz_prophoto[k][j];
                     }
                     ws_sRGB[i][j] = to_ws;
@@ -1293,12 +1259,15 @@ void DCPProfile::apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& param
         }
         else if (params.working_space.compare("AdobeRGB"))
         {
-            for (int i = 0; i < 3; i++) {
-                for (int j = 0; j < 3; j++) {
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < 3; j++)
+                {
                     double to_ws = 0.0;
                     double from_ws = 0.0;
-                    for (int k = 0; k < 3; k++) {
-                        to_ws   += AdobeRGB_xyz[i][k] * xyz_sRGB[k][j];
+                    for (int k = 0; k < 3; k++)
+                    {
+                        to_ws += AdobeRGB_xyz[i][k] * xyz_sRGB[k][j];
                         from_ws += sRGB_xyz[i][k] * xyz_AdobeRGB[k][j];
                     }
                     ws_sRGB[i][j] = to_ws;
@@ -1309,7 +1278,7 @@ void DCPProfile::apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& param
     }
 
     // Apply DCP profile
-    #pragma omp parallel for
+#pragma omp parallel for
     for (int i = 0; i < image.spec().height; ++i)
         for (int j = 0; j < image.spec().width; ++j)
         {
@@ -1330,23 +1299,30 @@ void DCPProfile::apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& param
 
 void DCPProfile::apply(float* rgb, const DCPProfileApplyParams& params) const
 {
-#define CLIPF_0_65535(a) ((a)>0.f?((a)<65535.5f?(a):65535.5f):0.f)
-#define CLIPF_0_1(a) ((a)>0?((a)<1?(a):1):0)
+#define CLIPF_0_65535(a) ((a) > 0.f ? ((a) < 65535.5f ? (a) : 65535.5f) : 0.f)
+#define CLIPF_0_1(a) ((a) > 0 ? ((a) < 1 ? (a) : 1) : 0)
 
-    const float exp_scale = (params.apply_baseline_exposure_offset && info.has_baseline_exposure_offset) ? powf(2.0, baseline_exposure_offset) : 1.0;
+    const float exp_scale = (params.apply_baseline_exposure_offset && info.has_baseline_exposure_offset)
+        ? powf(2.0, baseline_exposure_offset)
+        : 1.0;
 
-    if (!params.use_tone_curve && !params.apply_look_table) {
-        if (exp_scale == 1.f) {
+    if (!params.use_tone_curve && !params.apply_look_table)
+    {
+        if (exp_scale == 1.f)
+        {
             return;
         }
 
-        for (int c = 0; c < 3; c++) {
+        for (int c = 0; c < 3; c++)
+        {
             rgb[c] *= exp_scale;
         }
     }
-    else {
+    else
+    {
 
-        for (int c = 0; c < 3; c++) {
+        for (int c = 0; c < 3; c++)
+        {
             rgb[c] *= exp_scale;
         }
 
@@ -1363,7 +1339,8 @@ void DCPProfile::apply(float* rgb, const DCPProfileApplyParams& params) const
             }
         }
 
-        if (params.apply_look_table) {
+        if (params.apply_look_table)
+        {
             float clipped_ws_rgb[3];
             for (int i = 0; i < 3; i++)
             {
@@ -1381,15 +1358,18 @@ void DCPProfile::apply(float* rgb, const DCPProfileApplyParams& params) const
 
             hsv2rgbdcp(h, s, v, clipped_ws_rgb[0], clipped_ws_rgb[1], clipped_ws_rgb[2]);
 
-            if (!(ws_rgb[0] < 0.0 || ws_rgb[0] > 65535.0) || !(ws_rgb[1] < 0.0 || ws_rgb[1] > 65535.0) || !(ws_rgb[2] < 0.0 || ws_rgb[2] > 65535.0)) {
+            if (!(ws_rgb[0] < 0.0 || ws_rgb[0] > 65535.0) || !(ws_rgb[1] < 0.0 || ws_rgb[1] > 65535.0) ||
+                !(ws_rgb[2] < 0.0 || ws_rgb[2] > 65535.0))
+            {
                 ws_rgb[0] = clipped_ws_rgb[0];
                 ws_rgb[1] = clipped_ws_rgb[1];
                 ws_rgb[2] = clipped_ws_rgb[2];
             }
         }
 
-        if (params.use_tone_curve) {
-            //tone_curve.Apply(ws_rgb[0], ws_rgb[1], ws_rgb[2]);
+        if (params.use_tone_curve)
+        {
+            // tone_curve.Apply(ws_rgb[0], ws_rgb[1], ws_rgb[2]);
             AS_tone_curve.Apply(ws_rgb[0], ws_rgb[1], ws_rgb[2]);
         }
 
@@ -1401,11 +1381,11 @@ void DCPProfile::apply(float* rgb, const DCPProfileApplyParams& params) const
                 rgb[i] += sRGB_ws[i][j] * ws_rgb[j];
             }
         }
-
     }
 }
 
-inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h, float& s, float& v) const
+inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h,
+    float& s, float& v) const
 {
     // Apply the HueSatMap. Ported from Adobes reference implementation.
     float hue_shift;
@@ -1413,7 +1393,8 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
     float val_scale;
     float v_encoded = v;
 
-    if (table_info.val_divisions < 2) {
+    if (table_info.val_divisions < 2)
+    {
         // Optimize most common case of "2.5D" table
         const float h_scaled = h * table_info.pc.h_scale;
         const float s_scaled = s * table_info.pc.s_scale;
@@ -1423,7 +1404,8 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
 
         int h_index1 = h_index0 + 1;
 
-        if (h_index0 >= table_info.pc.max_hue_index0) {
+        if (h_index0 >= table_info.pc.max_hue_index0)
+        {
             h_index0 = table_info.pc.max_hue_index0;
             h_index1 = 0;
         }
@@ -1437,9 +1419,12 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
         std::vector<HsbModify>::size_type e00_index = h_index0 * table_info.pc.hue_step + s_index0;
         std::vector<HsbModify>::size_type e01_index = e00_index + (h_index1 - h_index0) * table_info.pc.hue_step;
 
-        const float hue_shift0 = h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift;
-        const float sat_scale0 = h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale;
-        const float val_scale0 = h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale;
+        const float hue_shift0 =
+            h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift;
+        const float sat_scale0 =
+            h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale;
+        const float val_scale0 =
+            h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale;
 
         ++e00_index;
         ++e01_index;
@@ -1451,11 +1436,14 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
         hue_shift = s_fract0 * hue_shift0 + s_fract1 * hueShift1;
         sat_scale = s_fract0 * sat_scale0 + s_fract1 * satScale1;
         val_scale = s_fract0 * val_scale0 + s_fract1 * valScale1;
-    } else {
+    }
+    else
+    {
         const float h_scaled = h * table_info.pc.h_scale;
         const float s_scaled = s * table_info.pc.s_scale;
 
-        if (table_info.srgb_gamma) {
+        if (table_info.srgb_gamma)
+        {
             v_encoded = gammatab_srgb[v * 65535.f];
         }
 
@@ -1467,7 +1455,8 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
 
         int h_index1 = h_index0 + 1;
 
-        if (h_index0 >= table_info.pc.max_hue_index0) {
+        if (h_index0 >= table_info.pc.max_hue_index0)
+        {
             h_index0 = table_info.pc.max_hue_index0;
             h_index1 = 0;
         }
@@ -1480,20 +1469,21 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
         const float s_fract0 = 1.0f - s_fract1;
         const float v_fract0 = 1.0f - v_fract1;
 
-        std::vector<HsbModify>::size_type e00_index = v_index0 * table_info.pc.val_step + h_index0 * table_info.pc.hue_step + s_index0;
+        std::vector<HsbModify>::size_type e00_index =
+            v_index0 * table_info.pc.val_step + h_index0 * table_info.pc.hue_step + s_index0;
         std::vector<HsbModify>::size_type e01_index = e00_index + (h_index1 - h_index0) * table_info.pc.hue_step;
         std::vector<HsbModify>::size_type e10_index = e00_index + table_info.pc.val_step;
         std::vector<HsbModify>::size_type e11_index = e01_index + table_info.pc.val_step;
 
         const float hueShift0 =
-            v_fract0 * (h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift)
-            + v_fract1 * (h_fract0 * table_base[e10_index].hue_shift + h_fract1 * table_base[e11_index].hue_shift);
+            v_fract0 * (h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift) +
+            v_fract1 * (h_fract0 * table_base[e10_index].hue_shift + h_fract1 * table_base[e11_index].hue_shift);
         const float satScale0 =
-            v_fract0 * (h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale)
-            + v_fract1 * (h_fract0 * table_base[e10_index].sat_scale + h_fract1 * table_base[e11_index].sat_scale);
+            v_fract0 * (h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale) +
+            v_fract1 * (h_fract0 * table_base[e10_index].sat_scale + h_fract1 * table_base[e11_index].sat_scale);
         const float valScale0 =
-            v_fract0 * (h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale)
-            + v_fract1 * (h_fract0 * table_base[e10_index].val_scale + h_fract1 * table_base[e11_index].val_scale);
+            v_fract0 * (h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale) +
+            v_fract1 * (h_fract0 * table_base[e10_index].val_scale + h_fract1 * table_base[e11_index].val_scale);
 
         ++e00_index;
         ++e01_index;
@@ -1501,14 +1491,14 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
         ++e11_index;
 
         const float hueShift1 =
-            v_fract0 * (h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift)
-            + v_fract1 * (h_fract0 * table_base[e10_index].hue_shift + h_fract1 * table_base[e11_index].hue_shift);
+            v_fract0 * (h_fract0 * table_base[e00_index].hue_shift + h_fract1 * table_base[e01_index].hue_shift) +
+            v_fract1 * (h_fract0 * table_base[e10_index].hue_shift + h_fract1 * table_base[e11_index].hue_shift);
         const float satScale1 =
-            v_fract0 * (h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale)
-            + v_fract1 * (h_fract0 * table_base[e10_index].sat_scale + h_fract1 * table_base[e11_index].sat_scale);
+            v_fract0 * (h_fract0 * table_base[e00_index].sat_scale + h_fract1 * table_base[e01_index].sat_scale) +
+            v_fract1 * (h_fract0 * table_base[e10_index].sat_scale + h_fract1 * table_base[e11_index].sat_scale);
         const float valScale1 =
-            v_fract0 * (h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale)
-            + v_fract1 * (h_fract0 * table_base[e10_index].val_scale + h_fract1 * table_base[e11_index].val_scale);
+            v_fract0 * (h_fract0 * table_base[e00_index].val_scale + h_fract1 * table_base[e01_index].val_scale) +
+            v_fract1 * (h_fract0 * table_base[e10_index].val_scale + h_fract1 * table_base[e11_index].val_scale);
 
         hue_shift = s_fract0 * hueShift0 + s_fract1 * hueShift1;
         sat_scale = s_fract0 * satScale0 + s_fract1 * satScale1;
@@ -1520,9 +1510,12 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
     h += hue_shift;
     s *= sat_scale; // No clipping here, we are RT float :-)
 
-    if (table_info.srgb_gamma) {
+    if (table_info.srgb_gamma)
+    {
         v = igammatab_srgb[v_encoded * val_scale * 65535.f];
-    } else {
+    }
+    else
+    {
         v *= val_scale;
     }
 }

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -1680,8 +1680,8 @@ void DCPProfile::setChromaticityCoordinates(const double x, const double y, doub
 
     for (int i = 1; i < 31; i++)
     {
-        std::vector<float> wrRuvt = WYSZECKI_ROBERSTON_TABLE[i];
-        std::vector<float> wrRuvtPrevious = WYSZECKI_ROBERSTON_TABLE[i - 1];
+        const std::vector<float> wrRuvt = WYSZECKI_ROBERSTON_TABLE[i];
+        const std::vector<float> wrRuvtPrevious = WYSZECKI_ROBERSTON_TABLE[i - 1];
 
         double du = 1.f;
         double dv = wrRuvt[3];
@@ -1737,8 +1737,8 @@ void DCPProfile::setChromaticityCoordinates(const double x, const double y, doub
 */
 void DCPProfile::getChromaticityCoordinates(const double cct, const double tint, double& x, double& y)
 {
-    double r = 1.0e6 / cct;
-    double offset = tint * (1.0 / TINT_SCALE);
+    const double r = 1.0e6 / cct;
+    const double offset = tint * (1.0 / TINT_SCALE);
 
     for (int i = 0; i < 30; ++i)
     {
@@ -2001,7 +2001,7 @@ DCPProfile::Matrix DCPProfile::getCameraToXyzD50Matrix(const double x, const dou
 {
     double cct, tint;
     setChromaticityCoordinates(x, y, cct, tint);
-    Triple xyz = {
+    const Triple xyz = {
         x * 1.f / y,
         1.f,
         (1.f - x - y) * 1.f / y};
@@ -2015,15 +2015,15 @@ DCPProfile::Matrix DCPProfile::getCameraToXyzD50Matrix(const double x, const dou
     {
         interpolatedColorMatrix = info.has_color_matrix_1 ? color_matrix_1 : color_matrix_2;
     }
-    Matrix interpolatedCalibMatrix = getInterpolatedMatrix(cct, "calib");
+    const Matrix interpolatedCalibMatrix = getInterpolatedMatrix(cct, "calib");
 
-    Triple rgb = matMult(interpolatedColorMatrix, xyz);
-    Triple asShotNeutral = {
+    const Triple rgb = matMult(interpolatedColorMatrix, xyz);
+    const Triple asShotNeutral = {
         rgb[0] / rgb[1],
         rgb[1] / rgb[1],
         rgb[2] / rgb[1]};
 
-    Triple referenceNeutral = matMult(matInv(matMult(analogBalance, interpolatedCalibMatrix)), asShotNeutral);
+    const Triple referenceNeutral = matMult(matInv(matMult(analogBalance, interpolatedCalibMatrix)), asShotNeutral);
 
     Matrix d = IdentityMatrix;
     d[0][0] = 1.0 / referenceNeutral[0];
@@ -2036,22 +2036,22 @@ DCPProfile::Matrix DCPProfile::getCameraToXyzD50Matrix(const double x, const dou
     {
         Matrix interpolatedForwardMatrix = IdentityMatrix;
 
-        Matrix xyzToCamera = matMult(analogBalance, matMult(interpolatedCalibMatrix, interpolatedColorMatrix));
-        Matrix cameraToXyz = matInv(xyzToCamera);
+        const Matrix xyzToCamera = matMult(analogBalance, matMult(interpolatedCalibMatrix, interpolatedColorMatrix));
+        const Matrix cameraToXyz = matInv(xyzToCamera);
 
-        double D50_cct = 5000.706605070579;  //
-        double D50_tint = 9.562965495510433; // Using x, y = 0.3457, 0.3585
-        Matrix cat = getChromaticAdaptationMatrix(getXyzFromChromaticityCoordinates(x, y), getXyzFromTemperature(D50_cct, D50_tint));
+        const double D50_cct = 5000.706605070579;  //
+        const double D50_tint = 9.562965495510433; // Using x, y = 0.3457, 0.3585
+        const Matrix cat = getChromaticAdaptationMatrix(getXyzFromChromaticityCoordinates(x, y), getXyzFromTemperature(D50_cct, D50_tint));
         cameraToXyzD50 = matMult(cat, cameraToXyz);
     }
     else if ((!info.has_forward_matrix_1) || (!info.has_forward_matrix_2))
     {
-        Matrix interpolatedForwardMatrix = info.has_forward_matrix_2 ? forward_matrix_2 : forward_matrix_1;
+        const Matrix interpolatedForwardMatrix = info.has_forward_matrix_2 ? forward_matrix_2 : forward_matrix_1;
         cameraToXyzD50 = matMult(interpolatedForwardMatrix, matMult(d, matInv(matMult(analogBalance, interpolatedCalibMatrix))));
     }
     else
     {
-        Matrix interpolatedForwardMatrix = getInterpolatedMatrix(cct, "forward");
+        const Matrix interpolatedForwardMatrix = getInterpolatedMatrix(cct, "forward");
         cameraToXyzD50 = matMult(interpolatedForwardMatrix, matMult(d, matInv(matMult(analogBalance, interpolatedCalibMatrix))));
     }
 
@@ -2062,7 +2062,7 @@ DCPProfile::Matrix DCPProfile::getCameraToSrgbLinearMatrix(const double x, const
 {
     double cct, tint;
     setChromaticityCoordinates(x, y, cct, tint);
-    Triple xyz = {
+    const Triple xyz = {
         x * 1.f / y,
         1.f,
         (1.f - x - y) * 1.f / y };
@@ -2081,28 +2081,28 @@ DCPProfile::Matrix DCPProfile::getCameraToSrgbLinearMatrix(const double x, const
 
     if ((!info.has_forward_matrix_1) && (!info.has_forward_matrix_2))
     {
-        Matrix interpolatedForwardMatrix = IdentityMatrix;
+        const Matrix interpolatedForwardMatrix = IdentityMatrix;
 
-        Matrix xyzToCamera = interpolatedColorMatrix;
-        Matrix cameraToXyz = matInv(xyzToCamera);
+        const Matrix xyzToCamera = interpolatedColorMatrix;
+        const Matrix cameraToXyz = matInv(xyzToCamera);
 
-        double D50_cct = 5000.706605070579;  //
-        double D50_tint = 9.562965495510433; // Using x, y = 0.3457, 0.3585
-        Matrix cat = getChromaticAdaptationMatrix(getXyzFromChromaticityCoordinates(x, y), getXyzFromTemperature(D50_cct, D50_tint));
+        const double D50_cct = 5000.706605070579;  //
+        const double D50_tint = 9.562965495510433; // Using x, y = 0.3457, 0.3585
+        const Matrix cat = getChromaticAdaptationMatrix(getXyzFromChromaticityCoordinates(x, y), getXyzFromTemperature(D50_cct, D50_tint));
         cameraToXyzD50 = matMult(cat, cameraToXyz);
     }
     else if ((!info.has_forward_matrix_1) || (!info.has_forward_matrix_2))
     {
-        Matrix interpolatedForwardMatrix = info.has_forward_matrix_2 ? forward_matrix_2 : forward_matrix_1;
+        const Matrix interpolatedForwardMatrix = info.has_forward_matrix_2 ? forward_matrix_2 : forward_matrix_1;
         cameraToXyzD50 = interpolatedForwardMatrix;
     }
     else
     {
-        Matrix interpolatedForwardMatrix = getInterpolatedMatrix(cct, "forward");
+        const Matrix interpolatedForwardMatrix = getInterpolatedMatrix(cct, "forward");
         cameraToXyzD50 = interpolatedForwardMatrix;
     }
 
-    Matrix cameraToSrgbLinear = matMult(xyzD50ToSrgbD65LinearMatrix, cameraToXyzD50);
+    const Matrix cameraToSrgbLinear = matMult(xyzD50ToSrgbD65LinearMatrix, cameraToXyzD50);
 
     return cameraToSrgbLinear;
 }
@@ -2138,11 +2138,11 @@ DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeu
         {
             xyzToCamera = color_matrix_1;
         }
-        Matrix cameraToXyz = matInv(xyzToCamera);
+        const Matrix cameraToXyz = matInv(xyzToCamera);
 
-        double D50_cct = 5000.706605070579;  //
-        double D50_tint = 9.562965495510433; // Using x, y = 0.3457, 0.3585
-        Matrix cat = getChromaticAdaptationMatrix(getXyzFromChromaticityCoordinates(x, y), getXyzFromTemperature(D50_cct, D50_tint));
+        const double D50_cct = 5000.706605070579;  //
+        const double D50_tint = 9.562965495510433; // Using x, y = 0.3457, 0.3585
+        const Matrix cat = getChromaticAdaptationMatrix(getXyzFromChromaticityCoordinates(x, y), getXyzFromTemperature(D50_cct, D50_tint));
         cameraToXyzD50 = matMult(cat, cameraToXyz);
     }
     else if ((info.has_forward_matrix_1) && (info.has_forward_matrix_2))
@@ -2204,7 +2204,7 @@ void DCPProfile::getMatricesAsStrings(const std::string& type, std::vector<std::
 
 void DCPProfile::applyLinear(OIIO::ImageBuf& image, Triple neutral, const bool sourceIsRaw)
 {
-    Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw);
+    const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw);
 
     #pragma omp parallel for
     for (int i = 0; i < image.spec().height; ++i)
@@ -2225,7 +2225,6 @@ void DCPProfile::applyLinear(OIIO::ImageBuf& image, Triple neutral, const bool s
             image.setpixel(j, i, rgbOut, 3);
         }
 }
-
 
 DCPDatabase::DCPDatabase(const std::string& databaseDirPath)
 {
@@ -2272,14 +2271,18 @@ bool DCPDatabase::getDcpForCamera(const std::string& make, const std::string& mo
 {
     const std::string dcpKey = make + "_" + model;
 
-    std::map<std::string, image::DCPProfile>::iterator it = dcpStore.find(dcpKey);
-    if (it != dcpStore.end())
     {
-        dcpProf = it->second;
-        return true;
+        // Retrieve preloaded DCPProfile
+        std::map<std::string, image::DCPProfile>::iterator it = dcpStore.find(dcpKey);
+        if (it != dcpStore.end())
+        {
+            dcpProf = it->second;
+            return true;
+        }
     }
-    else
+
     {
+        // Load DCPProfile from disk
         const std::vector<std::string>::iterator it = std::find_if(dcpFilenamesList.begin(), dcpFilenamesList.end(), [make, model](const std::string& s)
             { return (s.find(make) != std::string::npos) && (s.find(model) != std::string::npos); });
 
@@ -2289,11 +2292,9 @@ bool DCPDatabase::getDcpForCamera(const std::string& make, const std::string& mo
             dcpStore.insert(std::pair<std::string, image::DCPProfile>(dcpKey, dcpProf));
             return true;
         }
-        else
-        {
-            return false;
-        }
     }
+
+    return false;
 }
 
 void DCPDatabase::add_or_replace(DCPProfile& dcpProf, const std::string& make, const std::string& model)

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -1031,7 +1031,6 @@ DCPProfile::DCPProfile(const std::string& filename)
     if(!tag)
     {
         ALICEVISION_LOG_WARNING("DCP '" << filename << "' is missing 'ColorMatrix1'. Skipped.");
-        fclose(file);
         return;
     }
 
@@ -1244,11 +1243,6 @@ DCPProfile::DCPProfile(const std::string& filename)
         {
             will_interpolate = true;
         }
-    }
-
-    if(file)
-    {
-        fclose(file);
     }
 
     valid = true;

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -968,7 +968,7 @@ DCPProfile::DCPProfile(const std::string& filename)
         {
             type = TagType::T_INVALID;
             fclose(file);
-            ALICEVISION_LOG_WARNING("ERROR : Invalid Tag in dcp file !");
+            ALICEVISION_LOG_WARNING("ERROR : Invalid Tag in dcp file or file too big : datasize = " << datasize);
             return;
         }
 

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <map>
+#include <vector>
+#include <array>
+#include <memory>
+#include <string>
+
+#include <OpenImageIO/imagebuf.h>
+
+namespace alicevision
+{
+namespace image
+{
+    // Color space conversion to/from XYZ; color spaces adapted to D50 using Bradford transform
+    // Source : Bruce Lindbloom's website : http://www.brucelindbloom.com/
+    constexpr double xyz_sRGB[3][3] = {
+        {0.4360747,  0.3850649, 0.1430804},
+        {0.2225045,  0.7168786,  0.0606169},
+        {0.0139322,  0.0971045,  0.7141733}
+    };      
+    constexpr double sRGB_xyz[3][3] = {
+        {3.1338561, -1.6168667, -0.4906146},
+        { -0.9787684,  1.9161415,  0.0334540},
+        {0.0719453, -0.2289914,  1.4052427}
+    };
+        
+    constexpr double xyz_prophoto[3][3] = {
+        {0.7976749,  0.1351917,  0.0313534},
+        {0.2880402,  0.7118741,  0.0000857},
+        {0.0000000,  0.0000000,  0.8252100}
+    };        
+    constexpr double prophoto_xyz[3][3] = {
+        {1.3459433, -0.2556075, -0.0511118},
+        { -0.5445989,  1.5081673,  0.0205351},
+        {0.0000000,  0.0000000,  1.2118128}
+    };
+
+    constexpr double xyz_AdobeRGB[3][3] = {
+        {0.6097559,  0.2052401,  0.1492240},
+        {0.3111242,  0.6256560,  0.0632197},
+        {0.0194811,  0.0608902,  0.7448387}
+    };
+    constexpr double AdobeRGB_xyz[3][3] = {
+        { 1.9624274, -0.6105343, -0.3413404},
+        {-0.9787684,  1.9161415,  0.0334540},
+        { 0.0286869, -0.1406752,  1.3487655}
+    };
+
+    /**
+     * @brief A class representing a tone curve that can be embedded within a DCP color profile
+     */
+    class SplineToneCurve final
+    {
+    public:
+        SplineToneCurve() = default;
+        ~SplineToneCurve() = default;
+
+        void Set(const std::vector<double>& v_xy);
+        void Apply(float& ir, float& ig, float& ib) const;
+        float operator[](const float idx) const { return getval(idx); }
+
+    private:
+
+        void RGBTone(float& maxval, float& medval, float& minval) const;
+        float getval(const float idx) const;
+
+        std::vector<float> ffffToneCurve = std::vector<float>(65536, 0.f);
+    };
+
+    /**
+     * @brief Aggregate all color profile application options
+     */
+    struct DCPProfileApplyParams {
+        bool apply_hue_shift;
+        bool apply_baseline_exposure_offset;
+        bool use_tone_curve;
+        bool apply_look_table;
+        std::string working_space;
+
+        DCPProfileApplyParams()
+        {
+            apply_hue_shift = true;
+            apply_baseline_exposure_offset = true;
+            use_tone_curve = true;
+            apply_look_table = true;
+            working_space = "sRGB";
+        }
+
+    };
+
+    /**
+     * @brief Aggregate all color profile information
+     */
+    typedef struct DCPProfileInfo {
+        bool has_color_matrix_1;
+        bool has_color_matrix_2;
+        bool has_forward_matrix_1;
+        bool has_forward_matrix_2;
+        bool has_look_table;
+        bool has_hue_sat_map;
+        bool has_tone_curve;
+        bool has_baseline_exposure_offset;
+
+        short light_source_1;
+        short light_source_2;
+        double temperature_1;
+        double temperature_2;
+
+        DCPProfileInfo()
+        {
+            has_color_matrix_1 = false;
+            has_color_matrix_2 = false;
+            has_forward_matrix_1 = false;
+            has_forward_matrix_2 = false;
+            has_look_table = false;
+            has_hue_sat_map = false;
+            has_tone_curve = false;
+            has_baseline_exposure_offset = false;
+
+            light_source_1 = 0;
+            light_source_2 = 0;
+            temperature_1 = 0.0;
+            temperature_2 = 0.0;
+        }
+
+    } DCPProfileInfo;
+
+    /**
+     * @brief A class representing a DCP color profile
+     */
+    class DCPProfile final
+    {
+    public:
+        DCPProfileInfo info;
+
+        using Triple = std::array<double, 3>;
+        using Matrix = std::array<Triple, 3>;
+
+        explicit DCPProfile(const std::string filename);
+        ~DCPProfile();
+
+        void apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& params);
+        void apply(float* rgb, const DCPProfileApplyParams& params) const;
+
+    private:
+        struct HsbModify {
+            float hue_shift;
+            float sat_scale;
+            float val_scale;
+        };
+
+        struct HsdTableInfo {
+            int hue_divisions;
+            int sat_divisions;
+            int val_divisions;
+            int hue_step;
+            int val_step;
+            unsigned int array_count;
+            bool srgb_gamma;
+            struct {
+                float h_scale;
+                float s_scale;
+                float v_scale;
+                int max_hue_index0;
+                int max_sat_index0;
+                int max_val_index0;
+                int hue_step;
+                int val_step;
+            } pc;
+        };
+
+        void hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h, float& s, float& v) const;
+
+        Matrix ws_sRGB;
+        Matrix sRGB_ws;
+        Matrix color_matrix_1;
+        Matrix color_matrix_2;
+        bool will_interpolate;
+        bool valid;
+        Matrix forward_matrix_1;
+        Matrix forward_matrix_2;
+        double baseline_exposure_offset;
+        std::vector<HsbModify> deltas_1;
+        std::vector<HsbModify> deltas_2;
+        std::vector<HsbModify> look_table;
+        HsdTableInfo delta_info;
+        HsdTableInfo look_info;
+
+        SplineToneCurve AS_tone_curve;
+
+        SplineToneCurve gammatab_srgb;
+        SplineToneCurve igammatab_srgb;
+    };
+
+}
+}

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -119,9 +119,12 @@ struct DCPProfileApplyParams
 struct DCPProfileInfo
 {
     std::string filename = "";
+    std::string profileCalibrationSignature = "";
 
     bool has_color_matrix_1 = false;
     bool has_color_matrix_2 = false;
+    bool has_camera_calibration_1 = false;
+    bool has_camera_calibration_2 = false;
     bool has_forward_matrix_1 = false;
     bool has_forward_matrix_2 = false;
     bool has_look_table = false;
@@ -233,27 +236,25 @@ private:
     Triple matMult(const Matrix& M, const Triple& V);
     Matrix matInv(const Matrix& M);
 
-    Matrix getInterpolatedMatrix(const float cct, const std::string& type);
-    void getChromaticityCoordinatesFromXyz(const Triple& xyz, float& x, float& y);
-    Triple getXyzFromChromaticityCoordinates(const float x, const float y);
-    Triple getXyzFromTemperature(const float cct, const float tint = 0.f);
-    void setChromaticityCoordinates(const float x, const float y, float& cct, float& tint);
-    void getChromaticityCoordinates(const float cct, const float tint, float& x, float& y);
-    void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, float& x, float& y);
+    Matrix getInterpolatedMatrix(const double cct, const std::string& type);
+    void getChromaticityCoordinatesFromXyz(const Triple& xyz, double& x, double& y);
+    Triple getXyzFromChromaticityCoordinates(const double x, const double y);
+    Triple getXyzFromTemperature(const double cct, const double tint = 0.f);
+    void setChromaticityCoordinates(const double x, const double y, double& cct, double& tint);
+    void getChromaticityCoordinates(const double cct, const double tint, double& x, double& y);
+    void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, double& x, double& y);
     Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
-    Matrix getCameraToXyzD50Matrix(const float x, const float y);
-    Matrix getCameraToSrgbLinearMatrix(const float x, const float y);
+    Matrix getCameraToXyzD50Matrix(const double x, const double y);
+    Matrix getCameraToSrgbLinearMatrix(const double x, const double y);
     Matrix getCameraToSrgbLinearMatrix(const Triple& asShotNeutral, const bool sourceIsRaw = false);
 
     Matrix ws_sRGB; // working color space to sRGB
     Matrix sRGB_ws; // sRGB to working color space
     Matrix color_matrix_1; // Color matrix for illuminant 1
     Matrix color_matrix_2; // Color matrix for illuminant 2
-    Matrix calib_matrix_1; // Calibration matrix for illuminant 1
-    Matrix calib_matrix_2; // Calibration matrix for illuminant 2
+    Matrix camera_calibration_1; // Calibration matrix for illuminant 1
+    Matrix camera_calibration_2; // Calibration matrix for illuminant 2
     Matrix analogBalance;
-    bool will_interpolate;
-    bool valid;
     Matrix forward_matrix_1; // white balanced raw to xyzD50 for illumimant 1
     Matrix forward_matrix_2; // white balanced raw to xyzD50 for illumimant 2
     double baseline_exposure_offset;

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -8,7 +8,7 @@
 
 #include <OpenImageIO/imagebuf.h>
 
-namespace alicevision {
+namespace aliceVision {
 namespace image {
 
 /**
@@ -114,7 +114,7 @@ struct DCPProfileApplyParams
 };
 
  /**
-  * @brief DCPProfileInfo contains information about matrices, table and curves containes in the profile
+  * @brief DCPProfileInfo contains information about matrices, table and curves contained in the profile
   */
 struct DCPProfileInfo
 {
@@ -266,6 +266,69 @@ private:
     SplineToneCurve gammatab_srgb;
     SplineToneCurve igammatab_srgb;
 };
+
+/**
+* @brief DCPDatabase manages DCP profiles loading and caching
+*/
+class DCPDatabase final
+{
+public:
+    DCPDatabase() = default;
+    DCPDatabase(const std::string& databaseDirPath);
+
+    ~DCPDatabase() = default;
+
+    /**
+     * @brief load stores in a file list all the valid dcp filenames found in a folder (including subfolders). 
+     * None of them are loaded in cache.
+     * param[in] database folder name.
+     * param[in] if true loading is forced even if a database with the same folder name is already loaded.
+     * return Number of DCP files found.
+     */
+    int load(const std::string& databaseDirPath, bool force = false);
+
+    /**
+     * @brief clear clears the cache and the DCP file list.
+     */
+    void clear();
+
+    /**
+     * @brief Check if the databse is empty.
+     * return True if empty.
+     */
+    inline bool empty() { return dcpFilenamesList.empty(); }
+
+    /**
+     * @brief add_or_replace adds or replaces an existing DCP profile in the cache.
+     * Update the DCP file list with dcpProf.info.filename. 
+     * param[in] DCP profile to be stored.
+     * param[in] DSLR Maker.
+     * param[in] DSLR Model.
+     */
+    void add_or_replace(DCPProfile& dcpProf, const std::string& make, const std::string& model);
+
+    /**
+     * @brief getDcpForCamera gets a DCP profile in the database for a given camera.
+     * Search first in the cache. If no DCP profile is found search if an appropriate DCP file exists in the file list.
+     * If a dcp file is found then load it and store it in the cache.
+     * param[in] make The camera maker
+     * param[in] model The camera model
+     * param[in] dcpProf the DCP profile to be filled in
+     * return True if a corresponding profile has been found
+     */
+    bool getDcpForCamera(const std::string& make, const std::string& model, DCPProfile& dcpProf);
+
+private:
+
+    std::string folderName;
+
+    std::vector<std::string> dcpFilenamesList;
+
+    std::map<std::string, DCPProfile> dcpStore;
+
+};
+
+
 
 }
 }

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -118,6 +118,8 @@ struct DCPProfileApplyParams
   */
 struct DCPProfileInfo
 {
+    std::string filename = "";
+
     bool has_color_matrix_1 = false;
     bool has_color_matrix_2 = false;
     bool has_forward_matrix_1 = false;
@@ -146,6 +148,8 @@ public:
     using Triple = std::array<double, 3>;
     using Matrix = std::array<Triple, 3>;
 
+    DCPProfile();
+
     /**
     * @brief DCPProfile constructor
     * @param[in] filename The dcp path on disk
@@ -154,11 +158,24 @@ public:
     ~DCPProfile();
 
     /**
+    * @brief DCPProfile loader
+    * @param[in] filename The dcp path on disk
+    */
+    void Load(const std::string& filename);
+
+    /**
      * @brief getMatrices gets some matrices contained in the profile
      * param[in] type The matrices to get, "color" or "forward"
      * param[in] v_Mat A vector of matrices to be populated
      */
     void getMatrices(const std::string& type, std::vector<Matrix>& v_Mat);
+
+    /**
+     * @brief getMatrices gets some matrices contained in the profile in a string format (one string per matrix)
+     * param[in] type The matrices to get, "color" or "forward"
+     * param[in] v_Mat A vector of std::string to be populated
+     */
+    void getMatricesAsStrings(const std::string& type, std::vector<std::string>& v_strMat);
 
     /**
      * @brief applyLinear applies the linear part of a DCP profile on an OIIO image buffer

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -8,207 +8,216 @@
 
 #include <OpenImageIO/imagebuf.h>
 
-namespace alicevision
-{
-namespace image
-{
-    // Color space conversion to/from XYZ; color spaces adapted to D50 using Bradford transform
-    // Source : Bruce Lindbloom's website : http://www.brucelindbloom.com/
-    constexpr double xyz_sRGB[3][3] = {
-        {0.4360747,  0.3850649, 0.1430804},
-        {0.2225045,  0.7168786,  0.0606169},
-        {0.0139322,  0.0971045,  0.7141733}
-    };      
-    constexpr double sRGB_xyz[3][3] = {
-        {3.1338561, -1.6168667, -0.4906146},
-        { -0.9787684,  1.9161415,  0.0334540},
-        {0.0719453, -0.2289914,  1.4052427}
-    };
+namespace alicevision {
+namespace image {
+
+/**
+ * @defgroup colorConvertMatrices Color space conversion to/from XYZ
+ * color spaces adapted to D50 using Bradford transform
+ * Source : Bruce Lindbloom's website : http://www.brucelindbloom.com/
+ * @{
+ */
+constexpr double xyz_sRGB[3][3] = {
+    {0.4360747,  0.3850649, 0.1430804},
+    {0.2225045,  0.7168786,  0.0606169},
+    {0.0139322,  0.0971045,  0.7141733}
+};      
+constexpr double sRGB_xyz[3][3] = {
+    {3.1338561, -1.6168667, -0.4906146},
+    { -0.9787684,  1.9161415,  0.0334540},
+    {0.0719453, -0.2289914,  1.4052427}
+};
         
-    constexpr double xyz_prophoto[3][3] = {
-        {0.7976749,  0.1351917,  0.0313534},
-        {0.2880402,  0.7118741,  0.0000857},
-        {0.0000000,  0.0000000,  0.8252100}
-    };        
-    constexpr double prophoto_xyz[3][3] = {
-        {1.3459433, -0.2556075, -0.0511118},
-        { -0.5445989,  1.5081673,  0.0205351},
-        {0.0000000,  0.0000000,  1.2118128}
-    };
+constexpr double xyz_prophoto[3][3] = {
+    {0.7976749,  0.1351917,  0.0313534},
+    {0.2880402,  0.7118741,  0.0000857},
+    {0.0000000,  0.0000000,  0.8252100}
+};        
+constexpr double prophoto_xyz[3][3] = {
+    {1.3459433, -0.2556075, -0.0511118},
+    { -0.5445989,  1.5081673,  0.0205351},
+    {0.0000000,  0.0000000,  1.2118128}
+};
 
-    constexpr double xyz_AdobeRGB[3][3] = {
-        {0.6097559,  0.2052401,  0.1492240},
-        {0.3111242,  0.6256560,  0.0632197},
-        {0.0194811,  0.0608902,  0.7448387}
-    };
-    constexpr double AdobeRGB_xyz[3][3] = {
-        { 1.9624274, -0.6105343, -0.3413404},
-        {-0.9787684,  1.9161415,  0.0334540},
-        { 0.0286869, -0.1406752,  1.3487655}
-    };
+constexpr double xyz_AdobeRGB[3][3] = {
+    {0.6097559,  0.2052401,  0.1492240},
+    {0.3111242,  0.6256560,  0.0632197},
+    {0.0194811,  0.0608902,  0.7448387}
+};
+constexpr double AdobeRGB_xyz[3][3] = {
+    { 1.9624274, -0.6105343, -0.3413404},
+    {-0.9787684,  1.9161415,  0.0334540},
+    { 0.0286869, -0.1406752,  1.3487655}
+};
+/// @}
 
-    /**
-     * @brief A class representing a tone curve that can be embedded within a DCP color profile
-     */
-    class SplineToneCurve final
+enum class LightSource
+{
+    UNKNOWN = 0,
+    DAYLIGHT = 1,
+    FLUORESCENT = 2,
+    TUNGSTEN = 3,
+    FLASH = 4,
+    FINE_WEATHER = 9,
+    CLOUDY_WEATHER = 10,
+    SHADE = 11,
+    DAYLIGHT_FLUORESCENT = 12,   // D  5700 - 7100K
+    DAYWHITE_FLUORESCENT = 13,   // N  4600 - 5500K
+    COOL_WHITE_FLUORESCENT = 14, // W  3800 - 4500K
+    WHITE_FLUORESCENT = 15,      // WW 3250 - 3800K
+    WARM_WHITE_FLUORESCENT = 16, // L  2600 - 3250K
+    STANDARD_LIGHT_A = 17,
+    STANDARD_LIGHT_B = 18,
+    STANDARD_LIGHT_C = 19,
+    D55 = 20,
+    D65 = 21,
+    D75 = 22,
+    D50 = 23,
+    ISO_STUDIO_TUNGSTEN = 24,
+    OTHER = 255
+};
+
+double calibrationIlluminantToTemperature(LightSource light);
+
+
+/**
+ * @brief A class representing a tone curve that can be embedded within a DCP color profile
+ */
+class SplineToneCurve final
+{
+public:
+    SplineToneCurve() = default;
+    ~SplineToneCurve() = default;
+
+    void Set(const std::vector<double>& v_xy);
+    void Apply(float& ir, float& ig, float& ib) const;
+    float operator[](const float idx) const { return getval(idx); }
+
+private:
+
+    void RGBTone(float& maxval, float& medval, float& minval) const;
+    float getval(const float idx) const;
+
+    std::vector<float> ffffToneCurve = std::vector<float>(65536, 0.f);
+};
+
+/**
+ * @brief Aggregate all color profile application options
+ */
+struct DCPProfileApplyParams
+{
+    bool apply_hue_shift = true;
+    bool apply_baseline_exposure_offset = true;
+    bool use_tone_curve = true;
+    bool apply_look_table = true;
+    std::string working_space = "sRGB";
+};
+
+/**
+ * @brief Aggregate all color profile information
+ */
+struct DCPProfileInfo
+{
+    bool has_color_matrix_1 = false;
+    bool has_color_matrix_2 = false;
+    bool has_forward_matrix_1 = false;
+    bool has_forward_matrix_2 = false;
+    bool has_look_table = false;
+    bool has_hue_sat_map = false;
+    bool has_tone_curve = false;
+    bool has_baseline_exposure_offset = false;
+
+    short light_source_1 = 0;
+    short light_source_2 = 0;
+    double temperature_1 = 0.0;
+    double temperature_2 = 0.0;
+};
+
+/**
+    * @brief A class representing a DCP color profile
+    */
+class DCPProfile final
+{
+public:
+    DCPProfileInfo info;
+
+    using Triple = std::array<double, 3>;
+    using Matrix = std::array<Triple, 3>;
+
+    explicit DCPProfile(const std::string& filename);
+    ~DCPProfile();
+
+    void apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& params);
+    void apply(float* rgb, const DCPProfileApplyParams& params) const;
+
+private:
+    struct HsbModify
     {
-    public:
-        SplineToneCurve() = default;
-        ~SplineToneCurve() = default;
-
-        void Set(const std::vector<double>& v_xy);
-        void Apply(float& ir, float& ig, float& ib) const;
-        float operator[](const float idx) const { return getval(idx); }
-
-    private:
-
-        void RGBTone(float& maxval, float& medval, float& minval) const;
-        float getval(const float idx) const;
-
-        std::vector<float> ffffToneCurve = std::vector<float>(65536, 0.f);
+        float hue_shift;
+        float sat_scale;
+        float val_scale;
     };
 
-    /**
-     * @brief Aggregate all color profile application options
-     */
-    struct DCPProfileApplyParams {
-        bool apply_hue_shift;
-        bool apply_baseline_exposure_offset;
-        bool use_tone_curve;
-        bool apply_look_table;
-        std::string working_space;
-
-        DCPProfileApplyParams()
-        {
-            apply_hue_shift = true;
-            apply_baseline_exposure_offset = true;
-            use_tone_curve = true;
-            apply_look_table = true;
-            working_space = "sRGB";
-        }
-
-    };
-
-    /**
-     * @brief Aggregate all color profile information
-     */
-    typedef struct DCPProfileInfo {
-        bool has_color_matrix_1;
-        bool has_color_matrix_2;
-        bool has_forward_matrix_1;
-        bool has_forward_matrix_2;
-        bool has_look_table;
-        bool has_hue_sat_map;
-        bool has_tone_curve;
-        bool has_baseline_exposure_offset;
-
-        short light_source_1;
-        short light_source_2;
-        double temperature_1;
-        double temperature_2;
-
-        DCPProfileInfo()
-        {
-            has_color_matrix_1 = false;
-            has_color_matrix_2 = false;
-            has_forward_matrix_1 = false;
-            has_forward_matrix_2 = false;
-            has_look_table = false;
-            has_hue_sat_map = false;
-            has_tone_curve = false;
-            has_baseline_exposure_offset = false;
-
-            light_source_1 = 0;
-            light_source_2 = 0;
-            temperature_1 = 0.0;
-            temperature_2 = 0.0;
-        }
-
-    } DCPProfileInfo;
-
-    /**
-     * @brief A class representing a DCP color profile
-     */
-    class DCPProfile final
+    struct HsdTableInfo
     {
-    public:
-        DCPProfileInfo info;
-
-        using Triple = std::array<double, 3>;
-        using Matrix = std::array<Triple, 3>;
-
-        explicit DCPProfile(const std::string filename);
-        ~DCPProfile();
-
-        void apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& params);
-        void apply(float* rgb, const DCPProfileApplyParams& params) const;
-
-    private:
-        struct HsbModify {
-            float hue_shift;
-            float sat_scale;
-            float val_scale;
-        };
-
-        struct HsdTableInfo {
-            int hue_divisions;
-            int sat_divisions;
-            int val_divisions;
+        int hue_divisions;
+        int sat_divisions;
+        int val_divisions;
+        int hue_step;
+        int val_step;
+        unsigned int array_count;
+        bool srgb_gamma;
+        struct {
+            float h_scale;
+            float s_scale;
+            float v_scale;
+            int max_hue_index0;
+            int max_sat_index0;
+            int max_val_index0;
             int hue_step;
             int val_step;
-            unsigned int array_count;
-            bool srgb_gamma;
-            struct {
-                float h_scale;
-                float s_scale;
-                float v_scale;
-                int max_hue_index0;
-                int max_sat_index0;
-                int max_val_index0;
-                int hue_step;
-                int val_step;
-            } pc;
-        };
-
-        void hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h, float& s, float& v) const;
-
-        Matrix matMult(const Matrix& A, const Matrix& B);
-        Triple matMult(const Matrix& M, const Triple& V);
-        Matrix matInv(const Matrix& M);
-
-        Matrix getInterpolatedMatrix(const float& cct, const std::string& type);
-        void getChromaticityCoordinatesFromXyz(const Triple& xyz, float& x, float& y);
-        Triple getXyzFromChromaticityCoordinates(const float& x, const float& y);
-        Triple getXyzFromTemperature(const float& cct, const float& tint = 0.f);
-        void setChromaticityCoordinates(const float& x, const float& y, float& cct, float& tint);
-        void getChromaticityCoordinates(const float& cct, const float& tint, float& x, float& y);
-        void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, float& x, float& y);
-        Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
-        Matrix getCameraToXyzD50Matrix(const float& x, const float& y);
-
-        Matrix ws_sRGB;
-        Matrix sRGB_ws;
-        Matrix color_matrix_1;
-        Matrix color_matrix_2;
-        Matrix calib_matrix_1;
-        Matrix calib_matrix_2;
-        Matrix analogBalance;
-        bool will_interpolate;
-        bool valid;
-        Matrix forward_matrix_1;
-        Matrix forward_matrix_2;
-        double baseline_exposure_offset;
-        std::vector<HsbModify> deltas_1;
-        std::vector<HsbModify> deltas_2;
-        std::vector<HsbModify> look_table;
-        HsdTableInfo delta_info;
-        HsdTableInfo look_info;
-
-        SplineToneCurve AS_tone_curve;
-
-        SplineToneCurve gammatab_srgb;
-        SplineToneCurve igammatab_srgb;
+        } pc;
     };
+
+    void hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h, float& s, float& v) const;
+
+    Matrix matMult(const Matrix& A, const Matrix& B);
+    Triple matMult(const Matrix& M, const Triple& V);
+    Matrix matInv(const Matrix& M);
+
+    Matrix getInterpolatedMatrix(const float cct, const std::string& type);
+    void getChromaticityCoordinatesFromXyz(const Triple& xyz, float& x, float& y);
+    Triple getXyzFromChromaticityCoordinates(const float x, const float y);
+    Triple getXyzFromTemperature(const float cct, const float tint = 0.f);
+    void setChromaticityCoordinates(const float x, const float y, float& cct, float& tint);
+    void getChromaticityCoordinates(const float cct, const float tint, float& x, float& y);
+    void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, float& x, float& y);
+    Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
+    Matrix getCameraToXyzD50Matrix(const float x, const float y);
+
+    Matrix ws_sRGB;
+    Matrix sRGB_ws;
+    Matrix color_matrix_1;
+    Matrix color_matrix_2;
+    Matrix calib_matrix_1;
+    Matrix calib_matrix_2;
+    Matrix analogBalance;
+    bool will_interpolate;
+    bool valid;
+    Matrix forward_matrix_1;
+    Matrix forward_matrix_2;
+    double baseline_exposure_offset;
+    std::vector<HsbModify> deltas_1;
+    std::vector<HsbModify> deltas_2;
+    std::vector<HsbModify> look_table;
+    HsdTableInfo delta_info;
+    HsdTableInfo look_info;
+
+    SplineToneCurve AS_tone_curve;
+
+    SplineToneCurve gammatab_srgb;
+    SplineToneCurve igammatab_srgb;
+};
 
 }
 }

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -172,10 +172,27 @@ namespace image
 
         void hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h, float& s, float& v) const;
 
+        Matrix matMult(const Matrix& A, const Matrix& B);
+        Triple matMult(const Matrix& M, const Triple& V);
+        Matrix matInv(const Matrix& M);
+
+        Matrix getInterpolatedMatrix(const float& cct, const std::string& type);
+        void getChromaticityCoordinatesFromXyz(const Triple& xyz, float& x, float& y);
+        Triple getXyzFromChromaticityCoordinates(const float& x, const float& y);
+        Triple getXyzFromTemperature(const float& cct, const float& tint = 0.f);
+        void setChromaticityCoordinates(const float& x, const float& y, float& cct, float& tint);
+        void getChromaticityCoordinates(const float& cct, const float& tint, float& x, float& y);
+        void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, float& x, float& y);
+        Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
+        Matrix getCameraToXyzD50Matrix(const float& x, const float& y);
+
         Matrix ws_sRGB;
         Matrix sRGB_ws;
         Matrix color_matrix_1;
         Matrix color_matrix_2;
+        Matrix calib_matrix_1;
+        Matrix calib_matrix_2;
+        Matrix analogBalance;
         bool will_interpolate;
         bool valid;
         Matrix forward_matrix_1;

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -147,6 +147,10 @@ public:
     explicit DCPProfile(const std::string& filename);
     ~DCPProfile();
 
+    void getMatrices(const std::string& type, std::vector<Matrix>& v_Mat);
+
+    void applyLinear(OIIO::ImageBuf& image, Triple neutral);
+
     void apply(OIIO::ImageBuf& image, const DCPProfileApplyParams& params);
     void apply(float* rgb, const DCPProfileApplyParams& params) const;
 
@@ -194,6 +198,7 @@ private:
     void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, float& x, float& y);
     Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
     Matrix getCameraToXyzD50Matrix(const float x, const float y);
+    Matrix getCameraToSrgbLinearMatrix(const float x, const float y);
 
     Matrix ws_sRGB;
     Matrix sRGB_ws;

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -246,7 +246,7 @@ private:
     Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
     Matrix getCameraToXyzD50Matrix(const double x, const double y);
     Matrix getCameraToSrgbLinearMatrix(const double x, const double y);
-    Matrix getCameraToSrgbLinearMatrix(const Triple& asShotNeutral, const bool sourceIsRaw = false);
+    Matrix getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw = false);
 
     Matrix ws_sRGB; // working color space to sRGB
     Matrix sRGB_ws; // sRGB to working color space

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -181,8 +181,9 @@ public:
      * @brief applyLinear applies the linear part of a DCP profile on an OIIO image buffer
      * param[in] image The OIIO image on which the profile must be applied
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
+     * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      */
-    void applyLinear(OIIO::ImageBuf& image, Triple neutral);
+    void applyLinear(OIIO::ImageBuf& image, Triple neutral, const bool sourceIsRaw = false);
 
     /**
      * @brief apply applies the non linear part of a DCP profile on an OIIO image buffer
@@ -242,6 +243,7 @@ private:
     Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
     Matrix getCameraToXyzD50Matrix(const float x, const float y);
     Matrix getCameraToSrgbLinearMatrix(const float x, const float y);
+    Matrix getCameraToSrgbLinearMatrix(const Triple& asShotNeutral, const bool sourceIsRaw = false);
 
     Matrix ws_sRGB; // working color space to sRGB
     Matrix sRGB_ws; // sRGB to working color space

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -476,8 +476,11 @@ void readImage(const std::string& path,
             {
                 ALICEVISION_THROW_ERROR("A DCP color profile is required but cannot be found");
             }
+            float user_mul[4] = { 1,1,1,1 };
+
             configSpec.attribute("raw:auto_bright", 0); // disable exposure correction
             configSpec.attribute("raw:use_camera_wb", 0); // no white balance correction
+            configSpec.attribute("raw:user_mul", oiio::TypeDesc(oiio::TypeDesc::FLOAT, 4), user_mul); // no neutralization
             configSpec.attribute("raw:use_camera_matrix", 0); // do not use embeded color profile if any
             configSpec.attribute("raw:ColorSpace", "raw");
         }
@@ -538,7 +541,7 @@ void readImage(const std::string& path,
 
         ALICEVISION_LOG_TRACE("Apply DCP Linear processing with neutral = {" << neutral[0] << ", " << neutral[1] << ", " << neutral[2] << "}");
 
-        dcpProfile.applyLinear(inBuf, neutral, false); // inBuf is already neutralized but neutral is needed for color Temperature estimation
+        dcpProfile.applyLinear(inBuf, neutral, true);
     }
 
     // color conversion

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -395,7 +395,13 @@ void readImage(const std::string& path,
 
   ALICEVISION_LOG_TRACE("Read image " << path << " (encoded in " << fromColorSpaceName << " colorspace).");
 
-  if (imageReadOptions.workingColorSpace != image::EImageColorSpace::NO_CONVERSION)
+      alicevision::image::DCPProfileApplyParams DCPparams;
+      DCPparams.use_tone_curve = imageReadOptions.applyToneCurve;
+
+      colorProfile.apply(inBuf, DCPparams);
+  }
+
+  if(imageReadOptions.workingColorSpace == EImageColorSpace::SRGB) // color conversion to sRGB
   {
       imageAlgo::colorconvert(inBuf, fromColorSpaceName, imageReadOptions.workingColorSpace);
   }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -553,7 +553,7 @@ void readImage(const std::string& path,
         size_t next = 1;
         while ((next = cam_mul.find(",", last)) != std::string::npos)
         {
-            v_mult.push_back(atoi(cam_mul.substr(last, next - last).c_str()));
+            v_mult.push_back(atof(cam_mul.substr(last, next - last).c_str()));
             last = next + 1;
         }
         v_mult.push_back(atof(cam_mul.substr(last, cam_mul.find("}", last) - last).c_str()));
@@ -563,6 +563,8 @@ void readImage(const std::string& path,
         {
             neutral[i] = v_mult[i] / v_mult[1];
         }
+
+        ALICEVISION_LOG_TRACE("Apply DCP Linear processing with neutral = {" << neutral[0] << ", " << neutral[1] << ", " << neutral[2] << "}");
 
         dcpProfile.applyLinear(inBuf, neutral);
     }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -255,12 +255,11 @@ bool isSupportedUndistortFormat(const std::string &ext)
 std::string ERawColorInterpretation_informations()
 {
     return "Raw color interpretation :\n"
-           "* None \n"
-           "* libRaw whithout white balancing \n"
-           "* libRaw whith white balancing \n"
-           "* DCP linear processing mandatory \n"
-           "* None but DCP info in metadata mandatory \n"
-           "* Read image metadata to set processing method";
+           "* none : None \n"
+           "* librawnowhitebalancing : libRaw whithout white balancing \n"
+           "* librawwhitebalancing : libRaw whith white balancing \n"
+           "* dcplinearprocessing : DCP linear processing \n"
+           "* dcpmetadata : None but DCP info embedded in metadata";
 }
 
 ERawColorInterpretation ERawColorInterpretation_stringToEnum(const std::string& rawColorInterpretation)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -515,7 +515,7 @@ void readImage(const std::string& path,
     if (!imageReadOptions.colorProfileFileName.empty() &&
         imageReadOptions.rawColorInterpretation == ERawColorInterpretation::DcpLinearProcessing)
     {
-        alicevision::image::DCPProfile dcpProfile(imageReadOptions.colorProfileFileName);
+        image::DCPProfile dcpProfile(imageReadOptions.colorProfileFileName);
 
         oiio::ParamValueList imgMetadata = readImageMetadata(path);
         std::string cam_mul;
@@ -530,7 +530,7 @@ void readImage(const std::string& path,
         }
         v_mult.push_back(atof(cam_mul.substr(last, cam_mul.find("}", last) - last).c_str()));
 
-        alicevision::image::DCPProfile::Triple neutral;
+        image::DCPProfile::Triple neutral;
         for (int i = 0; i < 3; i++)
         {
             neutral[i] = v_mult[1] / v_mult[i];

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -255,14 +255,14 @@ bool isSupportedUndistortFormat(const std::string &ext)
 std::string ERawColorInterpretation_informations()
 {
     return "Raw color interpretation :\n"
-        "* None \n"
-        "* libRaw whithout white balancing ";
-        "* libRaw whith white balancing ";
-        "* DCP linear processing if available ";
-        "* DCP linear processing mandatory ";
-        "* None but if DCP available info in metadata ";
-        "* None but DCP info in metadata mandatory ";
-        "* Read image metadata to set processing method ";
+           "* None \n"
+           "* libRaw whithout white balancing \n"
+           "* libRaw whith white balancing \n"
+           "* DCP linear processing if available \n"
+           "* DCP linear processing mandatory \n"
+           "* None but if DCP available info in metadata \n"
+           "* None but DCP info in metadata mandatory \n"
+           "* Read image metadata to set processing method";
 }
 
 ERawColorInterpretation ERawColorInterpretation_stringToEnum(const std::string& rawColorInterpretation)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -262,6 +262,7 @@ std::string ERawColorInterpretation_informations()
         "* DCP linear processing mandatory ";
         "* None but if DCP available info in metadata ";
         "* None but DCP info in metadata mandatory ";
+        "* Read image metadata to set processing method ";
 }
 
 ERawColorInterpretation ERawColorInterpretation_stringToEnum(const std::string& rawColorInterpretation)
@@ -283,6 +284,8 @@ ERawColorInterpretation ERawColorInterpretation_stringToEnum(const std::string& 
         return ERawColorInterpretation::DcpMetadata_ifAvailable;
     if (type == "dcpmetadata_required")
         return ERawColorInterpretation::DcpMetadata_required;
+    if (type == "auto")
+        return ERawColorInterpretation::Auto;
 
     throw std::out_of_range("Invalid raw color interpretation : " + rawColorInterpretation);
 
@@ -299,6 +302,7 @@ std::string ERawColorInterpretation_enumToString(const ERawColorInterpretation r
         case ERawColorInterpretation::DcpLinearProcessing_required: return "dcpLinearprocessing_required";
         case ERawColorInterpretation::DcpMetadata_ifAvailable: return "dcpmetadata_ifavailable";
         case ERawColorInterpretation::DcpMetadata_required: return "dcpmetadata_required";
+        case ERawColorInterpretation::Auto: return "auto";
     }
     throw std::out_of_range("Invalid ERawColorInterpretation enum");
 }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -561,7 +561,7 @@ void readImage(const std::string& path,
         alicevision::image::DCPProfile::Triple neutral;
         for (int i = 0; i < 3; i++)
         {
-            neutral[i] = v_mult[i] / v_mult[1];
+            neutral[i] = v_mult[1] / v_mult[i];
         }
 
         ALICEVISION_LOG_TRACE("Apply DCP Linear processing with neutral = {" << neutral[0] << ", " << neutral[1] << ", " << neutral[2] << "}");

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -477,7 +477,7 @@ void readImage(const std::string& path,
                 ALICEVISION_THROW_ERROR("A DCP color profile is required but cannot be found");
             }
             configSpec.attribute("raw:auto_bright", 0); // disable exposure correction
-            configSpec.attribute("raw:use_camera_wb", 0); // white balance correction
+            configSpec.attribute("raw:use_camera_wb", 0); // no white balance correction
             configSpec.attribute("raw:use_camera_matrix", 0); // do not use embeded color profile if any
             configSpec.attribute("raw:ColorSpace", "raw");
         }
@@ -546,7 +546,9 @@ void readImage(const std::string& path,
         ALICEVISION_THROW_ERROR("You must specify a requested color space for image file '" + path + "'.");
 
     // Get color space name. Default image color space is sRGB
-    const std::string fromColorSpaceName = isRawImage ? "Linear" : inBuf.spec().get_string_attribute("aliceVision:ColorSpace", inBuf.spec().get_string_attribute("oiio:ColorSpace", "sRGB"));
+    const std::string fromColorSpaceName = (isRawImage && imageReadOptions.rawColorInterpretation == ERawColorInterpretation::DcpLinearProcessing) ? "aces2065-1" :
+                                            (isRawImage ? "linear" :
+                                             inBuf.spec().get_string_attribute("aliceVision:ColorSpace", inBuf.spec().get_string_attribute("oiio:ColorSpace", "sRGB")));
 
     ALICEVISION_LOG_TRACE("Read image " << path << " (encoded in " << fromColorSpaceName << " colorspace).");
   

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -395,11 +395,12 @@ void readImage(const std::string& path,
 
   ALICEVISION_LOG_TRACE("Read image " << path << " (encoded in " << fromColorSpaceName << " colorspace).");
 
-      alicevision::image::DCPProfileApplyParams DCPparams;
-      DCPparams.use_tone_curve = imageReadOptions.applyToneCurve;
+  
+  //    alicevision::image::DCPProfileApplyParams DCPparams;
+  //    DCPparams.use_tone_curve = imageReadOptions.applyToneCurve;
 
-      colorProfile.apply(inBuf, DCPparams);
-  }
+  //    colorProfile.apply(inBuf, DCPparams);
+  //}
 
   if(imageReadOptions.workingColorSpace != EImageColorSpace::NO_CONVERSION)
   {

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -401,7 +401,7 @@ void readImage(const std::string& path,
       colorProfile.apply(inBuf, DCPparams);
   }
 
-  if(imageReadOptions.workingColorSpace == EImageColorSpace::SRGB) // color conversion to sRGB
+  if(imageReadOptions.workingColorSpace != EImageColorSpace::NO_CONVERSION)
   {
       imageAlgo::colorconvert(inBuf, fromColorSpaceName, imageReadOptions.workingColorSpace);
   }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -450,11 +450,11 @@ void readImage(const std::string& path,
             float user_mul[4] = {1,1,1,1};
 
             configSpec.attribute("raw:auto_bright", 0); // disable exposure correction
-            configSpec.attribute("raw:use_camera_wb", 1); // white balance correction (with user multiplicators)
-            configSpec.attribute("raw:user_mul", oiio::TypeDesc::FLOAT, user_mul); // no neutralization
+            configSpec.attribute("raw:use_camera_wb", 0); // no white balance correction
+            configSpec.attribute("raw:user_mul", oiio::TypeDesc(oiio::TypeDesc::FLOAT, 4), user_mul); // no neutralization
             configSpec.attribute("raw:use_camera_matrix", 0); // do not use embeded color profile if any
             configSpec.attribute("raw:ColorSpace", "raw"); // use raw data
-            configSpec.attribute("raw:HighlightMode", 0); // unclip
+            configSpec.attribute("raw:HighlightMode", 1); // unclip
         }
         else if (imageReadOptions.rawColorInterpretation == ERawColorInterpretation::LibRawNoWhiteBalancing)
         {
@@ -490,11 +490,11 @@ void readImage(const std::string& path,
             float user_mul[4] = { 1,1,1,1 };
 
             configSpec.attribute("raw:auto_bright", 0); // disable exposure correction
-            configSpec.attribute("raw:use_camera_wb", 1); // white balance correction (with user multiplicators)
-            configSpec.attribute("raw:user_mul", oiio::TypeDesc::FLOAT, user_mul); // no neutralization
+            configSpec.attribute("raw:use_camera_wb", 0); // no white balance correction
+            configSpec.attribute("raw:user_mul", oiio::TypeDesc(oiio::TypeDesc::FLOAT, 4), user_mul); // no neutralization
             configSpec.attribute("raw:use_camera_matrix", 0); // do not use embeded color profile if any
             configSpec.attribute("raw:ColorSpace", "raw"); // use raw data
-            configSpec.attribute("raw:HighlightMode", 0); // unclip
+            configSpec.attribute("raw:HighlightMode", 1); // unclip
         }
     }
 
@@ -538,7 +538,7 @@ void readImage(const std::string& path,
 
         ALICEVISION_LOG_TRACE("Apply DCP Linear processing with neutral = {" << neutral[0] << ", " << neutral[1] << ", " << neutral[2] << "}");
 
-        dcpProfile.applyLinear(inBuf, neutral);
+        dcpProfile.applyLinear(inBuf, neutral, false); // inBuf is already neutralized but neutral is needed for color Temperature estimation
     }
 
     // color conversion

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -39,17 +39,41 @@ enum class EImageFileType
 };
 
 /**
+ * @brief Available raw processing methods
+ */
+enum class ERawColorInterpretation
+{
+    /// Debayering without any color processing
+    None,
+    /// Simple neutralization
+    LibRawNoWhiteBalancing,
+    /// Use internal white balancing from libraw
+    LibRawWhiteBalancing,
+    /// Apply the linear operations (forward matrix) from DCP profiles, if the DCP file is available.
+    /// If DCP file is not available fallback is simple neutralization (LibRawNoWhiteBalancing)
+    DcpLinearProcessing_ifAvailable,
+    /// If DCP file is not available throw an exception
+    DcpLinearProcessing_required,
+    /// Similar to LibRawNoWhiteBalancing, but put DCP profiles into metadata without applying color processing
+    DcpMetadata_ifAvailable,
+    /// If DCP file is not available throw an exception
+    DcpMetadata_required
+};
+
+/**
  * @brief aggregate for multiple image reading options
  */
 struct ImageReadOptions
 {  
-  ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO, bool useWhiteBalance = true, const std::string& colorProfile="", const oiio::ROI& roi = oiio::ROI()) :
-  workingColorSpace(colorSpace), applyWhiteBalance(useWhiteBalance), colorProfileFileName(colorProfile), applyToneCurve(false), subROI(roi)
+  ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
+                   ERawColorInterpretation rawColorInterpretation = ERawColorInterpretation::LibRawNoWhiteBalancing,
+                   const std::string& colorProfile = "", const oiio::ROI& roi = oiio::ROI()) :
+      workingColorSpace(colorSpace), rawColorInterpretation(rawColorInterpretation), colorProfileFileName(colorProfile), applyToneCurve(false), subROI(roi)
   {
   }
 
   EImageColorSpace workingColorSpace;
-  bool applyWhiteBalance;
+  ERawColorInterpretation rawColorInterpretation;
   std::string colorProfileFileName;
   bool applyToneCurve;
 
@@ -173,26 +197,26 @@ std::ostream& operator<<(std::ostream& os, EImageQuality imageQuality);
 std::istream& operator>>(std::istream& in, EImageQuality& imageQuality);
 
 
-/**
- * @brief aggregate for multiple image reading options
- */
-struct ImageReadOptions
-{
-    ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
-                     bool useWhiteBalance = true, const oiio::ROI & roi = oiio::ROI()) :
-        workingColorSpace(colorSpace),
-        applyWhiteBalance(useWhiteBalance),
-        subROI(roi)
-    {
-    }
-
-    EImageColorSpace workingColorSpace;
-    bool applyWhiteBalance;
-
-    //ROI for this image.
-    //If the image contains an roi, this is the roi INSIDE the roi.
-    oiio::ROI subROI;
-};
+///**
+// * @brief aggregate for multiple image reading options
+// */
+//struct ImageReadOptions
+//{
+//    ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
+//                     bool useWhiteBalance = true, const oiio::ROI & roi = oiio::ROI()) :
+//        workingColorSpace(colorSpace),
+//        applyWhiteBalance(useWhiteBalance),
+//        subROI(roi)
+//    {
+//    }
+//
+//    EImageColorSpace workingColorSpace;
+//    bool applyWhiteBalance;
+//
+//    //ROI for this image.
+//    //If the image contains an roi, this is the roi INSIDE the roi.
+//    oiio::ROI subROI;
+//};
 
 /**
  * @brief aggregate for multiple image writing options

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -45,7 +45,9 @@ enum class ERawColorInterpretation
     /// Similar to LibRawNoWhiteBalancing, but put DCP profiles into metadata without applying color processing
     DcpMetadata_ifAvailable,
     /// If DCP file is not available throw an exception
-    DcpMetadata_required
+    DcpMetadata_required,
+    /// Access aliceVision:rawColorInterpretation metadata to set the method
+    Auto
 };
 
 std::string ERawColorInterpretation_informations();
@@ -185,7 +187,7 @@ std::istream& operator>>(std::istream& in, EImageQuality& imageQuality);
 struct ImageReadOptions
 {
     ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
-        ERawColorInterpretation rawColorInterpretation = ERawColorInterpretation::LibRawNoWhiteBalancing,
+        ERawColorInterpretation rawColorInterpretation = ERawColorInterpretation::Auto,
         const std::string& colorProfile = "", const oiio::ROI& roi = oiio::ROI()) :
         workingColorSpace(colorSpace), rawColorInterpretation(rawColorInterpretation), colorProfileFileName(colorProfile), applyToneCurve(false), subROI(roi)
     {

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -37,15 +37,10 @@ enum class ERawColorInterpretation
     LibRawNoWhiteBalancing,
     /// Use internal white balancing from libraw
     LibRawWhiteBalancing,
-    /// Apply the linear operations (forward matrix) from DCP profiles, if the DCP file is available.
-    /// If DCP file is not available fallback is simple neutralization (LibRawNoWhiteBalancing)
-    DcpLinearProcessing_ifAvailable,
     /// If DCP file is not available throw an exception
-    DcpLinearProcessing_required,
-    /// Similar to LibRawNoWhiteBalancing, but put DCP profiles into metadata without applying color processing
-    DcpMetadata_ifAvailable,
+    DcpLinearProcessing,
     /// If DCP file is not available throw an exception
-    DcpMetadata_required,
+    DcpMetadata,
     /// Access aliceVision:rawColorInterpretation metadata to set the method
     Auto
 };

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -44,13 +44,14 @@ enum class EImageFileType
 struct ImageReadOptions
 {  
   ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO, bool useWhiteBalance = true, const std::string& colorProfile="", const oiio::ROI& roi = oiio::ROI()) :
-  workingColorSpace(colorSpace), applyWhiteBalance(useWhiteBalance), colorProfileFileName(colorProfile), subROI(roi)
+  workingColorSpace(colorSpace), applyWhiteBalance(useWhiteBalance), colorProfileFileName(colorProfile), applyToneCurve(false), subROI(roi)
   {
   }
 
   EImageColorSpace workingColorSpace;
   bool applyWhiteBalance;
   std::string colorProfileFileName;
+  bool applyToneCurve;
 
   //ROI for this image.
   //If the image contains an roi, this is the roi INSIDE the roi.

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -38,50 +38,6 @@ enum class EImageFileType
   NONE
 };
 
-/**
- * @brief Available raw processing methods
- */
-enum class ERawColorInterpretation
-{
-    /// Debayering without any color processing
-    None,
-    /// Simple neutralization
-    LibRawNoWhiteBalancing,
-    /// Use internal white balancing from libraw
-    LibRawWhiteBalancing,
-    /// Apply the linear operations (forward matrix) from DCP profiles, if the DCP file is available.
-    /// If DCP file is not available fallback is simple neutralization (LibRawNoWhiteBalancing)
-    DcpLinearProcessing_ifAvailable,
-    /// If DCP file is not available throw an exception
-    DcpLinearProcessing_required,
-    /// Similar to LibRawNoWhiteBalancing, but put DCP profiles into metadata without applying color processing
-    DcpMetadata_ifAvailable,
-    /// If DCP file is not available throw an exception
-    DcpMetadata_required
-};
-
-/**
- * @brief aggregate for multiple image reading options
- */
-struct ImageReadOptions
-{  
-  ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
-                   ERawColorInterpretation rawColorInterpretation = ERawColorInterpretation::LibRawNoWhiteBalancing,
-                   const std::string& colorProfile = "", const oiio::ROI& roi = oiio::ROI()) :
-      workingColorSpace(colorSpace), rawColorInterpretation(rawColorInterpretation), colorProfileFileName(colorProfile), applyToneCurve(false), subROI(roi)
-  {
-  }
-
-  EImageColorSpace workingColorSpace;
-  ERawColorInterpretation rawColorInterpretation;
-  std::string colorProfileFileName;
-  bool applyToneCurve;
-
-  //ROI for this image.
-  //If the image contains an roi, this is the roi INSIDE the roi.
-  oiio::ROI subROI;
-};
-
 
 /**
  * @brief get informations about each image file type
@@ -197,26 +153,30 @@ std::ostream& operator<<(std::ostream& os, EImageQuality imageQuality);
 std::istream& operator>>(std::istream& in, EImageQuality& imageQuality);
 
 
-///**
-// * @brief aggregate for multiple image reading options
-// */
-//struct ImageReadOptions
-//{
-//    ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
-//                     bool useWhiteBalance = true, const oiio::ROI & roi = oiio::ROI()) :
-//        workingColorSpace(colorSpace),
-//        applyWhiteBalance(useWhiteBalance),
-//        subROI(roi)
-//    {
-//    }
-//
-//    EImageColorSpace workingColorSpace;
-//    bool applyWhiteBalance;
-//
-//    //ROI for this image.
-//    //If the image contains an roi, this is the roi INSIDE the roi.
-//    oiio::ROI subROI;
-//};
+/**
+ * @brief aggregate for multiple image reading options
+ */
+struct ImageReadOptions
+{
+    ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO, bool useWhiteBalance = true,
+                     const std::string& colorProfile = "", const oiio::ROI& roi = oiio::ROI())
+        : workingColorSpace(colorSpace)
+        , applyWhiteBalance(useWhiteBalance)
+        , colorProfileFileName(colorProfile)
+        , applyToneCurve(false)
+        , subROI(roi)
+    {
+    }
+
+    EImageColorSpace workingColorSpace;
+    bool applyWhiteBalance;
+    std::string colorProfileFileName;
+    bool applyToneCurve;
+
+    // ROI for this image.
+    // If the image contains an roi, this is the roi INSIDE the roi.
+    oiio::ROI subROI;
+};
 
 /**
  * @brief aggregate for multiple image writing options

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -27,6 +27,34 @@ class rgb;
 namespace image {
 
 /**
+ * @brief Available raw processing methods
+ */
+enum class ERawColorInterpretation
+{
+    /// Debayering without any color processing
+    None,
+    /// Simple neutralization
+    LibRawNoWhiteBalancing,
+    /// Use internal white balancing from libraw
+    LibRawWhiteBalancing,
+    /// Apply the linear operations (forward matrix) from DCP profiles, if the DCP file is available.
+    /// If DCP file is not available fallback is simple neutralization (LibRawNoWhiteBalancing)
+    DcpLinearProcessing_ifAvailable,
+    /// If DCP file is not available throw an exception
+    DcpLinearProcessing_required,
+    /// Similar to LibRawNoWhiteBalancing, but put DCP profiles into metadata without applying color processing
+    DcpMetadata_ifAvailable,
+    /// If DCP file is not available throw an exception
+    DcpMetadata_required
+};
+
+std::string ERawColorInterpretation_informations();
+ERawColorInterpretation ERawColorInterpretation_stringToEnum(const std::string& dataType);
+std::string ERawColorInterpretation_enumToString(const ERawColorInterpretation dataType);
+std::ostream& operator<<(std::ostream& os, ERawColorInterpretation dataType);
+std::istream& operator>>(std::istream& in, ERawColorInterpretation& dataType);
+
+/**
  * @brief Available image file type for pipeline output
  */
 enum class EImageFileType
@@ -37,7 +65,6 @@ enum class EImageFileType
   EXR,
   NONE
 };
-
 
 /**
  * @brief get informations about each image file type
@@ -152,29 +179,26 @@ std::ostream& operator<<(std::ostream& os, EImageQuality imageQuality);
  */
 std::istream& operator>>(std::istream& in, EImageQuality& imageQuality);
 
-
 /**
  * @brief aggregate for multiple image reading options
  */
 struct ImageReadOptions
 {
-    ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO, bool useWhiteBalance = true,
-                     const std::string& colorProfile = "", const oiio::ROI& roi = oiio::ROI())
-        : workingColorSpace(colorSpace)
-        , applyWhiteBalance(useWhiteBalance)
-        , colorProfileFileName(colorProfile)
-        , applyToneCurve(false)
-        , subROI(roi)
+    ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
+        ERawColorInterpretation rawColorInterpretation = ERawColorInterpretation::LibRawNoWhiteBalancing,
+        const std::string& colorProfile = "", const oiio::ROI& roi = oiio::ROI()) :
+        workingColorSpace(colorSpace), rawColorInterpretation(rawColorInterpretation), colorProfileFileName(colorProfile), applyToneCurve(false), subROI(roi)
     {
     }
 
+
     EImageColorSpace workingColorSpace;
-    bool applyWhiteBalance;
+    ERawColorInterpretation rawColorInterpretation;
     std::string colorProfileFileName;
     bool applyToneCurve;
 
-    // ROI for this image.
-    // If the image contains an roi, this is the roi INSIDE the roi.
+    //ROI for this image.
+    //If the image contains an roi, this is the roi INSIDE the roi.
     oiio::ROI subROI;
 };
 

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -39,6 +39,26 @@ enum class EImageFileType
 };
 
 /**
+ * @brief aggregate for multiple image reading options
+ */
+struct ImageReadOptions
+{  
+  ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO, bool useWhiteBalance = true, const std::string& colorProfile="", const oiio::ROI& roi = oiio::ROI()) :
+  workingColorSpace(colorSpace), applyWhiteBalance(useWhiteBalance), colorProfileFileName(colorProfile), subROI(roi)
+  {
+  }
+
+  EImageColorSpace workingColorSpace;
+  bool applyWhiteBalance;
+  std::string colorProfileFileName;
+
+  //ROI for this image.
+  //If the image contains an roi, this is the roi INSIDE the roi.
+  oiio::ROI subROI;
+};
+
+
+/**
  * @brief get informations about each image file type
  * @return String
  */

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -549,14 +549,19 @@ public:
    */
   Vec3 getGpsPositionWGS84FromMetadata() const;
 
-  const bool getApplyWhiteBalance() const 
+  const bool getApplyWhiteBalance() const
   {
-    if (getIntMetadata({"AliceVision:useWhiteBalance"}) == 0)
-    {
-      return false;
-    }
-    
-    return true;
+      if (getIntMetadata({ "AliceVision:useWhiteBalance" }) == 0)
+      {
+          return false;
+      }
+
+      return true;
+  }
+
+  const std::string& getColorProfileFileName() const
+  {
+      return getMetadata({ "AliceVision:colorProfileFileName" });
   }
 
   const bool hasMetadataDateTimeOriginal() const

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -564,6 +564,11 @@ public:
       return getMetadata({ "AliceVision:colorProfileFileName" });
   }
 
+  const std::string& getRawColorInterpretation() const
+  {
+      return getMetadata({ "AliceVision:rawColorInterpretation" });
+  }
+
   const std::vector<int> getCameraMultiplicators() const
   {
       const std::string cam_mul = getMetadata({ "raw:cam_mul" });

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -564,6 +564,23 @@ public:
       return getMetadata({ "AliceVision:colorProfileFileName" });
   }
 
+  const std::vector<int> getCameraMultiplicators() const
+  {
+      const std::string cam_mul = getMetadata({ "raw:cam_mul" });
+      std::vector<int> v_mult;
+
+      size_t last = 0;
+      size_t next = 0;
+      while ((next = cam_mul.find(" ", last)) != std::string::npos)
+      {
+          v_mult.push_back(atoi(cam_mul.substr(last, next - last).c_str()));
+          last = next + 1;
+      }
+      v_mult.push_back(atoi(cam_mul.substr(last).c_str()));
+
+      return v_mult;
+  }
+
   const bool hasMetadataDateTimeOriginal() const
   {
       return hasMetadata(

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <utility>
 #include <aliceVision/numeric/numeric.hpp>
+#include <aliceVision/image/dcp.hpp>
 
 namespace aliceVision {
 namespace sfmData {
@@ -726,7 +727,41 @@ public:
    */
   void addMetadata(const std::string& key, const std::string& value)
   {
-    _metadata[key] = value;
+      _metadata[key] = value;
+  }
+
+  /**
+   * @brief Add DCP info in metadata
+   * @param[in] dcpProf The DCP color profile
+   */
+  void addDCPMetadata(image::DCPProfile& dcpProf)
+  {
+      addMetadata("AliceVision:DCP:colorProfileFileName", dcpProf.info.filename);
+
+      addMetadata("AliceVision:DCP:Temp1", std::to_string(dcpProf.info.temperature_1));
+      addMetadata("AliceVision:DCP:Temp2", std::to_string(dcpProf.info.temperature_2));
+
+      const int colorMatrixNumber = (dcpProf.info.has_color_matrix_1 && dcpProf.info.has_color_matrix_2) ? 2 :
+          (dcpProf.info.has_color_matrix_1 ? 1 : 0);
+      addMetadata("AliceVision:DCP:ColorMatrixNumber", std::to_string(colorMatrixNumber));
+
+      const int forwardMatrixNumber = (dcpProf.info.has_forward_matrix_1 && dcpProf.info.has_forward_matrix_2) ? 2 :
+          (dcpProf.info.has_forward_matrix_1 ? 1 : 0);
+      addMetadata("AliceVision:DCP:ForwardMatrixNumber", std::to_string(forwardMatrixNumber));
+
+      std::vector<std::string> v_strColorMatrix;
+      dcpProf.getMatricesAsStrings("color", v_strColorMatrix);
+      for (int k = 0; k < v_strColorMatrix.size(); k++)
+      {
+          addMetadata("AliceVision:DCP:ColorMat" + std::to_string(k + 1), v_strColorMatrix[k]);
+      }
+
+      std::vector<std::string> v_strForwardMatrix;
+      dcpProf.getMatricesAsStrings("forward", v_strForwardMatrix);
+      for (int k = 0; k < v_strForwardMatrix.size(); k++)
+      {
+          addMetadata("AliceVision:DCP:ForwardMat" + std::to_string(k + 1), v_strForwardMatrix[k]);
+      }
   }
 
 private:

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -749,6 +749,10 @@ public:
           (dcpProf.info.has_forward_matrix_1 ? 1 : 0);
       addMetadata("AliceVision:DCP:ForwardMatrixNumber", std::to_string(forwardMatrixNumber));
 
+      const int calibMatrixNumber = (dcpProf.info.has_camera_calibration_1 && dcpProf.info.has_camera_calibration_2) ? 2 :
+          (dcpProf.info.has_camera_calibration_1 ? 1 : 0);
+      addMetadata("AliceVision:DCP:CameraCalibrationMatrixNumber", std::to_string(calibMatrixNumber));
+
       std::vector<std::string> v_strColorMatrix;
       dcpProf.getMatricesAsStrings("color", v_strColorMatrix);
       for (int k = 0; k < v_strColorMatrix.size(); k++)
@@ -761,6 +765,13 @@ public:
       for (int k = 0; k < v_strForwardMatrix.size(); k++)
       {
           addMetadata("AliceVision:DCP:ForwardMat" + std::to_string(k + 1), v_strForwardMatrix[k]);
+      }
+
+      std::vector<std::string> v_strCalibMatrix;
+      dcpProf.getMatricesAsStrings("calib", v_strCalibMatrix);
+      for (int k = 0; k < v_strCalibMatrix.size(); k++)
+      {
+          addMetadata("AliceVision:DCP:CameraCalibrationMat" + std::to_string(k + 1), v_strCalibMatrix[k]);
       }
   }
 

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -549,19 +549,19 @@ public:
    */
   Vec3 getGpsPositionWGS84FromMetadata() const;
 
-  const bool getApplyWhiteBalance() const
-  {
-      if (getIntMetadata({ "AliceVision:useWhiteBalance" }) == 0)
-      {
-          return false;
-      }
+  //const bool getApplyWhiteBalance() const
+  //{
+  //    if (getIntMetadata({ "AliceVision:useWhiteBalance" }) == 0)
+  //    {
+  //        return false;
+  //    }
 
-      return true;
-  }
+  //    return true;
+  //}
 
   const std::string& getColorProfileFileName() const
   {
-      return getMetadata({ "AliceVision:colorProfileFileName" });
+      return getMetadata({ "AliceVision:DCP:colorProfileFileName" });
   }
 
   const std::string& getRawColorInterpretation() const

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -549,16 +549,6 @@ public:
    */
   Vec3 getGpsPositionWGS84FromMetadata() const;
 
-  //const bool getApplyWhiteBalance() const
-  //{
-  //    if (getIntMetadata({ "AliceVision:useWhiteBalance" }) == 0)
-  //    {
-  //        return false;
-  //    }
-
-  //    return true;
-  //}
-
   const std::string& getColorProfileFileName() const
   {
       return getMetadata({ "AliceVision:DCP:colorProfileFileName" });

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -255,6 +255,7 @@ int aliceVision_main(int argc, char** argv)
             image::ImageReadOptions options;
             options.workingColorSpace = image::EImageColorSpace::SRGB;
             options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
+            options.colorProfileFileName = group[i]->getColorProfileFileName();
             image::readImage(filepath, images[i], options);
 
             exposuresSetting[i] = group[i]->getCameraExposureSetting(/*targetView->getMetadataISO(), targetView->getMetadataFNumber()*/);

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -254,7 +254,7 @@ int aliceVision_main(int argc, char** argv)
 
             image::ImageReadOptions options;
             options.workingColorSpace = image::EImageColorSpace::SRGB;
-            options.applyWhiteBalance = group[i]->getApplyWhiteBalance();
+            options.rawColorInterpretation = group[i]->getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
             image::readImage(filepath, images[i], options);
 
             exposuresSetting[i] = group[i]->getCameraExposureSetting(/*targetView->getMetadataISO(), targetView->getMetadataFNumber()*/);

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -254,7 +254,7 @@ int aliceVision_main(int argc, char** argv)
 
             image::ImageReadOptions options;
             options.workingColorSpace = image::EImageColorSpace::SRGB;
-            options.rawColorInterpretation = group[i]->getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
+            options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
             image::readImage(filepath, images[i], options);
 
             exposuresSetting[i] = group[i]->getCameraExposureSetting(/*targetView->getMetadataISO(), targetView->getMetadataFNumber()*/);

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -188,14 +188,14 @@ int aliceVision_main(int argc, char** argv)
         std::vector<std::string> paths;
         std::vector<sfmData::ExposureSetting> exposuresSetting;
 
-        bool applyWhiteBalance = true;
+        image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
 
         for (auto & v : group)
         {
             paths.push_back(v->getImagePath());
             exposuresSetting.push_back(v->getCameraExposureSetting());
 
-            applyWhiteBalance &= v->getApplyWhiteBalance();
+            rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(v->getRawColorInterpretation());
 
             ALICEVISION_LOG_INFO("Image: " << paths.back() << ", exposure: " << exposuresSetting.back() << ", applyWhiteBalance: " << v->getApplyWhiteBalance());
         }
@@ -206,7 +206,7 @@ int aliceVision_main(int argc, char** argv)
         std::vector<double> exposures = getExposures(exposuresSetting);
 
         std::vector<hdr::ImageSample> out_samples;
-        const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, exposures, width, height, channelQuantization, image::EImageColorSpace::SRGB, applyWhiteBalance, params);
+        const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, exposures, width, height, channelQuantization, image::EImageColorSpace::SRGB, rawColorInterpretation, params);
         if (!res)
         {
             ALICEVISION_LOG_ERROR("Error while extracting samples from group " << groupIdx);

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -509,26 +509,18 @@ int aliceVision_main(int argc, char **argv)
                                             (dcpProf.info.has_forward_matrix_1 ? 1 : 0);
             view.addMetadata("AliceVision:DCP:ForwardMatrixNumber", std::to_string(forwardMatrixNumber));
 
-            std::vector<alicevision::image::DCPProfile::Matrix> v_ColorMatrix;
-            dcpProf.getMatrices("color", v_ColorMatrix);
-            for (int k = 1; k <= v_ColorMatrix.size(); k++)
+            std::vector<std::string> v_strColorMatrix;
+            dcpProf.getMatricesAsStrings("color", v_strColorMatrix);
+            for (int k = 0; k < v_strColorMatrix.size(); k++)
             {
-                std::string Matrixstr = "";
-                for (int i = 0; i < 3; i++)
-                    for (int j = 0; j < 3; j++)
-                        Matrixstr += (std::to_string(v_ColorMatrix[k - 1][i][j]) + " ");
-                view.addMetadata("AliceVision:DCP:ColorMat" + std::to_string(k), Matrixstr);
+                view.addMetadata("AliceVision:DCP:ColorMat" + std::to_string(k + 1), v_strColorMatrix[k]);
             }
 
-            std::vector<alicevision::image::DCPProfile::Matrix> v_ForwardMatrix;
-            dcpProf.getMatrices("forward", v_ForwardMatrix);
-            for (int k = 1; k <= v_ForwardMatrix.size(); k++)
+            std::vector<std::string> v_strForwardMatrix;
+            dcpProf.getMatricesAsStrings("forward", v_strForwardMatrix);
+            for (int k = 1; k <= v_strForwardMatrix.size(); k++)
             {
-                std::string Matrixstr = "";
-                for (int i = 0; i < 3; i++)
-                    for (int j = 0; j < 3; j++)
-                        Matrixstr += (std::to_string(v_ForwardMatrix[k - 1][i][j]) + " ");
-                view.addMetadata("AliceVision:DCP:ForwardMat" + std::to_string(k), Matrixstr);
+                view.addMetadata("AliceVision:DCP:ForwardMat" + std::to_string(k + 1), v_strForwardMatrix[k]);
             }
         }
         else if(allColorProfilesFound)

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -173,8 +173,8 @@ int aliceVision_main(int argc, char **argv)
   std::string viewIdRegex = ".*?(\\d+)";
 
   bool allowSingleView = false;
-  bool useInternalWhiteBalance = true;
   bool errorOnMissingColorProfile = true;
+  image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawNoWhiteBalancing;
 
 
   po::options_description requiredParams("Required parameters");
@@ -218,8 +218,8 @@ int aliceVision_main(int argc, char **argv)
       " * " + EViewIdMethod_enumToString(EViewIdMethod::FILENAME) + ": Generate viewId from file names using regex.") .c_str())
     ("viewIdRegex", po::value<std::string>(&viewIdRegex)->default_value(viewIdRegex),
       "Regex used to catch number used as viewId in filename.")
-    ("useInternalWhiteBalance", po::value<bool>(&useInternalWhiteBalance)->default_value(useInternalWhiteBalance),
-      "Apply the white balance included in the image metadata (Only for raw images)")
+    ("rawColorInterpretation", po::value<image::ERawColorInterpretation>(&rawColorInterpretation)->default_value(rawColorInterpretation),
+      ("RAW color interpretation: " + image::ERawColorInterpretation_informations()).c_str())
     ("errorOnMissingColorProfile", po::value<bool>(&errorOnMissingColorProfile)->default_value(errorOnMissingColorProfile),
       "Rise an error if a DCP color profiles database is specified but no DCP file matches with the camera model (maker+name) extracted from metadata (Only for raw images)")
     ("allowSingleView", po::value<bool>(&allowSingleView)->default_value(allowSingleView),
@@ -907,7 +907,7 @@ int aliceVision_main(int argc, char **argv)
   {
     if (vitem.second) 
     {
-      vitem.second->addMetadata("AliceVision:useWhiteBalance", (useInternalWhiteBalance)?"1":"0");
+        vitem.second->addMetadata("AliceVision:rawColorInterpretation", image::ERawColorInterpretation_enumToString(rawColorInterpretation));
     }
   }
   

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -332,7 +332,6 @@ int aliceVision_main(int argc, char **argv)
       {
           if (fs::is_regular_file(p))
           {
-              std::cout << p.filename() << " ; " << p.generic_string() << std::endl;
               colorProfileList.emplace_back(p.generic_string());
           }
       }
@@ -400,7 +399,7 @@ int aliceVision_main(int argc, char **argv)
   boost::regex extractNumberRegex("\\d+");
 
   std::map<IndexT, std::vector<IndexT>> poseGroups;
-  bool allColorProfilesFound = true;
+  int allColorProfilesFound = 1;
 
   #pragma omp parallel for
   for(int i = 0; i < sfmData.getViews().size(); ++i)
@@ -497,10 +496,8 @@ int aliceVision_main(int argc, char **argv)
             }
         }
 
-        #pragma omp critical
-        {
-            allColorProfilesFound &= colorProfileFound;
-        }
+        #pragma omp atomic
+        allColorProfilesFound &= static_cast<int>(colorProfileFound);
     }
 
     // check if the view intrinsic is already defined

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -322,7 +322,9 @@ int aliceVision_main(int argc, char **argv)
   }
 
   std::vector<std::string> colorProfileList;
-  if (!colorProfileDatabaseDirPath.empty())
+  if (!colorProfileDatabaseDirPath.empty() &&
+      (rawColorInterpretation == image::ERawColorInterpretation::DcpLinearProcessing ||
+       rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata))
   {
       if(!fs::is_directory(colorProfileDatabaseDirPath))
       {

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -399,7 +399,7 @@ int aliceVision_main(int argc, char **argv)
   boost::regex extractNumberRegex("\\d+");
 
   std::map<IndexT, std::vector<IndexT>> poseGroups;
-  int allColorProfilesFound = 1;
+  int allColorProfilesFound = 1; // int type instead of bool to support usage of omp atomic
 
   #pragma omp parallel for
   for(int i = 0; i < sfmData.getViews().size(); ++i)

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -253,6 +253,7 @@ int aliceVision_main(int argc, char* argv[])
         image::ImageReadOptions options;
         options.workingColorSpace = image::EImageColorSpace::LINEAR;
         options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(v.second->getRawColorInterpretation());
+        options.colorProfileFileName = v.second->getColorProfileFileName();
 
         image::readImage(v.second->getImagePath(), originalImage, options);
         oiio::ImageBuf bufInput(

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -252,8 +252,7 @@ int aliceVision_main(int argc, char* argv[])
 
         image::ImageReadOptions options;
         options.workingColorSpace = image::EImageColorSpace::LINEAR;
-        options.rawColorInterpretation = v.second->getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
-        
+        options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(v.second->getRawColorInterpretation());
 
         image::readImage(v.second->getImagePath(), originalImage, options);
         oiio::ImageBuf bufInput(

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -252,7 +252,7 @@ int aliceVision_main(int argc, char* argv[])
 
         image::ImageReadOptions options;
         options.workingColorSpace = image::EImageColorSpace::LINEAR;
-        options.applyWhiteBalance = v.second->getApplyWhiteBalance();
+        options.rawColorInterpretation = v.second->getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
         
 
         image::readImage(v.second->getImagePath(), originalImage, options);

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -236,7 +236,7 @@ int aliceVision_main(int argc, char** argv)
                 // Read image options and load image
                 image::ImageReadOptions options;
                 options.workingColorSpace = image::EImageColorSpace::NO_CONVERSION;
-                options.applyWhiteBalance = view.getApplyWhiteBalance();
+                options.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
 
                 image::Image<image::RGBAfColor> image;
                 image::readImage(viewPath, image, options);

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -236,7 +236,7 @@ int aliceVision_main(int argc, char** argv)
                 // Read image options and load image
                 image::ImageReadOptions options;
                 options.workingColorSpace = image::EImageColorSpace::NO_CONVERSION;
-                options.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
+                options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(view.getRawColorInterpretation());
 
                 image::Image<image::RGBAfColor> image;
                 image::readImage(viewPath, image, options);

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -465,7 +465,7 @@ int aliceVision_main(int argc, char** argv)
                 view.getMetadataBodySerialNumber(),
                 view.getMetadataLensSerialNumber() };
             imgOpt.readOptions.workingColorSpace = image::EImageColorSpace::SRGB;
-            imgOpt.readOptions.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
+            imgOpt.readOptions.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(view.getRawColorInterpretation());
             detectColorChecker(detectedCCheckers, imgOpt, settings);
         }
 

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -465,7 +465,7 @@ int aliceVision_main(int argc, char** argv)
                 view.getMetadataBodySerialNumber(),
                 view.getMetadataLensSerialNumber() };
             imgOpt.readOptions.workingColorSpace = image::EImageColorSpace::SRGB;
-            imgOpt.readOptions.applyWhiteBalance = view.getApplyWhiteBalance();
+            imgOpt.readOptions.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
             detectColorChecker(detectedCCheckers, imgOpt, settings);
         }
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -213,6 +213,12 @@ inline std::istream& operator>>(std::istream& in, EImageFormat& e)
     return in;
 }
 
+std::string getColorProfileDatabaseFolder()
+{
+    const char* value = std::getenv("ALICEVISION_COLOR_PROFILE_DB");
+    return value ? value : "";
+}
+
 struct ProcessingParams
 {
     bool reconstructedViewsOnly = false;
@@ -510,7 +516,7 @@ int aliceVision_main(int argc, char * argv[])
     std::string extension;
     bool applyToneCurve = false;
     image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawNoWhiteBalancing;
-    std::string colorProfileDatabaseDirPath;
+    std::string colorProfileDatabaseDirPath = "";
     bool errorOnMissingColorProfile = true;
 
     ProcessingParams pParams;
@@ -593,7 +599,7 @@ int aliceVision_main(int argc, char * argv[])
             ("Output color space: " + image::EImageColorSpace_informations()).c_str())
 
         ("rawColorInterpretation", po::value<image::ERawColorInterpretation>(&rawColorInterpretation)->default_value(rawColorInterpretation),
-            ("RAW color interpretation: " + image::ERawColorInterpretation_informations()).c_str())
+            ("RAW color interpretation: " + image::ERawColorInterpretation_informations() + "\ndefault : librawnowhitebalancing").c_str())
 
         ("colorProfileDatabase,c", po::value<std::string>(&colorProfileDatabaseDirPath)->default_value(""),
             "DNG Color Profiles (DCP) database path.")
@@ -849,6 +855,11 @@ int aliceVision_main(int argc, char * argv[])
             {
                 if (!dcpDatabaseLoaded)
                 {
+                    if (colorProfileDatabaseDirPath.empty())
+                    {
+                        colorProfileDatabaseDirPath = getColorProfileDatabaseFolder();
+                    }
+
                     if (!fs::is_directory(colorProfileDatabaseDirPath))
                     {
                         ALICEVISION_LOG_ERROR("The specified DCP database for color profiles does not exist.");

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -686,7 +686,7 @@ int aliceVision_main(int argc, char * argv[])
 
             image::ImageReadOptions options;
             options.workingColorSpace = workingColorSpace;
-            options.applyWhiteBalance = view.getApplyWhiteBalance();
+            options.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
             options.colorProfileFileName = view.getColorProfileFileName();
             options.applyToneCurve = applyToneCurve;
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -492,6 +492,7 @@ int aliceVision_main(int argc, char * argv[])
     image::EStorageDataType storageDataType = image::EStorageDataType::Float;
     std::string extension;
     bool applyToneCurve = false;
+    image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawNoWhiteBalancing;
 
     ProcessingParams pParams;
 
@@ -570,7 +571,10 @@ int aliceVision_main(int argc, char * argv[])
          "Output image format (rgba, rgb, grayscale)")
 
         ("outputColorSpace", po::value<image::EImageColorSpace>(&outputColorSpace)->default_value(outputColorSpace),
-         ("Output color space: " + image::EImageColorSpace_informations()).c_str())
+            ("Output color space: " + image::EImageColorSpace_informations()).c_str())
+
+        ("rawColorInterpretation", po::value<image::ERawColorInterpretation>(&rawColorInterpretation)->default_value(rawColorInterpretation),
+            ("RAW color interpretation: " + image::ERawColorInterpretation_informations()).c_str())
 
         ("applyToneCurve", po::value<bool>(&applyToneCurve)->default_value(applyToneCurve),
             "Apply color profile embedded tone curve if any.")
@@ -686,7 +690,8 @@ int aliceVision_main(int argc, char * argv[])
 
             image::ImageReadOptions options;
             options.workingColorSpace = workingColorSpace;
-            options.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
+            //options.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
+            options.rawColorInterpretation = rawColorInterpretation;
             options.colorProfileFileName = view.getColorProfileFileName();
             options.applyToneCurve = applyToneCurve;
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -491,6 +491,7 @@ int aliceVision_main(int argc, char * argv[])
     image::EImageColorSpace outputColorSpace = image::EImageColorSpace::LINEAR;
     image::EStorageDataType storageDataType = image::EStorageDataType::Float;
     std::string extension;
+    bool applyToneCurve = false;
 
     ProcessingParams pParams;
 
@@ -570,6 +571,9 @@ int aliceVision_main(int argc, char * argv[])
 
         ("outputColorSpace", po::value<image::EImageColorSpace>(&outputColorSpace)->default_value(outputColorSpace),
          ("Output color space: " + image::EImageColorSpace_informations()).c_str())
+
+        ("applyToneCurve", po::value<bool>(&applyToneCurve)->default_value(applyToneCurve),
+            "Apply color profile embedded tone curve if any.")
 
         ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
          ("Storage data type: " + image::EStorageDataType_informations()).c_str())
@@ -684,6 +688,7 @@ int aliceVision_main(int argc, char * argv[])
             options.workingColorSpace = workingColorSpace;
             options.applyWhiteBalance = view.getApplyWhiteBalance();
             options.colorProfileFileName = view.getColorProfileFileName();
+            options.applyToneCurve = applyToneCurve;
 
             // Read original image
             image::Image<image::RGBAfColor> image;

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -689,9 +689,15 @@ int aliceVision_main(int argc, char * argv[])
             ALICEVISION_LOG_INFO(++i << "/" << size << " - Process view '" << viewId << "'.");
 
             image::ImageReadOptions options;
-            options.workingColorSpace = workingColorSpace;
-            //options.rawColorInterpretation = view.getApplyWhiteBalance() ? image::ERawColorInterpretation::LibRawWhiteBalancing : image::ERawColorInterpretation::LibRawNoWhiteBalancing;
-            options.rawColorInterpretation = rawColorInterpretation;
+            options.workingColorSpace = workingColorSpace;           
+            if (rawColorInterpretation == image::ERawColorInterpretation::Auto)
+            {
+                options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(view.getRawColorInterpretation());
+            }
+            else
+            {
+                options.rawColorInterpretation = rawColorInterpretation;
+            }
             options.colorProfileFileName = view.getColorProfileFileName();
             options.applyToneCurve = applyToneCurve;
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -683,6 +683,7 @@ int aliceVision_main(int argc, char * argv[])
             image::ImageReadOptions options;
             options.workingColorSpace = workingColorSpace;
             options.applyWhiteBalance = view.getApplyWhiteBalance();
+            options.colorProfileFileName = view.getColorProfileFileName();
 
             // Read original image
             image::Image<image::RGBAfColor> image;


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Add dcp color profile loading and applying capabilities when raw images must be read.

## Features list
<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
- [X] dcp application possible in sRGB, AdobeRGB or prophoto color spaces.
- [X] dcp application parameters.

## Implementation remarks
<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
In cameraInit node, using the maker and model metadata, if a color profile database is provided, the complete filepath of the appropriate dcp file is added in the image metadata. Then, every time the image has to be read, the color profile can be applied. Application options are available. As a consequence if a node wants to get the original raw images, this is still possible by deactivating the color profile application.
A new parameter in cameraInit node allows to select the error level (warning or error) when a database is provided but no adapted color profile is found for a raw input image.
