### PR TITLE
Fix duplicate symbols across executables

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -709,5 +709,31 @@ void writeImage(const std::string& path, const Image<RGBColor>& image, EImageCol
   writeImage(path, oiio::TypeDesc::UINT8, 3, image, imageColorSpace, metadata);
 }
 
+bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& masksFolders,
+                 const IndexT viewId, const std::string & srcImage)
+{
+    for (const auto & masksFolder_str : masksFolders)
+    {
+        if (!masksFolder_str.empty() && fs::exists(masksFolder_str))
+        {
+            const auto masksFolder = fs::path(masksFolder_str);
+            const auto idMaskPath = masksFolder / fs::path(std::to_string(viewId)).replace_extension("png");
+            const auto nameMaskPath = masksFolder / fs::path(srcImage).filename().replace_extension("png");
+
+            if (fs::exists(idMaskPath))
+            {
+                readImage(idMaskPath.string(), *mask, EImageColorSpace::LINEAR);
+                return true;
+            }
+            else if (fs::exists(nameMaskPath))
+            {
+                readImage(nameMaskPath.string(), *mask, EImageColorSpace::LINEAR);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 }  // namespace image
 }  // namespace aliceVision

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -272,5 +272,8 @@ struct ColorTypeInfo<RGBAfColor>
     static const oiio::TypeDesc::BASETYPE typeDesc = oiio::TypeDesc::FLOAT;
 };
 
+bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& masksFolders,
+                 const IndexT viewId, const std::string & srcImage);
+
 }  // namespace image
 }  // namespace aliceVision

