### PR TITLE
[software] Add colmap exporter

### DIFF
--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(sfmDataIO_files_headers
   sfmDataIO.hpp
   bafIO.hpp
+  colmap.hpp
   gtIO.hpp
   jsonIO.hpp
   middlebury.hpp
@@ -14,6 +15,7 @@ set(sfmDataIO_files_headers
 set(sfmDataIO_files_sources
   sfmDataIO.cpp
   bafIO.cpp
+  colmap.cpp
   gtIO.cpp
   jsonIO.cpp
   middlebury.cpp

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -87,3 +87,10 @@ alicevision_add_test(middlebury_test.cpp
         aliceVision_numeric
         aliceVision_sfmDataIO
         )
+
+alicevision_add_test(colmap_test.cpp
+        NAME "sfmDataIO_colmap"
+        LINKS aliceVision_sfmData
+        aliceVision_numeric
+        aliceVision_sfmDataIO
+        )

--- a/src/aliceVision/sfmDataIO/colmap.cpp
+++ b/src/aliceVision/sfmDataIO/colmap.cpp
@@ -1,0 +1,452 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "colmap.hpp"
+#include <aliceVision/geometry/Pose3.hpp>
+#include <aliceVision/camera/cameraCommon.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <sstream>
+
+namespace fs = boost::filesystem;
+
+namespace aliceVision{
+namespace sfmDataIO{
+
+ColmapConfig::ColmapConfig(const std::string& basePath)
+    : _basePath(basePath)
+{
+    _sparseDirectory = (fs::path(_basePath) / fs::path("sparse/0")).string();
+    _denseDirectory = (fs::path(_basePath) / fs::path("dense/0")).string();
+    _imagesDirectory = (fs::path(_basePath) / fs::path("images/")).string();
+    _camerasTxtPath = (fs::path(_sparseDirectory) / fs::path("cameras.txt")).string();
+    _imagesTxtPath = (fs::path(_sparseDirectory) / fs::path("images.txt")).string();
+    _points3DPath = (fs::path(_sparseDirectory) / fs::path("points3D.txt")).string();
+}
+
+const std::set<camera::EINTRINSIC>& colmapCompatibleIntrinsics()
+{
+    static const std::set<camera::EINTRINSIC> compatibleIntrinsics{
+        camera::PINHOLE_CAMERA,       camera::PINHOLE_CAMERA_RADIAL1, camera::PINHOLE_CAMERA_RADIAL3,
+        camera::PINHOLE_CAMERA_BROWN, camera::PINHOLE_CAMERA_FISHEYE, camera::PINHOLE_CAMERA_FISHEYE1};
+    return compatibleIntrinsics;
+}
+
+
+bool isColmapCompatible(camera::EINTRINSIC intrinsicType)
+{
+    const auto compatible = colmapCompatibleIntrinsics();
+    return compatible.find(intrinsicType) != compatible.end();
+}
+
+CompatibleList getColmapCompatibleIntrinsics(const sfmData::SfMData& sfMData)
+{
+    CompatibleList compatible;
+    for(const auto& iter : sfMData.getIntrinsics())
+    {
+        const auto& intrinsics = iter.second;
+        const auto intrID = iter.first;
+        const auto intrType = intrinsics->getType();
+        if(isColmapCompatible(intrType))
+        {
+            compatible.insert(intrID);
+        }
+        else
+        {
+            ALICEVISION_LOG_INFO("The intrinsics " << intrID << " is of type " << intrType
+                                                      << " which is not supported in Colmap and it will be removed");
+        }
+    }
+    return compatible;
+}
+
+CompatibleList getColmapCompatibleViews(const sfmData::SfMData& sfmData)
+{
+    const auto compatibleIntrinsics = getColmapCompatibleIntrinsics(sfmData);
+
+    CompatibleList compatibleViews;
+    for(const auto& iter : sfmData.getViews())
+    {
+        const auto& view = iter.second;
+        const auto viewID = iter.first;
+        if(!sfmData.isPoseAndIntrinsicDefined(view.get()))
+        {
+            continue;
+        }
+        if(compatibleIntrinsics.find(view->getIntrinsicId()) != compatibleViews.end())
+        {
+            compatibleViews.insert(viewID);
+        }
+    }
+    return compatibleViews;
+}
+
+std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shared_ptr<camera::IntrinsicBase> intrinsic)
+{
+    std::stringstream intrString;
+
+    camera::EINTRINSIC current_type = intrinsic->getType();
+    switch(current_type)
+    {
+        case camera::PINHOLE_CAMERA:
+            // PINHOLE_CAMERA corresponds to Colmap's PINHOLE
+            // Parameters: f, cx, cy
+            {
+                const camera::Pinhole* pinhole_intrinsic = dynamic_cast<const camera::Pinhole*>(intrinsic.get());
+
+                intrString << intrinsicsID << " "
+                           << "PINHOLE"
+                           << " " << pinhole_intrinsic->w() << " " << pinhole_intrinsic->h() << " "
+                           << pinhole_intrinsic->getFocalLengthPixX() << " " << pinhole_intrinsic->getFocalLengthPixY()
+                           << " " << pinhole_intrinsic->getPrincipalPoint().x() << " "
+                           << pinhole_intrinsic->getPrincipalPoint().y() << "\n";
+            }
+            break;
+        case camera::PINHOLE_CAMERA_RADIAL1:
+            // PINHOLE_CAMERA_RADIAL1 can only be modeled by Colmap's FULL_OPENCV setting the unused parameters to 0
+            // Parameters: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
+            {
+                const camera::PinholeRadialK1* pinhole_intrinsic_radial =
+                    dynamic_cast<const camera::PinholeRadialK1*>(intrinsic.get());
+
+                intrString << intrinsicsID << " "
+                           << "FULL_OPENCV"
+                           << " " << pinhole_intrinsic_radial->w() << " " << pinhole_intrinsic_radial->h() << " "
+                           << pinhole_intrinsic_radial->getFocalLengthPixX() << " "
+                           << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
+                           << pinhole_intrinsic_radial->getPrincipalPoint().x() << " "
+                           << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
+                           << pinhole_intrinsic_radial->getParams().at(4)
+                           << " "
+                           // k2, p1, p2, k3, k4, k5, k6
+                           << "0.0 0.0 0.0 0.0 0.0 0.0 0.0"
+                           << "\n";
+            }
+            break;
+        case camera::PINHOLE_CAMERA_RADIAL3:
+            // PINHOLE_CAMERA_RADIAL3 can only be modeled by Colmap's FULL_OPENCV setting the unused parameters to 0
+            // Parameters: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
+            {
+                const camera::PinholeRadialK3* pinhole_intrinsic_radial =
+                    dynamic_cast<const camera::PinholeRadialK3*>(intrinsic.get());
+
+                intrString << intrinsicsID << " "
+                           << "FULL_OPENCV"
+                           << " " << pinhole_intrinsic_radial->w() << " " << pinhole_intrinsic_radial->h() << " "
+                           << pinhole_intrinsic_radial->getFocalLengthPixX() << " "
+                           << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
+                           << pinhole_intrinsic_radial->getPrincipalPoint().x() << " "
+                           << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
+                           << pinhole_intrinsic_radial->getParams().at(4) << " "
+                           << pinhole_intrinsic_radial->getParams().at(5)
+                           << " "
+                           // tangential params p1 and p2
+                           << 0.0 << " " << 0.0
+                           << " "
+                           // k3
+                           << pinhole_intrinsic_radial->getParams().at(6)
+                           << " "
+                           // remaining radial params k4-k6
+                           << 0.0 << " " << 0.0 << " " << 0.0 << "\n";
+            }
+            break;
+        case camera::PINHOLE_CAMERA_BROWN:
+            // PINHOLE_CAMERA_BROWN can only be modeled by Colmap's FULL_OPENCV setting the unused parameters to 0
+            // Parameters: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
+            {
+                const camera::PinholeBrownT2* pinholeCameraBrownIntrinsics =
+                    dynamic_cast<const camera::PinholeBrownT2*>(intrinsic.get());
+
+                intrString << intrinsicsID << " "
+                           << "FULL_OPENCV"
+                           << " " << pinholeCameraBrownIntrinsics->w() << " " << pinholeCameraBrownIntrinsics->h()
+                           << " " << pinholeCameraBrownIntrinsics->getFocalLengthPixX() << " "
+                           << pinholeCameraBrownIntrinsics->getFocalLengthPixY() << " "
+                           << pinholeCameraBrownIntrinsics->getPrincipalPoint().x() << " "
+                           << pinholeCameraBrownIntrinsics->getPrincipalPoint().y() << " "
+                           << pinholeCameraBrownIntrinsics->getParams().at(4) << " "
+                           << pinholeCameraBrownIntrinsics->getParams().at(5)
+                           << " "
+                           // tangential params p1 and p2
+                           << pinholeCameraBrownIntrinsics->getParams().at(7) << " "
+                           << pinholeCameraBrownIntrinsics->getParams().at(8)
+                           << " "
+                           // k3
+                           << pinholeCameraBrownIntrinsics->getParams().at(6)
+                           << " "
+                           // remaining radial params k4-k6
+                           << 0.0 << " " << 0.0 << " " << 0.0 << "\n";
+            }
+            break;
+        case camera::PINHOLE_CAMERA_FISHEYE:
+            // PINHOLE_CAMERA_FISHEYE is modeled by Colmap's OPENCV_FISHEYE
+            // Parameters: fx, fy, cx, cy, k1, k2, k3, k4
+            {
+                const camera::PinholeFisheye* pinholeIntrinsicFisheye =
+                    dynamic_cast<const camera::PinholeFisheye*>(intrinsic.get());
+
+                intrString << intrinsicsID << " "
+                           << "OPENCV_FISHEYE"
+                           << " " << pinholeIntrinsicFisheye->w() << " " << pinholeIntrinsicFisheye->h() << " "
+                           << pinholeIntrinsicFisheye->getFocalLengthPixX() << " "
+                           << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " "
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
+                           << pinholeIntrinsicFisheye->getParams().at(4) << " "
+                           << pinholeIntrinsicFisheye->getParams().at(5) << " "
+                           << pinholeIntrinsicFisheye->getParams().at(6) << " "
+                           << pinholeIntrinsicFisheye->getParams().at(7) << "\n";
+            }
+            break;
+        case camera::PINHOLE_CAMERA_FISHEYE1:
+            // PINHOLE_CAMERA_FISHEYE corresponds to Colmap's FOV
+            // Parameters: fx, fy, cx, cy, k1, k2, k3, k4
+            {
+                const camera::PinholeFisheye1* pinholeIntrinsicFisheye =
+                    dynamic_cast<const camera::PinholeFisheye1*>(intrinsic.get());
+
+                intrString << intrinsicsID << " "
+                           << "FOV"
+                           << " " << pinholeIntrinsicFisheye->w() << " " << pinholeIntrinsicFisheye->h() << " "
+                           << pinholeIntrinsicFisheye->getFocalLengthPixX() << " "
+                           << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " "
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
+                           << pinholeIntrinsicFisheye->getParams().at(4) << "\n";
+            }
+            break;
+        default:
+            throw std::invalid_argument("The intrinsics " + EINTRINSIC_enumToString(current_type) + " for camera " +
+                                     std::to_string(intrinsicsID) + " are not supported in Colmap");
+    }
+    return intrString.str();
+}
+
+void generateColmapCamerasTxtFile(const sfmData::SfMData& sfmData, const std::string& filename)
+{
+    // Adapted from Colmap Reconstruction::WriteCamerasText()
+    // The cameras.txt file has the following header
+    static const std::string camerasHeader = "# Camera list with one line of data per camera:\n"
+                                             "#   CAMERA_ID, MODEL, WIDTH, HEIGHT, PARAMS[]\n";
+
+    std::ofstream outfile(filename);
+
+    if(!outfile)
+    {
+        ALICEVISION_LOG_ERROR("Unable to create the cameras file " << filename);
+        throw std::runtime_error("Unable to create the cameras file " + filename);
+    }
+
+    outfile << camerasHeader;
+    outfile << "# Number of cameras: " << sfmData.getIntrinsics().size() << "\n";
+
+    std::vector<std::string> camera_lines;
+
+    for(const auto& iter : sfmData.getIntrinsics())
+    {
+        const IndexT intrID = iter.first;
+        std::shared_ptr<camera::IntrinsicBase> intrinsic = iter.second;
+
+        if(isColmapCompatible(intrinsic->getType()))
+        {
+            outfile << convertIntrinsicsToColmapString(intrID, intrinsic);
+        }
+    }
+}
+
+PerViewVisibility computePerViewVisibility(const sfmData::SfMData& sfmData, const CompatibleList& viewSelections)
+{
+    PerViewVisibility perCameraVisibility;
+
+    for(const auto& land : sfmData.getLandmarks())
+    {
+        const IndexT landID = land.first;
+        const auto& observations = land.second.observations;
+
+        for(const auto& iter : observations)
+        {
+            const IndexT viewID = iter.first;
+            const auto& obs = iter.second;
+
+            if(viewSelections.find(viewID) != viewSelections.end())
+            {
+                // for the current viewID add the feature point and its associate 3D point's ID
+                perCameraVisibility[viewID][landID] = obs.x;
+            }
+        }
+    }
+    return perCameraVisibility;
+}
+
+void generateColmapImagesTxtFile(const sfmData::SfMData& sfmData, const CompatibleList& viewSelections,
+                                 const std::string& filename)
+{
+    // adapted from Colmap's Reconstruction::WriteImagesText()
+    // An images.txt file has the following format
+    static const std::string imageHeader = "# Image list with two lines of data per image:\n"
+                                           "#   IMAGE_ID, QW, QX, QY, QZ, TX, TY, TZ, CAMERA_ID, NAME\n"
+                                           "#   POINTS2D[] as (X, Y, POINT3D_ID)\n";
+
+    std::ofstream outfile(filename);
+
+    if(!outfile)
+    {
+        ALICEVISION_LOG_ERROR("Unable to create the image file " << filename);
+        throw std::runtime_error("Unable to create the image file " + filename);
+    }
+    // Ensure no loss of precision by storing in text.
+    outfile.precision(17);
+    outfile << imageHeader;
+
+    // colmap requires per-camera visibility rather per-landmark, so for each camera we need to create the relevant
+    // visibility list
+    const auto perViewVisibility = computePerViewVisibility(sfmData, viewSelections);
+
+    // for each view to export add a line with the pose and the intrinsics ID and another with point visibility
+    for(const auto& iter : sfmData.getViews())
+    {
+        const auto view = iter.second.get();
+        const auto viewID = view->getViewId();
+
+        if(viewSelections.find(viewID) == viewSelections.end())
+        {
+            continue;
+        }
+
+        // this is necessary if we copy the images in the image folder because the image path is absolute in AV
+        const std::string imageFilename = fs::path(view->getImagePath()).filename().string();
+        const IndexT intrID = view->getIntrinsicId();
+
+        const auto pose = sfmData.getPose(*view).getTransform();
+        const Mat3 rot = pose.rotation();
+        const Vec3 tra = pose.translation();
+        Eigen::Quaterniond quat(rot);
+
+        //"#   IMAGE_ID, QW, QX, QY, QZ, TX, TY, TZ, CAMERA_ID, NAME\n"
+        //"#   POINTS2D[] as (X, Y, POINT3D_ID)\n"
+        outfile << viewID << " " << quat.w() << " " << quat.x() << " " << quat.y() << " " << quat.z() << " " << tra[0]
+                << " " << tra[1] << " " << tra[2] << " " << intrID << " " << imageFilename << "\n";
+
+        for(const auto& obs : perViewVisibility.at(viewID))
+        {
+            const auto& id = obs.first;
+            const auto& pts = obs.second;
+            outfile << pts.x() << " " << pts.y() << " " << id << " ";
+        }
+        outfile << "\n";
+    }
+}
+
+void copyImagesFromSfmData(const sfmData::SfMData& sfmData, const std::string& destinationFolder,
+                           const CompatibleList selection)
+{
+    for(const auto viewId : selection)
+    {
+        const auto& view = sfmData.getView(viewId);
+        const auto& from = fs::path(view.getImagePath());
+        const auto& to = fs::path(destinationFolder) / from.filename();
+        fs::copy_file(from, to);
+    }
+}
+
+void generateColmapPoints3DTxtFile(const sfmData::SfMData& sfmData, const CompatibleList& viewSelections,
+                                   const std::string& filename)
+{
+    // adapted from Colmap's Reconstruction::WritePoints3DText()
+    // The points3D.txt file has the following header
+    static const std::string points3dHeader =
+        "# 3D point list with one line of data per point:\n"
+        "#   POINT3D_ID, X, Y, Z, R, G, B, ERROR, TRACK[] as (IMAGE_ID, POINT2D_IDX)\n";
+
+    std::ofstream outfile(filename);
+
+    if(!outfile)
+    {
+        ALICEVISION_LOG_ERROR("Unable to create the 3D point file " << filename);
+        throw std::runtime_error("Unable to create the 3D point file " + filename);
+    }
+
+    outfile << points3dHeader;
+    // default reprojection error (not used)
+    const double defaultError{-1.0};
+
+    for(const auto& iter : sfmData.getLandmarks())
+    {
+        const IndexT id = iter.first;
+        const Vec3 exportPoint = iter.second.X;
+        const auto pointColor = iter.second.rgb;
+        outfile << id << " " << exportPoint.x() << " " << exportPoint.y() << " " << exportPoint.z() << " "
+                << static_cast<int>(pointColor.r()) << " " << static_cast<int>(pointColor.g()) << " "
+                << static_cast<int>(pointColor.b()) << " ";
+
+        outfile << defaultError;
+
+        for(const auto& itObs : iter.second.observations)
+        {
+            const IndexT viewId = itObs.first;
+            const IndexT featId = itObs.second.id_feat;
+
+            if(viewSelections.find(viewId) != viewSelections.end())
+            {
+                outfile << " " << viewId << " " << featId;
+            }
+        }
+        outfile << "\n";
+    }
+}
+
+void generateColmapSceneFiles(const sfmData::SfMData& sfmData, const CompatibleList& viewsSelection,
+                              const ColmapConfig& colmapParams)
+{
+    generateColmapCamerasTxtFile(sfmData, colmapParams._camerasTxtPath);
+    generateColmapImagesTxtFile(sfmData, viewsSelection, colmapParams._imagesTxtPath);
+    generateColmapPoints3DTxtFile(sfmData, viewsSelection, colmapParams._points3DPath);
+}
+
+void create_directories(const std::string& directory)
+{
+    const bool ok = fs::create_directories(directory);
+    if(!ok)
+    {
+        ALICEVISION_LOG_ERROR("Cannot create directory " << directory);
+        throw std::runtime_error("Cannot create directory " + directory);
+    }
+}
+
+void convertToColmapScene(const sfmData::SfMData& sfmData, const std::string& colmapBaseDir, bool copyImages)
+{
+    // retrieve the views that are compatible with Colmap and that can be exported
+    const auto views2export = getColmapCompatibleViews(sfmData);
+    if(views2export.empty())
+    {
+        ALICEVISION_LOG_WARNING("No camera in the scene is compatible with Colmap");
+        return;
+    }
+    ALICEVISION_LOG_INFO("Found " << views2export.size() << "/" << sfmData.getValidViews().size()
+                                  << " views to export "
+                                     "that are compatible with Colmap");
+
+    ColmapConfig colmapParams{colmapBaseDir};
+
+    // Generate the folder structure for colmap
+    ALICEVISION_LOG_INFO("Creating Colmap subfolders...");
+    create_directories(colmapParams._sparseDirectory);
+    create_directories(colmapParams._denseDirectory);
+    create_directories(colmapParams._imagesDirectory);
+
+    if(copyImages)
+    {
+        ALICEVISION_LOG_INFO("Copying source images...");
+        copyImagesFromSfmData(sfmData, colmapParams._imagesDirectory, views2export);
+    }
+
+    ALICEVISION_LOG_INFO("Generating Colmap files...");
+    generateColmapSceneFiles(sfmData, views2export, colmapParams);
+}
+
+}
+}

--- a/src/aliceVision/sfmDataIO/colmap.hpp
+++ b/src/aliceVision/sfmDataIO/colmap.hpp
@@ -1,0 +1,155 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/camera/cameraCommon.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/types.hpp>
+
+#include <string>
+#include <set>
+#include <unordered_set>
+
+namespace aliceVision{
+namespace sfmDataIO{
+
+using CompatibleList = std::unordered_set<IndexT>;
+
+/**
+ * @brief Struct containing the configuration parameters for the Colmap's scene structure
+ */
+struct ColmapConfig
+{
+    /**
+     * @brief Initialize the configuration from the given base path.
+     * @param[in] basePath The path where the directory structure and the various Colmap's file will be created.
+     */
+    ColmapConfig(const std::string& basePath);
+
+    /// the base path
+    std::string _basePath{};
+    /// the directory containing the sparse reconstruction
+    std::string _sparseDirectory{};
+    /// the directory containing the dense reconstruction
+    std::string _denseDirectory{};
+    /// the directory containing the undistorted images
+    std::string _imagesDirectory{};
+    /// the full path for the cameras.txt file
+    std::string _camerasTxtPath{};
+    /// the full path for the images.txt file
+    std::string _imagesTxtPath{};
+    /// the full path for the points3d.txt file
+    std::string _points3DPath{};
+};
+
+/**
+ * @brief Return the set of intrinsic types that are compatible with those of Colmap.
+ * @return the set of compatible intrinsics.
+ */
+const std::set<camera::EINTRINSIC>& colmapCompatibleIntrinsics();
+
+/**
+ * @brief Check whether a given intrinsic type is compatible with Colmap.
+ * @param[in] intrinsicType the intrinsic to check.
+ * @return \p true if the intrinsic is compatible.
+ */
+bool isColmapCompatible(camera::EINTRINSIC intrinsicType);
+
+/**
+ * @brief Given an SfMData scene returns the list of the IDs of the Colmap-compatible intrinsics.
+ * @param[in] sfMData the sfm scene.
+ * @return the set of IDs of the intrinsics that are compatible with Colmap.
+ */
+CompatibleList getColmapCompatibleIntrinsics(const sfmData::SfMData& sfMData);
+
+/**
+ * @brief Given an SfMData scene returns the list of the IDs of the views that have Colmap-compatible intrinsics.
+ * @param[in] sfmData the sfm scene.
+ * @return the set of IDs of the views that have intrinsics compatible with Colmap.
+ */
+CompatibleList getColmapCompatibleViews(const sfmData::SfMData& sfmData);
+
+/**
+ * @brief Convert the given intrinsic to the equivalent string to be placed in a cameras.txt file.
+ * @param[in] intrinsicsID the id of the intrinsics.
+ * @param[in] intrinsic the intrinsics.
+ * @return a string format for the colmap equivalent intrinsics in the format CAMERA_ID, MODEL, WIDTH, HEIGHT, PARAMS[].
+ * @throws std::runtime_error() if the intrinsic is not compatible with Colmap.
+ */
+std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shared_ptr<camera::IntrinsicBase> intrinsic);
+
+/**
+ * @brief Given the sfmData it generates the equivalent cameras.txt file with the Colmap compatible cameras.
+ * @param[in] sfmData the input sfmData.
+ * @param[in] filename the filename where to save the Colmap's scene (usually a cameras.txt)
+ */
+void generateColmapCamerasTxtFile(const sfmData::SfMData& sfmData, const std::string& filename);
+
+/// map< viewID, map<landmarkID, pt2d>>
+using PerViewVisibility = std::map<IndexT, std::map<IndexT, Vec2>>;
+
+/**
+ * @brief Given an sfm scene and a selection of its views, it computes the visibility of the 3D points per each view:
+ * for each view, it maps a 2d feature of the view to its relevant 3D point.
+ * @param[in] sfmData the input scene.
+ * @param[in] viewSelections a selection of view IDs.
+ * @return the visibility of 3D points for each view.
+ */
+PerViewVisibility computePerViewVisibility(const sfmData::SfMData& sfmData, const CompatibleList& viewSelections);
+
+/**
+ * @brief Given an sfm scene and a selection of its views that are compatible with Colmap, it generates the images.txt
+ * file for Colmap scene.
+ * @param[in] sfmData  the input scene.
+ * @param[in] viewSelections  a selection of view IDs that have compatible intrinsics with Colmap.
+ * @param[in] filename the filename where to save the scene (usually a images.txt file)
+ */
+void generateColmapImagesTxtFile(const sfmData::SfMData& sfmData, const CompatibleList& viewSelections,
+                                 const std::string& filename);
+
+/**
+ * @brief Given an sfm scene and a selection of its views that are compatible with Colmap, it copies the source images to
+ * the given directory.
+ * @param[in] sfmData the input scene.
+ * @param[in] destinationFolder the folder where to copy the images.
+ * @param[in] selection  a selection of view IDs that have compatible intrinsics with Colmap.
+ */
+void copyImagesFromSfmData(const sfmData::SfMData& sfmData, const std::string& destinationFolder,
+                           const CompatibleList selection);
+
+/**
+ * @brief Given an sfm scene and a selection of its views that are compatible with Colmap, it generates the points3d.txt
+ * file for Colmap scene.
+ * @param[in] sfmData the input scene.
+ * @param[in] viewSelections a selection of view IDs that have compatible intrinsics with Colmap.
+ * @param[in] filename the filename where to save the points (usually a points3d.txt file)
+ */
+void generateColmapPoints3DTxtFile(const sfmData::SfMData& sfmData, const CompatibleList& viewSelections,
+                                   const std::string& filename);
+
+/**
+ * @brief Given an sfm scene and a selection of its views that are compatible with Colmap, it generates all the Colmap
+ * files that represent the scene.
+ * @param sfmData the input scene.
+ * @param viewsSelection a selection of view IDs that have compatible intrinsics with Colmap.
+ * @param colmapParams the configuration data for the Colmap scene.
+ */
+void generateColmapSceneFiles(const sfmData::SfMData& sfmData, const CompatibleList& viewsSelection,
+                              const ColmapConfig& colmapParams);
+
+/**
+ * @brief iven an sfm scene it generate the folder structure and all the files in Colmap format.
+ * @param sfmData the input scene.
+ * @param colmapBaseDir the base path where to generate the equivalent Colmap scene.
+ * @param copyImages enable copying the source image into the Colmap scene folder. This can be set to false when the
+ * sfmData scene contains images from a single directory: in this case copy can be skipped and the first undistort step
+ * of Colmap's MVS process can be called directly on the source folder without copying the images.
+ */
+void convertToColmapScene(const sfmData::SfMData& sfmData, const std::string& colmapBaseDir, bool copyImages);
+
+}
+}

--- a/src/aliceVision/sfmDataIO/colmap_test.cpp
+++ b/src/aliceVision/sfmDataIO/colmap_test.cpp
@@ -1,0 +1,128 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE colmap
+
+
+#include <aliceVision/camera/cameraCommon.hpp>
+
+#include <aliceVision/sfmDataIO/colmap.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+#include <aliceVision/unitTest.hpp>
+
+using namespace aliceVision;
+
+BOOST_AUTO_TEST_CASE(colmap_isCompatible)
+{
+    const std::map<camera::EINTRINSIC, bool> compatibility {
+        {camera::EINTRINSIC::PINHOLE_CAMERA, true},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL1, true},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3, true},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_BROWN, true},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE, true},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE1, true},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_3DEANAMORPHIC4, false},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_3DECLASSICLD, false},
+        {camera::EINTRINSIC::PINHOLE_CAMERA_3DERADIAL4, false},
+        {camera::EINTRINSIC::EQUIDISTANT_CAMERA, false},
+        {camera::EINTRINSIC::EQUIDISTANT_CAMERA_RADIAL3, false},
+    };
+
+    for(const auto& c : compatibility)
+    {
+        BOOST_CHECK(sfmDataIO::isColmapCompatible(c.first) == c.second);
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(colmap_convertIntrinsicsToColmapString)
+{
+    sfmData::SfMData sfmTest{};
+    auto& intrTest = sfmTest.getIntrinsics();
+    BOOST_CHECK(intrTest.empty());
+    // add some compatible intrinsics
+    intrTest.emplace(10, std::make_shared<camera::Pinhole>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54));
+    intrTest.emplace(11, std::make_shared<camera::PinholeRadialK1>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.02078));
+    intrTest.emplace(12, std::make_shared<camera::PinholeRadialK3>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.02078, 0.1705, -0.00714));
+    intrTest.emplace(13, std::make_shared<camera::PinholeBrownT2>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.02078, 0.1705, -0.00714, 0.00134, -0.000542));
+    intrTest.emplace(14, std::make_shared<camera::PinholeFisheye>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.02078, 0.1705, -0.00714, 0.00134));
+    intrTest.emplace(15, std::make_shared<camera::PinholeFisheye1>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.000542));
+    // add some incompatible intrinsics
+    intrTest.emplace(20, std::make_shared<camera::Pinhole3DEAnamorphic4>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.02078, 0.1705, -0.00714, 0.00134));
+    intrTest.emplace(21, std::make_shared<camera::Pinhole3DEClassicLD>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.02078, 0.1705, -0.00714, 0.00134, -0.000542));
+    intrTest.emplace(22, std::make_shared<camera::Pinhole3DERadial4>(1920, 1080, 1548.76, 1547.32, 992.36, 549.54, -0.02078, 0.1705, -0.00714, 0.00134, -0.00714, 0.00134));
+    intrTest.emplace(23, std::make_shared<camera::EquiDistant>(1920, 1080, 1548.76, 992.36, 549.54, -0.02078));
+    intrTest.emplace(24, std::make_shared<camera::EquiDistantRadialK3>(1920, 1080, 1548.76, 992.36, 549.54, -0.02078, 0.1705, -0.00714, 0.00134));
+
+    // reference for each intrinsic ID the relevant expected string
+    const std::map<IndexT, std::string> stringRef{
+        {10, "10 PINHOLE 1920 1080 1548.76 1547.32 1952.36 1089.54\n"},
+        {11, "11 FULL_OPENCV 1920 1080 1548.76 1547.32 1952.36 1089.54 -0.02078 0.0 0.0 0.0 0.0 0.0 0.0 0.0\n"},
+        {12, "12 FULL_OPENCV 1920 1080 1548.76 1547.32 1952.36 1089.54 -0.02078 0.1705 0 0 -0.00714 0 0 0\n"},
+        {13, "13 FULL_OPENCV 1920 1080 1548.76 1547.32 1952.36 1089.54 -0.02078 0.1705 0.00134 -0.000542 -0.00714 0 0 0\n"},
+        {14, "14 OPENCV_FISHEYE 1920 1080 1548.76 1547.32 1952.36 1089.54 -0.02078 0.1705 -0.00714 0.00134\n"},
+        {15, "15 FOV 1920 1080 1548.76 1547.32 1952.36 1089.54 -0.000542\n"}
+    };
+
+    // test the string conversion
+    for(const auto& toTest : stringRef)
+    {
+        const auto id = toTest.first;
+        const auto& ref = toTest.second;
+        const auto out = sfmDataIO::convertIntrinsicsToColmapString(id, intrTest.at(id));
+        BOOST_CHECK(ref == out);
+    }
+
+    // test throw if not compatible
+    for(const auto& item : intrTest)
+    {
+        const auto id = item.first;
+        const auto& intr = item.second;
+        if(id >= 20)
+        {
+            BOOST_CHECK_THROW(sfmDataIO::convertIntrinsicsToColmapString(id, intr), std::invalid_argument);
+        }
+        else
+        {
+            BOOST_CHECK(sfmDataIO::isColmapCompatible(intr->getType()));
+        }
+    }
+
+    // test get compatible intrinsics from sfmdata
+    {
+        const auto compIntr = sfmDataIO::getColmapCompatibleIntrinsics(sfmTest);
+        BOOST_CHECK(compIntr.size() == 6);
+        for(const auto& id : compIntr)
+        {
+            BOOST_CHECK(id < 20);
+        }
+    }
+
+    // test compatible views
+    {
+        // add some fake view for each intrinsics and test get compatible views
+        for(const auto& item : intrTest)
+        {
+            const auto intrID = item.first;
+            for(IndexT cam = 0; cam < 5; ++cam)
+            {
+                const auto camID = intrID * 10 + cam;
+                sfmTest.getViews().emplace(camID, std::make_shared<sfmData::View>("", cam, intrID, camID));
+                sfmTest.getPoses().emplace(camID, sfmData::CameraPose());
+            }
+        }
+
+        const auto compatibleViews = sfmDataIO::getColmapCompatibleViews(sfmTest);
+        BOOST_CHECK(compatibleViews.size() == 30);
+        // check the retrieved views are compatible
+        for(const auto& id : compatibleViews)
+        {
+            const auto intrID = sfmTest.getViews().at(id)->getIntrinsicId();
+            BOOST_CHECK(sfmDataIO::isColmapCompatible(sfmTest.getIntrinsics().at(intrID)->getType()));
+        }
+    }
+}

