### PR TITLE
[mvsUtils] Remove trivial boost::filesystem wrappers

### DIFF
--- a/src/aliceVision/depthMap/depthMap.cpp
+++ b/src/aliceVision/depthMap/depthMap.cpp
@@ -16,6 +16,10 @@
 #include <aliceVision/depthMap/SgmParams.hpp>
 #include <aliceVision/depthMap/cuda/PlaneSweepingCuda.hpp>
 
+#include <boost/filesystem.hpp>
+
+namespace fs = boost::filesystem;
+
 namespace aliceVision {
 namespace depthMap {
 
@@ -120,7 +124,7 @@ void computeNormalMaps(int cudaDeviceIndex, mvsUtils::MultiViewParams& mp, const
     {
         const std::string normalMapFilepath = getFileNameFromIndex(mp, rc, mvsUtils::EFileType::normalMap, 0);
 
-        if(!mvsUtils::FileExists(normalMapFilepath))
+        if (!fs::exists(normalMapFilepath))
         {
             std::vector<float> depthMap;
             int w = 0;

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -902,7 +902,7 @@ void deleteTempPtsSimsFiles(mvsUtils::MultiViewParams& mp, std::string depthMaps
         remove(ptsfn.c_str());
         remove(simsfn.c_str());
     }
-    mvsUtils::DeleteDirectory(depthMapsPtsSimsTmpDir);
+    bfs::remove_all(depthMapsPtsSimsTmpDir);
 }
 
 } // namespace fuseCut

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -149,7 +149,7 @@ void Fuser::filterGroups(const std::vector<int>& cams, float pixToleranceFactor,
 // minNumOfModals number of other cams including this cam ... minNumOfModals /in 2,3,...
 bool Fuser::filterGroupsRC(int rc, float pixToleranceFactor, int pixSizeBall, int pixSizeBallWSP, int nNearestCams)
 {
-    if(mvsUtils::FileExists(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap)))
+    if (bfs::exists(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap)))
     {
         return true;
     }

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -733,7 +733,7 @@ std::string generateTempPtsSimsFiles(std::string tmpDir, mvsUtils::MultiViewPara
     ALICEVISION_LOG_INFO("generating temp files.");
     std::string depthMapsPtsSimsTmpDir = tmpDir + "depthMapsPtsSimsTmp/";
 
-    if(!mvsUtils::FolderExists(depthMapsPtsSimsTmpDir))
+    if (!bfs::is_directory(depthMapsPtsSimsTmpDir))
     {
         bfs::create_directory(depthMapsPtsSimsTmpDir);
 

--- a/src/aliceVision/fuseCut/LargeScale.cpp
+++ b/src/aliceVision/fuseCut/LargeScale.cpp
@@ -35,7 +35,7 @@ LargeScale::~LargeScale()
 
 bool LargeScale::isSpaceSaved()
 {
-    return mvsUtils::FileExists(spaceFileName);
+    return bfs::exists(spaceFileName);
 }
 
 void LargeScale::saveSpaceToFile()

--- a/src/aliceVision/fuseCut/LargeScale.cpp
+++ b/src/aliceVision/fuseCut/LargeScale.cpp
@@ -190,7 +190,7 @@ bool LargeScale::generateSpace(int maxPts, int ocTreeDim, bool generateTracks)
         delete vgnew;
         delete vg;
 
-        mvsUtils::DeleteDirectory(tmpdir);
+        bfs::remove_all(tmpdir);
 
         deleteTempPtsSimsFiles(*mp, depthMapsPtsSimsTmpDir);
 

--- a/src/aliceVision/fuseCut/ReconstructionPlan.cpp
+++ b/src/aliceVision/fuseCut/ReconstructionPlan.cpp
@@ -257,7 +257,7 @@ StaticVector<StaticVector<int>*>* loadLargeScalePtsCams(const std::vector<std::s
 
         std::string filePtsCamsFromDCTName = folderName + "meshPtsCamsFromDGC.bin";
 
-        if(!mvsUtils::FileExists(filePtsCamsFromDCTName))
+        if (!bfs::exists(filePtsCamsFromDCTName))
         {
             delete ptsCamsFromDct;
             throw std::runtime_error("Missing file: " + filePtsCamsFromDCTName);
@@ -281,7 +281,7 @@ void loadLargeScalePtsCams(const std::vector<std::string>& recsDirs, StaticVecto
 
         std::string filePtsCamsFromDCTName = folderName + "meshPtsCamsFromDGC.bin";
 
-        if(!mvsUtils::FileExists(filePtsCamsFromDCTName))
+        if (!bfs::exists(filePtsCamsFromDCTName))
         {
             throw std::runtime_error("Missing file: " + filePtsCamsFromDCTName);
         }
@@ -324,7 +324,7 @@ mesh::Mesh* joinMeshes(const std::vector<std::string>& recsDirs, StaticVector<Po
         std::string folderName = recsDirs[i];
 
         std::string fileName = folderName + "mesh.bin";
-        if(mvsUtils::FileExists(fileName))
+        if (bfs::exists(fileName))
         {
             mesh::Mesh* mei = new mesh::Mesh();
             mei->loadFromBin(fileName);
@@ -360,7 +360,7 @@ mesh::Mesh* joinMeshes(const std::vector<std::string>& recsDirs, StaticVector<Po
         std::string folderName = recsDirs[i];
 
         std::string fileName = folderName + "mesh.bin";
-        if(mvsUtils::FileExists(fileName))
+        if (bfs::exists(fileName))
         {
             mesh::Mesh* mei = new mesh::Mesh();
             mei->loadFromBin(fileName);
@@ -376,7 +376,7 @@ mesh::Mesh* joinMeshes(const std::vector<std::string>& recsDirs, StaticVector<Po
 
             ALICEVISION_LOG_DEBUG("Merging colors of part: s" << i);
             fileName = folderName + "meshAvImgCol.ply.ptsColors";
-            if(mvsUtils::FileExists(fileName))
+            if (bfs::exists(fileName))
             {
                 StaticVector<rgb>* ptsColsi = loadArrayFromFile<rgb>(fileName);
                 StaticVector<rgb>* trisColsi = getTrisColorsRgb(mei, ptsColsi);

--- a/src/aliceVision/fuseCut/VoxelsGrid.cpp
+++ b/src/aliceVision/fuseCut/VoxelsGrid.cpp
@@ -162,7 +162,7 @@ StaticVector<OctreeTracks::trackStruct*>* VoxelsGrid::loadTracksFromVoxelFiles(S
     const std::string fileNameTracksPtsCams = folderName + "tracksGridPtsCams.bin";
     const std::string fileNameTracksStat = folderName + "tracksGridStat.bin";
 
-    if(!mvsUtils::FileExists(fileNameTracksPts))
+    if (!bfs::exists(fileNameTracksPts))
         return nullptr;
 
     StaticVector<Point3d>* tracksStat = loadArrayFromFile<Point3d>(fileNameTracksStat); // minPixSize, minSim, npts
@@ -384,7 +384,7 @@ void VoxelsGrid::generateSpace(VoxelsGrid* vgnew, const Voxel& LU, const Voxel& 
         Voxel subRD = LU + (v + 1) * ns;
 
         // if (FolderExists(subfn)==true)
-        if(mvsUtils::FileExists(subfnFileMark))
+        if (bfs::exists(subfnFileMark))
         {
             VoxelsGrid* vgrec = new VoxelsGrid(Voxel(2, 2, 2), &(*voxels)[voxid * 8], mp, subfn, doVisualize);
             vgrec->generateSpace(vgnew, subLU, subRD, depthMapsPtsSimsTmpDir);
@@ -479,7 +479,7 @@ void VoxelsGrid::cloneSpaceVoxel(int voxelId, int numSubVoxs, VoxelsGrid* newSpa
     std::string folderName = getVoxelFolderName(voxelId);
     std::string fileNameTracksPts = folderName + "tracksGridPts.bin";
 
-    if(mvsUtils::FileExists(fileNameTracksPts))
+    if (bfs::exists(fileNameTracksPts))
     {
         OctreeTracks* ott =
             new OctreeTracks(&(*voxels)[voxelId * 8], mp, Voxel(numSubVoxs, numSubVoxs, numSubVoxs));
@@ -525,7 +525,7 @@ void VoxelsGrid::copySpaceVoxel(int voxelId, VoxelsGrid* newSpace)
     std::string folderName = getVoxelFolderName(voxelId);
     std::string fileNameTracksPts = folderName + "tracksGridPts.bin";
 
-    if(mvsUtils::FileExists(fileNameTracksPts))
+    if (bfs::exists(fileNameTracksPts))
     {
         StaticVector<int>* tcams;
         StaticVector<OctreeTracks::trackStruct*>* tracksOld = loadTracksFromVoxelFiles(&tcams, voxelId);
@@ -579,7 +579,7 @@ void VoxelsGrid::generateCamsPtsFromVoxelsTracks()
 
         // printf("SAVING %i-th VOXEL POINTS TO CAMS FILES\n",i);
 
-        if(mvsUtils::FileExists(fileNameTracksPts))
+        if (bfs::exists(fileNameTracksPts))
         {
             StaticVector<Point3d>* tracksPoints = loadArrayFromFile<Point3d>(fileNameTracksPts);
             StaticVector<StaticVector<Pixel>*>* tracksPointsCams =

--- a/src/aliceVision/fuseCut/VoxelsGrid.cpp
+++ b/src/aliceVision/fuseCut/VoxelsGrid.cpp
@@ -142,11 +142,11 @@ std::string VoxelsGrid::getVoxelFolderName(int id) const
     std::string fnxyz = spaceRootDir + "X" + mvsUtils::num2str(v.x) + "Y" + mvsUtils::num2str(v.y) + "Z" + mvsUtils::num2str(v.z) + "/";
     // bfs::create_directory(fnxyz);
 
-    // if (FolderExists(fnx)==false) {
+    // if (bfs::is_directory(fnx)==false) {
     //	printf("Warning folder %s does not exist!\n",fnx.c_str());
     //}
 
-    // if (FolderExists(fnxyz)==false) {
+    // if (bfs::is_directory(fnxyz)==false) {
     //	printf("Warning folder %s does not exist!\n",fnxyz.c_str());
     //}
 
@@ -203,7 +203,7 @@ bool VoxelsGrid::saveTracksToVoxelFiles(StaticVector<int>* cams, StaticVector<Oc
     std::string folderName = getVoxelFolderName(id);
 
     bfs::create_directory(folderName);
-    if(!mvsUtils::FolderExists(folderName))
+    if (!bfs::is_directory(folderName))
     {
         ALICEVISION_LOG_WARNING("Folder '" << folderName << "' does not exist.");
     }
@@ -383,7 +383,7 @@ void VoxelsGrid::generateSpace(VoxelsGrid* vgnew, const Voxel& LU, const Voxel& 
         Voxel subLU = LU + v * ns;
         Voxel subRD = LU + (v + 1) * ns;
 
-        // if (FolderExists(subfn)==true)
+        // if (bfs::is_directory(subfn)==true)
         if (bfs::exists(subfnFileMark))
         {
             VoxelsGrid* vgrec = new VoxelsGrid(Voxel(2, 2, 2), &(*voxels)[voxid * 8], mp, subfn, doVisualize);
@@ -635,7 +635,7 @@ void VoxelsGrid::vizualize()
     {
         std::string subFoldeName = getVoxelFolderName(i);
         std::string fname = subFoldeName + "tracks.wrl";
-        if(mvsUtils::FolderExists(subFoldeName.c_str()))
+        if (bfs::is_directory(subFoldeName.c_str()))
         {
             fprintf(f, "Inline{ url [\"%s\"] \n }\n", fname.c_str());
         }

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -232,7 +232,7 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
 
 void MultiViewParams::loadMatricesFromTxtFile(int index, const std::string& fileNameP, const std::string& fileNameD)
 {
-    if(!FileExists(fileNameP))
+    if (!fs::exists(fileNameP))
         throw std::runtime_error(std::string("mv_multiview_params: no such file: ") + fileNameP);
 
     FILE* f = fopen(fileNameP.c_str(), "r");
@@ -268,7 +268,7 @@ void MultiViewParams::loadMatricesFromTxtFile(int index, const std::string& file
     iRArr[index] = RArr[index].inverse();
     iCamArr[index] = iRArr[index] * iKArr[index];
 
-    if(FileExists(fileNameD))
+    if (fs::exists(fileNameD))
     {
         FILE* f = fopen(fileNameD.c_str(), "r");
         fscanf(f, "%f %f %f", &FocK1K2Arr[index].x, &FocK1K2Arr[index].y, &FocK1K2Arr[index].z);

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -17,11 +17,6 @@
 namespace aliceVision {
 namespace mvsUtils {
 
-bool FileExists(const std::string& filePath)
-{
-    return boost::filesystem::exists(filePath);
-}
-
 bool FolderExists(const std::string& folderPath)
 {
     return boost::filesystem::is_directory(folderPath);

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -376,11 +376,5 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
 template void loadImage<ImageRGBf>(const std::string& path, const MultiViewParams& mp, int camId, ImageRGBf& img, imageIO::EImageColorSpace colorspace, ECorrectEV correctEV);
 template void loadImage<ImageRGBAf>(const std::string& path, const MultiViewParams& mp, int camId, ImageRGBAf& img, imageIO::EImageColorSpace colorspace, ECorrectEV correctEV);
 
-bool DeleteDirectory(const std::string& sPath)
-{
-    boost::filesystem::remove_all(sPath);
-    return true;
-}
-
 } // namespace mvsUtils
 } // namespace aliceVision

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -17,11 +17,6 @@
 namespace aliceVision {
 namespace mvsUtils {
 
-bool FolderExists(const std::string& folderPath)
-{
-    return boost::filesystem::is_directory(folderPath);
-}
-
 std::string getFileNameFromViewId(const MultiViewParams& mp, int viewId, EFileType fileType, int scale, const std::string& customSuffix)
 {
   std::string folder = mp._imagesFolder;

--- a/src/aliceVision/mvsUtils/fileIO.hpp
+++ b/src/aliceVision/mvsUtils/fileIO.hpp
@@ -25,7 +25,6 @@ namespace oiio = OIIO;
 namespace aliceVision {
 namespace mvsUtils {
 
-bool FileExists(const std::string& filePath);
 bool FolderExists(const std::string& folderPath);
 
 std::string getFileNameFromViewId(const MultiViewParams& mp, int viewId, EFileType fileType, int scale = 0, const std::string& customSuffix = "");

--- a/src/aliceVision/mvsUtils/fileIO.hpp
+++ b/src/aliceVision/mvsUtils/fileIO.hpp
@@ -37,7 +37,5 @@ template<class Image>
 void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Image& img,
     imageIO::EImageColorSpace colorspace, ECorrectEV correctEV);
 
-bool DeleteDirectory(const std::string& sPath);
-
 } // namespace mvsUtils
 } // namespace aliceVision

--- a/src/aliceVision/mvsUtils/fileIO.hpp
+++ b/src/aliceVision/mvsUtils/fileIO.hpp
@@ -25,8 +25,6 @@ namespace oiio = OIIO;
 namespace aliceVision {
 namespace mvsUtils {
 
-bool FolderExists(const std::string& folderPath);
-
 std::string getFileNameFromViewId(const MultiViewParams& mp, int viewId, EFileType fileType, int scale = 0, const std::string& customSuffix = "");
 
 std::string getFileNameFromIndex(const MultiViewParams& mp, int index, EFileType fileType, int scale = 0, const std::string& customSuffix = "");


### PR DESCRIPTION
This PR removes several trivial wrappers of boost::filesystem functionality. Using boost::filesystem directly makes code easier to read and maintain, as there's less things to know about.