### PR TITLE
Improve test reproducibility

### DIFF
--- a/src/aliceVision/camera/distortion_test.cpp
+++ b/src/aliceVision/camera/distortion_test.cpp
@@ -21,6 +21,8 @@ using namespace aliceVision::camera;
 //-----------------
 BOOST_AUTO_TEST_CASE(distortion_distort_undistort)
 {
+    makeRandomOperationsReproducible();
+
     std::array<std::unique_ptr<Distortion>, 6> distortionsModels;
     distortionsModels[0].reset(new DistortionBrown(-0.25349, 0.11868, -0.00028, 0.00005, 0.0000001));
     distortionsModels[1].reset(new DistortionFisheye(0.02, -0.03, 0.1, -0.2));

--- a/src/aliceVision/camera/equidistant_test.cpp
+++ b/src/aliceVision/camera/equidistant_test.cpp
@@ -26,6 +26,8 @@ using namespace aliceVision::camera;
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraEquidistant_disto_undisto_Radial)
 {
+  makeRandomOperationsReproducible();
+
   const int w = 1000;
   const int h = 800;
   const double focal = 800.0;

--- a/src/aliceVision/camera/pinhole3DE_test.cpp
+++ b/src/aliceVision/camera/pinhole3DE_test.cpp
@@ -26,6 +26,8 @@ using namespace aliceVision::camera;
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraPinhole3DE_disto_undisto_Radial4)
 {
+  makeRandomOperationsReproducible();
+
   const Pinhole3DERadial4 cam(1000, 1000, 1000, 1000, 0, 0,
     -0.4839495643487452,
     1.0301284234642258,
@@ -70,6 +72,8 @@ BOOST_AUTO_TEST_CASE(cameraPinhole3DE_disto_undisto_Radial4)
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraPinhole3DE_disto_undisto_ClassicLD)
 {
+  makeRandomOperationsReproducible();
+
   const Pinhole3DEClassicLD cam(1000, 1000, 1000, 1000, 0, 0,
     -0.34768564335290314,
     1.5809150001711287,

--- a/src/aliceVision/camera/pinholeBrown_test.cpp
+++ b/src/aliceVision/camera/pinholeBrown_test.cpp
@@ -27,6 +27,8 @@ using namespace aliceVision::camera;
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraPinholeBrown_disto_undisto_T2)
 {
+  makeRandomOperationsReproducible();
+
   const PinholeBrownT2 cam(1000, 1000, 1000, 1000, 0, 0,
   // K1, K2, K3, T1, T2
   -0.054, 0.014, 0.006, 0.001, -0.001);

--- a/src/aliceVision/camera/pinholeFisheye1_test.cpp
+++ b/src/aliceVision/camera/pinholeFisheye1_test.cpp
@@ -26,6 +26,7 @@ using namespace aliceVision::camera;
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraPinholeFisheye_disto_undisto_Fisheye1)
 {
+  makeRandomOperationsReproducible();
   const PinholeFisheye1 cam(1000, 1000, 1000, 1000, 0, 0,
                                     0.1); // K1
 

--- a/src/aliceVision/camera/pinholeFisheye_test.cpp
+++ b/src/aliceVision/camera/pinholeFisheye_test.cpp
@@ -27,6 +27,8 @@ using namespace aliceVision::camera;
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraPinholeFisheye_disto_undisto_Fisheye)
 {
+  makeRandomOperationsReproducible();
+
   const PinholeFisheye cam(1000, 1000, 1000, 1000, 0, 0,
                                     -0.054, 0.014, 0.006, 0.011); // K1, K2, K3, K4
 

--- a/src/aliceVision/camera/pinholeRadial_test.cpp
+++ b/src/aliceVision/camera/pinholeRadial_test.cpp
@@ -27,6 +27,8 @@ using namespace aliceVision::camera;
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraPinholeRadial_disto_undisto_K1)
 {
+  makeRandomOperationsReproducible();
+
   const PinholeRadialK1 cam(1000, 1000, 1000, 1000, 0, 0,
     // K1
     0.1);
@@ -67,6 +69,8 @@ BOOST_AUTO_TEST_CASE(cameraPinholeRadial_disto_undisto_K1)
 //-----------------
 BOOST_AUTO_TEST_CASE(cameraPinholeRadial_disto_undisto_K3)
 {
+  makeRandomOperationsReproducible();
+
   const PinholeRadialK3 cam(1000, 1000, 1000, 1000, 0, 0,
     // K1, K2, K3
     -0.245539, 0.255195, 0.163773);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
@@ -56,6 +56,8 @@ SfMData generateSfm(const NViewDatasetConfigurator& config, const size_t size = 
 
 BOOST_AUTO_TEST_CASE(fuseCut_delaunayGraphCut)
 {
+    makeRandomOperationsReproducible();
+
     system::Logger::get()->setLogLevel(system::EVerboseLevel::Trace);
 
     const NViewDatasetConfigurator config(1000, 1000, 500, 500, 1, 0);

--- a/src/aliceVision/geometry/rigidTransformation3D_test.cpp
+++ b/src/aliceVision/geometry/rigidTransformation3D_test.cpp
@@ -20,6 +20,7 @@ using namespace aliceVision::geometry;
 
 BOOST_AUTO_TEST_CASE(SRT_precision_Experiment_ScaleOnly)
 {
+  makeRandomOperationsReproducible();
 
   const std::size_t nbPoints = 10;
   Mat x1 = Mat::Random(3, nbPoints);
@@ -50,6 +51,7 @@ BOOST_AUTO_TEST_CASE(SRT_precision_Experiment_ScaleOnly)
 
 BOOST_AUTO_TEST_CASE(SRT_precision_Experiment_ScaleAndRot)
 {
+  makeRandomOperationsReproducible();
 
   const std::size_t nbPoints = 10;
   Mat x1 = Mat::Random(3, nbPoints);
@@ -87,6 +89,7 @@ BOOST_AUTO_TEST_CASE(SRT_precision_Experiment_ScaleAndRot)
 
 BOOST_AUTO_TEST_CASE(SRT_precision_Experiment_ScaleRotTranslation)
 {
+  makeRandomOperationsReproducible();
 
   const std::size_t nbPoints = 10;
   Mat x1 = Mat::Random(3, nbPoints);
@@ -124,6 +127,8 @@ BOOST_AUTO_TEST_CASE(SRT_precision_Experiment_ScaleRotTranslation)
 
 BOOST_AUTO_TEST_CASE(SRT_precision_ACRANSAC_noNoise)
 {
+  makeRandomOperationsReproducible();
+
   std::mt19937 randomNumberGenerator;
   const std::size_t nbPoints = 100;
   Mat x1 = Mat::Random(3, nbPoints);
@@ -179,6 +184,8 @@ BOOST_AUTO_TEST_CASE(SRT_precision_ACRANSAC_noNoise)
 
 BOOST_AUTO_TEST_CASE(SRT_precision_ACRANSAC_noiseByShuffling)
 {
+  makeRandomOperationsReproducible();
+
   std::mt19937 randomNumberGenerator;
   // it generates some points x1, it only generates the corresponding 
   // transformed points x2 for nbPoints-nbShuffles of them while the rest

--- a/src/aliceVision/lightingEstimation/lightingEstimation_test.cpp
+++ b/src/aliceVision/lightingEstimation/lightingEstimation_test.cpp
@@ -30,6 +30,8 @@ inline float zeroOneRand()
 
 BOOST_AUTO_TEST_CASE(LIGHTING_ESTIMATION_Lambertian_GT)
 {
+  makeRandomOperationsReproducible();
+
   const std::size_t sx = 4;
   const std::size_t sy = 3;
 
@@ -80,6 +82,8 @@ BOOST_AUTO_TEST_CASE(LIGHTING_ESTIMATION_Lambertian_GT)
 
 BOOST_AUTO_TEST_CASE(LIGHTING_ESTIMATION_Lambertian_noise)
 {
+  makeRandomOperationsReproducible();
+
   const std::size_t sx = 500;
   const std::size_t sy = 300;
 

--- a/src/aliceVision/localization/LocalizationResult_test.cpp
+++ b/src/aliceVision/localization/LocalizationResult_test.cpp
@@ -69,6 +69,8 @@ localization::LocalizationResult generateRandomResult(std::size_t numPts)
 
 BOOST_AUTO_TEST_CASE(LocalizationResult_LoadSaveVector)
 {
+  makeRandomOperationsReproducible();
+
   const double threshold = 1e-10;
   const std::size_t numResults = 10;
   const std::string filename = "test_localizationResults.json";

--- a/src/aliceVision/localization/rigResection_test.cpp
+++ b/src/aliceVision/localization/rigResection_test.cpp
@@ -221,6 +221,8 @@ void generateRandomExperiment(std::size_t numCameras,
 
 BOOST_AUTO_TEST_CASE(rigResection_simpleNoNoiseNoOutliers)
 {
+  makeRandomOperationsReproducible();
+
   const std::size_t numCameras = 3;
   const std::size_t numPoints = 10;
   const std::size_t numTrials = 10;
@@ -330,6 +332,8 @@ BOOST_AUTO_TEST_CASE(rigResection_simpleNoNoiseNoOutliers)
 
 BOOST_AUTO_TEST_CASE(rigResection_simpleWithNoiseNoOutliers)
 {
+  makeRandomOperationsReproducible();
+
   const std::size_t numCameras = 3;
   const std::size_t numPoints = 10;
   const std::size_t numTrials = 10;
@@ -412,6 +416,8 @@ BOOST_AUTO_TEST_CASE(rigResection_simpleWithNoiseNoOutliers)
 /*
 BOOST_AUTO_TEST_CASE(rigResection_simpleNoNoiseWithOutliers)
 {
+  makeRandomOperationsReproducible();
+
   const std::size_t numCameras = 3;
   const std::size_t numPoints = 10;
   const std::size_t numTrials = 10;

--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils_test.cpp
@@ -22,6 +22,8 @@ void meanAndStd(const Eigen::Matrix2Xf& points2d, Vec2f& mean, Vec2f& stdDev)
 
 BOOST_AUTO_TEST_CASE(matchingImageCollection_centerMatrix)
 {
+  makeRandomOperationsReproducible();
+
   const std::size_t numPoints{100};
   const std::size_t numTrials{100};
   const float threshold{0.0001f};
@@ -48,6 +50,8 @@ BOOST_AUTO_TEST_CASE(matchingImageCollection_centerMatrix)
 
 BOOST_AUTO_TEST_CASE(matchingImageCollection_similarityEstimation)
 {
+  makeRandomOperationsReproducible();
+
   // same point should give the identity matrix
   const feature::PointFeature feat1 {1.0f, 5.0f, 1.0f, 0.1f};
   Mat3 S;

--- a/src/aliceVision/multiview/relativePose/essential5PSolver_test.cpp
+++ b/src/aliceVision/multiview/relativePose/essential5PSolver_test.cpp
@@ -98,6 +98,7 @@ double EvalPolynomial(Vec p, double x, double y, double z)
 BOOST_AUTO_TEST_CASE(o1_Evaluation)
 {
   using namespace aliceVision::multiview::relativePose;
+  makeRandomOperationsReproducible();
 
   Vec p1 = Vec::Zero(20), p2 = Vec::Zero(20);
 
@@ -121,6 +122,7 @@ BOOST_AUTO_TEST_CASE(o1_Evaluation)
 BOOST_AUTO_TEST_CASE(o2_Evaluation)
 {
   using namespace aliceVision::multiview::relativePose;
+  makeRandomOperationsReproducible();
 
   Vec p1 = Vec::Zero(20), p2 = Vec::Zero(20);
 

--- a/src/aliceVision/multiview/resection/resectionKernel_test.cpp
+++ b/src/aliceVision/multiview/resection/resectionKernel_test.cpp
@@ -151,6 +151,8 @@ void CreateCameraSystem(const Mat3& KK,
 
 
 BOOST_AUTO_TEST_CASE(EuclideanResection_Points6AllRandomInput) {
+  makeRandomOperationsReproducible();
+
   Mat3 KK;
   KK << 2796, 0,    800,
         0 ,   2796, 600,

--- a/src/aliceVision/multiview/rotationAveraging/rotationAveraging_test.cpp
+++ b/src/aliceVision/multiview/rotationAveraging/rotationAveraging_test.cpp
@@ -319,6 +319,8 @@ BOOST_AUTO_TEST_CASE ( rotationAveraging_RefineRotationsAvgL1IRLS_CompleteGraph_
 template<typename TYPE, int N>
 inline REAL ComputePSNR(const Eigen::Matrix<REAL, N,1>& x0, const Eigen::Matrix<REAL, N,1>& x)
 {
+  makeRandomOperationsReproducible();
+
   REAL ret = std::numeric_limits<REAL>::infinity();
 
   REAL err = (x0 - x).squaredNorm() / N;
@@ -390,6 +392,8 @@ bool TestRobustRegressionL1PD()
 
 BOOST_AUTO_TEST_CASE ( rotationAveraging_RobustRegressionL1PD)
 {
+  makeRandomOperationsReproducible();
+
   TestRobustRegressionL1PD();
 }
 */

--- a/src/aliceVision/multiview/translationAveraging/translationAveraging_test.cpp
+++ b/src/aliceVision/multiview/translationAveraging/translationAveraging_test.cpp
@@ -122,6 +122,7 @@ BOOST_AUTO_TEST_CASE(translation_averaging_globalTi_from_tijs_softl1_Ceres) {
 }
 
 BOOST_AUTO_TEST_CASE(translation_averaging_globalTi_from_tijs_Triplets_l2_chordal) {
+  makeRandomOperationsReproducible();
 
   const int focal = 1000;
   const int principal_Point = 500;

--- a/src/aliceVision/multiview/triangulation/triangulation_test.cpp
+++ b/src/aliceVision/multiview/triangulation/triangulation_test.cpp
@@ -95,6 +95,8 @@ BOOST_AUTO_TEST_CASE(TriangulateNViewAlgebraic_FiveViews) {
 // is considered).
 BOOST_AUTO_TEST_CASE(Triangulate_NViewAlgebraic_WithWeights)
 {
+  makeRandomOperationsReproducible();
+
   const std::size_t nbViews = 20;
   const std::size_t nbOutliers = 8;
   
@@ -174,6 +176,8 @@ BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_FiveViews)
 //// is considered).
 BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_LORANSAC)
 {
+  makeRandomOperationsReproducible();
+
   std::mt19937 randomNumberGenerator;
   
   const std::size_t numTrials = 100;

--- a/src/aliceVision/numeric/numeric.cpp
+++ b/src/aliceVision/numeric/numeric.cpp
@@ -155,5 +155,18 @@ bool exportMatToTextFile(const Mat & mat, const std::string & filename,
   return bOk;
 }
 
+void makeRandomOperationsReproducible()
+{
+  unsigned seed = 1234567;
+
+  const char* seed_string = std::getenv("ALICEVISION_RANDOM_SEED");
+  if (seed_string != nullptr) {
+    seed = std::stol(seed_string);
+  }
+
+  // Eigen uses std::rand in its Random() member functions.
+  std::srand(seed);
+}
+
 }  // namespace aliceVision
 

--- a/src/aliceVision/numeric/numeric.hpp
+++ b/src/aliceVision/numeric/numeric.hpp
@@ -568,5 +568,14 @@ void SplitRange(const T range_start, const T range_end, const int nb_split,
   }
 }
 
+/**
+ * This function initializes the global state of random number generators that e.g. our tests
+ * depend on. This makes it possible to have exactly reproducible program runtime behavior
+ * without random changes. In order to introduce variation in execution,
+ * ALICEVISION_RANDOM_SEED environment variable can be set to an integer value.
+ *
+ * This function is especially useful in tests where it allows to prevent random failures.
+ */
+void makeRandomOperationsReproducible();
 
 } // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
@@ -40,6 +40,8 @@ namespace fs = boost::filesystem;
 //   - the desired number of poses are found.
 BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL1)
 {
+  makeRandomOperationsReproducible();
+
   const int nviews = 6;
   const int npoints = 64;
   const NViewDatasetConfigurator config;
@@ -90,6 +92,8 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL1)
 
 BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL1_TranslationAveragingL1)
 {
+  makeRandomOperationsReproducible();
+
   const int nviews = 6;
   const int npoints = 64;
   const NViewDatasetConfigurator config;
@@ -140,6 +144,8 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL1_TranslationAveragingL1)
 
 BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL2_Chordal)
 {
+  makeRandomOperationsReproducible();
+
   const int nviews = 6;
   const int npoints = 64;
   const NViewDatasetConfigurator config;
@@ -190,6 +196,8 @@ BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingL2_Chord
 
 BOOST_AUTO_TEST_CASE(GLOBAL_SFM_RotationAveragingL2_TranslationAveragingSoftL1)
 {
+  makeRandomOperationsReproducible();
+
   const int nviews = 6;
   const int npoints = 64;
   const NViewDatasetConfigurator config;

--- a/src/aliceVision/sfmDataIO/alembicIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/alembicIO_test.cpp
@@ -146,6 +146,7 @@ SfMData createTestScene(IndexT singleViewsCount,
 // - Import to .json
 //-----------------
 BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
+    makeRandomOperationsReproducible();
 
     int flags = ALL;
 

--- a/src/aliceVision/voctree/kmeans_test.cpp
+++ b/src/aliceVision/voctree/kmeans_test.cpp
@@ -5,6 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/voctree/SimpleKmeans.hpp>
 
 #include <iostream>
@@ -22,6 +23,8 @@ BOOST_AUTO_TEST_CASE(kmeanInitializer)
   using namespace aliceVision;
   
   ALICEVISION_LOG_DEBUG("Testing kmeanspp Initializer...");
+
+  makeRandomOperationsReproducible();
 
   const std::size_t DIMENSION = 128;
   const std::size_t FEATURENUMBER = 500;
@@ -80,6 +83,8 @@ BOOST_AUTO_TEST_CASE(kmeanInitializerVarying)
   
   ALICEVISION_LOG_DEBUG("Testing kmeanspp Initializer with variable k and DIM...");
 
+  makeRandomOperationsReproducible();
+
   const int FEATURENUMBER = 500;
   const std::size_t numTrial = 3;
 
@@ -131,6 +136,8 @@ BOOST_AUTO_TEST_CASE(kmeanSimple)
   using namespace aliceVision;
 
   ALICEVISION_LOG_DEBUG("Testing kmeans...");
+
+  makeRandomOperationsReproducible();
 
   const std::size_t DIMENSION = 8;
   const std::size_t FEATURENUMBER = 500;
@@ -209,6 +216,8 @@ BOOST_AUTO_TEST_CASE(kmeanVarying)
 {
   using namespace aliceVision;
   ALICEVISION_LOG_DEBUG("Testing kmeans with variable k and DIM...");
+
+  makeRandomOperationsReproducible();
 
   const std::size_t FEATURENUMBER = 300;
   const std::size_t numTrial = 3;

--- a/src/aliceVision/voctree/vocabularyTreeBuild_test.cpp
+++ b/src/aliceVision/voctree/vocabularyTreeBuild_test.cpp
@@ -22,6 +22,8 @@ BOOST_AUTO_TEST_CASE(voctreeBuilder)
 {
   using namespace aliceVision;
 
+  makeRandomOperationsReproducible();
+
   const std::string treeName = "test.tree";
 
   const std::size_t DIMENSION = 3;


### PR DESCRIPTION
Many tests call Vec*::Random() and similar functions from Eigen, which make the tests not reproducible. This is problematic, because the tests become unstable and even if some of them sometimes fail indicating a problem, it's hard to debug and fix the failure as the exact conditions of the failing test are not known. Initializing random number generators to a static seed fixes the issue.

In order to introduce variation in test execution, `ALICEVISION_TEST_RANDOM_SEED` environment variable can be set to an integer value. This effectively allows to keep the previous behavior, because this value can be set to a different integer on each test execution.