### PR TITLE
[sfm] make sure we give other chances to candidates

### DIFF
--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -330,6 +330,14 @@ private:
       std::map<IndexT, std::set<IndexT> > & mapTracksToTriangulate) const;
 
   /**
+   * @brief  Loop over the reconstructed views, and for each landmarks of the reconstructed views, 
+   * loop over their tracks to detect which views may have new information using this newly reconstructed views
+   * 
+   * @param newReconstructedViews a list of reconstructed views to analyse
+   */
+  void registerChanges(const std::set<IndexT>& newReconstructedViews);
+
+  /**
    * @brief Remove observation/tracks that have:
    * - too large residual error
    * - too small angular value
@@ -354,6 +362,9 @@ private:
   /// internal cache of precomputed values for the weighting of the pyramid levels
   std::vector<int> _pyramidWeights;
   int _pyramidThreshold;
+
+  //List of views which are affected by a previous update
+  std::set<IndexT> _registeredCandidatesViews;
 
   // Temporary data
 

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -363,10 +363,10 @@ private:
   std::vector<int> _pyramidWeights;
   int _pyramidThreshold;
 
-  //List of views which are affected by a previous update
-  std::set<IndexT> _registeredCandidatesViews;
-
   // Temporary data
+
+  /// List of views which are affected by a previous update
+  std::set<IndexT> _registeredCandidatesViews;
 
   /// Putative landmark tracks (visibility per potential 3D point)
   track::TracksMap _map_tracks;

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -330,7 +330,7 @@ private:
       std::map<IndexT, std::set<IndexT> > & mapTracksToTriangulate) const;
 
   /**
-   * @brief  Loop over the reconstructed views, and for each landmarks of the reconstructed views, 
+   * @brief  Loop over the reconstructed views, and for each landmark of the reconstructed views, 
    * loop over their tracks to detect which views may have new information using this newly reconstructed views
    * 
    * @param newReconstructedViews a list of reconstructed views to analyse


### PR DESCRIPTION
In the incremental SFM, the reconstruction select iteratively some candidates for resection. It may happens that this selection is not good and the resection fail. In this case, the frame is definitely discarded. This PR gives them other chances to shine ! 

- If a resection fail, the frame id is **not** removed from the set of available frames.
- To make sure we don't retry at each iteration those frames, we estimate at each iteration which frames are affected by the changes on the reconstruction in the current iteration. For all frames which have been newly inserted into the reconstruction, trigger the connected frames (through tracks) for the next iteration.
