### PR TITLE
Remove uses of fscanf

### DIFF
--- a/src/aliceVision/fuseCut/CMakeLists.txt
+++ b/src/aliceVision/fuseCut/CMakeLists.txt
@@ -47,3 +47,10 @@ alicevision_add_test(DelaunayGraphCut_test.cpp
     aliceVision_multiview
     aliceVision_multiview_test_data
 )
+
+alicevision_add_test(LargeScale_test.cpp
+  NAME "fuseCut_LargeScale"
+  LINKS
+    aliceVision_fuseCut
+    aliceVision_sfm
+)

--- a/src/aliceVision/fuseCut/LargeScale.cpp
+++ b/src/aliceVision/fuseCut/LargeScale.cpp
@@ -40,33 +40,34 @@ bool LargeScale::isSpaceSaved()
 
 void LargeScale::saveSpaceToFile()
 {
-    FILE* f = fopen(spaceFileName.c_str(), "w");
-    fprintf(f, "%lf %lf %lf %lf %lf %lf %lf %lf\n", space[0].x, space[1].x, space[2].x, space[3].x, space[4].x,
-            space[5].x, space[6].x, space[7].x);
-    fprintf(f, "%lf %lf %lf %lf %lf %lf %lf %lf\n", space[0].y, space[1].y, space[2].y, space[3].y, space[4].y,
-            space[5].y, space[6].y, space[7].y);
-    fprintf(f, "%lf %lf %lf %lf %lf %lf %lf %lf\n", space[0].z, space[1].z, space[2].z, space[3].z, space[4].z,
-            space[5].z, space[6].z, space[7].z);
-    fprintf(f, "%i %i %i\n", dimensions.x, dimensions.y, dimensions.z);
-    fprintf(f, "%i\n", maxOcTreeDim);
-    fclose(f);
+    std::ofstream out(spaceFileName);
+    out << space[0].x << " " << space[1].x << " " << space[2].x << " " << space[3].x << " "
+        << space[4].x << " " << space[5].x << " " << space[6].x << " " << space[7].x << "\n";
+
+    out << space[0].y << " " << space[1].y << " " << space[2].y << " " << space[3].y << " "
+        << space[4].y << " " << space[5].y << " " << space[6].y << " " << space[7].y << "\n";
+
+    out << space[0].z << " " << space[1].z << " " << space[2].z << " " << space[3].z << " "
+        << space[4].z << " " << space[5].z << " " << space[6].z << " " << space[7].z << "\n";
+
+    out << dimensions.x << " " << dimensions.y << " " << dimensions.z << "\n";
+    out << maxOcTreeDim << "\n";
 }
 
 void LargeScale::loadSpaceFromFile()
 {
-    FILE* f = fopen(spaceFileName.c_str(), "r");
-    fscanf(f, "%lf %lf %lf %lf %lf %lf %lf %lf\n",
-           &space[0].x, &space[1].x, &space[2].x, &space[3].x,
-           &space[4].x, &space[5].x, &space[6].x, &space[7].x);
-    fscanf(f, "%lf %lf %lf %lf %lf %lf %lf %lf\n",
-           &space[0].y, &space[1].y, &space[2].y, &space[3].y,
-           &space[4].y, &space[5].y, &space[6].y, &space[7].y);
-    fscanf(f, "%lf %lf %lf %lf %lf %lf %lf %lf\n",
-           &space[0].z, &space[1].z, &space[2].z, &space[3].z,
-           &space[4].z, &space[5].z, &space[6].z, &space[7].z);
-    fscanf(f, "%i %i %i\n", &dimensions.x, &dimensions.y, &dimensions.z);
-    fscanf(f, "%i\n", &maxOcTreeDim);
-    fclose(f);
+    std::ifstream in(spaceFileName);
+    in >> space[0].x >> space[1].x >> space[2].x >> space[3].x
+       >> space[4].x >> space[5].x >> space[6].x >> space[7].x;
+
+    in >> space[0].y >> space[1].y >> space[2].y >> space[3].y
+       >> space[4].y >> space[5].y >> space[6].y >> space[7].y;
+
+    in >> space[0].z >> space[1].z >> space[2].z >> space[3].z
+       >> space[4].z >> space[5].z >> space[6].z >> space[7].z;
+
+    in >> dimensions.x >> dimensions.y >> dimensions.z;
+    in >> maxOcTreeDim;
 }
 
 void LargeScale::initialEstimateSpace(int maxOcTreeDim)

--- a/src/aliceVision/fuseCut/LargeScale_test.cpp
+++ b/src/aliceVision/fuseCut/LargeScale_test.cpp
@@ -1,0 +1,46 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/fuseCut/LargeScale.hpp>
+
+#include <string>
+
+#define BOOST_TEST_MODULE fuseCut
+
+#include <boost/test/unit_test.hpp>
+
+using namespace aliceVision;
+using namespace aliceVision::fuseCut;
+
+BOOST_AUTO_TEST_CASE(fuseCut_largeScale_io)
+{
+    sfmData::SfMData sfmData;
+    mvsUtils::MultiViewParams mp{sfmData};
+    LargeScale ls{&mp, "test_tmp"};
+    ls.space = {{
+        { 1.1, 1.2, 1.3 },
+        { 2.1, 2.2, 2.3 },
+        { 3.1, 3.2, 3.3 },
+        { 4.1, 4.2, 4.3 },
+        { 5.1, 5.2, 5.3 },
+        { 6.1, 6.2, 6.3 },
+        { 7.1, 7.2, 7.3 },
+        { 8.1, 8.2, 8.3 },
+    }};
+    ls.dimensions = {1, 2, 3};
+    ls.maxOcTreeDim = 5;
+    ls.spaceFileName = "test_tmp/ls_space.txt";
+    ls.saveSpaceToFile();
+
+    LargeScale newLs{&mp, "test_tmp"};
+    newLs.spaceFileName = "test_tmp/ls_space.txt";
+    newLs.loadSpaceFromFile();
+
+    BOOST_CHECK_EQUAL(ls.space, newLs.space);
+    BOOST_CHECK_EQUAL(ls.dimensions, newLs.dimensions);
+    BOOST_CHECK_EQUAL(ls.maxOcTreeDim, newLs.maxOcTreeDim);
+}

