### PR TITLE
Avoid unnecessary string copies

### DIFF
--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -727,7 +727,8 @@ Voxel Fuser::estimateDimensions(Point3d* vox, Point3d* newSpace, int scale, int 
     return maxDim;
 }
 
-std::string generateTempPtsSimsFiles(std::string tmpDir, mvsUtils::MultiViewParams& mp, bool addRandomNoise, float percNoisePts,
+std::string generateTempPtsSimsFiles(const std::string& tmpDir, mvsUtils::MultiViewParams& mp,
+                                     bool addRandomNoise, float percNoisePts,
                                      int noisPixSizeDistHalfThr)
 {
     ALICEVISION_LOG_INFO("generating temp files.");
@@ -893,7 +894,7 @@ std::string generateTempPtsSimsFiles(std::string tmpDir, mvsUtils::MultiViewPara
     return depthMapsPtsSimsTmpDir;
 }
 
-void deleteTempPtsSimsFiles(mvsUtils::MultiViewParams& mp, std::string depthMapsPtsSimsTmpDir)
+void deleteTempPtsSimsFiles(mvsUtils::MultiViewParams& mp, const std::string& depthMapsPtsSimsTmpDir)
 {
     for(int rc = 0; rc < mp.ncams; rc++)
     {

--- a/src/aliceVision/fuseCut/Fuser.hpp
+++ b/src/aliceVision/fuseCut/Fuser.hpp
@@ -51,9 +51,10 @@ private:
 
 unsigned long computeNumberOfAllPoints(const mvsUtils::MultiViewParams& mp, int scale);
 
-std::string generateTempPtsSimsFiles(std::string tmpDir, mvsUtils::MultiViewParams& mp, bool addRandomNoise = false,
-                                     float percNoisePts = 0.0, int noisPixSizeDistHalfThr = 0);
-void deleteTempPtsSimsFiles(mvsUtils::MultiViewParams& mp, std::string depthMapsPtsSimsTmpDir);
+std::string generateTempPtsSimsFiles(const std::string& tmpDir, mvsUtils::MultiViewParams& mp,
+                                     bool addRandomNoise = false, float percNoisePts = 0.0,
+                                     int noisPixSizeDistHalfThr = 0);
+void deleteTempPtsSimsFiles(mvsUtils::MultiViewParams& mp, const std::string& depthMapsPtsSimsTmpDir);
 
 } // namespace fuseCut
 } // namespace aliceVision

--- a/src/aliceVision/fuseCut/LargeScale.cpp
+++ b/src/aliceVision/fuseCut/LargeScale.cpp
@@ -17,7 +17,7 @@ namespace fuseCut {
 
 namespace bfs = boost::filesystem;
 
-LargeScale::LargeScale(mvsUtils::MultiViewParams* _mp, std::string _spaceFolderName)
+LargeScale::LargeScale(mvsUtils::MultiViewParams* _mp, const std::string& _spaceFolderName)
   : mp(_mp)
   , spaceFolderName(_spaceFolderName)
   , spaceVoxelsFolderName(_spaceFolderName + "_data/")
@@ -87,7 +87,8 @@ std::string LargeScale::getSpaceCamsTracksDir()
     return out;
 }
 
-LargeScale* LargeScale::cloneSpaceIfDoesNotExists(int newOcTreeDim, std::string newSpaceFolderName)
+LargeScale* LargeScale::cloneSpaceIfDoesNotExists(int newOcTreeDim,
+                                                  const std::string& newSpaceFolderName)
 {
     if(isSpaceSaved())
     {

--- a/src/aliceVision/fuseCut/LargeScale.hpp
+++ b/src/aliceVision/fuseCut/LargeScale.hpp
@@ -29,7 +29,7 @@ public:
     int maxOcTreeDim;
     bool doVisualize;
 
-    LargeScale(mvsUtils::MultiViewParams* _mp, std::string _spaceFolderName);
+    LargeScale(mvsUtils::MultiViewParams* _mp, const std::string& _spaceFolderName);
     ~LargeScale();
 
     std::string getSpaceCamsTracksDir();
@@ -37,7 +37,7 @@ public:
     void saveSpaceToFile();
     void loadSpaceFromFile();
     void initialEstimateSpace(int maxOcTreeDim);
-    LargeScale* cloneSpaceIfDoesNotExists(int newOcTreeDim, std::string newSpaceFolderName);
+    LargeScale* cloneSpaceIfDoesNotExists(int newOcTreeDim, const std::string& newSpaceFolderName);
     bool generateSpace(int maxPts, int ocTreeDim, bool generateTracks);
     Point3d getSpaceSteps();
 

--- a/src/aliceVision/fuseCut/OctreeTracks.cpp
+++ b/src/aliceVision/fuseCut/OctreeTracks.cpp
@@ -667,7 +667,8 @@ void OctreeTracks::filterOctreeTracks2(StaticVector<trackStruct*>* tracks)
     tracks->swap(tracksOut);
 }
 
-StaticVector<OctreeTracks::trackStruct*>* OctreeTracks::fillOctree(int maxPts, std::string depthMapsPtsSimsTmpDir)
+StaticVector<OctreeTracks::trackStruct*>*
+    OctreeTracks::fillOctree(int maxPts, const std::string& depthMapsPtsSimsTmpDir)
 {
     long t1 = clock();
     StaticVector<int> cams = _mp.findCamsWhichIntersectsHexahedron(vox, depthMapsPtsSimsTmpDir + "minMaxDepths.bin");

--- a/src/aliceVision/fuseCut/OctreeTracks.hpp
+++ b/src/aliceVision/fuseCut/OctreeTracks.hpp
@@ -98,7 +98,7 @@ public:
     void filterOctreeTracks2(StaticVector<trackStruct*>* tracks);
     void updateOctreeTracksCams(StaticVector<trackStruct*>* tracks);
     StaticVector<trackStruct*>* fillOctreeFromTracks(StaticVector<trackStruct*>* tracksIn);
-    StaticVector<trackStruct*>* fillOctree(int maxPts, std::string depthMapsPtsSimsTmpDir);
+    StaticVector<trackStruct*>* fillOctree(int maxPts, const std::string& depthMapsPtsSimsTmpDir);
     StaticVector<int>* getTracksCams(StaticVector<OctreeTracks::trackStruct*>* tracks);
     void getNPointsByLevelsRecursive(Node* node, int level, StaticVector<int>* nptsAtLevel);
 };

--- a/src/aliceVision/fuseCut/ReconstructionPlan.cpp
+++ b/src/aliceVision/fuseCut/ReconstructionPlan.cpp
@@ -20,7 +20,7 @@ namespace fuseCut {
 
 namespace bfs = boost::filesystem;
 
-ReconstructionPlan::ReconstructionPlan(Voxel& dimmensions, Point3d* space, mvsUtils::MultiViewParams* _mp, std::string _spaceRootDir)
+ReconstructionPlan::ReconstructionPlan(Voxel& dimmensions, Point3d* space, mvsUtils::MultiViewParams* _mp, const std::string& _spaceRootDir)
     : VoxelsGrid(dimmensions, space, _mp, _spaceRootDir)
 {
     nVoxelsTracks = getNVoxelsTracks();

--- a/src/aliceVision/fuseCut/ReconstructionPlan.hpp
+++ b/src/aliceVision/fuseCut/ReconstructionPlan.hpp
@@ -20,7 +20,7 @@ class ReconstructionPlan : public VoxelsGrid
 {
 public:
     StaticVector<int>* nVoxelsTracks;
-    ReconstructionPlan(Voxel& dimmensions, Point3d* space, mvsUtils::MultiViewParams* _mp, std::string _spaceRootDir);
+    ReconstructionPlan(Voxel& dimmensions, Point3d* space, mvsUtils::MultiViewParams* _mp, const std::string& _spaceRootDir);
     ~ReconstructionPlan();
 
     unsigned long getNTracks(const Voxel& LU, const Voxel& RD);

--- a/src/aliceVision/fuseCut/VoxelsGrid.cpp
+++ b/src/aliceVision/fuseCut/VoxelsGrid.cpp
@@ -499,7 +499,7 @@ void VoxelsGrid::cloneSpaceVoxel(int voxelId, int numSubVoxs, VoxelsGrid* newSpa
     }
 }
 
-VoxelsGrid* VoxelsGrid::cloneSpace(int numSubVoxs, std::string newSpaceRootDir)
+VoxelsGrid* VoxelsGrid::cloneSpace(int numSubVoxs, const std::string& newSpaceRootDir)
 {
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("cloning space.");
@@ -540,7 +540,7 @@ void VoxelsGrid::copySpaceVoxel(int voxelId, VoxelsGrid* newSpace)
     }
 }
 
-VoxelsGrid* VoxelsGrid::copySpace(std::string newSpaceRootDir)
+VoxelsGrid* VoxelsGrid::copySpace(const std::string& newSpaceRootDir)
 {
     if(mp->verbose)
         ALICEVISION_LOG_DEBUG("Copy space.");

--- a/src/aliceVision/fuseCut/VoxelsGrid.hpp
+++ b/src/aliceVision/fuseCut/VoxelsGrid.hpp
@@ -48,10 +48,10 @@ public:
     void vizualize();
 
     void cloneSpaceVoxel(int voxelId, int numSubVoxs, VoxelsGrid* newSpace);
-    VoxelsGrid* cloneSpace(int numSubVoxs, std::string newSpaceRootDir);
+    VoxelsGrid* cloneSpace(int numSubVoxs, const std::string& newSpaceRootDir);
 
     void copySpaceVoxel(int voxelId, VoxelsGrid* newSpace);
-    VoxelsGrid* copySpace(std::string newSpaceRootDir);
+    VoxelsGrid* copySpace(const std::string& newSpaceRootDir);
 
     void getHexah(Point3d* hexahOut, const Voxel& LUi, const Voxel& RDi);
 };

--- a/src/aliceVision/mvsData/StaticVector.cpp
+++ b/src/aliceVision/mvsData/StaticVector.cpp
@@ -10,7 +10,7 @@
 
 namespace aliceVision {
 
-int getArrayLengthFromFile(std::string fileName)
+int getArrayLengthFromFile(const std::string& fileName)
 {
     FILE* f = fopen(fileName.c_str(), "rb");
     if(f == nullptr)

--- a/src/aliceVision/mvsData/StaticVector.hpp
+++ b/src/aliceVision/mvsData/StaticVector.hpp
@@ -219,7 +219,7 @@ int indexOf(T* arr, int n, const T& what)
 }
 
 template <class T>
-void saveArrayOfArraysToFile(std::string fileName, StaticVector<StaticVector<T>*>* aa)
+void saveArrayOfArraysToFile(const std::string& fileName, StaticVector<StaticVector<T>*>* aa)
 {
     ALICEVISION_LOG_DEBUG("[IO] saveArrayOfArraysToFile: " << fileName);
     FILE* f = fopen(fileName.c_str(), "wb");
@@ -723,7 +723,7 @@ void loadArrayFromFileIntoArray(StaticVector<T>* a, const std::string& fileName,
     fclose(f);
 }
 
-int getArrayLengthFromFile(std::string fileName);
+int getArrayLengthFromFile(const std::string& fileName);
 
 template <class T>
 void deleteAllPointers(StaticVector<T*>& vec)

--- a/src/aliceVision/mvsData/structures.hpp
+++ b/src/aliceVision/mvsData/structures.hpp
@@ -27,7 +27,7 @@ struct ImageParams
     int size;
     std::string path;
 
-    ImageParams(IndexT _viewId, int _width, int _height, std::string _path)
+    ImageParams(IndexT _viewId, int _width, int _height, const std::string& _path)
       : viewId(_viewId)
       , width(_width)
       , height(_height)

--- a/src/aliceVision/mvsUtils/common.hpp
+++ b/src/aliceVision/mvsUtils/common.hpp
@@ -29,7 +29,7 @@ long initEstimate();
 void printfEstimate(int i, int n, long startTime);
 void finishEstimate();
 std::string formatElapsedTime(long t1);
-inline void printfElapsedTime(long t1, std::string prefix = "")
+inline void printfElapsedTime(long t1, const std::string& prefix = "")
 {
     ALICEVISION_LOG_DEBUG(prefix << " " << formatElapsedTime(t1));
 }

--- a/src/software/convert/main_importKnownPoses.cpp
+++ b/src/software/convert/main_importKnownPoses.cpp
@@ -59,7 +59,7 @@ struct XMPData
 };
 
 
-XMPData read_xmp(const std::string& xmpFilepath, std::string knownPosesFilePath, std::string stem, fs::directory_entry pathIt)
+XMPData read_xmp(const std::string& xmpFilepath, const std::string& knownPosesFilePath, const std::string& stem, fs::directory_entry pathIt)
 {
     XMPData xmp;
     const fs::path path = pathIt.path();
@@ -93,7 +93,7 @@ XMPData read_xmp(const std::string& xmpFilepath, std::string knownPosesFilePath,
     ALICEVISION_LOG_TRACE("stem: " << stem);
     ALICEVISION_LOG_TRACE("rotation: " << rotationStrings);
 
-    for(std::string rot_val : rotationStrings)
+    for (const auto& rot_val : rotationStrings)
     {
         xmp.rotation.push_back(std::stod(rot_val));
     }
@@ -111,7 +111,7 @@ XMPData read_xmp(const std::string& xmpFilepath, std::string knownPosesFilePath,
         boost::split(positionStrings, positionStr, boost::is_any_of(" \t"), boost::token_compress_on);
     }
 
-    for(std::string pos_val : positionStrings)
+    for (const auto& pos_val : positionStrings)
     {
         xmp.position.push_back(std::stod(pos_val));
     }
@@ -121,7 +121,7 @@ XMPData read_xmp(const std::string& xmpFilepath, std::string knownPosesFilePath,
     boost::split(distortionStrings, distortionStr, boost::is_any_of(" \t"), boost::token_compress_on);
     ALICEVISION_LOG_TRACE("distortion: " << distortionStrings);
 
-    for(std::string disto_val : distortionStrings)
+    for (const auto& disto_val : distortionStrings)
     {
         xmp.distortionCoefficients.push_back(std::stod(disto_val));
     }

--- a/src/software/utils/precisionEvaluationToGt.hpp
+++ b/src/software/utils/precisionEvaluationToGt.hpp
@@ -316,7 +316,7 @@ inline void EvaluteToGT(
 
 // Find a file in a list and return the index, or -1 if nothing found.
 // Handle relative/absolute paths
-inline int findIdGT(std::string file, std::vector<std::string> filelist)
+inline int findIdGT(const std::string& file, const std::vector<std::string>& filelist)
 {
   int result = -1;
   std::string file_relative = fs::path(file).filename().string();


### PR DESCRIPTION
This is a simple cleanup PR that removes accidental copies of strings where needed. The performance impact is trivial, but it's still worth to consistently use pass-by-reference lest some function does end up in a critical path.