--- a/src/software/export/CMakeLists.txt
+++ b/src/software/export/CMakeLists.txt
@@ -80,6 +80,22 @@ alicevision_add_software(aliceVision_exportPMVS
         Boost::timer
 )
 
+# Export a SfM aliceVision scene to PMVS format
+alicevision_add_software(aliceVision_exportColmap
+        SOURCE main_exportColmap.cpp
+        FOLDER ${FOLDER_SOFTWARE_EXPORT}
+        LINKS aliceVision_system
+        aliceVision_image
+        aliceVision_feature
+        aliceVision_sfmData
+        aliceVision_sfmDataIO
+        Boost::program_options
+        Boost::filesystem
+        Boost::boost
+        Boost::timer
+        )
+
+
 # Export point cloud
 alicevision_add_software(aliceVision_exportColoredPointCloud
   SOURCE main_exportColoredPointCloud.cpp

--- a/src/software/export/main_exportColmap.cpp
+++ b/src/software/export/main_exportColmap.cpp
@@ -1,0 +1,99 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfmDataIO/colmap.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/main.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = boost::filesystem;
+
+
+int aliceVision_main(int argc, char* argv[])
+{
+    std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+    std::string sfmDataFilename;
+    std::string outDirectory;
+    bool copyImages{false};
+
+    po::options_description allParams("Export an AV sfmdata to a Colmap scene, creating the folder structure and "
+                                      "the scene files that can be used for running a MVS step");
+
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
+        ("output,o", po::value<std::string>(&outDirectory)->required(),
+        "The base path where the folder structure will be created with the relevant cameras.txt, images.txt "
+             "and points3D.txt files.")
+        ("copyImages", po::value<bool>(&copyImages)->default_value(copyImages),
+             "Copy original images to colmap folder. This is required if your images are not all in the same "
+             "folder.");
+
+    po::options_description logParams("Log parameters");
+    logParams.add_options()("verboseLevel,v", po::value<std::string>(&verboseLevel)->default_value(verboseLevel),
+                            "verbosity level (fatal,  error, warning, info, debug, trace).");
+
+    allParams.add(requiredParams).add(logParams);
+
+    po::variables_map vm;
+    try
+    {
+        po::store(po::parse_command_line(argc, argv, allParams), vm);
+
+        if(vm.count("help") || (argc == 1))
+        {
+            ALICEVISION_COUT(allParams);
+            return EXIT_SUCCESS;
+        }
+        po::notify(vm);
+    }
+    catch(boost::program_options::required_option& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
+        return EXIT_FAILURE;
+    }
+    catch(boost::program_options::error& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << allParams);
+        return EXIT_FAILURE;
+    }
+
+    // set verbose level
+    system::Logger::get()->setLogLevel(verboseLevel);
+
+    if(!fs::exists(outDirectory))
+    {
+        fs::create_directory(outDirectory);
+    }
+
+    // Read the input SfM scene
+    sfmData::SfMData sfmData;
+    if(!sfmDataIO::Load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::ALL)))
+    {
+        ALICEVISION_LOG_ERROR("Unable to read the sfmdata file " << sfmDataFilename);
+        return EXIT_FAILURE;
+    }
+
+    sfmDataIO::convertToColmapScene(sfmData, outDirectory, copyImages);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Description

Add the exporter to Colmap to convert an AV SfMData into Colmap's format with the relevant folder structure and the txt files for the scene representation.

## Features list

* helper functions to extract and convert the scene
* helper functions to test the compatibility of intrinsics
* unit tests
* software to perform the conversion

## Implementation remarks

* Since not all the intrinsic types are compatible between the two libraries, the choice has been made to export only those that are compatible and remove the others from the scene.
* An option is added to copy or not the source images into the Colmap destination folder. This enables the user to skip the copy if all the (many) images are in the same folder: since the first step of Colmap's MVS processing is to remove the optical distortion, that command can be run directly on the source folder without an explicit copy.
