### PR TITLE
[sensorDB] Add Samsung SM-G991B (Samsung Galaxy S21 5G)

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5765,6 +5765,7 @@ Samsung;Samsung SM-G988;10.82;devicespecifications
 Samsung;Samsung SM-G9880;10.82;devicespecifications
 Samsung;Samsung SM-G988B/DS;10.82;devicespecifications
 Samsung;Samsung SM-G988N;10.82;devicespecifications
+Samsung;Samsung SM-G991B;7.26;usercontribution
 Samsung;Samsung SM-M315F;7.42;devicespecifications
 Samsung;Samsung SM-N985F;9.6;devicespecifications
 Samsung;Samsung SM-N986B;9.6;devicespecifications


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR adds the camera sensor (Sony IMX555) for the Samsung Galaxy S21 5G (Samsung SM-G991B).

Width calculation: 4032px * 1.8um/1000 = 7.26mm
Also matches the specs from: https://www.deviceranks.com/en/camera-sensor/718/sony-imx555

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

