### PR TITLE
Switch to non-deprecated overload of oiio::ImageBufAlgo::make_kernel()

### DIFF
--- a/src/aliceVision/mvsData/imageAlgo.cpp
+++ b/src/aliceVision/mvsData/imageAlgo.cpp
@@ -302,8 +302,7 @@ void convolveImage(oiio::TypeDesc typeDesc,
     const oiio::ImageBuf inBuf(oiio::ImageSpec(inWidth, inHeight, nchannels, typeDesc), const_cast<T*>(inBuffer.data()));
     oiio::ImageBuf outBuf(oiio::ImageSpec(inWidth, inHeight, nchannels, typeDesc), outBuffer.data());
 
-    oiio::ImageBuf K;
-    oiio::ImageBufAlgo::make_kernel(K, kernel, kernelWidth, kernelHeight);
+    oiio::ImageBuf K = oiio::ImageBufAlgo::make_kernel(kernel, kernelWidth, kernelHeight);
 
     oiio::ImageBufAlgo::convolve(outBuf, inBuf, K);
 }

--- a/src/aliceVision/panorama/gaussian.cpp
+++ b/src/aliceVision/panorama/gaussian.cpp
@@ -44,8 +44,7 @@ bool GaussianPyramidNoMask::process(const image::Image<image::RGBfColor>& input)
     /**
      * Kernel
      */
-    oiio::ImageBuf K;
-    oiio::ImageBufAlgo::make_kernel(K, "gaussian", 5, 5);
+    oiio::ImageBuf K = oiio::ImageBufAlgo::make_kernel("gaussian", 5, 5);
 
     /**
      * Build pyramid

--- a/src/software/utils/main_lightingEstimation.cpp
+++ b/src/software/utils/main_lightingEstimation.cpp
@@ -214,8 +214,7 @@ void initAlbedo(image::Image<image::RGBfColor>& albedo, const image::Image<image
       albedo.resize(picture.Width(), picture.Height());
       const oiio::ImageBuf pictureBuf(oiio::ImageSpec(picture.Width(), picture.Height(), 3, oiio::TypeDesc::FLOAT), const_cast<void*>((void*)&picture(0,0)(0)));
       oiio::ImageBuf albedoBuf(oiio::ImageSpec(picture.Width(), picture.Height(), 3, oiio::TypeDesc::FLOAT), albedo.data());
-      oiio::ImageBuf K;
-      oiio::ImageBufAlgo::make_kernel(K, "gaussian", albedoEstimationFilterSize, albedoEstimationFilterSize);
+      oiio::ImageBuf K = oiio::ImageBufAlgo::make_kernel("gaussian", albedoEstimationFilterSize, albedoEstimationFilterSize);
       oiio::ImageBufAlgo::convolve(albedoBuf, pictureBuf, K);
       image::writeImage((fs::path(outputFolder) / (std::to_string(viewId) + "_albedo.jpg")).string(), albedo,
                         image::EImageColorSpace::AUTO);
@@ -254,8 +253,7 @@ void initAlbedo(image::Image<float>& albedo, const image::Image<float>& picture,
       albedo.resize(picture.Width(), picture.Height());
       const oiio::ImageBuf pictureBuf(oiio::ImageSpec(picture.Width(), picture.Height(), 1, oiio::TypeDesc::FLOAT), const_cast<float*>(picture.data()));
       oiio::ImageBuf albedoBuf(oiio::ImageSpec(picture.Width(), picture.Height(), 1, oiio::TypeDesc::FLOAT), albedo.data());
-      oiio::ImageBuf K;
-      oiio::ImageBufAlgo::make_kernel(K, "gaussian", albedoEstimationFilterSize, albedoEstimationFilterSize);
+      oiio::ImageBuf K = oiio::ImageBufAlgo::make_kernel("gaussian", albedoEstimationFilterSize, albedoEstimationFilterSize);
       oiio::ImageBufAlgo::convolve(albedoBuf, pictureBuf, K);
       image::writeImage((fs::path(outputFolder) / (std::to_string(viewId) + "_albedo.jpg")).string(), albedo,
                         image::EImageColorSpace::AUTO);


### PR DESCRIPTION
The overload of oiio::ImageBufAlgo::make_kernel() that returns the ImageBuf instance via a reference has been deprecated since oiio 1.9. AliceVision requires OpenImageIO >= 2.1.0 so we can switch to the replacement API now.


