### PR TITLE
Remove using namespace std and add std:: qualifications where needed

### DIFF
--- a/src/aliceVision/depthMap/cuda/LRUCache.hpp
+++ b/src/aliceVision/depthMap/cuda/LRUCache.hpp
@@ -149,7 +149,6 @@ private:
  * #include <algorithm>
  * #include "lrucache.hpp"
  * 
- * using namespace std;
  * using namespace aliceVision::depthMap;
  * 
  * int main()
@@ -157,16 +156,16 @@ private:
  *     LRUCache<int> cache(10);
  *     int oldValue, position;
  * 
- *     vector<int> v(100);
+ *     std::vector<int> v(100);
  *     generate( v.begin(), v.end(), [](){ return (int)(rand()%20); } );
  * 
  *     for( auto newValue : v ) {
  *         if( cache.insert( newValue, position, oldValue ) ) {
  *             cout << newValue << " inserted at " << position;
  *             if( oldValue != -1 ) cout << " removed oldValue " << oldValue;
- *             cout << endl;
+ *             std::cout << std::endl;
  *         } else
- *             cout << newValue << " cached at " << position << endl;
+ *             std::cout << newValue << " cached at " << position << std::endl;
  *         cache.dump(cout) << endl;
  *     }
  * }

--- a/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.cpp
+++ b/src/aliceVision/feature/akaze/ImageDescriber_AKAZE.cpp
@@ -10,8 +10,6 @@
 namespace aliceVision {
 namespace feature {
 
-using namespace std;
-
 bool ImageDescriber_AKAZE::describe(const image::Image<float>& image,
                                     std::unique_ptr<Regions>& regions,
                                     const image::Image<unsigned char>* mask)

--- a/src/aliceVision/feature/features_test.cpp
+++ b/src/aliceVision/feature/features_test.cpp
@@ -17,8 +17,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-using namespace std;
-using std::string;
 using namespace aliceVision;
 using namespace aliceVision::feature;
 

--- a/src/aliceVision/feature/metric_test.cpp
+++ b/src/aliceVision/feature/metric_test.cpp
@@ -15,7 +15,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-using namespace std;
 using namespace aliceVision;
 using namespace feature;
 

--- a/src/aliceVision/geometry/halfSpaceIntersection_test.cpp
+++ b/src/aliceVision/geometry/halfSpaceIntersection_test.cpp
@@ -17,7 +17,6 @@
 
 using namespace aliceVision;
 using namespace aliceVision::geometry::halfPlane;
-using namespace std;
 
 BOOST_AUTO_TEST_CASE(ExistingSubspace) {
 

--- a/src/aliceVision/geometry/rigidTransformation3D_test.cpp
+++ b/src/aliceVision/geometry/rigidTransformation3D_test.cpp
@@ -17,7 +17,6 @@
 
 using namespace aliceVision;
 using namespace aliceVision::geometry;
-using namespace std;
 
 BOOST_AUTO_TEST_CASE(SRT_precision_Experiment_ScaleOnly)
 {

--- a/src/aliceVision/image/filtering_test.cpp
+++ b/src/aliceVision/image/filtering_test.cpp
@@ -16,7 +16,6 @@
 
 using namespace aliceVision;
 using namespace aliceVision::image;
-using namespace std;
 
 BOOST_AUTO_TEST_CASE(Image_Convolution)
 {

--- a/src/aliceVision/image/image_test.cpp
+++ b/src/aliceVision/image/image_test.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::image;
 
@@ -30,7 +29,7 @@ BOOST_AUTO_TEST_CASE(Image_Basis)
   //-- Get raw ptr to image data :
   const unsigned char * ptr = imaGray.data();
   ((unsigned char*)ptr)[0] = 2;
-  fill(((unsigned char*)ptr+9*10),((unsigned char*)ptr+10*10),2);
+  std::fill(((unsigned char*)ptr+9*10),((unsigned char*)ptr+10*10),2);
   //cout << "After" << endl << imaGray;
 
   // Construction by re-copy

--- a/src/aliceVision/linearProgramming/MOSEKSolver.cpp
+++ b/src/aliceVision/linearProgramming/MOSEKSolver.cpp
@@ -12,8 +12,6 @@
 namespace aliceVision {
 namespace linearProgramming {
 
-using namespace std;
-
 // This function prints log output from MOSEK to the terminal.
 inline void MSKAPI printstr(void *handle,
                             char str[])

--- a/src/aliceVision/linearProgramming/lInfinityCV/lInftyCV_global_translations_fromTij_test.cpp
+++ b/src/aliceVision/linearProgramming/lInfinityCV/lInftyCV_global_translations_fromTij_test.cpp
@@ -20,7 +20,6 @@
 using namespace aliceVision;
 using namespace aliceVision::linearProgramming;
 using namespace lInfinityCV;
-using namespace std;
 
 BOOST_AUTO_TEST_CASE(translation_averaging_globalTi_from_tijs) {
 

--- a/src/aliceVision/linearProgramming/lInfinityCV/lInftyCV_global_translations_fromTriplets_test.cpp
+++ b/src/aliceVision/linearProgramming/lInfinityCV/lInftyCV_global_translations_fromTriplets_test.cpp
@@ -20,7 +20,6 @@
 using namespace aliceVision;
 using namespace aliceVision::linearProgramming;
 using namespace lInfinityCV;
-using namespace std;
 
 BOOST_AUTO_TEST_CASE(translation_averaging_globalTi_from_tijs_Triplets) {
 

--- a/src/aliceVision/linearProgramming/lInfinityCV/resection_kernel.cpp
+++ b/src/aliceVision/linearProgramming/lInfinityCV/resection_kernel.cpp
@@ -18,8 +18,6 @@ namespace aliceVision {
 namespace lInfinityCV {
 namespace kernel {
 
-using namespace std;
-
 void translate(const Mat3X & X, const Vec3 & vecTranslation,
                Mat3X * XPoints) {
   XPoints->resize(X.rows(), X.cols());

--- a/src/aliceVision/matching/filters.hpp
+++ b/src/aliceVision/matching/filters.hpp
@@ -17,8 +17,6 @@
 namespace aliceVision {
 namespace matching {
 
-using namespace std;
-
 /**
   * Nearest neighbor distance ratio filtering ( a < fratio * b) :
   * Ratio between best and second best matches must be superior to
@@ -83,10 +81,10 @@ inline void NNdistanceRatio
   *
   * \return void.
   */
-inline void SymmetricMatches(const vector<int> & vec_matches,
-  const vector<int> & vec_reversematches,
+inline void SymmetricMatches(const std::vector<int> & vec_matches,
+  const std::vector<int> & vec_reversematches,
   int NN,
-  vector<int> & vec_goodIndex)
+  std::vector<int> & vec_goodIndex)
 {
   assert (NN >= 1);
 
@@ -115,7 +113,7 @@ inline void SymmetricMatches(const vector<int> & vec_matches,
 template <typename Iterator, typename Type>
 inline void IntersectMatches( Iterator aStart, Iterator aEnd,
                        Iterator bStart, Iterator bEnd,
-                       vector<Type> & vec_out)
+                       std::vector<Type> & vec_out)
 {
   //-- Compute the intersection of the two vector
   //--- Use STL to perform it. Require that the input vectors are sorted.
@@ -124,7 +122,7 @@ inline void IntersectMatches( Iterator aStart, Iterator aEnd,
                          bStart, bEnd,
                          std::inserter( intersect, intersect.begin() ) );
 
-  vec_out = vector<Type>(intersect.begin(), intersect.end());
+  vec_out = std::vector<Type>(intersect.begin(), intersect.end());
 }
 
 enum eMatchFilter
@@ -135,15 +133,15 @@ enum eMatchFilter
 };
 
 inline void Filter( int NN,
-       const vector<int> & vec_Matches01,
-       const vector<float> & vec_distance01,
-       const vector<int> & vec_Matches10,
-       const vector<float> & vec_distance10,
-       vector<IndMatch> & vec_outIndex,
+       const std::vector<int> & vec_Matches01,
+       const std::vector<float> & vec_distance01,
+       const std::vector<int> & vec_Matches10,
+       const std::vector<float> & vec_distance10,
+       std::vector<IndMatch> & vec_outIndex,
        eMatchFilter matchFilter,
        float fNNDistanceRatio = 0.6f)
 {
-  vector<int> vec_symmetricIndex, vec_NNDistRatioIndexes;
+  std::vector<int> vec_symmetricIndex, vec_NNDistRatioIndexes;
 
   if (matchFilter == MATCHFILTER_SYMMETRIC ||
       matchFilter == MATCHFILER_SYM_AND_NNDISTANCERATIO)
@@ -191,7 +189,7 @@ inline void Filter( int NN,
 
   case MATCHFILER_SYM_AND_NNDISTANCERATIO:
 
-    vector<int> vec_indexes;
+    std::vector<int> vec_indexes;
     //-- Compute the intersection of the two vector
     IntersectMatches(vec_symmetricIndex.begin(), vec_symmetricIndex.end(),
       vec_NNDistRatioIndexes.begin(), vec_NNDistRatioIndexes.end(),

--- a/src/aliceVision/matching/filters_test.cpp
+++ b/src/aliceVision/matching/filters_test.cpp
@@ -13,18 +13,17 @@
 
 using namespace aliceVision;
 using namespace aliceVision::matching;
-using namespace std;
 
 /// Sorted vector intersection (increasing order)
 BOOST_AUTO_TEST_CASE(matching_setIntersection)
 {
   int tab0[] = {0, 1, 2, 3, 4, 5, 6, 7};
   int tab1[] = {0, 1, 8, 3, 4, 9, 6, 7};
-  set<int> vec_0(tab0, tab0+8);
-  set<int> vec_1(tab1, tab1+8);
+  std::set<int> vec_0(tab0, tab0+8);
+  std::set<int> vec_1(tab1, tab1+8);
   /// Array must be sorted
 
-  vector<int> vec_intersect;
+  std::vector<int> vec_intersect;
   IntersectMatches(vec_0.begin(), vec_0.end(),
     vec_1.begin(), vec_1.end(),
     vec_intersect);

--- a/src/aliceVision/matching/kvld/kvld.cpp
+++ b/src/aliceVision/matching/kvld/kvld.cpp
@@ -20,7 +20,6 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/config.hpp>
 
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::image;
 
@@ -28,8 +27,8 @@ ImageScale::ImageScale( const Image< float >& I, double r )
 {
   IntegralImages inter( I );
   radius_size = r;
-  step = sqrt( 2.0 );
-  int size = max( I.Width(),I.Height() );
+  step = std::sqrt( 2.0 );
+  int size = std::max( I.Width(),I.Height() );
 
   int number= int( log( size / r ) / log( 2.0 ) ) + 1;
   angles.resize( number );
@@ -120,9 +119,9 @@ VLD::VLD( const ImageScale& series, T const& P1, T const& P2 ) : contrast( 0.0 )
   distance = std::hypot( dy, dx );
 
   if( distance == 0 )
-    cerr<<"Two SIFT points have the same coordinate"<<endl;
+    std::cerr << "Two SIFT points have the same coordinate" << std::endl;
 
-  const float radius = max( distance / float( dimension + 1 ), 2.0f );//at least 2
+  const float radius = std::max( distance / float( dimension + 1 ), 2.0f );//at least 2
 
   const double mainAngle = get_orientation();//absolute angle
 
@@ -141,7 +140,7 @@ VLD::VLD( const ImageScale& series, T const& P1, T const& P2 ) : contrast( 0.0 )
   double statistic[ binNum ];
   for( int i = 0; i < dimension; i++ )
   {
-    fill_n( statistic, binNum, 0.0);
+    std::fill_n( statistic, binNum, 0.0);
 
     float xi = float( begin_point[ 0 ] + float( i + 1 ) / ( dimension + 1 ) * ( dx ) );
     float yi = float( begin_point[ 1 ] + float( i + 1 ) / ( dimension + 1 ) * ( dy ) );
@@ -204,11 +203,11 @@ float KVLD( const Image< float >& I1,
             const Image< float >& I2,
             const std::vector<feature::PointFeature> & F1,
             const std::vector<feature::PointFeature> & F2,
-            const vector< Pair >& matches,
-            vector< Pair >& matchesFiltered,
-            vector< double >& score,
+            const std::vector< Pair >& matches,
+            std::vector< Pair >& matchesFiltered,
+            std::vector< double >& score,
             aliceVision::Mat& E,
-            vector< bool >& valide,
+            std::vector< bool >& valide,
             KvldParameters& kvldParameters )
 {
   matchesFiltered.clear();
@@ -216,15 +215,15 @@ float KVLD( const Image< float >& I1,
   ImageScale Chaine1( I1 );
   ImageScale Chaine2( I2 );
 
-  cout << "Image scale-space complete..." << endl;
+  std::cout << "Image scale-space complete..." << std::endl;
 
-  const float range1 = getRange( I1, min( F1.size(), matches.size() ), kvldParameters.inlierRate );
-  const float range2 = getRange( I2, min( F2.size(), matches.size() ), kvldParameters.inlierRate );
+  const float range1 = getRange( I1, std::min( F1.size(), matches.size() ), kvldParameters.inlierRate );
+  const float range2 = getRange( I2, std::min( F2.size(), matches.size() ), kvldParameters.inlierRate );
 
   const size_t size = matches.size();
 
   //================distance map construction, foruse of selecting neighbors===============//
-  cout << "computing distance maps" << endl;
+  std::cout << "computing distance maps" << std::endl;
 
   bool bPrecomputedDist = false;
 
@@ -243,9 +242,9 @@ float KVLD( const Image< float >& I1,
         dist2( b1, b2 ) = dist2( b2, b1 ) = point_distance( F2[ b1 ], F2[ b2 ] );
   }
 
-  fill( valide.begin(), valide.end(), true );
-  vector< double > scoretable( size, 0.0 );
-  vector< size_t > result( size, 0 );
+  std::fill( valide.begin(), valide.end(), true );
+  std::vector< double > scoretable( size, 0.0 );
+  std::vector< size_t > result( size, 0 );
 
 
 //============main iteration formatch verification==========//
@@ -256,8 +255,8 @@ float KVLD( const Image< float >& I1,
   {
     change = false;
 
-    fill( scoretable.begin(), scoretable.end(), 0.0 );
-    fill( result.begin(), result.end(), 0 );
+    std::fill( scoretable.begin(), scoretable.end(), 0.0 );
+    std::fill( result.begin(), result.end(), 0 );
     //========substep 1: search foreach match its neighbors and verify if they are gvld-consistent ============//
     for( int it1 = 0; it1 < size - 1; it1++ )
     {
@@ -375,7 +374,7 @@ float KVLD( const Image< float >& I1,
       for( int i = 0; i < size; i++ )
         scoretable[ i ]=0;
 
-      vector< bool > switching;
+      std::vector< bool > switching;
       for( int i = 0; i < size; i++ )
         switching.push_back( false );
 

--- a/src/aliceVision/matching/matching_test.cpp
+++ b/src/aliceVision/matching/matching_test.cpp
@@ -16,7 +16,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-using namespace std;
 using namespace aliceVision;
 using namespace matching;
 
@@ -50,7 +49,7 @@ BOOST_AUTO_TEST_CASE(Matching_ArrayMatcher_bruteForce_NN)
 
   const float query[] = {2};
   IndMatches vec_nIndice;
-  vector<float> vec_fDistance;
+  std::vector<float> vec_fDistance;
   BOOST_CHECK( matcher.SearchNeighbours(query,1, &vec_nIndice, &vec_fDistance, 5) );
 
   BOOST_CHECK_EQUAL( 5, vec_nIndice.size());
@@ -105,7 +104,7 @@ BOOST_AUTO_TEST_CASE(Matching_ArrayMatcher_kdtreeFlann_Simple__NN)
 
   const float query[] = {2};
   IndMatches vec_nIndice;
-  vector<float> vec_fDistance;
+  std::vector<float> vec_fDistance;
   const int NN = 5;
   BOOST_CHECK( matcher.SearchNeighbours(query, 1, &vec_nIndice, &vec_fDistance, NN) );
 

--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
@@ -11,7 +11,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-using namespace std;
 using namespace aliceVision;
 
 void meanAndStd(const Eigen::Matrix2Xf& points2d, Vec2f& mean, Vec2f& stdDev)

--- a/src/aliceVision/matchingImageCollection/pairBuilder_test.cpp
+++ b/src/aliceVision/matchingImageCollection/pairBuilder_test.cpp
@@ -18,7 +18,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-using namespace std;
 using namespace aliceVision;
 
 // Check pairs follow a weak ordering pair.first < pair.second

--- a/src/aliceVision/mesh/UVAtlas.cpp
+++ b/src/aliceVision/mesh/UVAtlas.cpp
@@ -12,15 +12,13 @@
 namespace aliceVision {
 namespace mesh {
 
-using namespace std;
-
 UVAtlas::UVAtlas(const Mesh& mesh, mvsUtils::MultiViewParams& mp,
                                  unsigned int textureSide, unsigned int gutterSize)
     : _textureSide(textureSide)
     , _gutterSize(gutterSize)
     , _mesh(mesh)
 {
-    vector<Chart> charts;
+    std::vector<Chart> charts;
 
     // create texture charts
     createCharts(charts, mp);
@@ -35,7 +33,7 @@ UVAtlas::UVAtlas(const Mesh& mesh, mvsUtils::MultiViewParams& mp,
     createTextureAtlases(charts, mp);
 }
 
-void UVAtlas::createCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
+void UVAtlas::createCharts(std::vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
 {
     ALICEVISION_LOG_INFO("Creating texture charts.");
 
@@ -88,11 +86,11 @@ void UVAtlas::createCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
     }
 }
 
-void UVAtlas::packCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
+void UVAtlas::packCharts(std::vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
 {
     ALICEVISION_LOG_INFO("Packing texture charts (" <<  charts.size() << " charts).");
 
-    function<int(int)> findChart = [&](int cid)
+    std::function<int(int)> findChart = [&](int cid)
     {
         Chart& c = charts[cid];
         if(c.mergedWith >= 0)
@@ -105,29 +103,29 @@ void UVAtlas::packCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
     };
 
     // list mesh edges (with duplicates)
-    vector<Edge> alledges;
+    std::vector<Edge> alledges;
     for(int i = 0; i < _mesh.tris.size(); ++i)
     {
         int a = _mesh.tris[i].v[0];
         int b = _mesh.tris[i].v[1];
         int c = _mesh.tris[i].v[2];
         Edge e1;
-        e1.pointIDs = make_pair(min(a, b), max(a, b));
+        e1.pointIDs = std::make_pair(std::min(a, b), std::max(a, b));
         e1.triangleIDs.emplace_back(i);
         alledges.emplace_back(e1);
         Edge e2;
-        e2.pointIDs = make_pair(min(b, c), max(b, c));
+        e2.pointIDs = std::make_pair(std::min(b, c), std::max(b, c));
         e2.triangleIDs.emplace_back(i);
         alledges.emplace_back(e2);
         Edge e3;
-        e3.pointIDs = make_pair(min(c, a), max(c, a));
+        e3.pointIDs = std::make_pair(std::min(c, a), std::max(c, a));
         e3.triangleIDs.emplace_back(i);
         alledges.emplace_back(e3);
     }
-    sort(alledges.begin(), alledges.end());
+    std::sort(alledges.begin(), alledges.end());
 
     // merge edges (no duplicate)
-    vector<Edge> edges;
+    std::vector<Edge> edges;
     auto eit = alledges.begin() + 1;
     while(eit != alledges.end())
     {
@@ -154,11 +152,11 @@ void UVAtlas::packCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
             continue;
         Chart& a = charts[chartIDA];
         Chart& b = charts[chartIDB];
-        vector<int> cameraIntersection;
-        set_intersection(
+        std::vector<int> cameraIntersection;
+        std::set_intersection(
                     a.commonCameraIDs.begin(), a.commonCameraIDs.end(),
                     b.commonCameraIDs.begin(), b.commonCameraIDs.end(),
-                    back_inserter(cameraIntersection));
+                    std::back_inserter(cameraIntersection));
         if(cameraIntersection.empty()) // need at least 1 camera in common
             continue;
         if(a.triangleIDs.size() > b.triangleIDs.size())
@@ -185,7 +183,7 @@ void UVAtlas::packCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
             }), charts.end());
 }
 
-void UVAtlas::finalizeCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
+void UVAtlas::finalizeCharts(std::vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
 {
     ALICEVISION_LOG_INFO("Finalize packed charts (" <<  charts.size() << " charts).");
 
@@ -213,10 +211,10 @@ void UVAtlas::finalizeCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& m
             for(auto it = chart.triangleIDs.begin(); it != chart.triangleIDs.end(); ++it)
             {
                 Mesh::triangle_proj tp = _mesh.getTriangleProjection(*it, mp, camId, mp.getWidth(camId), mp.getHeight(camId));
-                sourceLU.x = min(sourceLU.x, tp.lu.x);
-                sourceLU.y = min(sourceLU.y, tp.lu.y);
-                sourceRD.x = max(sourceRD.x, tp.rd.x);
-                sourceRD.y = max(sourceRD.y, tp.rd.y);
+                sourceLU.x = std::min(sourceLU.x, tp.lu.x);
+                sourceLU.y = std::min(sourceLU.y, tp.lu.y);
+                sourceRD.x = std::max(sourceRD.x, tp.rd.x);
+                sourceRD.y = std::max(sourceRD.y, tp.rd.y);
             }
             if ((sourceRD - sourceLU).size2() > (chart.sourceRD - chart.sourceLU).size2())
             {
@@ -236,7 +234,7 @@ void UVAtlas::finalizeCharts(vector<Chart>& charts, mvsUtils::MultiViewParams& m
     }
 }
 
-void UVAtlas::createTextureAtlases(vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
+void UVAtlas::createTextureAtlases(std::vector<Chart>& charts, mvsUtils::MultiViewParams& mp)
 {
     ALICEVISION_LOG_INFO("Creating texture atlases.");
 
@@ -260,7 +258,7 @@ void UVAtlas::createTextureAtlases(vector<Chart>& charts, mvsUtils::MultiViewPar
         texCount++;
         // create a texture atlas
         ALICEVISION_LOG_INFO("\t- texture atlas " << texCount);
-        vector<Chart> atlas;
+        std::vector<Chart> atlas;
         // create a tree root
         ChartRect* root = new ChartRect();
         root->LU.x = 0;

--- a/src/aliceVision/multiview/rotationAveraging/rotationAveraging_test.cpp
+++ b/src/aliceVision/multiview/rotationAveraging/rotationAveraging_test.cpp
@@ -64,8 +64,6 @@ BOOST_AUTO_TEST_CASE ( rotationAveraging_ClosestSVDRotationMatrixNoisy )
 //     1
 BOOST_AUTO_TEST_CASE ( rotationAveraging_RotationLeastSquare_3_Camera)
 {
-  using namespace std;
-
   //--
   // Setup 3 camera that have a relative orientation of 120deg
   // Set Z axis as UP Vector for the rotation
@@ -106,8 +104,6 @@ BOOST_AUTO_TEST_CASE ( rotationAveraging_RotationLeastSquare_3_Camera)
 
 BOOST_AUTO_TEST_CASE ( rotationAveraging_RefineRotationsAvgL1IRLS_SimpleTriplet)
 {
-  using namespace std;
-
   //--
   // Setup 3 camera that have a relative orientation of 120deg
   // Set Z axis as UP Vector for the rotation

--- a/src/aliceVision/multiview/translationAveraging/translationAveragingTest.hpp
+++ b/src/aliceVision/multiview/translationAveraging/translationAveragingTest.hpp
@@ -27,7 +27,6 @@
 using namespace aliceVision;
 using namespace aliceVision::graph;
 
-using namespace std;
 using namespace svg;
 
 int modifiedMod

--- a/src/aliceVision/multiview/translationAveraging/translationAveraging_test.cpp
+++ b/src/aliceVision/multiview/translationAveraging/translationAveraging_test.cpp
@@ -22,7 +22,6 @@
 
 using namespace aliceVision;
 using namespace aliceVision::translationAveraging;
-using namespace std;
 
 BOOST_AUTO_TEST_CASE(translation_averaging_globalTi_from_tijs_Triplets_softL1_Ceres) {
 

--- a/src/aliceVision/numeric/gps_test.cpp
+++ b/src/aliceVision/numeric/gps_test.cpp
@@ -16,8 +16,6 @@
 #include <aliceVision/unitTest.hpp>
 
 using namespace aliceVision;
-using namespace std;
-
 
 BOOST_AUTO_TEST_CASE ( conversionTest )
 {

--- a/src/aliceVision/numeric/lmFunctor_test.cpp
+++ b/src/aliceVision/numeric/lmFunctor_test.cpp
@@ -22,7 +22,6 @@
 
 using namespace aliceVision;
 using namespace svg;
-using namespace std;
 
 // Implementation of the prolem found here :
 // digilander.libero.it/foxes/optimiz/Optimiz1.htm

--- a/src/aliceVision/numeric/numeric_test.cpp
+++ b/src/aliceVision/numeric/numeric_test.cpp
@@ -17,7 +17,6 @@
 #include <aliceVision/unitTest.hpp>
 
 using namespace aliceVision;
-using namespace std;
 
 //-- Assert that stream interface is available
 BOOST_AUTO_TEST_CASE ( TinyMatrix_print )

--- a/src/aliceVision/robustEstimation/ScoreEvaluator.hpp
+++ b/src/aliceVision/robustEstimation/ScoreEvaluator.hpp
@@ -10,8 +10,6 @@
 namespace aliceVision {
 namespace robustEstimation{
 
-using namespace std;
-
 /**
  * @brief Templated Functor class to evaluate a given model over a set of samples.
  */

--- a/src/aliceVision/robustEstimation/loRansac_test.cpp
+++ b/src/aliceVision/robustEstimation/loRansac_test.cpp
@@ -38,7 +38,7 @@ void lineFittingTest(std::size_t numPoints,
   assert(gaussianNoiseLevel >= 0);
   
   Mat2X xy(2, numPoints);
-  vector<std::size_t> vec_inliersGT;
+  std::vector<std::size_t> vec_inliersGT;
   generateLine(numPoints, outlierRatio, gaussianNoiseLevel, GTModel, gen, xy, vec_inliersGT);
 
   const bool withNoise = (gaussianNoiseLevel > std::numeric_limits<double>::epsilon());

--- a/src/aliceVision/robustEstimation/maxConsensus_test.cpp
+++ b/src/aliceVision/robustEstimation/maxConsensus_test.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(MaxConsensusLineFitter_RealisticCase)
 
   //-- Add some noise (for the asked percentage amount)
   int nbPtToNoise = (int) numPoints * outlierRatio;
-  vector<std::size_t> vec_samples; // Fit with unique random index
+  std::vector<std::size_t> vec_samples; // Fit with unique random index
   uniformSample(randomNumberGenerator, nbPtToNoise, numPoints, vec_samples);
   for(std::size_t i = 0; i <vec_samples.size(); ++i)
   {

--- a/src/aliceVision/voctree/kmeans_test.cpp
+++ b/src/aliceVision/voctree/kmeans_test.cpp
@@ -82,7 +82,6 @@ BOOST_AUTO_TEST_CASE(kmeanInitializerVarying)
 
   const int FEATURENUMBER = 500;
   const std::size_t numTrial = 3;
-  using namespace std;
 
   // generate random values for K and DIMENSION
   std::default_random_engine generator;

--- a/src/aliceVision/voctree/vocabularyTree_test.cpp
+++ b/src/aliceVision/voctree/vocabularyTree_test.cpp
@@ -15,7 +15,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-using namespace std;
 using namespace aliceVision::voctree;
 
 BOOST_AUTO_TEST_CASE(database)
@@ -24,7 +23,7 @@ BOOST_AUTO_TEST_CASE(database)
   const int cardWords = 12;
 
   // Create a documents vector
-  vector<vector<Word>> documentsToInsert;
+  std::vector<std::vector<Word>> documentsToInsert;
   documentsToInsert.resize(cardDocuments);
   for(int i = 0; i < documentsToInsert.size(); ++i)
   {
@@ -51,7 +50,7 @@ BOOST_AUTO_TEST_CASE(database)
   for(int i = 0; i < documentsToInsert.size(); i++)
   {
     // Create match vectors
-    vector<DocMatch> match(1);
+    std::vector<DocMatch> match(1);
     // Query both databases with the same document
     db.find(documentsToInsert[i], 1, match, "classic");
     // Check the matches scores are 0 (or near)

--- a/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
+++ b/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
@@ -31,7 +31,6 @@
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace svg;
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::image;
 using namespace aliceVision::matching;

--- a/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
+++ b/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
@@ -25,7 +25,6 @@
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace svg;
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::image;
 
@@ -118,7 +117,7 @@ int main(int argc, char **argv)
     //- Show images side by side
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    const string out_filename = "00_images.jpg";
+    const std::string out_filename = "00_images.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -136,7 +135,7 @@ int main(int argc, char **argv)
       const PointFeature & imaB = featsR[i];
       DrawCircle(imaB.x()+imageL.Width(), imaB.y(), 3.0f, 255, &concat);
     }
-    const string out_filename = "01_features.jpg";
+    const std::string out_filename = "01_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -154,7 +153,7 @@ int main(int argc, char **argv)
 
   // Draw correspondences after Nearest Neighbor ratio filter
   {
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpgFilenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpgFilenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -165,8 +164,8 @@ int main(int argc, char **argv)
       svgStream.drawCircle(L.x(), L.y(), 3.0f, svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), 3.0f,svgStyle().stroke("yellow", 2.0));
     }
-    const string out_filename = "02_Matches.svg";
-    ofstream svgFile( out_filename.c_str() );
+    const std::string out_filename = "02_Matches.svg";
+    std::ofstream svgFile(out_filename.c_str());
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }

--- a/src/samples/kvldFilter/main_kvldFilter.cpp
+++ b/src/samples/kvldFilter/main_kvldFilter.cpp
@@ -28,7 +28,6 @@
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
-using namespace std;
 using namespace svg;
 using namespace aliceVision;
 using namespace aliceVision::image;
@@ -97,8 +96,8 @@ int main(int argc, char **argv)
   if (!fs::exists(outputFolder))
     fs::create_directory(outputFolder);
 
-  const string jpg_filenameL = imageAFilename;
-  const string jpg_filenameR = imageBFilename;
+  const std::string jpg_filenameL = imageAFilename;
+  const std::string jpg_filenameR = imageBFilename;
 
   Image<unsigned char> imageL, imageR;
   readImage(jpg_filenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
@@ -126,7 +125,7 @@ int main(int argc, char **argv)
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "00_images.jpg";
+    std::string out_filename = "00_images.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -144,7 +143,7 @@ int main(int argc, char **argv)
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "01_features.jpg";
+    std::string out_filename = "01_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -160,7 +159,7 @@ int main(int argc, char **argv)
       vec_PutativeMatches);
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -215,7 +214,7 @@ int main(int argc, char **argv)
 
   //Print K-VLD consistent matches
   {
-    svgDrawer svgStream(imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
 
     // ".svg"
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
@@ -246,9 +245,9 @@ int main(int argc, char **argv)
         }
       }
     }
-    string out_filename = "05_KVLD_Matches.svg";
+    std::string out_filename = "05_KVLD_Matches.svg";
     out_filename = (fs::path(outputFolder) / out_filename).string();
-    ofstream svgFile( out_filename.c_str() );
+    std::ofstream svgFile(out_filename.c_str());
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }
@@ -256,7 +255,7 @@ int main(int argc, char **argv)
 
   {
     //Print keypoints kept by K-VLD
-    svgDrawer svgStream(imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
 
     // ".svg"
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
@@ -275,9 +274,9 @@ int main(int argc, char **argv)
         svgStream.drawCircle(right.x() + imageL.Width(), right.y(), 10, svgStyle().stroke("yellow", 2.0));
       }
     }
-    string out_filename = "06_KVLD_Keypoints.svg";
+    std::string out_filename = "06_KVLD_Keypoints.svg";
     out_filename = (fs::path(outputFolder) / out_filename).string();
-    ofstream svgFile( out_filename.c_str() );
+    std::ofstream svgFile(out_filename.c_str());
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }
@@ -293,12 +292,12 @@ int main(int argc, char **argv)
     E);
 
   {
-    string out_filename = "07_Left-K-VLD-MASK.jpg";
+    std::string out_filename = "07_Left-K-VLD-MASK.jpg";
     out_filename = (fs::path(outputFolder) / out_filename).string();
     writeImage(out_filename, imageOutL, image::EImageColorSpace::NO_CONVERSION);
   }
   {
-    string out_filename = "08_Right-K-VLD-MASK.jpg";
+    std::string out_filename = "08_Right-K-VLD-MASK.jpg";
     out_filename = (fs::path(outputFolder) / out_filename).string();
     writeImage(out_filename, imageOutR, image::EImageColorSpace::NO_CONVERSION);
   }

--- a/src/samples/robustEssential/main_robustEssential.cpp
+++ b/src/samples/robustEssential/main_robustEssential.cpp
@@ -28,7 +28,6 @@ using namespace aliceVision::image;
 using namespace aliceVision::camera;
 using namespace aliceVision::geometry;
 using namespace svg;
-using namespace std;
 
 namespace fs = boost::filesystem;
 
@@ -46,9 +45,9 @@ bool exportToPly(const std::vector<Vec3> & vec_points,
 int main() {
 
   std::mt19937 randomNumberGenerator;
-  const std::string sInputDir = string("../") + string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
-  const string jpg_filenameL = sInputDir + "100_7101.jpg";
-  const string jpg_filenameR = sInputDir + "100_7102.jpg";
+  const std::string sInputDir = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
+  const std::string jpg_filenameL = sInputDir + "100_7101.jpg";
+  const std::string jpg_filenameR = sInputDir + "100_7102.jpg";
 
   Image<unsigned char> imageL, imageR;
   readImage(jpg_filenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
@@ -74,7 +73,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -92,7 +91,7 @@ int main() {
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "02_features.jpg";
+    std::string out_filename = "02_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -117,7 +116,7 @@ int main() {
       << vec_PutativeMatches.size() << " #matches with Distance Ratio filter" << std::endl;
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -172,7 +171,7 @@ int main() {
       << std::endl;
 
     // Show Essential validated point
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < relativePose_info.vec_inliers.size(); ++i)  {
@@ -241,8 +240,8 @@ int main() {
 bool readIntrinsic(const std::string & fileName, Mat3 & K)
 {
   // Load the K matrix
-  ifstream in;
-  in.open( fileName.c_str(), ifstream::in);
+  std::ifstream in;
+  in.open(fileName.c_str(), std::ifstream::in);
   if(in.is_open())  {
     for (int j=0; j < 3; ++j)
       for (int i=0; i < 3; ++i)

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -36,7 +36,6 @@ using namespace aliceVision::camera;
 using namespace aliceVision::geometry;
 using namespace aliceVision::sfm;
 using namespace svg;
-using namespace std;
 
 namespace fs = boost::filesystem;
 
@@ -53,10 +52,10 @@ bool readIntrinsic(const std::string & fileName, Mat3 & K);
 ///   way 2: independent cameras motion [R|t], shared focal [f] and structure
 int main() {
   std::mt19937 randomNumberGenerator;
-  const std::string sInputDir = string("../") + string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
+  const std::string sInputDir = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
   Image<RGBColor> image;
-  const string jpg_filenameL = sInputDir + "100_7101.jpg";
-  const string jpg_filenameR = sInputDir + "100_7102.jpg";
+  const std::string jpg_filenameL = sInputDir + "100_7101.jpg";
+  const std::string jpg_filenameR = sInputDir + "100_7102.jpg";
 
   Image<unsigned char> imageL, imageR;
   readImage(jpg_filenameL, imageL, EImageColorSpace::NO_CONVERSION);
@@ -82,7 +81,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -100,7 +99,7 @@ int main() {
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "02_features.jpg";
+    std::string out_filename = "02_features.jpg";
     writeImage(out_filename, concat, EImageColorSpace::NO_CONVERSION);
   }
 
@@ -125,7 +124,7 @@ int main() {
       << vec_PutativeMatches.size() << " #matches with Distance Ratio filter" << std::endl;
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -180,7 +179,7 @@ int main() {
       << std::endl;
 
     // Show Essential validated point
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < relativePose_info.vec_inliers.size(); ++i)  {
@@ -278,8 +277,8 @@ int main() {
 bool readIntrinsic(const std::string & fileName, Mat3 & K)
 {
   // Load the K matrix
-  ifstream in;
-  in.open( fileName.c_str(), ifstream::in);
+  std::ifstream in;
+  in.open(fileName.c_str(), std::ifstream::in);
   if(in.is_open())  {
     for (int j=0; j < 3; ++j)
       for (int i=0; i < 3; ++i)

--- a/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
+++ b/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
@@ -33,7 +33,6 @@ using namespace aliceVision::image;
 using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
-using namespace std;
 
 int main() {
   std::mt19937 randomNumberGenerator;
@@ -41,12 +40,12 @@ int main() {
    << "\nUse an Acontrario robust estimation based on angular errors." << std::endl;
 
   const std::string sInputDir = std::string(THIS_SOURCE_DIR);
-  const string jpg_filenameL = sInputDir + "/SponzaLion000.jpg";
+  const std::string jpg_filenameL = sInputDir + "/SponzaLion000.jpg";
 
   Image<unsigned char> imageL;
   readImage(jpg_filenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
 
-  const string jpg_filenameR = sInputDir + "/SponzaLion001.jpg";
+  const std::string jpg_filenameR = sInputDir + "/SponzaLion001.jpg";
 
   Image<unsigned char> imageR;
   readImage(jpg_filenameR, imageR, image::EImageColorSpace::NO_CONVERSION);
@@ -76,7 +75,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -94,7 +93,7 @@ int main() {
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "02_features.jpg";
+    std::string out_filename = "02_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -113,7 +112,7 @@ int main() {
     matchDeduplicator.getDeduplicated(vec_PutativeMatches);
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -124,8 +123,8 @@ int main() {
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
     }
-    string out_filename = "03_siftMatches.svg";
-    ofstream svgFile( out_filename.c_str() );
+    std::string out_filename = "03_siftMatches.svg";
+    std::ofstream svgFile(out_filename.c_str());
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }

--- a/src/samples/robustEssentialSpherical/sphericalCam.hpp
+++ b/src/samples/robustEssentialSpherical/sphericalCam.hpp
@@ -43,8 +43,6 @@ inline void planarToSpherical(
   }
 }
 
-using namespace std;
-
 /**
  * Eight-point algorithm for solving for the essential matrix from normalized
  * image coordinates of point correspondences.
@@ -148,7 +146,7 @@ public:
       : KernelBase(x1, x2)
   {}
 
-  void fit(const vector<std::size_t>& samples, std::vector<ModelT>& models) const
+  void fit(const std::vector<std::size_t>& samples, std::vector<ModelT>& models) const
   {
     assert(3 == KernelBase::_x1.rows());
     assert(KernelBase::getMinimumNbRequiredSamples() <= KernelBase::_x1.cols());

--- a/src/samples/robustFundamental/main_robustFundamental.cpp
+++ b/src/samples/robustFundamental/main_robustFundamental.cpp
@@ -27,7 +27,6 @@
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace svg;
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::image;
 using namespace aliceVision::matching;
@@ -104,7 +103,7 @@ int main(int argc, char **argv)
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -122,7 +121,7 @@ int main(int argc, char **argv)
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "02_features.jpg";
+    std::string out_filename = "02_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -138,7 +137,7 @@ int main(int argc, char **argv)
       vec_PutativeMatches);
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpgFilenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpgFilenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) 
@@ -150,8 +149,8 @@ int main(int argc, char **argv)
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
     }
-    const string out_filename = "03_siftMatches.svg";
-    ofstream svgFile( out_filename.c_str() );
+    const std::string out_filename = "03_siftMatches.svg";
+    std::ofstream svgFile( out_filename.c_str() );
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }
@@ -201,7 +200,7 @@ int main(int argc, char **argv)
 
       //Show fundamental validated point and compute residuals
       std::vector<double> vec_residuals(vec_inliers.size(), 0.0);
-      svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+      svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
       svgStream.drawImage(jpgFilenameL, imageL.Width(), imageL.Height());
       svgStream.drawImage(jpgFilenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  
@@ -216,8 +215,8 @@ int main(int argc, char **argv)
         // residual computation
         vec_residuals[i] = std::sqrt(KernelType::ErrorT().error(F, LL.coords().cast<double>(), RR.coords().cast<double>()));
       }
-      const string out_filename = "04_ACRansacFundamental.svg";
-      ofstream svgFile( out_filename.c_str() );
+      const std::string out_filename = "04_ACRansacFundamental.svg";
+      std::ofstream svgFile( out_filename.c_str() );
       svgFile << svgStream.closeSvgFile().str();
       svgFile.close();
 

--- a/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
+++ b/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
@@ -31,7 +31,6 @@
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace svg;
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::image;
 using namespace aliceVision::matching;
@@ -110,7 +109,7 @@ int main(int argc, char **argv)
 
   // Show both images side by side
   {
-    const string out_filename = "01.features."+describerTypesName+".svg";
+    const std::string out_filename = "01.features."+describerTypesName+".svg";
     drawKeypointsSideBySide(filenameLeft,
                             imageLeftSize,
                             featsL,
@@ -202,7 +201,7 @@ int main(int argc, char **argv)
 
       //Show fundamental validated point and compute residuals
       std::vector<double> vec_residuals(vec_inliers.size(), 0.0);
-      svgDrawer svgStream( imageLeft.Width() + imageRight.Width(), max(imageLeft.Height(), imageRight.Height()));
+      svgDrawer svgStream(imageLeft.Width() + imageRight.Width(), std::max(imageLeft.Height(), imageRight.Height()));
       svgStream.drawImage(filenameLeft, imageLeft.Width(), imageLeft.Height());
       svgStream.drawImage(filenameRight, imageRight.Width(), imageRight.Height(), imageLeft.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  
@@ -219,8 +218,8 @@ int main(int argc, char **argv)
                                        LL.coords().cast<double>(),
                                        RR.coords().cast<double>()));
       }
-      const string out_filename = "04_ACRansacFundamental.svg";
-      ofstream svgFile( out_filename.c_str() );
+      const std::string out_filename = "04_ACRansacFundamental.svg";
+      std::ofstream svgFile( out_filename.c_str() );
       svgFile << svgStream.closeSvgFile().str();
       svgFile.close();
 

--- a/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
+++ b/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
@@ -30,14 +30,13 @@ using namespace aliceVision::image;
 using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
-using namespace std;
 
 int main() {
   std::mt19937 randomNumberGenerator;
-  const std::string sInputDir = string("../") + string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
+  const std::string sInputDir = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
   Image<RGBColor> image;
-  const string jpg_filenameL = sInputDir + "100_7101.jpg";
-  const string jpg_filenameR = sInputDir + "100_7102.jpg";
+  const std::string jpg_filenameL = sInputDir + "100_7101.jpg";
+  const std::string jpg_filenameR = sInputDir + "100_7102.jpg";
 
   Image<unsigned char> imageL, imageR;
   readImage(jpg_filenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
@@ -63,7 +62,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -81,7 +80,7 @@ int main() {
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "02_features.jpg";
+    std::string out_filename = "02_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -97,7 +96,7 @@ int main() {
       vec_PutativeMatches);
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -108,8 +107,8 @@ int main() {
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
     }
-    const string out_filename = "03_siftMatches.svg";
-    ofstream svgFile( out_filename.c_str() );
+    const std::string out_filename = "03_siftMatches.svg";
+    std::ofstream svgFile( out_filename.c_str() );
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }
@@ -156,7 +155,7 @@ int main() {
 
       //Show fundamental validated point and compute residuals
       std::vector<double> vec_residuals(vec_inliers.size(), 0.0);
-      svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+      svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
       svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
       svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  {
@@ -170,8 +169,8 @@ int main() {
         // residual computation
         vec_residuals[i] = std::sqrt(KernelType::ErrorT().error(F, LL.coords().cast<double>(), RR.coords().cast<double>()));
       }
-      const string out_filename = "04_ACRansacFundamental.svg";
-      ofstream svgFile( out_filename.c_str() );
+      const std::string out_filename = "04_ACRansacFundamental.svg";
+      std::ofstream svgFile(out_filename.c_str());
       svgFile << svgStream.closeSvgFile().str();
       svgFile.close();
 
@@ -224,7 +223,7 @@ int main() {
       {
         const std::vector<IndMatch> & vec_corresponding_index = vec_corresponding_indexes[idx];
         //Show fundamental validated correspondences
-        svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+        svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
         svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
         svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
         for ( size_t i = 0; i < vec_corresponding_index.size(); ++i)  {
@@ -237,10 +236,10 @@ int main() {
           svgStream.drawCircle(L.x(), L.y(), LL.scale(), svgStyle().stroke("yellow", 2.0));
           svgStream.drawCircle(R.x()+imageL.Width(), R.y(), RR.scale(),svgStyle().stroke("yellow", 2.0));
         }
-        const string out_filename =
+        const std::string out_filename =
           (idx == 0) ? "04_ACRansacFundamental_guided_geom.svg"
             : "04_ACRansacFundamental_guided_geom_distratio.svg";
-        ofstream svgFile( out_filename.c_str() );
+        std::ofstream svgFile(out_filename.c_str());
         svgFile << svgStream.closeSvgFile().str();
         svgFile.close();
       }

--- a/src/samples/robustHomography/main_robustHomography.cpp
+++ b/src/samples/robustHomography/main_robustHomography.cpp
@@ -32,13 +32,12 @@ using namespace aliceVision::image;
 using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
-using namespace std;
 
 int main() {
   std::mt19937 randomNumberGenerator;
   Image<RGBColor> image;
-  const string jpg_filenameL = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  const string jpg_filenameR = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
+  const std::string jpg_filenameL = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
+  const std::string jpg_filenameR = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
   readImage(jpg_filenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
@@ -66,7 +65,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -84,7 +83,7 @@ int main() {
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "02_features.jpg";
+    std::string out_filename = "02_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -100,7 +99,7 @@ int main() {
       vec_PutativeMatches);
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -161,7 +160,7 @@ int main() {
 
       //Show homography validated point and compute residuals
       std::vector<double> vec_residuals(vec_inliers.size(), 0.0);
-      svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+      svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
       svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
       svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  {
@@ -175,8 +174,8 @@ int main() {
         // residual computation
         vec_residuals[i] = std::sqrt(KernelType::ErrorT().error(H, LL.coords().cast<double>(), RR.coords().cast<double>()));
       }
-      string out_filename = "04_ACRansacHomography.svg";
-      ofstream svgFile( out_filename.c_str() );
+      std::string out_filename = "04_ACRansacHomography.svg";
+      std::ofstream svgFile(out_filename.c_str());
       svgFile << svgStream.closeSvgFile().str();
       svgFile.close();
 

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -24,7 +24,6 @@
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace svg;
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::image;
 
@@ -205,7 +204,7 @@ int main(int argc, char **argv)
   // Display images sides by side with extracted features
   //--
   {
-    const string out_filename = "01.features."+describerTypesName+".svg";
+    const std::string out_filename = "01.features."+describerTypesName+".svg";
     matching::drawKeypointsSideBySide(filenameLeft,
                             imageLeftSize,
                             regions_perImage.at(0).get()->Features(),

--- a/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
+++ b/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
@@ -30,13 +30,12 @@ using namespace aliceVision::image;
 using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
-using namespace std;
 
 int main() {
   std::mt19937 randomNumberGenerator;
   Image<RGBColor> image;
-  const string jpg_filenameL = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  const string jpg_filenameR = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
+  const std::string jpg_filenameL = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
+  const std::string jpg_filenameR = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
   readImage(jpg_filenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
@@ -64,7 +63,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "01_concat.jpg";
+    std::string out_filename = "01_concat.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -82,7 +81,7 @@ int main() {
       const PointFeature point = regionsR->Features()[i];
       DrawCircle(point.x()+imageL.Width(), point.y(), point.scale(), 255, &concat);
     }
-    string out_filename = "02_features.jpg";
+    std::string out_filename = "02_features.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -98,7 +97,7 @@ int main() {
       vec_PutativeMatches);
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -159,7 +158,7 @@ int main() {
 
       //Show homography validated point and compute residuals
       std::vector<double> vec_residuals(vec_inliers.size(), 0.0);
-      svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+      svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
       svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
       svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
       for ( size_t i = 0; i < vec_inliers.size(); ++i)  {
@@ -173,8 +172,8 @@ int main() {
         // residual computation
         vec_residuals[i] = std::sqrt(KernelType::ErrorT().error(H,  LL.coords().cast<double>(), RR.coords().cast<double>()));
       }
-      string out_filename = "04_ACRansacHomography.svg";
-      ofstream svgFile( out_filename.c_str() );
+      std::string out_filename = "04_ACRansacHomography.svg";
+      std::ofstream svgFile(out_filename.c_str());
       svgFile << svgStream.closeSvgFile().str();
       svgFile.close();
 
@@ -227,7 +226,7 @@ int main() {
       {
         const std::vector<IndMatch> & vec_corresponding_index = vec_corresponding_indexes[idx];
         //Show homography validated correspondences
-        svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+        svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
         svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
         svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
         for ( size_t i = 0; i < vec_corresponding_index.size(); ++i)  {
@@ -240,10 +239,10 @@ int main() {
           svgStream.drawCircle(L.x(), L.y(), LL.scale(), svgStyle().stroke("yellow", 2.0));
           svgStream.drawCircle(R.x()+imageL.Width(), R.y(), RR.scale(),svgStyle().stroke("yellow", 2.0));
         }
-        const string out_filename =
+        const std::string out_filename =
           (idx == 0) ? "04_ACRansacHomography_guided_geom.svg"
             : "04_ACRansacHomography_guided_geom_distratio.svg";
-        ofstream svgFile( out_filename.c_str() );
+        std::ofstream svgFile(out_filename.c_str());
         svgFile << svgStream.closeSvgFile().str();
         svgFile.close();
       }

--- a/src/samples/siftPutativeMatches/main_siftMatching.cpp
+++ b/src/samples/siftPutativeMatches/main_siftMatching.cpp
@@ -24,13 +24,12 @@ using namespace aliceVision;
 using namespace aliceVision::image;
 using namespace aliceVision::matching;
 using namespace svg;
-using namespace std;
 
 int main() {
   std::mt19937 randomNumberGenerator;
   Image<RGBColor> image;
-  string jpg_filenameL = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
-  string jpg_filenameR = string("../") + string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
+  std::string jpg_filenameL = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";
+  std::string jpg_filenameR = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_1.png";
 
   Image<unsigned char> imageL, imageR;
   readImage(jpg_filenameL, imageL, image::EImageColorSpace::NO_CONVERSION);
@@ -53,7 +52,7 @@ int main() {
   {
     Image<unsigned char> concat;
     ConcatH(imageL, imageR, concat);
-    string out_filename = "00_images.jpg";
+    std::string out_filename = "00_images.jpg";
     writeImage(out_filename, concat, image::EImageColorSpace::NO_CONVERSION);
   }
 
@@ -90,7 +89,7 @@ int main() {
       vec_PutativeMatches);
 
     // Draw correspondences after Nearest Neighbor ratio filter
-    svgDrawer svgStream( imageL.Width() + imageR.Width(), max(imageL.Height(), imageR.Height()));
+    svgDrawer svgStream(imageL.Width() + imageR.Width(), std::max(imageL.Height(), imageR.Height()));
     svgStream.drawImage(jpg_filenameL, imageL.Width(), imageL.Height());
     svgStream.drawImage(jpg_filenameR, imageR.Width(), imageR.Height(), imageL.Width());
     for (size_t i = 0; i < vec_PutativeMatches.size(); ++i) {
@@ -101,8 +100,8 @@ int main() {
       svgStream.drawCircle(L.x(), L.y(), L.scale(), svgStyle().stroke("yellow", 2.0));
       svgStream.drawCircle(R.x()+imageL.Width(), R.y(), R.scale(),svgStyle().stroke("yellow", 2.0));
     }
-    string out_filename = "02_siftMatches.svg";
-    ofstream svgFile( out_filename.c_str() );
+    std::string out_filename = "02_siftMatches.svg";
+    std::ofstream svgFile(out_filename.c_str());
     svgFile << svgStream.closeSvgFile().str();
     svgFile.close();
   }

--- a/src/samples/undistoBrown/main_undistoBrown.cpp
+++ b/src/samples/undistoBrown/main_undistoBrown.cpp
@@ -21,7 +21,6 @@
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
-using namespace std;
 using namespace aliceVision;
 using namespace aliceVision::camera;
 using namespace aliceVision::image;
@@ -124,8 +123,8 @@ int main(int argc, char **argv)
   boost::progress_display my_progress_bar( vec_fileNames.size() );
   for (size_t j = 0; j < vec_fileNames.size(); ++j, ++my_progress_bar)
   {
-    const string inFileName = (fs::path(inputImagePath) / fs::path(vec_fileNames[j]).filename()).string();
-    const string outFileName = (fs::path(outputImagePath) / fs::path(vec_fileNames[j]).filename()).string();
+    const std::string inFileName = (fs::path(inputImagePath) / fs::path(vec_fileNames[j]).filename()).string();
+    const std::string outFileName = (fs::path(outputImagePath) / fs::path(vec_fileNames[j]).filename()).string();
 
     Image<RGBColor> image, imageUd;
     readImage(inFileName, image, image::EImageColorSpace::NO_CONVERSION);

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -52,7 +52,6 @@ using namespace aliceVision::robustEstimation;
 using namespace aliceVision::sfm;
 using namespace aliceVision::sfmData;
 using namespace aliceVision::matchingImageCollection;
-using namespace std;
 
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;

--- a/src/software/utils/main_voctreeCreation.cpp
+++ b/src/software/utils/main_voctreeCreation.cpp
@@ -31,7 +31,6 @@
 
 static const int DIMENSION = 128;
 
-using namespace std;
 using namespace aliceVision;
 
 //using namespace boost::accumulators;
@@ -64,8 +63,8 @@ int aliceVision_main(int argc, char** argv)
   po::options_description requiredParams("Required parameters");
   requiredParams.add_options()
     ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "a SfMData file.")
-    ("weights,w", po::value<string>(&weightName)->required(), "Output name for the weight file")
-    ("tree,t", po::value<string>(&treeName)->required(), "Output name for the tree file");
+    ("weights,w", po::value<std::string>(&weightName)->required(), "Output name for the weight file")
+    ("tree,t", po::value<std::string>(&treeName)->required(), "Output name for the tree file");
 
   po::options_description optionalParams("Optional parameters");
   optionalParams.add_options()
@@ -229,7 +228,7 @@ int aliceVision_main(int argc, char** argv)
 			  << " took " << detect_elapsed.count()
 			  << " ms and has " << matches.size() 
 			  << " matches\tBest " << matches[0].id 
-			  << " with score " << matches[0].score << endl);
+              << " with score " << matches[0].score << std::endl);
       // for each found match print the score, ideally the first one should be the document itself
       for(size_t j = 0; j < matches.size(); ++j)
       {

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -37,7 +37,6 @@
 
 static const int DIMENSION = 128;
 
-using namespace std;
 using namespace boost::accumulators;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
@@ -71,7 +70,7 @@ std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::Document 
 
 std::string myToString(std::size_t i, std::size_t zeroPadding)
 {
-  stringstream ss;
+  std::stringstream ss;
   ss << std::setw(zeroPadding) << std::setfill('0') << i;
   return ss.str();
 }
@@ -345,7 +344,7 @@ int aliceVision_main(int argc, char** argv)
   std::ofstream fileout;
   if(withOutput)
   {
-    fileout.open(outfile, ofstream::out);
+    fileout.open(outfile, std::ofstream::out);
   }
 
   std::map<std::size_t, voctree::SparseHistogram> histograms;
@@ -520,8 +519,8 @@ int aliceVision_main(int argc, char** argv)
   }
 
 #ifdef ALICEVISION_DEBUG_MATCHING
-  std::cout << " ---------------------------- \n" << endl;
-  std::cout << "Matching distances - Histogram: \n" << endl;
+  std::cout << " ---------------------------- \n" << std::endl;
+  std::cout << "Matching distances - Histogram: \n" << std::endl;
   std::map<int,int> stats;
   for( const auto& imgMatches: allMatches)
   {

--- a/src/software/utils/main_voctreeStatistics.cpp
+++ b/src/software/utils/main_voctreeStatistics.cpp
@@ -34,7 +34,6 @@
 
 static const int DIMENSION = 128;
 
-using namespace std;
 using namespace boost::accumulators;
 using namespace aliceVision;
 
@@ -67,7 +66,7 @@ std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::Document 
 
 std::string myToString(std::size_t i, std::size_t zeroPadding)
 {
-  stringstream ss;
+  std::stringstream ss;
   ss << std::setw(zeroPadding) << std::setfill('0') << i;
   return ss.str();
 }

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -51,13 +51,13 @@ using namespace aliceVision::sfm;
 using namespace aliceVision::sfmData;
 
 typedef feature::PointFeature FeatureT;
-typedef vector<FeatureT> featsT;
+typedef std::vector<FeatureT> featsT;
 
 ColorHarmonizationEngineGlobal::ColorHarmonizationEngineGlobal(
-    const string& sfmDataFilename,
+    const std::string& sfmDataFilename,
     const std::vector<std::string>& featuresFolders,
     const std::vector<std::string>& matchesFolders,
-    const string& outputDirectory,
+    const std::string& outputDirectory,
     const std::vector<feature::EImageDescriberType>& descTypes,
     int selectionMethod,
     int imgRef)
@@ -73,23 +73,23 @@ ColorHarmonizationEngineGlobal::ColorHarmonizationEngineGlobal(
   // choose image reference
   while(imgRef < 0 || imgRef >= _fileNames.size())
   {
-      cout << "Choose your reference image:\n";
+      std::cout << "Choose your reference image:\n";
       for( int i = 0; i < _fileNames.size(); ++i )
       {
-        cout << "id: " << i << "\t" << _fileNames[ i ] << endl;
+        std::cout << "id: " << i << "\t" << _fileNames[ i ] << std::endl;
       }
-      cin >> imgRef;
+      std::cin >> imgRef;
   }
   _imgRef = imgRef;
 
   // choose selection method
   while(selectionMethod < 0 || selectionMethod > 2)
   {
-    cout << "Choose your selection method:\n"
+    std::cout << "Choose your selection method:\n"
       << "- FullFrame: 0\n"
       << "- Matched Points: 1\n"
       << "- VLD Segment: 2\n";
-    cin >> selectionMethod;
+    std::cin >> selectionMethod;
   }
   _selectionMethod = static_cast<EHistogramSelectionMethod>(selectionMethod);
 
@@ -101,7 +101,7 @@ ColorHarmonizationEngineGlobal::~ColorHarmonizationEngineGlobal()
 inline void pauseProcess()
 {
   unsigned char i;
-  cout << "\nPause : type key and press enter: ";
+  std::cout << "\nPause : type key and press enter: ";
   std::cin >> i;
 }
 
@@ -120,7 +120,7 @@ bool ColorHarmonizationEngineGlobal::Process()
     return false;
   if( _pairwiseMatches.empty() )
   {
-    cout << endl << "Matches file is empty" << endl;
+    std::cout << std::endl << "Matches file is empty" << std::endl;
     return false;
   }
 
@@ -270,16 +270,16 @@ bool ColorHarmonizationEngineGlobal::Process()
     bool bExportMask = false;
     if (bExportMask)
     {
-      string sEdge = _fileNames[ viewI ] + "_" + _fileNames[ viewJ ];
+      std::string sEdge = _fileNames[ viewI ] + "_" + _fileNames[ viewJ ];
       sEdge = (fs::path(_outputDirectory) / sEdge ).string();
 
       if( !fs::exists(sEdge) )
         fs::create_directory(sEdge);
 
-      string out_filename_I = "00_mask_I.png";
+      std::string out_filename_I = "00_mask_I.png";
       out_filename_I = (fs::path(sEdge) / out_filename_I).string();
 
-      string out_filename_J = "00_mask_J.png";
+      std::string out_filename_J = "00_mask_J.png";
       out_filename_J = (fs::path(sEdge) / out_filename_J).string();
       writeImage(out_filename_I, maskI, image::EImageColorSpace::AUTO);
       writeImage(out_filename_J, maskJ, image::EImageColorSpace::AUTO);


### PR DESCRIPTION
`using namespace std;` is generally an antipattern as it imports a huge number of common names into the global namespace. We already qualify names with std:: in majority of cases and `using namespace std` is not actually needed most of the time. This commit addresses a small number of remaining cases where std:: is missing and removes all `using namespace std`, thus achieving consistent code.