--- a/src/aliceVision/localization/VoctreeLocalizer.cpp
+++ b/src/aliceVision/localization/VoctreeLocalizer.cpp
@@ -34,17 +34,6 @@
 namespace aliceVision {
 namespace localization {
 
-std::ostream& operator<<( std::ostream& os, const voctree::Document &doc )	
-{
-  os << "[ ";
-  for( const voctree::Word &w : doc )
-  {
-          os << w << ", ";
-  }
-  os << "];\n";
-  return os;
-}
-
 std::ostream& operator<<(std::ostream& os, VoctreeLocalizer::Algorithm a)
 {
   switch(a)

--- a/src/aliceVision/matching/kvld/kvld_draw.h
+++ b/src/aliceVision/matching/kvld/kvld_draw.h
@@ -14,7 +14,7 @@
 namespace aliceVision {
 
 //-- A slow but accurate way to draw K-VLD lines
-void getKVLDMask(
+inline void getKVLDMask(
   image::Image< unsigned char > *maskL,
   image::Image< unsigned char > *maskR,
   const std::vector< feature::PointFeature > &vec_F1,

--- a/src/aliceVision/utils/convert.hpp
+++ b/src/aliceVision/utils/convert.hpp
@@ -1,0 +1,24 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+namespace aliceVision {
+namespace utils {
+
+inline std::string toStringZeroPadded(std::size_t i, std::size_t zeroPadding)
+{
+  std::stringstream ss;
+  ss << std::setw(zeroPadding) << std::setfill('0') << i;
+  return ss.str();
+}
+
+} // namespace utils
+} // namespace aliceVision

--- a/src/aliceVision/voctree/Database.cpp
+++ b/src/aliceVision/voctree/Database.cpp
@@ -26,6 +26,17 @@ std::ostream& operator<<(std::ostream& os, const SparseHistogram &dv)
 	return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const DocMatches& matches)
+{
+    os << "[ ";
+    for (const auto &e : matches)
+    {
+        os << e.id << ", " << e.score << "; ";
+    }
+    os << "];\n";
+    return os;
+}
+
 Database::Database(uint32_t num_words)
 : word_files_(num_words),
 word_weights_( num_words, 1.0f ) { }

--- a/src/aliceVision/voctree/Database.hpp
+++ b/src/aliceVision/voctree/Database.hpp
@@ -51,6 +51,8 @@ struct DocMatch
 
 typedef std::vector<DocMatch> DocMatches;
 
+std::ostream& operator<<(std::ostream& os, const DocMatches& matches);
+
 /**
  * @brief Class for efficiently matching a bag-of-words representation of a document (image) against
  * a database of known documents.

--- a/src/aliceVision/voctree/VocabularyTree.cpp
+++ b/src/aliceVision/voctree/VocabularyTree.cpp
@@ -11,6 +11,17 @@
 namespace aliceVision {
 namespace voctree {
 
+std::ostream& operator<<(std::ostream& os, const Document& doc)
+{
+  os << "[ ";
+  for (const auto &w : doc)
+  {
+    os << w << ", ";
+  }
+  os << "];\n";
+  return os;
+}
+
 float sparseDistance(const SparseHistogram& v1, const SparseHistogram& v2, const std::string &distanceMethod, const std::vector<float>& word_weights)
 {
 

--- a/src/aliceVision/voctree/VocabularyTree.hpp
+++ b/src/aliceVision/voctree/VocabularyTree.hpp
@@ -37,6 +37,8 @@ typedef std::vector<Word> Document;
 typedef std::map<Word, std::vector<IndexT> > SparseHistogram;
 typedef std::map<DocId, SparseHistogram> SparseHistogramPerImage;
 
+std::ostream& operator<<(std::ostream& os, const Document &doc);
+
 /**
  * Given a list of visual words associated to the features of a document it computes the 
  * vector of unique weighted visual words

--- a/src/samples/robustEssential/main_robustEssential.cpp
+++ b/src/samples/robustEssential/main_robustEssential.cpp
@@ -31,6 +31,8 @@ using namespace svg;
 
 namespace fs = boost::filesystem;
 
+namespace {
+
 /// Read intrinsic K matrix from a file (ASCII)
 /// F 0 ppx
 /// 0 F ppy
@@ -41,6 +43,8 @@ bool readIntrinsic(const std::string & fileName, Mat3 & K);
 bool exportToPly(const std::vector<Vec3> & vec_points,
   const std::vector<Vec3> & vec_camPos,
   const std::string & sFileName);
+
+} // namespace
 
 int main() {
 
@@ -237,6 +241,8 @@ int main() {
   return EXIT_SUCCESS;
 }
 
+namespace {
+
 bool readIntrinsic(const std::string & fileName, Mat3 & K)
 {
   // Load the K matrix
@@ -288,3 +294,5 @@ bool exportToPly(const std::vector<Vec3> & vec_points,
   outfile.close();
   return bOk;
 }
+
+} // namespace

--- a/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
+++ b/src/samples/robustEssentialBA/main_robustEssentialBA.cpp
@@ -39,11 +39,15 @@ using namespace svg;
 
 namespace fs = boost::filesystem;
 
+namespace {
+
 /// Read intrinsic K matrix from a file (ASCII)
 /// F 0 ppx
 /// 0 F ppy
 /// 0 0 1
 bool readIntrinsic(const std::string & fileName, Mat3 & K);
+
+} // namespace
 
 /// Show :
 ///  how computing an essential with know internal calibration matrix K
@@ -274,6 +278,8 @@ int main() {
   return EXIT_SUCCESS;
 }
 
+namespace {
+
 bool readIntrinsic(const std::string & fileName, Mat3 & K)
 {
   // Load the K matrix
@@ -291,3 +297,5 @@ bool readIntrinsic(const std::string & fileName, Mat3 & K)
   }
   return true;
 }
+
+} // namespace

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -22,6 +22,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/progress.hpp>
@@ -53,13 +54,6 @@ using namespace aliceVision;
 namespace bfs = boost::filesystem;
 namespace bacc = boost::accumulators;
 namespace po = boost::program_options;
-
-std::string myToString(std::size_t i, std::size_t zeroPadding)
-{
-  std::stringstream ss;
-  ss << std::setw(zeroPadding) << std::setfill('0') << i;
-  return ss.str();
-}
 
 int aliceVision_main(int argc, char** argv)
 {
@@ -418,7 +412,7 @@ int aliceVision_main(int argc, char** argv)
   while(feed.readImage(imageGrey, queryIntrinsics, currentImgName, hasIntrinsics))
   {
     ALICEVISION_COUT("******************************");
-    ALICEVISION_COUT("FRAME " << myToString(frameCounter,4));
+    ALICEVISION_COUT("FRAME " << utils::toStringZeroPadded(frameCounter, 4));
     ALICEVISION_COUT("******************************");
     localization::LocalizationResult localizationResult;
     auto detect_start = std::chrono::steady_clock::now();

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -31,32 +31,6 @@ using namespace aliceVision;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
-
-bool tryLoadMask(image::Image<unsigned char>* mask, const std::vector<std::string>& masksFolders, const IndexT viewId, const std::string& srcImage)
-{
-    for (const auto& masksFolder_str : masksFolders)
-    {
-        if (!masksFolder_str.empty() && fs::exists(masksFolder_str))
-        {
-            const auto masksFolder = fs::path(masksFolder_str);
-            const auto idMaskPath = masksFolder / fs::path(std::to_string(viewId)).replace_extension("png");
-            const auto nameMaskPath = masksFolder / fs::path(srcImage).filename().replace_extension("png");
-
-            if (fs::exists(idMaskPath))
-            {
-                image::readImage(idMaskPath.string(), *mask, image::EImageColorSpace::LINEAR);
-                return true;
-            }
-            else if (fs::exists(nameMaskPath))
-            {
-                image::readImage(nameMaskPath.string(), *mask, image::EImageColorSpace::LINEAR);
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 /**
  * @brief Basic cache system to manage masks.
  * 

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -74,31 +74,6 @@ void process(const std::string &dstColorImage, const IntrinsicBase* cam, const o
   }
 }
 
-bool tryLoadMask(image::Image<unsigned char>* mask, const std::vector<std::string>& masksFolders, const IndexT viewId, const std::string & srcImage)
-{
-  for(const auto & masksFolder_str : masksFolders)
-  {
-    if(!masksFolder_str.empty() && fs::exists(masksFolder_str))
-    {
-      const auto masksFolder = fs::path(masksFolder_str);
-      const auto idMaskPath = masksFolder / fs::path(std::to_string(viewId)).replace_extension("png");
-      const auto nameMaskPath = masksFolder / fs::path(srcImage).filename().replace_extension("png");
-
-      if(fs::exists(idMaskPath))
-      {
-        image::readImage(idMaskPath.string(), *mask, image::EImageColorSpace::LINEAR);
-        return true;
-      }
-      else if(fs::exists(nameMaskPath))
-      {
-        image::readImage(nameMaskPath.string(), *mask, image::EImageColorSpace::LINEAR);
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 bool prepareDenseScene(const SfMData& sfmData,
                        const std::vector<std::string>& imagesFolders,
                        const std::vector<std::string>& masksFolders,

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -19,6 +19,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/progress.hpp>
@@ -50,14 +51,6 @@ using namespace aliceVision;
 namespace bfs = boost::filesystem;
 namespace bacc = boost::accumulators;
 namespace po = boost::program_options;
-
-std::string myToString(std::size_t i, std::size_t zeroPadding)
-{
-  std::stringstream ss;
-  ss << std::setw(zeroPadding) << std::setfill('0') << i;
-  return ss.str();
-}
-
 
 int aliceVision_main(int argc, char** argv)
 {
@@ -386,7 +379,8 @@ int aliceVision_main(int argc, char** argv)
     while(feed.readImage(imageGrey, *queryIntrinsics, currentImgName, hasIntrinsics))
     {
       ALICEVISION_COUT("******************************");
-      ALICEVISION_COUT("Stream " << idCamera << " Frame " << myToString(currentFrame, 4) << "/" << nbFrames << " : (" << iInputFrame << "/" << nbFramesToProcess << ")");
+      ALICEVISION_COUT("Stream " << idCamera << " Frame " << utils::toStringZeroPadded(currentFrame, 4)
+                       << "/" << nbFrames << " : (" << iInputFrame << "/" << nbFramesToProcess << ")");
       ALICEVISION_COUT("******************************");
       auto detect_start = std::chrono::steady_clock::now();
       localization::LocalizationResult localizationResult;
@@ -408,7 +402,7 @@ int aliceVision_main(int argc, char** argv)
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_ALEMBIC)
       if(localizationResult.isValid())
       {
-        exporter.addCamera("camera"+std::to_string(idCamera)+"."+myToString(currentFrame,4),
+        exporter.addCamera("camera"+std::to_string(idCamera)+"." + utils::toStringZeroPadded(currentFrame, 4),
                            sfmData::View(subMediaFilepath, currentFrame, currentFrame),
                            &pose,
                            queryIntrinsics);
@@ -416,7 +410,7 @@ int aliceVision_main(int argc, char** argv)
       else
       {
         // @fixme for now just add a fake camera so that it still can be see in MAYA
-        exporter.addCamera("camera"+std::to_string(idCamera)+".V."+myToString(currentFrame,4),
+        exporter.addCamera("camera"+std::to_string(idCamera)+".V." + utils::toStringZeroPadded(currentFrame, 4),
                            sfmData::View(subMediaFilepath, currentFrame, currentFrame),
                            &pose,
                            queryIntrinsics);

--- a/src/software/pipeline/main_rigLocalization.cpp
+++ b/src/software/pipeline/main_rigLocalization.cpp
@@ -19,6 +19,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/progress.hpp>
@@ -52,14 +53,6 @@ using namespace aliceVision;
 namespace bfs = boost::filesystem;
 namespace bacc = boost::accumulators;
 namespace po = boost::program_options;
-
-std::string myToString(std::size_t i, std::size_t zeroPadding)
-{
-  std::stringstream ss;
-  ss << std::setw(zeroPadding) << std::setfill('0') << i;
-  return ss.str();
-}
-
 
 int aliceVision_main(int argc, char** argv)
 {
@@ -341,8 +334,9 @@ int aliceVision_main(int argc, char** argv)
 
   for(std::size_t i = 0; i < numCameras; ++i)
   {
-    cameraExporters.push_back( new sfmDataIO::AlembicExporter(basename+".cam"+myToString(i, 2)+".abc"));
-    cameraExporters.back().initAnimatedCamera("cam"+myToString(i, 2));
+    auto camIndexStr = utils::toStringZeroPadded(i, 2);
+    cameraExporters.push_back(new sfmDataIO::AlembicExporter(basename + ".cam" + camIndexStr + ".abc"));
+    cameraExporters.back().initAnimatedCamera("cam" + camIndexStr);
   }
 #endif
 
@@ -438,7 +432,7 @@ int aliceVision_main(int argc, char** argv)
     }
     
     ALICEVISION_COUT("******************************");
-    ALICEVISION_COUT("FRAME " << myToString(frameCounter, 4));
+    ALICEVISION_COUT("FRAME " << utils::toStringZeroPadded(frameCounter, 4));
     ALICEVISION_COUT("******************************");
     auto detect_start = std::chrono::steady_clock::now();
     std::vector<localization::LocalizationResult> localizationResults;

--- a/src/software/utils/main_sfmAlignment.cpp
+++ b/src/software/utils/main_sfmAlignment.cpp
@@ -27,6 +27,7 @@ using namespace aliceVision::sfm;
 
 namespace po = boost::program_options;
 
+namespace {
 
 /**
 * @brief Alignment method enum
@@ -89,6 +90,7 @@ inline std::ostream& operator<<(std::ostream& os, EAlignmentMethod e)
     return os << EAlignmentMethod_enumToString(e);
 }
 
+} // namespace
 
 int aliceVision_main(int argc, char **argv)
 {

--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -28,6 +28,8 @@ using namespace aliceVision;
 
 namespace po = boost::program_options;
 
+namespace {
+
 /**
  * @brief Alignment method enum
  */
@@ -177,6 +179,7 @@ static void parseManualTransform(const std::string& manualTransform, double& S, 
     R = rotateMat; // Assign Rotation
 }
 
+} // namespace
 
 int aliceVision_main(int argc, char **argv)
 {

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -58,17 +58,6 @@ std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::DocMatche
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::Document &doc)
-{
-  os << "[ ";
-  for(const aliceVision::voctree::Word &w : doc)
-  {
-    os << w << ", ";
-  }
-  os << "];\n";
-  return os;
-}
-
 bool saveSparseHistogramPerImage(const std::string &filename, const aliceVision::voctree::SparseHistogramPerImage &docs)
 {
   std::ofstream fileout(filename);

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -47,17 +47,6 @@ using namespace aliceVision::feature;
 typedef aliceVision::feature::Descriptor<float, DIMENSION> DescriptorFloat;
 typedef aliceVision::feature::Descriptor<unsigned char, DIMENSION> DescriptorUChar;
 
-std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::DocMatches &matches)
-{
-  os << "[ ";
-  for(const auto &e : matches)
-  {
-    os << e.id << ", " << e.score << "; ";
-  }
-  os << "];\n";
-  return os;
-}
-
 bool saveSparseHistogramPerImage(const std::string &filename, const aliceVision::voctree::SparseHistogramPerImage &docs)
 {
   std::ofstream fileout(filename);

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -16,6 +16,7 @@
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/types.hpp>
+#include <aliceVision/utils/convert.hpp>
 
 #include <Eigen/Core>
 
@@ -66,13 +67,6 @@ std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::Document 
   }
   os << "];\n";
   return os;
-}
-
-std::string myToString(std::size_t i, std::size_t zeroPadding)
-{
-  std::stringstream ss;
-  ss << std::setw(zeroPadding) << std::setfill('0') << i;
-  return ss.str();
 }
 
 bool saveSparseHistogramPerImage(const std::string &filename, const aliceVision::voctree::SparseHistogramPerImage &docs)
@@ -495,7 +489,8 @@ int aliceVision_main(int argc, char** argv)
         if(it != sfmData.getViews().end())
         {
           absoluteFilename = it->second->getImagePath();
-          sylinkName = fs::path(myToString(j, 4) + "." + std::to_string(matches[j].score) + "." + absoluteFilename.filename().string());
+          sylinkName = fs::path(utils::toStringZeroPadded(j, 4) + "." + std::to_string(matches[j].score) +
+                                "." + absoluteFilename.filename().string());
         }
         else
         {

--- a/src/software/utils/main_voctreeStatistics.cpp
+++ b/src/software/utils/main_voctreeStatistics.cpp
@@ -42,17 +42,6 @@ namespace po = boost::program_options;
 typedef aliceVision::feature::Descriptor<float, DIMENSION> DescriptorFloat;
 typedef aliceVision::feature::Descriptor<unsigned char, DIMENSION> DescriptorUChar;
 
-std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::DocMatches &matches)
-{
-  os << "[ ";
-  for(const auto &e : matches)
-  {
-    os << e.id << ", " << e.score << "; ";
-  }
-  os << "];\n";
-  return os;
-}
-
 static const std::string programDescription =
         "This program is used to generate some statistics.\n ";
 

--- a/src/software/utils/main_voctreeStatistics.cpp
+++ b/src/software/utils/main_voctreeStatistics.cpp
@@ -64,13 +64,6 @@ std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::Document 
   return os;
 }
 
-std::string myToString(std::size_t i, std::size_t zeroPadding)
-{
-  std::stringstream ss;
-  ss << std::setw(zeroPadding) << std::setfill('0') << i;
-  return ss.str();
-}
-
 static const std::string programDescription =
         "This program is used to generate some statistics.\n ";
 

--- a/src/software/utils/main_voctreeStatistics.cpp
+++ b/src/software/utils/main_voctreeStatistics.cpp
@@ -53,17 +53,6 @@ std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::DocMatche
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const aliceVision::voctree::Document &doc)
-{
-  os << "[ ";
-  for(const aliceVision::voctree::Word &w : doc)
-  {
-    os << w << ", ";
-  }
-  os << "];\n";
-  return os;
-}
-
 static const std::string programDescription =
         "This program is used to generate some statistics.\n ";
 


### PR DESCRIPTION
This is related to https://github.com/alicevision/AliceVision/pull/1208. With the ability to compile most of the code that comprises aliceVision pipeline nodes into a single executable, it is now important that there are no duplicate symbols. This PR fixes all of the occurrences of this issue. In many cases this was not just duplicate symbols, but duplicate code as well.