### PR TITLE
Fix typo: temporay -> temporary

### DIFF
--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -196,7 +196,7 @@ void ImageDescriber::Save(const Regions* regions, const std::string& sfileNameFe
 
   regions->Save(tmpFeatsPath, tmpDescsPath);
 
-  // rename temporay filenames
+  // rename temporary filenames
   fs::rename(tmpFeatsPath, sfileNameFeats);
   fs::rename(tmpDescsPath, sfileNameDescs);
 }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -577,7 +577,7 @@ void writeImage(const std::string& path,
   if(!outBuf->write(tmpPath))
     throw std::runtime_error("Can't write output image file '" + path + "'.");
 
-  // rename temporay filename
+  // rename temporary filename
   fs::rename(tmpPath, path);
 }
 
@@ -625,7 +625,7 @@ void writeImageNoFloat(const std::string& path,
   if(!outBuf->write(tmpPath))
     throw std::runtime_error("Can't write output image file '" + path + "'.");
 
-  // rename temporay filename
+  // rename temporary filename
   fs::rename(tmpPath, path);
 }
 

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -433,7 +433,7 @@ void writeImage(const std::string& path,
     if(!outBuf->write(tmpPath))
       throw std::runtime_error("Can't write output image file '" + path + "'.");
 
-    // rename temporay filename
+    // rename temporary filename
     fs::rename(tmpPath, path);
 }
 

--- a/src/aliceVision/sfmDataIO/sfmDataIO.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIO.cpp
@@ -166,7 +166,7 @@ bool Save(const sfmData::SfMData& sfmData, const std::string& filename, ESfMData
     return false;
   }
 
-  // rename temporay filename
+  // rename temporary filename
   if(status)
     fs::rename(tmpPath, filename);
 


### PR DESCRIPTION
This is trivial PR to fix a particular spelling error that happened in several places.