--- a/src/aliceVision/mvsData/Point3d.hpp
+++ b/src/aliceVision/mvsData/Point3d.hpp
@@ -84,7 +84,7 @@ public:
         return *this;
     }
 
-    inline bool operator==(const Point3d& param)
+    inline bool operator==(const Point3d& param) const
     {
         return (x == param.x) && (y == param.y) && (z == param.z);
     }

--- a/src/aliceVision/mvsData/Voxel.hpp
+++ b/src/aliceVision/mvsData/Voxel.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cmath>
+#include <iostream>
 
 namespace aliceVision {
 
@@ -122,5 +123,11 @@ struct Voxel
         return (x != param.x) || (y != param.y) || (z != param.z);
     }
 };
+
+inline std::ostream& operator<<(std::ostream& out, const Voxel& v)
+{
+    out << v.x << "," << v.y << "," << v.z;
+    return out;
+}
 
 } // namespace aliceVision

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -235,28 +235,27 @@ void MultiViewParams::loadMatricesFromTxtFile(int index, const std::string& file
     if(!FileExists(fileNameP))
         throw std::runtime_error(std::string("mv_multiview_params: no such file: ") + fileNameP);
 
-    FILE* f = fopen(fileNameP.c_str(), "r");
+    std::ifstream in{fileNameP};
     char fc;
-    fscanf(f, "%c", &fc);
+    in >> fc;
     if(fc == 'C') // FURUKAWA'S PROJCTION MATRIX FILE FORMAT
     {
-        fscanf(f, "%c", &fc);   // O
-        fscanf(f, "%c", &fc);   // N
-        fscanf(f, "%c", &fc);   // T
-        fscanf(f, "%c", &fc);   // O
-        fscanf(f, "%c", &fc);   // U
-        fscanf(f, "%c\n", &fc); // R
+        in >> fc; // O
+        in >> fc; // N
+        in >> fc; // T
+        in >> fc; // O
+        in >> fc; // U
+        in >> fc; // R
     }
     else
     {
-        fclose(f);
-        f = fopen(fileNameP.c_str(), "r");
+        in.close();
+        in.open(fileNameP);
     }
 
     Matrix3x4& pMatrix = camArr.at(index);
 
-    pMatrix = load3x4MatrixFromFile(f);
-    fclose(f);
+    pMatrix = load3x4MatrixFromFile(in);
 
     // apply scale to camera matrix (camera matrix is scale 1)
     const int imgScale = _imagesScale.at(index) * _processDownscale;
@@ -270,9 +269,8 @@ void MultiViewParams::loadMatricesFromTxtFile(int index, const std::string& file
 
     if(FileExists(fileNameD))
     {
-        FILE* f = fopen(fileNameD.c_str(), "r");
-        fscanf(f, "%f %f %f", &FocK1K2Arr[index].x, &FocK1K2Arr[index].y, &FocK1K2Arr[index].z);
-        fclose(f);
+        std::ifstream inD{fileNameD};
+        inD >> FocK1K2Arr[index].x >> FocK1K2Arr[index].y >> FocK1K2Arr[index].z;
     }
 }
 

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -298,23 +298,23 @@ FILE* mv_openFile(const MultiViewParams& mp, int index, EFileType mv_file_type, 
 }
 
 
-Matrix3x4 load3x4MatrixFromFile(FILE* fi)
+Matrix3x4 load3x4MatrixFromFile(std::istream& in)
 {
     Matrix3x4 m;
 
     // M[col*3 + row]
     float a, b, c, d;
-    fscanf(fi, "%f %f %f %f \n", &a, &b, &c, &d);
+    in >> a >> b >> c >> d;
     m.m11 = a;
     m.m12 = b;
     m.m13 = c;
     m.m14 = d;
-    fscanf(fi, "%f %f %f %f \n", &a, &b, &c, &d);
+    in >> a >> b >> c >> d;
     m.m21 = a;
     m.m22 = b;
     m.m23 = c;
     m.m24 = d;
-    fscanf(fi, "%f %f %f %f \n", &a, &b, &c, &d);
+    in >> a >> b >> c >> d;
     m.m31 = a;
     m.m32 = b;
     m.m33 = c;

--- a/src/aliceVision/mvsUtils/fileIO.hpp
+++ b/src/aliceVision/mvsUtils/fileIO.hpp
@@ -33,7 +33,7 @@ std::string getFileNameFromViewId(const MultiViewParams& mp, int viewId, EFileTy
 std::string getFileNameFromIndex(const MultiViewParams& mp, int index, EFileType fileType, int scale = 0, const std::string& customSuffix = "");
 
 FILE* mv_openFile(const MultiViewParams& mp, int index, EFileType mv_file_type, const char* readWrite);
-Matrix3x4 load3x4MatrixFromFile(FILE* fi);
+Matrix3x4 load3x4MatrixFromFile(std::istream& in);
 
 
 template<class Image>


### PR DESCRIPTION
This PR removes several uses of C fscanf functionality. Using it directly is unsafe because numeric overflow yields undefined behavior which may crash the program in the worst case. Using C++ equivalents is less problematic, because numeric overflow is well defined there.

A test for changed serialization implementations has been added where possible. A couple of small fixes needed for tests are also included into the PR.