### PR TITLE
Allow using all pipeline nodes from a single executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ string(TOLOWER ${DEPS_CMAKE_BUILD_TYPE} DEPS_CMAKE_BUILD_TYPE_LOWERCASE)
 
 option(ALICEVISION_BUILD_TESTS "Build AliceVision tests" OFF)
 
+# Enabling this one will cause an expensive link step after pretty much any
+# modification to the sources. Use it only in cases where rebuilding full project
+# e.g. in continuous integration tests.
+option(ALICEVISION_BUILD_STATIC_LIB_SYMBOL_TEST
+       "Build an internal test for checking against duplicate symbols" OFF)
+
 set(ALICEVISION_BUNDLE_PREFIX "${CMAKE_INSTALL_PREFIX}/bundle" CACHE STRING "Path for bundle installation")
 
 set(ALICEVISION_ROOT ${PROJECT_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -937,6 +937,7 @@ message("** Build Shared libs: " ${BUILD_SHARED_LIBS})
 message("** Build SfM part: " ${ALICEVISION_BUILD_SFM})
 message("** Build MVS part: " ${ALICEVISION_BUILD_MVS})
 message("** Build AliceVision tests: " ${ALICEVISION_BUILD_TESTS})
+message("** Build AliceVision static lib symbol test: " ${ALICEVISION_BUILD_STATIC_LIB_SYMBOL_TEST})
 message("** Build AliceVision documentation: " ${ALICEVISION_HAVE_DOC})
 message("** Build AliceVision samples programs: " ${ALICEVISION_BUILD_EXAMPLES})
 message("** Build AliceVision+OpenCV samples programs: " ${ALICEVISION_HAVE_OPENCV})
@@ -1005,6 +1006,8 @@ add_subdirectory(dependencies)
 # AliceVision modules
 # ==============================================================================
 
+set_property(GLOBAL PROPERTY global_all_static_libs)
+
 # software(s) under patent or commercial licence
 # Included for research purpose only
 if(ALICEVISION_BUILD_SFM)
@@ -1022,6 +1025,25 @@ endif()
 # Complete software(s) build on aliceVision libraries
 if(ALICEVISION_BUILD_SOFTWARE)
   add_subdirectory(software)
+endif()
+
+# Create a unused dynamic library to ensure that there are no name clashes
+# between symbols exported from source files passed to alicevision_add_software
+#
+# Since we're using global property to collect the list of all libraries, this
+# is the only place where we can put the definition of such test.
+get_property(all_static_libs GLOBAL PROPERTY global_all_static_libs)
+if(CMAKE_COMPILER_IS_GNUCXX AND ALICEVISION_BUILD_STATIC_LIB_SYMBOL_TEST)
+    # CMake 3.24 will have cross-platform feature to force inclusion of all static
+    # library members. Until then, do this test only on GNU systems.
+    set(empty_cpp ${CMAKE_CURRENT_BINARY_DIR}/test_aliceVision_combined_library_empty.cpp)
+    if(NOT EXISTS ${empty_cpp})
+      file(WRITE ${empty_cpp} "")
+    endif()
+
+    add_executable(test_aliceVision_combined_libraries aliceVision/system/empty_main.cpp)
+    target_link_libraries(test_aliceVision_combined_libraries
+      PUBLIC -Wl,--whole-archive ${all_static_libs} -Wl,--no-whole-archive)
 endif()
 
 # ==============================================================================

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Headers
 set(system_files_headers
   cpu.hpp
-  main.hpp
   MemoryInfo.hpp
   system.hpp
   Timer.hpp
@@ -17,6 +16,10 @@ set(system_files_sources
   Logger.cpp
   nvtx.cpp
 )
+
+# Note that main.hpp is not included because it's not part of aliceVision_system library, but
+# is added to all executables declared via alicevision_add_software() using CMake code in
+# alicevision_add_software() function.
 
 alicevision_add_library(aliceVision_system
   SOURCES ${system_files_headers} ${system_files_sources}

--- a/src/aliceVision/system/empty_main.cpp
+++ b/src/aliceVision/system/empty_main.cpp
@@ -1,0 +1,13 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This file is used in static library symbol duplication test that is enabled
+// via ALICEVISION_BUILD_STATIC_LIB_SYMBOL_TEST.
+
+int main()
+{
+    return 0;
+}

--- a/src/aliceVision/system/main.cpp
+++ b/src/aliceVision/system/main.cpp
@@ -4,15 +4,13 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#pragma once
-
 /**
  * @file \c main() function wrapper
  * Provides an implementation of \c main() that automatically catches and logs
  * otherwise unhandled exceptions.
  *
  * To use this wrapper you need to change your source file containing \c main() as such:
- * 1. Include this header
+ * 1. Include this source file to the list of files for the executable.
  * 2. Rename \c main() to \c aliceVision_main()
  */
 

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -167,7 +167,9 @@ function(alicevision_add_software software_name)
     list(APPEND SOFTWARE_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/${software_name}_version.rc")
   endif()
 
-  add_executable(${software_name}_exe ${SOFTWARE_SOURCE})
+  add_executable(${software_name}_exe ${SOFTWARE_SOURCE}
+                 "${CMAKE_SOURCE_DIR}/src/aliceVision/system/main.cpp")
+
   set_target_properties(${software_name}_exe PROPERTIES
     OUTPUT_NAME ${software_name}
     )

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -186,6 +186,10 @@ function(alicevision_add_software software_name)
     PUBLIC ${SOFTWARE_INCLUDE_DIRS}
   )
 
+  get_property(all_static_libs GLOBAL PROPERTY global_all_static_libs)
+  set(all_static_libs ${all_static_libs} ${software_name}_static_lib)
+  set_property(GLOBAL PROPERTY global_all_static_libs ${all_static_libs})
+
   # The executable will depend on the static library and will only include a main() function that
   # calls the aliceVision_main symbol.
   add_executable(${software_name}_exe ${SOFTWARE_SOURCE}

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -167,6 +167,21 @@ function(alicevision_add_software software_name)
     list(APPEND SOFTWARE_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/${software_name}_version.rc")
   endif()
 
+  # Declare a static library with all the code of the executable. End users may link this static
+  # library to their executables to use AliceVision on e.g. mobile platforms where stuff like
+  # dlopen and dlsym are not well supported.
+  add_library(${software_name}_static_lib STATIC ${SOFTWARE_SOURCE})
+
+  target_link_libraries(${software_name}_static_lib
+    PUBLIC ${SOFTWARE_LINKS}
+  )
+
+  target_include_directories(${software_name}_static_lib
+    PUBLIC ${SOFTWARE_INCLUDE_DIRS}
+  )
+
+  # The executable will depend on the static library and will only include a main() function that
+  # calls the aliceVision_main symbol.
   add_executable(${software_name}_exe ${SOFTWARE_SOURCE}
                  "${CMAKE_SOURCE_DIR}/src/aliceVision/system/main.cpp")
 
@@ -175,11 +190,7 @@ function(alicevision_add_software software_name)
     )
 
   target_link_libraries(${software_name}_exe
-    PUBLIC ${SOFTWARE_LINKS}
-  )
-
-  target_include_directories(${software_name}_exe
-    PUBLIC ${SOFTWARE_INCLUDE_DIRS}
+    PRIVATE ${software_name}_static_lib
   )
 
   set_property(TARGET ${software_name}_exe

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -170,7 +170,13 @@ function(alicevision_add_software software_name)
   # Declare a static library with all the code of the executable. End users may link this static
   # library to their executables to use AliceVision on e.g. mobile platforms where stuff like
   # dlopen and dlsym are not well supported.
+  #
+  # The aliceVision_main symbol is redefined to unique name that depends on ${software_name} so
+  # that multiple such static libraries can be linked into single executable.
   add_library(${software_name}_static_lib STATIC ${SOFTWARE_SOURCE})
+
+  target_compile_definitions(${software_name}_static_lib
+    PRIVATE -DaliceVision_main=aliceVision_main_${software_name})
 
   target_link_libraries(${software_name}_static_lib
     PUBLIC ${SOFTWARE_LINKS}
@@ -184,6 +190,9 @@ function(alicevision_add_software software_name)
   # calls the aliceVision_main symbol.
   add_executable(${software_name}_exe ${SOFTWARE_SOURCE}
                  "${CMAKE_SOURCE_DIR}/src/aliceVision/system/main.cpp")
+
+  target_compile_definitions(${software_name}_exe
+    PRIVATE -DaliceVision_main=aliceVision_main_${software_name})
 
   set_target_properties(${software_name}_exe PROPERTIES
     OUTPUT_NAME ${software_name}

--- a/src/samples/accv12Demo/main_openCVFitting.cpp
+++ b/src/samples/accv12Demo/main_openCVFitting.cpp
@@ -12,6 +12,7 @@
 #include "aliceVision/robustEstimation/ScoreEvaluator.hpp"
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/robustEstimation/ACRansacKernelAdaptator.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
@@ -64,7 +65,7 @@ int thickness = 1;
  * Pierre Moulon, Pascal Monasse and Renaud Marlet.
  * In 11th Asian Confence on Computer Vision (ACCV 2012)
  */
-int main(int, char**)
+int aliceVision_main(int, char**)
 {
   cout << "Press:" << endl
        << " 'q' to quit." << endl;

--- a/src/samples/accv12Demo/main_openCVFitting.cpp
+++ b/src/samples/accv12Demo/main_openCVFitting.cpp
@@ -12,7 +12,6 @@
 #include "aliceVision/robustEstimation/ScoreEvaluator.hpp"
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/robustEstimation/ACRansacKernelAdaptator.hpp"
-#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 

--- a/src/samples/featuresAKAZEDemo/main_computeAKAZE.cpp
+++ b/src/samples/featuresAKAZEDemo/main_computeAKAZE.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/image/image.hpp>
 #include <aliceVision/feature/akaze/AKAZE.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 #include <dependencies/cmdLine/cmdLine.h>
@@ -34,7 +35,7 @@ void usage( const std::string & appName )
   exit( EXIT_FAILURE ) ;
 }
 
-int main( int argc , char ** argv )
+int aliceVision_main( int argc , char ** argv )
 {
   CmdLine cmd;
 

--- a/src/samples/featuresAKAZEDemo/main_computeAKAZE.cpp
+++ b/src/samples/featuresAKAZEDemo/main_computeAKAZE.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/image/image.hpp>
 #include <aliceVision/feature/akaze/AKAZE.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 #include <dependencies/cmdLine/cmdLine.h>

--- a/src/samples/featuresAKAZEDemo/main_demoAKAZE
+++ b/src/samples/featuresAKAZEDemo/main_demoAKAZE
@@ -11,6 +11,7 @@
 #include "aliceVision/matching/matcher_brute_force.hpp"
 #include "aliceVision/matching/matching_filters.hpp"
 #include "aliceVision_Samples/siftPutativeMatches/two_view_matches.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 #include "third_party/vectorGraphics/svgDrawer.hpp"
@@ -23,7 +24,7 @@ using namespace aliceVision::matching;
 using namespace svg;
 using namespace std;
 
-int main() {
+int aliceVision_main(int argc, char** argv) {
 
   Image<RGBColor> image;
   const std::string jpg_filenameL =

--- a/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
+++ b/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/multiview/relativePose/HomographyKernel.hpp>
 #include <aliceVision/matching/RegionsMatcher.hpp>
 
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>

--- a/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
+++ b/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
@@ -11,7 +11,6 @@
 #include "aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp"
 #include "aliceVision/matching/filters.hpp"
 #include "aliceVision/matching/RegionsMatcher.hpp"
-#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 

--- a/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
+++ b/src/samples/imageDescriberMatches/main_describeAndMatch.cpp
@@ -11,6 +11,7 @@
 #include "aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp"
 #include "aliceVision/matching/filters.hpp"
 #include "aliceVision/matching/RegionsMatcher.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
@@ -30,7 +31,7 @@ using namespace aliceVision::image;
 
 namespace po = boost::program_options;
 
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
   std::string jpgFilenameL;
   std::string jpgFilenameR;

--- a/src/samples/kvldFilter/main_kvldFilter.cpp
+++ b/src/samples/kvldFilter/main_kvldFilter.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/matching/kvld/kvld.h>
 #include <aliceVision/matching/kvld/kvld_draw.h>
 #include <aliceVision/robustEstimation/ACRansac.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 
@@ -37,7 +38,7 @@ using namespace aliceVision::robustEstimation;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
   std::string imageAFilename;
   std::string imageBFilename;

--- a/src/samples/kvldFilter/main_kvldFilter.cpp
+++ b/src/samples/kvldFilter/main_kvldFilter.cpp
@@ -14,7 +14,6 @@
 #include <aliceVision/matching/kvld/kvld.h>
 #include <aliceVision/matching/kvld/kvld_draw.h>
 #include <aliceVision/robustEstimation/ACRansac.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 

--- a/src/samples/multiBandBlending/main_multibandtest.cpp
+++ b/src/samples/multiBandBlending/main_multibandtest.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision//mvsData/Color.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -26,7 +27,7 @@ using namespace aliceVision::mesh;
 
 namespace po = boost::program_options;
 
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
   // command-line parameters
 

--- a/src/samples/multiBandBlending/main_multibandtest.cpp
+++ b/src/samples/multiBandBlending/main_multibandtest.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision//mvsData/Color.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 

--- a/src/samples/robustEssential/main_robustEssential.cpp
+++ b/src/samples/robustEssential/main_robustEssential.cpp
@@ -11,7 +11,6 @@
 #include <aliceVision/feature/sift/ImageDescriber_SIFT.hpp>
 #include <aliceVision/matching/RegionsMatcher.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 

--- a/src/samples/robustEssential/main_robustEssential.cpp
+++ b/src/samples/robustEssential/main_robustEssential.cpp
@@ -11,6 +11,7 @@
 #include <aliceVision/feature/sift/ImageDescriber_SIFT.hpp>
 #include <aliceVision/matching/RegionsMatcher.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 
@@ -46,7 +47,7 @@ bool exportToPly(const std::vector<Vec3> & vec_points,
 
 } // namespace
 
-int main() {
+int aliceVision_main(int argc, char** argv) {
 
   std::mt19937 randomNumberGenerator;
   const std::string sInputDir = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -16,7 +16,6 @@
 #include <aliceVision/matching/IndMatchDecorator.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
 #include <aliceVision/matching/RegionsMatcher.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -16,6 +16,7 @@
 #include <aliceVision/matching/IndMatchDecorator.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
 #include <aliceVision/matching/RegionsMatcher.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 
@@ -54,7 +55,7 @@ bool readIntrinsic(const std::string & fileName, Mat3 & K);
 ///  how refine the camera motion, focal and structure with Bundle Adjustment
 ///   way 1: independent cameras [R|t|f] and structure
 ///   way 2: independent cameras motion [R|t], shared focal [f] and structure
-int main() {
+int aliceVision_main(int argc, char** argv) {
   std::mt19937 randomNumberGenerator;
   const std::string sInputDir = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
   Image<RGBColor> image;

--- a/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
+++ b/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
@@ -13,7 +13,6 @@
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/robustEstimation/conditioning.hpp"
 #include "aliceVision/multiview/AngularRadianErrorKernel.hpp"
-#include <aliceVision/system/main.hpp>
 
 #include "sphericalCam.hpp"
 

--- a/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
+++ b/src/samples/robustEssentialSpherical/main_robustEssentialSpherical.cpp
@@ -13,6 +13,7 @@
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/robustEstimation/conditioning.hpp"
 #include "aliceVision/multiview/AngularRadianErrorKernel.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "sphericalCam.hpp"
 
@@ -34,7 +35,7 @@ using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
 
-int main() {
+int aliceVision_main(int argc, char** argv) {
   std::mt19937 randomNumberGenerator;
   std::cout << "Compute the relative pose between two spherical image."
    << "\nUse an Acontrario robust estimation based on angular errors." << std::endl;

--- a/src/samples/robustFundamental/main_robustFundamental.cpp
+++ b/src/samples/robustFundamental/main_robustFundamental.cpp
@@ -13,7 +13,6 @@
 #include "aliceVision/robustEstimation/conditioning.hpp"
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/multiview/RelativePoseKernel.hpp"
-#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 

--- a/src/samples/robustFundamental/main_robustFundamental.cpp
+++ b/src/samples/robustFundamental/main_robustFundamental.cpp
@@ -13,6 +13,7 @@
 #include "aliceVision/robustEstimation/conditioning.hpp"
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/multiview/RelativePoseKernel.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
@@ -34,7 +35,7 @@ using namespace aliceVision::robustEstimation;
 
 namespace po = boost::program_options;
 
-int main(int argc, char **argv) 
+int aliceVision_main(int argc, char** argv)
 {
   std::string jpgFilenameL;
   std::string jpgFilenameR;

--- a/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
+++ b/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
@@ -17,7 +17,6 @@
 #include <aliceVision/robustEstimation/ACRansac.hpp>
 #include <aliceVision/robustEstimation/IRansacKernel.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 

--- a/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
+++ b/src/samples/robustFundamentalF10/main_robustFundamentalF10.cpp
@@ -17,6 +17,7 @@
 #include <aliceVision/robustEstimation/ACRansac.hpp>
 #include <aliceVision/robustEstimation/IRansacKernel.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
@@ -38,7 +39,7 @@ using namespace aliceVision::robustEstimation;
 
 namespace po = boost::program_options;
 
-int main(int argc, char **argv) 
+int aliceVision_main(int argc, char **argv)
 {
   std::string filenameLeft;
   std::string filenameRight;

--- a/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
+++ b/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/robustEstimation/ACRansac.hpp>
 #include <aliceVision/multiview/RelativePoseKernel.hpp>
 #include <aliceVision/matching/guidedMatching.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 
@@ -31,7 +32,7 @@ using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
 
-int main() {
+int aliceVision_main(int argc, char** argv) {
   std::mt19937 randomNumberGenerator;
   const std::string sInputDir = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/SceauxCastle/";
   Image<RGBColor> image;

--- a/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
+++ b/src/samples/robustFundamentalGuided/main_robustFundamentalGuided.cpp
@@ -14,7 +14,6 @@
 #include <aliceVision/robustEstimation/ACRansac.hpp>
 #include <aliceVision/multiview/RelativePoseKernel.hpp>
 #include <aliceVision/matching/guidedMatching.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 

--- a/src/samples/robustHomography/main_robustHomography.cpp
+++ b/src/samples/robustHomography/main_robustHomography.cpp
@@ -16,7 +16,6 @@
 #include "aliceVision/robustEstimation/conditioning.hpp"
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/multiview/RelativePoseKernel.hpp"
-#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 

--- a/src/samples/robustHomography/main_robustHomography.cpp
+++ b/src/samples/robustHomography/main_robustHomography.cpp
@@ -16,6 +16,7 @@
 #include "aliceVision/robustEstimation/conditioning.hpp"
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/multiview/RelativePoseKernel.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
@@ -33,7 +34,7 @@ using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
 
-int main() {
+int aliceVision_main(int argc, char** argv) {
   std::mt19937 randomNumberGenerator;
   Image<RGBColor> image;
   const std::string jpg_filenameL = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
 
+#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
@@ -121,7 +122,7 @@ void extract(std::shared_ptr<aliceVision::feature::ImageDescriber>& imageDescrib
   }
 }
 
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
   std::string filenameLeft;
   std::string filenameRight;

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -14,7 +14,6 @@
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
 
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <dependencies/vectorGraphics/svgDrawer.hpp>

--- a/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
+++ b/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
@@ -14,7 +14,6 @@
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/multiview/RelativePoseKernel.hpp"
 #include "aliceVision/matching/guidedMatching.hpp"
-#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 

--- a/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
+++ b/src/samples/robustHomographyGuided/main_robustHomographyGuided.cpp
@@ -14,6 +14,7 @@
 #include "aliceVision/robustEstimation/ACRansac.hpp"
 #include "aliceVision/multiview/RelativePoseKernel.hpp"
 #include "aliceVision/matching/guidedMatching.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
@@ -31,7 +32,7 @@ using namespace aliceVision::matching;
 using namespace aliceVision::robustEstimation;
 using namespace svg;
 
-int main() {
+int aliceVision_main(int argc, char** argv) {
   std::mt19937 randomNumberGenerator;
   Image<RGBColor> image;
   const std::string jpg_filenameL = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";

--- a/src/samples/sensorWidthDatabase/main_parseDatabase.cpp
+++ b/src/samples/sensorWidthDatabase/main_parseDatabase.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/config.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/sensorDB/parseDatabase.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 

--- a/src/samples/sensorWidthDatabase/main_parseDatabase.cpp
+++ b/src/samples/sensorWidthDatabase/main_parseDatabase.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/config.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/sensorDB/parseDatabase.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -18,7 +19,7 @@
 
 namespace po = boost::program_options;
 
-int main(int argc, char ** argv)
+int aliceVision_main(int argc, char** argv)
 {
   std::string sensorDatabasePath;
   std::string brandName;

--- a/src/samples/siftPutativeMatches/main_siftMatching.cpp
+++ b/src/samples/siftPutativeMatches/main_siftMatching.cpp
@@ -9,6 +9,7 @@
 #include "aliceVision/feature/feature.hpp"
 #include "aliceVision/matching/RegionsMatcher.hpp"
 #include "aliceVision/feature/sift/ImageDescriber_SIFT.hpp"
+#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
@@ -25,7 +26,7 @@ using namespace aliceVision::image;
 using namespace aliceVision::matching;
 using namespace svg;
 
-int main() {
+int aliceVision_main(int argc, char** argv) {
   std::mt19937 randomNumberGenerator;
   Image<RGBColor> image;
   std::string jpg_filenameL = std::string("../") + std::string(THIS_SOURCE_DIR) + "/imageData/StanfordMobileVisualSearch/Ace_0.png";

--- a/src/samples/siftPutativeMatches/main_siftMatching.cpp
+++ b/src/samples/siftPutativeMatches/main_siftMatching.cpp
@@ -9,7 +9,6 @@
 #include "aliceVision/feature/feature.hpp"
 #include "aliceVision/matching/RegionsMatcher.hpp"
 #include "aliceVision/feature/sift/ImageDescriber_SIFT.hpp"
-#include <aliceVision/system/main.hpp>
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 

--- a/src/samples/texturing/main_evcorrection.cpp
+++ b/src/samples/texturing/main_evcorrection.cpp
@@ -9,7 +9,8 @@
 #include <aliceVision/system/cmdline.hpp> 
 #include <aliceVision/image/io.hpp> 
 #include <aliceVision/image/pixelTypes.hpp> 
- 
+#include <aliceVision/system/main.hpp>
+
 #include <boost/program_options.hpp> 
 #include <boost/filesystem.hpp> 
  
@@ -30,7 +31,7 @@ namespace fs = boost::filesystem;
  
 namespace oiio = OIIO; 
  
-int main(int argc, char **argv) 
+int aliceVision_main(int argc, char **argv)
 { 
     // command-line parameters 
  

--- a/src/samples/texturing/main_evcorrection.cpp
+++ b/src/samples/texturing/main_evcorrection.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/system/cmdline.hpp> 
 #include <aliceVision/image/io.hpp> 
 #include <aliceVision/image/pixelTypes.hpp> 
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 
 #include <boost/filesystem.hpp> 

--- a/src/samples/undistoBrown/main_undistoBrown.cpp
+++ b/src/samples/undistoBrown/main_undistoBrown.cpp
@@ -7,7 +7,6 @@
 
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/camera/camera.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/regex.hpp>
 #include <boost/progress.hpp>

--- a/src/samples/undistoBrown/main_undistoBrown.cpp
+++ b/src/samples/undistoBrown/main_undistoBrown.cpp
@@ -7,6 +7,7 @@
 
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/camera/camera.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <boost/regex.hpp>
 #include <boost/progress.hpp>
@@ -28,7 +29,7 @@ using namespace aliceVision::image;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
   std::string inputImagePath;
   std::string outputImagePath;

--- a/src/software/convert/main_convertFloatDescriptorToUchar.cpp
+++ b/src/software/convert/main_convertFloatDescriptorToUchar.cpp
@@ -7,7 +7,6 @@
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/progress.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/convert/main_convertMesh.cpp
+++ b/src/software/convert/main_convertMesh.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/mesh/Texturing.hpp>
 #include <aliceVision/mesh/Mesh.hpp>

--- a/src/software/convert/main_convertRAW.cpp
+++ b/src/software/convert/main_convertRAW.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/stl/regex.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/utils/regexFilter.hpp>

--- a/src/software/convert/main_importKnownPoses.cpp
+++ b/src/software/convert/main_importKnownPoses.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/utils/regexFilter.hpp>
 

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/AlembicExporter.hpp>

--- a/src/software/export/main_exportCameraFrustums.cpp
+++ b/src/software/export/main_exportCameraFrustums.cpp
@@ -11,7 +11,6 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/export/main_exportColoredPointCloud.cpp
+++ b/src/software/export/main_exportColoredPointCloud.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/export/main_exportKeypoints.cpp
+++ b/src/software/export/main_exportKeypoints.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/image/all.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/export/main_exportMVSTexturing.cpp
+++ b/src/software/export/main_exportMVSTexturing.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/export/main_exportMatches.cpp
+++ b/src/software/export/main_exportMatches.cpp
@@ -15,7 +15,6 @@
 #include <aliceVision/matching/svgVisualization.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/convertion.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/export/main_exportMeshlab.cpp
+++ b/src/software/export/main_exportMeshlab.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/export/main_exportMeshroomMaya.cpp
+++ b/src/software/export/main_exportMeshroomMaya.cpp
@@ -7,7 +7,6 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/export/main_exportTracks.cpp
+++ b/src/software/export/main_exportTracks.cpp
@@ -18,7 +18,6 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <software/utils/sfmHelper/sfmIOHelper.hpp>
 

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <OpenImageIO/imagebufalgo.h>
 
 // SFMData

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <OpenImageIO/imagebufalgo.h>
 
 // SFMData

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 // SFMData
 #include <aliceVision/sfmData/SfMData.hpp>

--- a/src/software/pipeline/main_cameraCalibration.cpp
+++ b/src/software/pipeline/main_cameraCalibration.cpp
@@ -14,7 +14,6 @@
 #include <aliceVision/calibration/exportData.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/sensorDB/parseDatabase.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/image/io.cpp>
 

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -20,7 +20,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/robustEstimation/estimators.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/utils/convert.hpp>
 

--- a/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
+++ b/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/matching/IndMatch.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/pipeline/main_depthMapEstimation.cpp
+++ b/src/software/pipeline/main_depthMapEstimation.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/depthMap/RefineParams.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/gpu/gpu.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/pipeline/main_depthMapFiltering.cpp
+++ b/src/software/pipeline/main_depthMapFiltering.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/mvsUtils/MultiViewParams.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 
 #include <aliceVision/depthMap/depthMap.hpp>

--- a/src/software/pipeline/main_distortionCalibration.cpp
+++ b/src/software/pipeline/main_distortionCalibration.cpp
@@ -12,7 +12,6 @@
 
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 
 #include <aliceVision/sfmData/SfMData.hpp>

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -19,7 +19,6 @@
 #include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -26,7 +26,6 @@
 #include <aliceVision/matchingImageCollection/GeometricFilterType.hpp>
 #include <aliceVision/matching/pairwiseAdjacencyDisplay.hpp>
 #include <aliceVision/matching/io.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/graph/graph.hpp>

--- a/src/software/pipeline/main_globalSfM.cpp
+++ b/src/software/pipeline/main_globalSfM.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/pipeline/main_imageMasking.cpp
+++ b/src/software/pipeline/main_imageMasking.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
@@ -78,7 +79,7 @@ inline std::istream& operator>>(std::istream& in, EAlgorithm& s)
 /**
  * @brief Write mask images from input images based on chosen algorithm.
  */
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
     // command-line parameters
     std::string sfmFilePath;

--- a/src/software/pipeline/main_imageMasking.cpp
+++ b/src/software/pipeline/main_imageMasking.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -11,7 +11,6 @@
 #include <aliceVision/voctree/VocabularyTree.hpp>
 #include <aliceVision/voctree/databaseIO.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/feature/imageDescriberCommon.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/config.hpp>

--- a/src/software/pipeline/main_meshDecimate.cpp
+++ b/src/software/pipeline/main_meshDecimate.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 

--- a/src/software/pipeline/main_meshDenoising.cpp
+++ b/src/software/pipeline/main_meshDenoising.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/mesh/MeshEnergyOpt.hpp>
 #include <aliceVision/mesh/Texturing.hpp>

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -14,7 +14,6 @@
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/sfmMvsUtils/visibility.hpp>
 #include <aliceVision/camera/cameraUndistortImage.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/sfmMvsUtils/visibility.hpp>
 #include <aliceVision/camera/cameraUndistortImage.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
@@ -500,7 +501,7 @@ void meshMasking(
 /**
  * @brief Write mask images from input images based on chosen algorithm.
  */
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
     // command-line parameters
     std::string sfmFilePath;

--- a/src/software/pipeline/main_meshResampling.cpp
+++ b/src/software/pipeline/main_meshResampling.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -19,7 +19,6 @@
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 
 #include <Eigen/Geometry>

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -24,7 +24,6 @@
 // Reading command line options
 #include <boost/program_options.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 // IO
 #include <fstream>

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/sfm/liealgebra.hpp>

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -6,7 +6,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/mvsData/imageAlgo.hpp>
 #include <aliceVision/image/drawing.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <random>
 #include <algorithm>

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -6,6 +6,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/mvsData/imageAlgo.hpp>
 #include <aliceVision/image/drawing.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <random>
 #include <algorithm>
@@ -619,7 +620,7 @@ private:
   size_t _minimal_size;
 };
 
-int main(int argc, char * argv[])
+int aliceVision_main(int argc, char** argv)
 {
     using namespace aliceVision;
 

--- a/src/software/pipeline/main_panoramaMerging.cpp
+++ b/src/software/pipeline/main_panoramaMerging.cpp
@@ -19,7 +19,6 @@
 // Reading command line options
 #include <boost/program_options.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 // IO
 #include <fstream>

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <OpenImageIO/imagebufalgo.h>
 
 /*SFMData*/

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -22,7 +22,6 @@
 // Reading command line options
 #include <boost/program_options.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 // IO
 #include <fstream>

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -8,7 +8,6 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 // Image related
 #include <aliceVision/image/all.hpp>

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -18,7 +18,6 @@
 #include <aliceVision/robustEstimation/estimators.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>

--- a/src/software/pipeline/main_rigLocalization.cpp
+++ b/src/software/pipeline/main_rigLocalization.cpp
@@ -18,7 +18,6 @@
 #include <aliceVision/robustEstimation/estimators.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -17,7 +17,6 @@
 #include <aliceVision/sfmMvsUtils/visibility.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 
 #include <geogram/basic/common.h>

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/utils/filesIO.hpp>
 
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/filesystem.hpp>

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -9,7 +9,6 @@
 
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/utils/regexFilter.hpp>

--- a/src/software/utils/main_computeUncertainty.cpp
+++ b/src/software/utils/main_computeUncertainty.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
 #include <uncertaintyTE/uncertainty.h>

--- a/src/software/utils/main_fisheyeProjection.cpp
+++ b/src/software/utils/main_fisheyeProjection.cpp
@@ -11,7 +11,6 @@
 #include <aliceVision/image/convertion.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/camera/camera.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>

--- a/src/software/utils/main_frustumFiltering.cpp
+++ b/src/software/utils/main_frustumFiltering.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/matchingImageCollection/pairBuilder.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/utils/main_generateSampleScene.cpp
+++ b/src/software/utils/main_generateSampleScene.cpp
@@ -7,7 +7,6 @@
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/sceneSample.hpp>
 

--- a/src/software/utils/main_hardwareResources.cpp
+++ b/src/software/utils/main_hardwareResources.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/gpu/gpu.hpp>
 #include <aliceVision/config.hpp>

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -2,7 +2,6 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>

--- a/src/software/utils/main_importMiddlebury.cpp
+++ b/src/software/utils/main_importMiddlebury.cpp
@@ -10,7 +10,6 @@
 
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -7,7 +7,6 @@
 #include <aliceVision/keyframe/KeyframeSelector.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 
 #include <boost/filesystem.hpp>

--- a/src/software/utils/main_lightingEstimation.cpp
+++ b/src/software/utils/main_lightingEstimation.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/lightingEstimation/lightingEstimation.hpp>
 #include <aliceVision/image/io.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo_util.h>

--- a/src/software/utils/main_lightingEstimation.cpp
+++ b/src/software/utils/main_lightingEstimation.cpp
@@ -13,6 +13,7 @@
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/lightingEstimation/lightingEstimation.hpp>
 #include <aliceVision/image/io.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo_util.h>
@@ -262,7 +263,7 @@ void initAlbedo(image::Image<float>& albedo, const image::Image<float>& picture,
   }
 }
 
-int main(int argc, char** argv)
+int aliceVision_main(int argc, char** argv)
 {
   system::Timer timer;
 

--- a/src/software/utils/main_mergeMeshes.cpp
+++ b/src/software/utils/main_mergeMeshes.cpp
@@ -6,7 +6,6 @@
 
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_qualityEvaluation.cpp
+++ b/src/software/utils/main_qualityEvaluation.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
 #include <software/utils/precisionEvaluationToGt.hpp>

--- a/src/software/utils/main_rigTransform.cpp
+++ b/src/software/utils/main_rigTransform.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision/rig/Rig.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 
 #include <boost/progress.hpp>

--- a/src/software/utils/main_sfmAlignment.cpp
+++ b/src/software/utils/main_sfmAlignment.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_sfmColorHarmonize.cpp
+++ b/src/software/utils/main_sfmColorHarmonize.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp>
 

--- a/src/software/utils/main_sfmDistances.cpp
+++ b/src/software/utils/main_sfmDistances.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/config.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string/split.hpp>

--- a/src/software/utils/main_sfmDistances.cpp
+++ b/src/software/utils/main_sfmDistances.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/config.hpp>
+#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -138,7 +139,7 @@ void extractCamerasPositions(std::vector<std::pair<std::string, Vec3>>& outputPo
 }
 
 
-int main(int argc, char **argv)
+int aliceVision_main(int argc, char **argv)
 {
   // command-line parameters
 

--- a/src/software/utils/main_sfmLocalization.cpp
+++ b/src/software/utils/main_sfmLocalization.cpp
@@ -14,7 +14,6 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision/image/Sampler.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 #include <aliceVision/panorama/sphericalMapping.hpp>

--- a/src/software/utils/main_voctreeCreation.cpp
+++ b/src/software/utils/main_voctreeCreation.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <Eigen/Core>
 

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -14,7 +14,6 @@
 #include <aliceVision/matching/IndMatch.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/utils/convert.hpp>
 

--- a/src/software/utils/main_voctreeStatistics.cpp
+++ b/src/software/utils/main_voctreeStatistics.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/voctree/descriptorLoader.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 
 #include <boost/accumulators/accumulators.hpp>


### PR DESCRIPTION
This will make it possible to compile the reusable parts of the executables once and then link into whatever destination needed, be it a part of user application, a standalone executable or a shared library.

Ability to not require usage of multiple executables is especially important on certain mobile platforms where this is not supported.

The idea behind the implementation is relatively simple: all aliceVision executables are compiled through a single CMake function (`alicevision_add_software`) and all entry points of these executables are already named as `aliceVision_main`. If `alicevision_add_software` is modified to compile the reusable code as a static library and redefine `aliceVision_main` to a unique symbol, then all of such static libraries can be easily combined into a single executable.

The current solution is the minimal one and the most simple one (whole PR is only around a hundred of lines). Going into the future we can expose the pipeline nodes better and provide more user-friendly API.