### PR TITLE
Introduce API for displaying progress

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -19,6 +19,7 @@
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/mvsData/imageIO.hpp>
 #include <aliceVision/mvsData/imageAlgo.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/alicevision_omp.hpp>
 
 #include "nanoflann.hpp"
@@ -34,7 +35,6 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
-#include <boost/progress.hpp>
 
 namespace aliceVision {
 namespace fuseCut {
@@ -1874,7 +1874,8 @@ void DelaunayGraphCut::fillGraph(double nPixelSizeBehind, bool labatutWeights, b
     GeometriesCount totalGeometriesIntersectedFrontCount;
     GeometriesCount totalGeometriesIntersectedBehindCount;
 
-    boost::progress_display progressBar(std::min(size_t(100), verticesRandIds.size()), std::cout, "fillGraphPartPtRc\n");
+    auto progressBar = system::createConsoleProgressDisplay(std::min(size_t(100), verticesRandIds.size()),
+                                                            std::cout, "fillGraphPartPtRc\n");
     size_t progressStep = verticesRandIds.size() / 100;
     progressStep = std::max(size_t(1), progressStep);
 #pragma omp parallel for reduction(+:totalStepsFront,totalRayFront,totalStepsBehind,totalRayBehind,totalCamHaveVisibilityOnVertex,totalOfVertex,totalIsRealNrc)

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1874,8 +1874,10 @@ void DelaunayGraphCut::fillGraph(double nPixelSizeBehind, bool labatutWeights, b
     GeometriesCount totalGeometriesIntersectedFrontCount;
     GeometriesCount totalGeometriesIntersectedBehindCount;
 
-    auto progressBar = system::createConsoleProgressDisplay(std::min(size_t(100), verticesRandIds.size()),
-                                                            std::cout, "fillGraphPartPtRc\n");
+    auto progressDisplay =
+            system::createConsoleProgressDisplay(std::min(size_t(100), verticesRandIds.size()),
+                                                 std::cout, "fillGraphPartPtRc\n");
+
     size_t progressStep = verticesRandIds.size() / 100;
     progressStep = std::max(size_t(1), progressStep);
 #pragma omp parallel for reduction(+:totalStepsFront,totalRayFront,totalStepsBehind,totalRayBehind,totalCamHaveVisibilityOnVertex,totalOfVertex,totalIsRealNrc)
@@ -1884,7 +1886,7 @@ void DelaunayGraphCut::fillGraph(double nPixelSizeBehind, bool labatutWeights, b
         if(i % progressStep == 0)
         {
 #pragma omp critical
-            ++progressBar;
+            ++progressDisplay;
         }
 
         const int vertexIndex = verticesRandIds[i];

--- a/src/aliceVision/localization/CCTagLocalizer.cpp
+++ b/src/aliceVision/localization/CCTagLocalizer.cpp
@@ -21,7 +21,6 @@
 
 #include <cctag/ICCTag.hpp>
 
-#include <boost/progress.hpp>
 #include <boost/filesystem.hpp>
 
 #include <algorithm>

--- a/src/aliceVision/localization/VoctreeLocalizer.cpp
+++ b/src/aliceVision/localization/VoctreeLocalizer.cpp
@@ -23,9 +23,9 @@
 #include <aliceVision/multiview/relativePose/FundamentalError.hpp>
 #include <aliceVision/matching/guidedMatching.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
 
-#include <boost/progress.hpp>
 #include <boost/filesystem.hpp>
 
 #include <algorithm>
@@ -291,8 +291,9 @@ bool VoctreeLocalizer::initDatabase(const std::string & vocTreeFilepath,
   // add its visual words to the database.
   // then only store the feature and descriptors that have a 3D point associated
   ALICEVISION_LOG_DEBUG("Build observations per view");
-  boost::progress_display my_progress_bar(_sfm_data.getViews().size(),
-                                     std::cout, "\n- Load Features and Descriptors per view -\n");
+  auto my_progress_bar =
+          system::createConsoleProgressDisplay(_sfm_data.getViews().size(), std::cout,
+                                               "\n- Load Features and Descriptors per view -\n");
 
   // Build observations per view
   std::map<IndexT, std::map<feature::EImageDescriberType, std::vector<feature::FeatureInImage>>> observationsPerView;

--- a/src/aliceVision/localization/VoctreeLocalizer.cpp
+++ b/src/aliceVision/localization/VoctreeLocalizer.cpp
@@ -291,7 +291,7 @@ bool VoctreeLocalizer::initDatabase(const std::string & vocTreeFilepath,
   // add its visual words to the database.
   // then only store the feature and descriptors that have a 3D point associated
   ALICEVISION_LOG_DEBUG("Build observations per view");
-  auto my_progress_bar =
+  auto progressDisplay =
           system::createConsoleProgressDisplay(_sfm_data.getViews().size(), std::cout,
                                                "\n- Load Features and Descriptors per view -\n");
 
@@ -375,7 +375,7 @@ bool VoctreeLocalizer::initDatabase(const std::string & vocTreeFilepath,
     }
 #pragma omp critical
     {
-      ++my_progress_bar;
+      ++progressDisplay;
     }
   }
   return true;

--- a/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
@@ -12,8 +12,7 @@
 #include <aliceVision/feature/RegionsPerView.hpp>
 #include <aliceVision/matching/IndMatch.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
-
-#include <boost/progress.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 
 #include <vector>
 #include <map>
@@ -51,7 +50,8 @@ void robustModelEstimation(
 {
   out_geometricMatches.clear();
 
-  boost::progress_display progressBar(putativeMatches.size(), std::cout, "Robust Model Estimation\n");
+  auto progressBar = system::createConsoleProgressDisplay(putativeMatches.size(), std::cout,
+                                                          "Robust Model Estimation\n");
   
 #pragma omp parallel for schedule(dynamic)
   for (int i = 0; i < (int)putativeMatches.size(); ++i)

--- a/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
@@ -50,8 +50,9 @@ void robustModelEstimation(
 {
   out_geometricMatches.clear();
 
-  auto progressBar = system::createConsoleProgressDisplay(putativeMatches.size(), std::cout,
-                                                          "Robust Model Estimation\n");
+  auto progressDisplay =
+          system::createConsoleProgressDisplay(putativeMatches.size(), std::cout,
+                                               "Robust Model Estimation\n");
   
 #pragma omp parallel for schedule(dynamic)
   for (int i = 0; i < (int)putativeMatches.size(); ++i)
@@ -88,7 +89,7 @@ void robustModelEstimation(
 
 #pragma omp critical
     {
-      ++progressBar;
+      ++progressDisplay;
     }
   }
 }

--- a/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_cascadeHashing.cpp
+++ b/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_cascadeHashing.cpp
@@ -39,7 +39,7 @@ void Match
   PairwiseMatches & map_PutativesMatches // the pairwise photometric corresponding points
 )
 {
-  auto my_progress_bar = system::createConsoleProgressDisplay(pairs.size(), std::cout);
+  auto progressDisplay = system::createConsoleProgressDisplay(pairs.size(), std::cout);
 
   // Collect used view indexes
   std::set<IndexT> used_index;
@@ -125,7 +125,7 @@ void Match
     const feature::Regions &regionsI = regionsPerView.getRegions(I, descType);
     if (regionsI.RegionCount() == 0)
     {
-      my_progress_bar += indexToCompare.size();
+      progressDisplay += indexToCompare.size();
       continue;
     }
 
@@ -144,7 +144,7 @@ void Match
           || regionsI.Type_id() != regionsJ.Type_id())
       {
         #pragma omp critical
-        ++my_progress_bar;
+        ++progressDisplay;
         continue;
       }
 
@@ -195,7 +195,7 @@ void Match
 
       #pragma omp critical
       {
-        ++my_progress_bar;
+        ++progressDisplay;
         if (!vec_putative_matches.empty())
         {
           assert(map_PutativesMatches.count(std::make_pair(I,J)) == 0);

--- a/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_cascadeHashing.cpp
+++ b/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_cascadeHashing.cpp
@@ -9,9 +9,8 @@
 #include <aliceVision/matching/ArrayMatcher_cascadeHashing.hpp>
 #include <aliceVision/matching/IndMatchDecorator.hpp>
 #include <aliceVision/matching/filters.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/config.hpp>
-
-#include <boost/progress.hpp>
 
 namespace aliceVision {
 namespace matchingImageCollection {
@@ -40,7 +39,7 @@ void Match
   PairwiseMatches & map_PutativesMatches // the pairwise photometric corresponding points
 )
 {
-  boost::progress_display my_progress_bar( pairs.size() );
+  auto my_progress_bar = system::createConsoleProgressDisplay(pairs.size(), std::cout);
 
   // Collect used view indexes
   std::set<IndexT> used_index;

--- a/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_generic.cpp
+++ b/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_generic.cpp
@@ -42,7 +42,7 @@ void ImageCollectionMatcher_generic::Match(
   const bool b_multithreaded_pair_search = (_matcherType == CASCADE_HASHING_L2);
   // -> set to true for CASCADE_HASHING_L2, since OpenMP instructions are not used in this matcher
 
-  auto my_progress_bar = system::createConsoleProgressDisplay(pairs.size(), std::cout);
+  auto progressDisplay = system::createConsoleProgressDisplay(pairs.size(), std::cout);
 
   // Sort pairs according the first index to minimize the MatcherT build operations
   typedef std::map<size_t, std::vector<size_t> > Map_vectorT;
@@ -62,7 +62,7 @@ void ImageCollectionMatcher_generic::Match(
     const feature::Regions & regionsI = regionsPerView.getRegions(I, descType);
     if (regionsI.RegionCount() == 0)
     {
-      my_progress_bar += indexToCompare.size();
+      progressDisplay += indexToCompare.size();
       continue;
     }
 
@@ -79,7 +79,7 @@ void ImageCollectionMatcher_generic::Match(
           || regionsI.Type_id() != regionsJ.Type_id())
       {
         #pragma omp critical
-        ++my_progress_bar;
+        ++progressDisplay;
         continue;
       }
 
@@ -118,7 +118,7 @@ void ImageCollectionMatcher_generic::Match(
 
       #pragma omp critical
       {
-        ++my_progress_bar;
+        ++progressDisplay;
         if (!vec_putatives_matches.empty())
         {
           map_PutativesMatches[std::make_pair(I,J)].emplace(descType, std::move(vec_putatives_matches));

--- a/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_generic.cpp
+++ b/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_generic.cpp
@@ -11,9 +11,8 @@
 #include <aliceVision/matching/ArrayMatcher_cascadeHashing.hpp>
 #include <aliceVision/matching/RegionsMatcher.hpp>
 #include <aliceVision/matchingImageCollection/IImageCollectionMatcher.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/config.hpp>
-
-#include <boost/progress.hpp>
 
 namespace aliceVision {
 namespace matchingImageCollection {
@@ -43,7 +42,7 @@ void ImageCollectionMatcher_generic::Match(
   const bool b_multithreaded_pair_search = (_matcherType == CASCADE_HASHING_L2);
   // -> set to true for CASCADE_HASHING_L2, since OpenMP instructions are not used in this matcher
 
-  boost::progress_display my_progress_bar( pairs.size() );
+  auto my_progress_bar = system::createConsoleProgressDisplay(pairs.size(), std::cout);
 
   // Sort pairs according the first index to minimize the MatcherT build operations
   typedef std::map<size_t, std::vector<size_t> > Map_vectorT;

--- a/src/aliceVision/sfm/FrustumFilter.cpp
+++ b/src/aliceVision/sfm/FrustumFilter.cpp
@@ -8,12 +8,11 @@
 #include <aliceVision/sfm/FrustumFilter.hpp>
 #include <aliceVision/sfm/sfm.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/stl/mapUtils.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/geometry/HalfPlane.hpp>
 #include <aliceVision/config.hpp>
-
-#include <boost/progress.hpp>
 
 #include <fstream>
 
@@ -68,9 +67,8 @@ PairSet FrustumFilter::getFrustumIntersectionPairs() const
   std::transform(z_near_z_far_perView.begin(), z_near_z_far_perView.end(),
     std::back_inserter(viewIds), stl::RetrieveKey());
 
-  boost::progress_display my_progress_bar(
-    viewIds.size() * (viewIds.size()-1)/2,
-    std::cout, "\nCompute frustum intersection\n");
+  auto my_progress_bar = system::createConsoleProgressDisplay(viewIds.size() * (viewIds.size()-1)/2,
+                                                              std::cout, "\nCompute frustum intersection\n");
 
   // Exhaustive comparison (use the fact that the intersect function is symmetric)
   #pragma omp parallel for

--- a/src/aliceVision/sfm/FrustumFilter.cpp
+++ b/src/aliceVision/sfm/FrustumFilter.cpp
@@ -67,7 +67,7 @@ PairSet FrustumFilter::getFrustumIntersectionPairs() const
   std::transform(z_near_z_far_perView.begin(), z_near_z_far_perView.end(),
     std::back_inserter(viewIds), stl::RetrieveKey());
 
-  auto my_progress_bar = system::createConsoleProgressDisplay(viewIds.size() * (viewIds.size()-1)/2,
+  auto progressDisplay = system::createConsoleProgressDisplay(viewIds.size() * (viewIds.size()-1)/2,
                                                               std::cout, "\nCompute frustum intersection\n");
 
   // Exhaustive comparison (use the fact that the intersect function is symmetric)
@@ -86,7 +86,7 @@ PairSet FrustumFilter::getFrustumIntersectionPairs() const
       // Progress bar update
       #pragma omp critical
       {
-        ++my_progress_bar;
+        ++progressDisplay;
       }
     }
   }

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
@@ -18,6 +18,7 @@
 #include <aliceVision/graph/graph.hpp>
 #include <aliceVision/track/TracksBuilder.hpp>
 #include <aliceVision/stl/stl.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/linearProgramming/linearProgramming.hpp>
 #include <aliceVision/multiview/essential.hpp>
@@ -29,8 +30,6 @@
 #include <aliceVision/alicevision_omp.hpp>
 
 #include <aliceVision/utils/Histogram.hpp>
-
-#include <boost/progress.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -403,10 +402,9 @@ void GlobalSfMTranslationAveragingSolver::ComputePutativeTranslation_EdgesCovera
 
     aliceVision::sfm::MutexSet<myEdge> m_mutexSet;
 
-    boost::progress_display my_progress_bar(
-      vec_edges.size(),
-      std::cout,
-      "\nRelative translations computation (edge coverage algorithm)\n");
+    auto my_progress_bar = system::createConsoleProgressDisplay(
+                vec_edges.size(), std::cout,
+                "\nRelative translations computation (edge coverage algorithm)\n");
 
     // set number of threads, 1 if openMP is not enabled  
     std::vector<translationAveraging::RelativeInfoVec> initial_estimates(omp_get_max_threads());

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
@@ -402,7 +402,7 @@ void GlobalSfMTranslationAveragingSolver::ComputePutativeTranslation_EdgesCovera
 
     aliceVision::sfm::MutexSet<myEdge> m_mutexSet;
 
-    auto my_progress_bar = system::createConsoleProgressDisplay(
+    auto progressDisplay = system::createConsoleProgressDisplay(
                 vec_edges.size(), std::cout,
                 "\nRelative translations computation (edge coverage algorithm)\n");
 
@@ -416,7 +416,7 @@ void GlobalSfMTranslationAveragingSolver::ComputePutativeTranslation_EdgesCovera
       const myEdge & edge = vec_edges[k];
       #pragma omp critical
       {
-        ++my_progress_bar;
+        ++progressDisplay;
       }
       if (m_mutexSet.count(edge) == 0 && m_mutexSet.size() != vec_edges.size())
       {

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -11,6 +11,7 @@
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
 #include <aliceVision/multiview/triangulation/Triangulation.hpp>
 #include <aliceVision/graph/connectedComponent.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/stl/stl.hpp>
 #include <aliceVision/multiview/essential.hpp>
@@ -19,8 +20,6 @@
 #include <aliceVision/config.hpp>
 
 #include <dependencies/htmlDoc/htmlDoc.hpp>
-
-#include <boost/progress.hpp>
 
 #ifdef _MSC_VER
 #pragma warning( once : 4267 ) //warning C4267: 'argument' : conversion from 'size_t' to 'const int', possible loss of data
@@ -448,7 +447,8 @@ void ReconstructionEngine_globalSfM::Compute_Relative_Rotations(rotationAveragin
     poseWiseMatches[Pair(v1->getPoseId(), v2->getPoseId())].insert(pair);
   }
 
-  boost::progress_display progressBar( poseWiseMatches.size(), std::cout, "\n- Relative pose computation -\n" );
+  auto progressBar = system::createConsoleProgressDisplay(poseWiseMatches.size(), std::cout,
+                                                          "\n- Relative pose computation -\n" );
   #pragma omp parallel for schedule(dynamic)
   // Compute the relative pose from pairwise point matches:
   for (int i = 0; i < poseWiseMatches.size(); ++i)

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -447,15 +447,15 @@ void ReconstructionEngine_globalSfM::Compute_Relative_Rotations(rotationAveragin
     poseWiseMatches[Pair(v1->getPoseId(), v2->getPoseId())].insert(pair);
   }
 
-  auto progressBar = system::createConsoleProgressDisplay(poseWiseMatches.size(), std::cout,
-                                                          "\n- Relative pose computation -\n" );
+  auto progressDisplay = system::createConsoleProgressDisplay(poseWiseMatches.size(), std::cout,
+                                                              "\n- Relative pose computation -\n" );
   #pragma omp parallel for schedule(dynamic)
   // Compute the relative pose from pairwise point matches:
   for (int i = 0; i < poseWiseMatches.size(); ++i)
   {
     #pragma omp critical
     {
-      ++progressBar;
+      ++progressDisplay;
     }
     {
       PoseWiseMatches::const_iterator iter (poseWiseMatches.begin());

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
@@ -37,8 +37,6 @@
 
 #include <dependencies/htmlDoc/htmlDoc.hpp>
 
-#include <boost/progress.hpp>
-
 #ifdef _MSC_VER
 #pragma warning( once : 4267 ) //warning C4267: 'argument' : conversion from 'size_t' to 'const int', possible loss of data
 #endif

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -191,8 +191,9 @@ bool loadRegionsPerView(feature::RegionsPerView& regionsPerView,
   auto last = std::unique(featuresFolders.begin(), featuresFolders.end());
   featuresFolders.erase(last, featuresFolders.end());
 
-  auto progressBar = system::createConsoleProgressDisplay(sfmData.getViews().size() * imageDescriberTypes.size(),
-                                                          std::cout, "Loading regions\n");
+  auto progressDisplay =
+          system::createConsoleProgressDisplay(sfmData.getViews().size() * imageDescriberTypes.size(),
+                                               std::cout, "Loading regions\n");
 
   std::atomic_bool invalid(false);
 
@@ -217,7 +218,7 @@ bool loadRegionsPerView(feature::RegionsPerView& regionsPerView,
 #pragma omp critical
            {
              regionsPerView.addRegions(iter->second.get()->getViewId(), imageDescriberTypes.at(i), regionsPtr.release());
-             ++progressBar;
+             ++progressDisplay;
            }
          }
          else
@@ -240,8 +241,8 @@ bool loadFeaturesPerView(feature::FeaturesPerView& featuresPerView,
   std::vector<std::string> featuresFolders = sfmData.getFeaturesFolders(); // add sfm features folders
   featuresFolders.insert(featuresFolders.end(), folders.begin(), folders.end()); // add user features folders
 
-  auto progressBar = system::createConsoleProgressDisplay(sfmData.getViews().size(), std::cout,
-                                                          "Loading features\n");
+  auto progressDisplay = system::createConsoleProgressDisplay(sfmData.getViews().size(), std::cout,
+                                                              "Loading features\n");
 
   // read for each view the corresponding features and store them as PointFeatures
   std::atomic_bool invalid(false);
@@ -265,7 +266,7 @@ bool loadFeaturesPerView(feature::FeaturesPerView& featuresPerView,
         {
           // save loaded Features as PointFeature
           featuresPerView.addFeatures(iter->second.get()->getViewId(), imageDescriberTypes[i], regionsPtr->GetRegionsPositions());
-          ++progressBar;
+          ++progressDisplay;
         }
       }
     }

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -7,7 +7,7 @@
 
 #include "regionsIO.hpp"
 
-#include <boost/progress.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <boost/filesystem.hpp>
 
 #include <atomic>
@@ -191,7 +191,8 @@ bool loadRegionsPerView(feature::RegionsPerView& regionsPerView,
   auto last = std::unique(featuresFolders.begin(), featuresFolders.end());
   featuresFolders.erase(last, featuresFolders.end());
 
-  boost::progress_display progressBar(sfmData.getViews().size() * imageDescriberTypes.size(), std::cout, "Loading regions\n");
+  auto progressBar = system::createConsoleProgressDisplay(sfmData.getViews().size() * imageDescriberTypes.size(),
+                                                          std::cout, "Loading regions\n");
 
   std::atomic_bool invalid(false);
 
@@ -239,7 +240,8 @@ bool loadFeaturesPerView(feature::FeaturesPerView& featuresPerView,
   std::vector<std::string> featuresFolders = sfmData.getFeaturesFolders(); // add sfm features folders
   featuresFolders.insert(featuresFolders.end(), folders.begin(), folders.end()); // add user features folders
 
-  boost::progress_display progressBar(sfmData.getViews().size(), std::cout, "Loading features\n");
+  auto progressBar = system::createConsoleProgressDisplay(sfmData.getViews().size(), std::cout,
+                                                          "Loading features\n");
 
   // read for each view the corresponding features and store them as PointFeatures
   std::atomic_bool invalid(false);

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1248,7 +1248,7 @@ bool ReconstructionEngine_sequentialSfM::getBestInitialImagePairs(std::vector<Pa
   bestImagePairs.reserve(_pairwiseMatches->size());
   
   // Compute the relative pose & the 'baseline score'
-  auto my_progress_bar = system::createConsoleProgressDisplay(_pairwiseMatches->size(), std::cout,
+  auto progressDisplay = system::createConsoleProgressDisplay(_pairwiseMatches->size(), std::cout,
                                                               "Automatic selection of an initial pair:\n" );
 
 #pragma omp parallel for schedule(dynamic)
@@ -1258,7 +1258,7 @@ bool ReconstructionEngine_sequentialSfM::getBestInitialImagePairs(std::vector<Pa
     std::advance(iter, i);
     
 #pragma omp critical
-    ++my_progress_bar;
+    ++progressDisplay;
     
     const Pair current_pair = iter->first;
 

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -24,6 +24,7 @@
 #include <aliceVision/robustEstimation/LORansac.hpp>
 #include <aliceVision/robustEstimation/ScoreEvaluator.hpp>
 #include <aliceVision/stl/stl.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/cpu.hpp>
 #include <aliceVision/system/MemoryInfo.hpp>
@@ -32,7 +33,6 @@
 
 #include <dependencies/htmlDoc/htmlDoc.hpp>
 
-#include <boost/progress.hpp>
 #include <boost/format.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -1248,8 +1248,8 @@ bool ReconstructionEngine_sequentialSfM::getBestInitialImagePairs(std::vector<Pa
   bestImagePairs.reserve(_pairwiseMatches->size());
   
   // Compute the relative pose & the 'baseline score'
-  boost::progress_display my_progress_bar( _pairwiseMatches->size(),
-    std::cout,"Automatic selection of an initial pair:\n" );
+  auto my_progress_bar = system::createConsoleProgressDisplay(_pairwiseMatches->size(), std::cout,
+                                                              "Automatic selection of an initial pair:\n" );
 
 #pragma omp parallel for schedule(dynamic)
   for (int i = 0; i < _pairwiseMatches->size(); ++i)

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -78,7 +78,7 @@ void StructureEstimationFromKnownPoses::match(const SfMData& sfmData,
   const feature::RegionsPerView& regionsPerView,
   double geometricErrorMax)
 {
-  auto my_progress_bar = system::createConsoleProgressDisplay(pairs.size(), std::cout,
+  auto progressDisplay = system::createConsoleProgressDisplay(pairs.size(), std::cout,
     "Compute pairwise fundamental guided matching:\n" );
 
   #pragma omp parallel
@@ -160,7 +160,7 @@ void StructureEstimationFromKnownPoses::match(const SfMData& sfmData,
 
       #pragma omp critical
       {
-        ++my_progress_bar;
+        ++progressDisplay;
         _putativeMatches[*it] = allImagePairMatches;
       }
     }
@@ -181,7 +181,7 @@ void StructureEstimationFromKnownPoses::filter(
   typedef std::vector< graph::Triplet > Triplets;
   const Triplets triplets = graph::tripletListing(pairs);
 
-  auto my_progress_bar = system::createConsoleProgressDisplay(triplets.size(), std::cout,
+  auto progressDisplay = system::createConsoleProgressDisplay(triplets.size(), std::cout,
     "Per triplet tracks validation (discard spurious correspondences):\n" );
   #pragma omp parallel
   for( Triplets::const_iterator it = triplets.begin(); it != triplets.end(); ++it)
@@ -189,7 +189,7 @@ void StructureEstimationFromKnownPoses::filter(
     #pragma omp single nowait
     {
       #pragma omp critical
-      {++my_progress_bar;}
+      {++progressDisplay;}
 
       const graph::Triplet & triplet = *it;
       const IndexT I = triplet.i, J = triplet.j , K = triplet.k;

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -14,9 +14,8 @@
 #include <aliceVision/graph/graph.hpp>
 #include <aliceVision/track/TracksBuilder.hpp>
 #include <aliceVision/sfm/sfmTriangulation.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/config.hpp>
-
-#include <boost/progress.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -79,7 +78,7 @@ void StructureEstimationFromKnownPoses::match(const SfMData& sfmData,
   const feature::RegionsPerView& regionsPerView,
   double geometricErrorMax)
 {
-  boost::progress_display my_progress_bar( pairs.size(), std::cout,
+  auto my_progress_bar = system::createConsoleProgressDisplay(pairs.size(), std::cout,
     "Compute pairwise fundamental guided matching:\n" );
 
   #pragma omp parallel
@@ -182,7 +181,7 @@ void StructureEstimationFromKnownPoses::filter(
   typedef std::vector< graph::Triplet > Triplets;
   const Triplets triplets = graph::tripletListing(pairs);
 
-  boost::progress_display my_progress_bar( triplets.size(), std::cout,
+  auto my_progress_bar = system::createConsoleProgressDisplay(triplets.size(), std::cout,
     "Per triplet tracks validation (discard spurious correspondences):\n" );
   #pragma omp parallel
   for( Triplets::const_iterator it = triplets.begin(); it != triplets.end(); ++it)

--- a/src/aliceVision/sfm/sfmTriangulation.cpp
+++ b/src/aliceVision/sfm/sfmTriangulation.cpp
@@ -31,9 +31,9 @@ StructureComputation_blind::StructureComputation_blind(bool verbose)
 void StructureComputation_blind::triangulate(sfmData::SfMData& sfmData, std::mt19937 & randomNumberGenerator) const
 {
   std::deque<IndexT> rejectedId;
-  system::ProgressDisplay my_progress_bar;
+  system::ProgressDisplay progressDisplay;
   if (_bConsoleVerbose)
-    my_progress_bar = system::createConsoleProgressDisplay(sfmData.structure.size(), std::cout,
+    progressDisplay = system::createConsoleProgressDisplay(sfmData.structure.size(), std::cout,
                                                            "Blind triangulation progress:\n");
 
   #pragma omp parallel
@@ -46,7 +46,7 @@ void StructureComputation_blind::triangulate(sfmData::SfMData& sfmData, std::mt1
       if (_bConsoleVerbose)
       {
         #pragma omp critical
-        ++(my_progress_bar);
+        ++(progressDisplay);
       }
       // Triangulate each landmark
       multiview::Triangulation trianObj;
@@ -117,9 +117,9 @@ void StructureComputation_robust::robust_triangulation(sfmData::SfMData& sfmData
 {
   std::deque<IndexT> rejectedId;
 
-  system::ProgressDisplay my_progress_bar;
+  system::ProgressDisplay progressDisplay;
   if (_bConsoleVerbose)
-    my_progress_bar = system::createConsoleProgressDisplay(sfmData.structure.size(), std::cout,
+    progressDisplay = system::createConsoleProgressDisplay(sfmData.structure.size(), std::cout,
                                                            "Robust triangulation progress:\n");
 
   #pragma omp parallel
@@ -132,7 +132,7 @@ void StructureComputation_robust::robust_triangulation(sfmData::SfMData& sfmData
       if (_bConsoleVerbose)
       {
         #pragma omp critical
-        ++(my_progress_bar);
+        ++(progressDisplay);
       }
       Vec3 X;
       if (robust_triangulation(sfmData, iterTracks->second.observations, randomNumberGenerator, X)) {

--- a/src/aliceVision/sfm/sfmTriangulation.cpp
+++ b/src/aliceVision/sfm/sfmTriangulation.cpp
@@ -8,9 +8,8 @@
 #include "sfmTriangulation.hpp"
 #include <aliceVision/multiview/triangulation/Triangulation.hpp>
 #include <aliceVision/robustEstimation/randSampling.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/config.hpp>
-
-#include <boost/progress.hpp>
 
 #include <deque>
 #include <memory>
@@ -32,12 +31,11 @@ StructureComputation_blind::StructureComputation_blind(bool verbose)
 void StructureComputation_blind::triangulate(sfmData::SfMData& sfmData, std::mt19937 & randomNumberGenerator) const
 {
   std::deque<IndexT> rejectedId;
-  std::unique_ptr<boost::progress_display> my_progress_bar;
+  system::ProgressDisplay my_progress_bar;
   if (_bConsoleVerbose)
-    my_progress_bar.reset( new boost::progress_display(
-    sfmData.structure.size(),
-    std::cout,
-    "Blind triangulation progress:\n" ));
+    my_progress_bar = system::createConsoleProgressDisplay(sfmData.structure.size(), std::cout,
+                                                           "Blind triangulation progress:\n");
+
   #pragma omp parallel
   for(sfmData::Landmarks::iterator iterTracks = sfmData.structure.begin();
     iterTracks != sfmData.structure.end();
@@ -48,7 +46,7 @@ void StructureComputation_blind::triangulate(sfmData::SfMData& sfmData, std::mt1
       if (_bConsoleVerbose)
       {
         #pragma omp critical
-        ++(*my_progress_bar);
+        ++(my_progress_bar);
       }
       // Triangulate each landmark
       multiview::Triangulation trianObj;
@@ -118,12 +116,12 @@ void StructureComputation_robust::triangulate(sfmData::SfMData& sfmData, std::mt
 void StructureComputation_robust::robust_triangulation(sfmData::SfMData& sfmData, std::mt19937 & randomNumberGenerator) const
 {
   std::deque<IndexT> rejectedId;
-  std::unique_ptr<boost::progress_display> my_progress_bar;
-  if(_bConsoleVerbose)
-    my_progress_bar.reset( new boost::progress_display(
-    sfmData.structure.size(),
-    std::cout,
-    "Robust triangulation progress:\n" ));
+
+  system::ProgressDisplay my_progress_bar;
+  if (_bConsoleVerbose)
+    my_progress_bar = system::createConsoleProgressDisplay(sfmData.structure.size(), std::cout,
+                                                           "Robust triangulation progress:\n");
+
   #pragma omp parallel
   for(sfmData::Landmarks::iterator iterTracks = sfmData.structure.begin();
     iterTracks != sfmData.structure.end();
@@ -134,7 +132,7 @@ void StructureComputation_robust::robust_triangulation(sfmData::SfMData& sfmData
       if (_bConsoleVerbose)
       {
         #pragma omp critical
-        ++(*my_progress_bar);
+        ++(my_progress_bar);
       }
       Vec3 X;
       if (robust_triangulation(sfmData, iterTracks->second.observations, randomNumberGenerator, X)) {

--- a/src/aliceVision/sfmData/colorize.cpp
+++ b/src/aliceVision/sfmData/colorize.cpp
@@ -21,8 +21,8 @@ namespace sfmData {
 
 void colorizeTracks(SfMData& sfmData)
 {
-  auto progressBar = system::createConsoleProgressDisplay(sfmData.getLandmarks().size(), std::cout,
-                                                          "\nCompute scene structure color\n");
+  auto progressDisplay = system::createConsoleProgressDisplay(sfmData.getLandmarks().size(), std::cout,
+                                                              "\nCompute scene structure color\n");
 
   std::vector<std::reference_wrapper<Landmark>> remainingLandmarksToColor;
   remainingLandmarksToColor.reserve(sfmData.getLandmarks().size());
@@ -117,7 +117,7 @@ void colorizeTracks(SfMData& sfmData)
 
 #pragma omp critical
       {
-        progressBar += viewCardinal.landmarks.size();
+        progressDisplay += viewCardinal.landmarks.size();
       }
     }
   }

--- a/src/aliceVision/sfmData/colorize.cpp
+++ b/src/aliceVision/sfmData/colorize.cpp
@@ -11,8 +11,7 @@
 #include <aliceVision/stl/indexedSort.hpp>
 #include <aliceVision/stl/mapUtils.hpp>
 #include <aliceVision/image/io.hpp>
-
-#include <boost/progress.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 
 #include <map>
 #include <vector>
@@ -22,7 +21,8 @@ namespace sfmData {
 
 void colorizeTracks(SfMData& sfmData)
 {
-  boost::progress_display progressBar(sfmData.getLandmarks().size(), std::cout, "\nCompute scene structure color\n");
+  auto progressBar = system::createConsoleProgressDisplay(sfmData.getLandmarks().size(), std::cout,
+                                                          "\nCompute scene structure color\n");
 
   std::vector<std::reference_wrapper<Landmark>> remainingLandmarksToColor;
   remainingLandmarksToColor.reserve(sfmData.getLandmarks().size());

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -6,6 +6,7 @@ set(system_files_headers
   system.hpp
   Timer.hpp
   Logger.hpp
+  ProgressDisplay.hpp
   nvtx.hpp
 )
 
@@ -15,6 +16,7 @@ set(system_files_sources
   MemoryInfo.cpp
   Timer.cpp
   Logger.cpp
+  ProgressDisplay.cpp
   nvtx.cpp
 )
 

--- a/src/aliceVision/system/ProgressDisplay.cpp
+++ b/src/aliceVision/system/ProgressDisplay.cpp
@@ -1,0 +1,75 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ProgressDisplay.hpp"
+#include <boost/progress.hpp>
+
+namespace aliceVision {
+namespace system {
+
+ProgressDisplayImpl::~ProgressDisplayImpl() = default;
+
+class ProgressDisplayImplEmpty : public ProgressDisplayImpl {
+public:
+    void restart(unsigned long expectedCount) override {}
+    void increment(unsigned long count) override {}
+    unsigned long count() override { return 0; }
+    unsigned long expectedCount() override { return 0; }
+};
+
+ProgressDisplay::ProgressDisplay() : _impl{std::make_shared<ProgressDisplayImplEmpty>()}
+{}
+
+class ProgressDisplayImplBoostProgress : public ProgressDisplayImpl {
+public:
+    ProgressDisplayImplBoostProgress(unsigned long expectedCount,
+                                     std::ostream& os,
+                                     const std::string& s1,
+                                     const std::string& s2,
+                                     const std::string& s3) :
+        _display{expectedCount, os, s1, s2, s3}
+    {
+    }
+
+    ~ProgressDisplayImplBoostProgress() override = default;
+
+    void restart(unsigned long expectedCount) override
+    {
+        _display.restart(expectedCount);
+    }
+
+    void increment(unsigned long count) override
+    {
+        _display += count;
+    }
+
+    unsigned long count() override
+    {
+        return _display.count();
+    }
+
+    unsigned long expectedCount() override
+    {
+        return _display.expected_count();
+    }
+
+private:
+    boost::progress_display _display;
+};
+
+
+ProgressDisplay createConsoleProgressDisplay(unsigned long expectedCount,
+                                             std::ostream& os,
+                                             const std::string& s1,
+                                             const std::string& s2,
+                                             const std::string& s3)
+{
+    auto impl = std::make_shared<ProgressDisplayImplBoostProgress>(expectedCount, os, s1, s2, s3);
+    return ProgressDisplay(impl);
+}
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ProgressDisplay.hpp
+++ b/src/aliceVision/system/ProgressDisplay.hpp
@@ -1,0 +1,75 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <iosfwd>
+#include <memory>
+#include <string>
+
+namespace aliceVision {
+namespace system {
+
+class ProgressDisplayImpl {
+public:
+    virtual ~ProgressDisplayImpl();
+    virtual void restart(unsigned long expectedCount) = 0;
+    virtual void increment(unsigned long count) = 0;
+    virtual unsigned long count() = 0;
+    virtual unsigned long expectedCount() = 0;
+};
+
+/**
+ * This is a generic API to display progress bars. Depending on implementation different
+ * destinations for display data may be used. Currently only console output is supported.
+ *
+ * The API is essentially the same as boost::progress_display
+ *
+ * For ease of use value semantics are exposed.
+ */
+class ProgressDisplay {
+public:
+    ProgressDisplay();
+    ProgressDisplay(const std::shared_ptr<ProgressDisplayImpl>& impl) : _impl{impl} {}
+
+    void restart(unsigned long expectedCount)
+    {
+        _impl->restart(expectedCount);
+    }
+
+    void operator++()
+    {
+        _impl->increment(1);
+    }
+
+    void operator+=(unsigned long increment)
+    {
+        _impl->increment(increment);
+    }
+
+    unsigned long count()
+    {
+        return _impl->count();
+    }
+
+    unsigned long expectedCount()
+    {
+        return _impl->expectedCount();
+    }
+
+private:
+    std::shared_ptr<ProgressDisplayImpl> _impl;
+};
+
+/// Creates console-based progress bar
+ProgressDisplay createConsoleProgressDisplay(unsigned long expectedCount,
+                                             std::ostream& os,
+                                             const std::string& s1 = "\n", //leading strings
+                                             const std::string& s2 = "",
+                                             const std::string& s3 = "");
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/voctree/Database.cpp
+++ b/src/aliceVision/voctree/Database.cpp
@@ -5,9 +5,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Database.hpp"
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/tail.hpp>
-#include <boost/progress.hpp>
 #include <cmath>
 #include <fstream>
 #include <stdexcept>
@@ -80,7 +80,7 @@ void Database::sanityCheck(std::size_t N, std::map<std::size_t, DocMatches>& mat
   matches.clear();
   // since we already know the size of the vectors, in order to parallelize the 
   // query allocate the whole memory
-  boost::progress_display display(database_.size());
+  auto display = system::createConsoleProgressDisplay(database_.size(), std::cout);
   
   //#pragma omp parallel for default(none) shared(database_)
   for(const auto &doc : database_)

--- a/src/aliceVision/voctree/databaseIO.tcc
+++ b/src/aliceVision/voctree/databaseIO.tcc
@@ -7,12 +7,12 @@
 #include "descriptorLoader.hpp"
 
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
-#include <boost/progress.hpp>
 
 #include <exception>
 #include <iostream>
@@ -34,7 +34,7 @@ std::size_t populateDatabase(const sfmData::SfMData& sfmData,
   
   // Read the descriptors
   ALICEVISION_LOG_DEBUG("Reading the descriptors from " << descriptorsFiles.size() <<" files...");
-  boost::progress_display display(descriptorsFiles.size());
+  auto display = system::createConsoleProgressDisplay(descriptorsFiles.size(), std::cout);
 
   // Run through the path vector and read the descriptors
   for(const auto &currentFile : descriptorsFiles)
@@ -75,7 +75,7 @@ std::size_t populateDatabase(const sfmData::SfMData& sfmData,
 
   // Read the descriptors
   ALICEVISION_LOG_DEBUG("Reading the descriptors from " << descriptorsFiles.size() <<" files...");
-  boost::progress_display display(descriptorsFiles.size());
+  auto display = system::createConsoleProgressDisplay(descriptorsFiles.size(), std::cout);
 
   // Run through the path vector and read the descriptors
   for(const auto &currentFile : descriptorsFiles)
@@ -147,7 +147,7 @@ void queryDatabase(const sfmData::SfMData& sfmData,
   
   // Read the descriptors
   ALICEVISION_LOG_DEBUG("queryDatabase: Reading the descriptors from " << descriptorsFiles.size() << " files...");
-  boost::progress_display display(descriptorsFiles.size());
+  auto display = system::createConsoleProgressDisplay(descriptorsFiles.size(), std::cout);
 
   #pragma omp parallel for
   // Run through the path vector and read the descriptors

--- a/src/aliceVision/voctree/descriptorLoader.tcc
+++ b/src/aliceVision/voctree/descriptorLoader.tcc
@@ -5,11 +5,11 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/feature/Descriptor.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
-#include <boost/progress.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -34,7 +34,7 @@ std::size_t readDescFromFiles(const sfmData::SfMData& sfmData,
 
   // Display infos and progress bar
   ALICEVISION_LOG_DEBUG("Pre-computing the memory needed...");
-  boost::progress_display display(descriptorsFiles.size());
+  auto display = system::createConsoleProgressDisplay(descriptorsFiles.size(), std::cout);
 
   // Read all files and get the number of descriptors to load
   for(const auto &currentFile : descriptorsFiles)

--- a/src/samples/undistoBrown/main_undistoBrown.cpp
+++ b/src/samples/undistoBrown/main_undistoBrown.cpp
@@ -7,9 +7,9 @@
 
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/camera/camera.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 
 #include <boost/regex.hpp>
-#include <boost/progress.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
   std::cout << "\nLocated " << vec_fileNames.size() << " files in " << inputImagePath
     << " with suffix " << suffix;
 
-  boost::progress_display my_progress_bar( vec_fileNames.size() );
+  auto my_progress_bar = system::createConsoleProgressDisplay(vec_fileNames.size(), std::cout);
   for (size_t j = 0; j < vec_fileNames.size(); ++j, ++my_progress_bar)
   {
     const std::string inFileName = (fs::path(inputImagePath) / fs::path(vec_fileNames[j]).filename()).string();

--- a/src/samples/undistoBrown/main_undistoBrown.cpp
+++ b/src/samples/undistoBrown/main_undistoBrown.cpp
@@ -120,8 +120,8 @@ int main(int argc, char **argv)
   std::cout << "\nLocated " << vec_fileNames.size() << " files in " << inputImagePath
     << " with suffix " << suffix;
 
-  auto my_progress_bar = system::createConsoleProgressDisplay(vec_fileNames.size(), std::cout);
-  for (size_t j = 0; j < vec_fileNames.size(); ++j, ++my_progress_bar)
+  auto progressDisplay = system::createConsoleProgressDisplay(vec_fileNames.size(), std::cout);
+  for (size_t j = 0; j < vec_fileNames.size(); ++j, ++progressDisplay)
   {
     const std::string inFileName = (fs::path(inputImagePath) / fs::path(vec_fileNames[j]).filename()).string();
     const std::string outFileName = (fs::path(outputImagePath) / fs::path(vec_fileNames[j]).filename()).string();

--- a/src/software/convert/main_convertFloatDescriptorToUchar.cpp
+++ b/src/software/convert/main_convertFloatDescriptorToUchar.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
-#include <boost/progress.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp> 
 #include <boost/algorithm/string/case_conv.hpp> 

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -12,11 +12,11 @@
 #include <aliceVision/sfmDataIO/AlembicExporter.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/image/all.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/utils/regexFilter.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <cstdlib>
 #include <limits>
@@ -331,7 +331,7 @@ int aliceVision_main(int argc, char** argv)
   ALICEVISION_LOG_INFO("Build animated camera(s)...");
 
   image::Image<image::RGBfColor> image, image_ud;
-  boost::progress_display progressBar(sfmDataExport.getViews().size());
+  auto progressBar = system::createConsoleProgressDisplay(sfmDataExport.getViews().size(), std::cout);
 
   for(const auto& viewPair : sfmDataExport.getViews())
   {

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -331,13 +331,14 @@ int aliceVision_main(int argc, char** argv)
   ALICEVISION_LOG_INFO("Build animated camera(s)...");
 
   image::Image<image::RGBfColor> image, image_ud;
-  auto progressBar = system::createConsoleProgressDisplay(sfmDataExport.getViews().size(), std::cout);
+  auto progressDisplay = system::createConsoleProgressDisplay(sfmDataExport.getViews().size(),
+                                                              std::cout);
 
   for(const auto& viewPair : sfmDataExport.getViews())
   {
     const sfmData::View& view = *(viewPair.second);
 
-    ++progressBar;
+    ++progressDisplay;
 
     const std::string imagePathStem = fs::path(viewPair.second->getImagePath()).stem().string();
 

--- a/src/software/export/main_exportKeypoints.cpp
+++ b/src/software/export/main_exportKeypoints.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/matching/svgVisualization.hpp>
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/image/all.hpp>
@@ -20,7 +21,6 @@
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <cstdlib>
 #include <string>
@@ -140,7 +140,7 @@ int aliceVision_main(int argc, char ** argv)
 
   fs::create_directory(outputFolder);
   ALICEVISION_LOG_INFO("Export extracted keypoints for all images");
-  boost::progress_display myProgressBar(sfmData.views.size());
+  auto myProgressBar = system::createConsoleProgressDisplay(sfmData.views.size(), std::cout);
   for(const auto &iterViews : sfmData.views)
   {
     const View * view = iterViews.second.get();

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -105,14 +105,14 @@ bool exportToMVE2Format(
     out << cameraCount << " " << featureCount << "\n";
 
     // Export (calibrated) views as undistorted images
-    auto my_progress_bar = system::createConsoleProgressDisplay(sfm_data.getViews().size(), std::cout);
+    auto progressDisplay = system::createConsoleProgressDisplay(sfm_data.getViews().size(), std::cout);
     std::pair<int,int> w_h_image_size;
     Image<RGBColor> image, image_ud, thumbnail;
     std::string sOutViewIteratorDirectory;
     std::size_t view_index = 0;
     std::map<std::size_t, IndexT> viewIdToviewIndex;
     for(Views::const_iterator iter = sfm_data.getViews().begin();
-      iter != sfm_data.getViews().end(); ++iter, ++my_progress_bar)
+      iter != sfm_data.getViews().end(); ++iter, ++progressDisplay)
     {
       const View * view = iter->second.get();
 

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -8,11 +8,11 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -105,7 +105,7 @@ bool exportToMVE2Format(
     out << cameraCount << " " << featureCount << "\n";
 
     // Export (calibrated) views as undistorted images
-    boost::progress_display my_progress_bar(sfm_data.getViews().size());
+    auto my_progress_bar = system::createConsoleProgressDisplay(sfm_data.getViews().size(), std::cout);
     std::pair<int,int> w_h_image_size;
     Image<RGBColor> image, image_ud, thumbnail;
     std::string sOutViewIteratorDirectory;

--- a/src/software/export/main_exportMatches.cpp
+++ b/src/software/export/main_exportMatches.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
@@ -21,7 +22,6 @@
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <cstdlib>
 #include <string>
@@ -182,7 +182,7 @@ int aliceVision_main(int argc, char ** argv)
   fs::create_directory(outputFolder);
   ALICEVISION_LOG_INFO("Export pairwise matches");
   const PairSet pairs = matching::getImagePairs(pairwiseMatches);
-  boost::progress_display myProgressBar(pairs.size());
+  auto myProgressBar = system::createConsoleProgressDisplay(pairs.size(), std::cout);
   for (PairSet::const_iterator iter = pairs.begin(); iter != pairs.end(); ++iter, ++myProgressBar)
   {
     const std::size_t I = iter->first;

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -12,7 +12,6 @@
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/software/export/main_exportMeshroomMaya.cpp
+++ b/src/software/export/main_exportMeshroomMaya.cpp
@@ -8,10 +8,10 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <OpenImageIO/imagebufalgo.h>
 
@@ -103,7 +103,8 @@ int aliceVision_main(int argc, char **argv)
   sfmDataIO::Save(sfmData, outputFolder + "/scene.abc", sfmDataIO::ESfMData::ALL);
 
   // export undistorted images and thumbnail images
-  boost::progress_display progressBar(sfmData.getViews().size(), std::cout, "Exporting Images for MeshroomMaya\n");
+  auto progressBar = system::createConsoleProgressDisplay(sfmData.getViews().size(), std::cout,
+                                                          "Exporting Images for MeshroomMaya\n");
   for(auto& viewPair : sfmData.getViews())
   {
     const sfmData::View& view = *viewPair.second;

--- a/src/software/export/main_exportMeshroomMaya.cpp
+++ b/src/software/export/main_exportMeshroomMaya.cpp
@@ -103,8 +103,8 @@ int aliceVision_main(int argc, char **argv)
   sfmDataIO::Save(sfmData, outputFolder + "/scene.abc", sfmDataIO::ESfMData::ALL);
 
   // export undistorted images and thumbnail images
-  auto progressBar = system::createConsoleProgressDisplay(sfmData.getViews().size(), std::cout,
-                                                          "Exporting Images for MeshroomMaya\n");
+  auto progressDisplay = system::createConsoleProgressDisplay(sfmData.getViews().size(), std::cout,
+                                                              "Exporting Images for MeshroomMaya\n");
   for(auto& viewPair : sfmData.getViews())
   {
     const sfmData::View& view = *viewPair.second;
@@ -152,7 +152,7 @@ int aliceVision_main(int argc, char **argv)
     image::writeImage(outputFolder + "/undistort/thumbnail/" + basename + "-" + std::to_string(view.getViewId()) + "-UOT.jpg",
                       imageThumbnail, image::EImageColorSpace::AUTO);
 
-    ++progressBar;
+    ++progressDisplay;
   }
 
   return EXIT_SUCCESS;

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -8,11 +8,11 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -68,7 +68,8 @@ bool exportToPMVSFormat(
 
   if (bOk)
   {
-    boost::progress_display my_progress_bar( sfm_data.getViews().size()*2 );
+    auto my_progress_bar = system::createConsoleProgressDisplay(sfm_data.getViews().size() * 2,
+                                                                std::cout);
 
     // Since PMVS requires contiguous camera index, and that some views can have some missing poses,
     // we reindex the poses to ensure a contiguous pose list.

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -68,7 +68,7 @@ bool exportToPMVSFormat(
 
   if (bOk)
   {
-    auto my_progress_bar = system::createConsoleProgressDisplay(sfm_data.getViews().size() * 2,
+    auto progressDisplay = system::createConsoleProgressDisplay(sfm_data.getViews().size() * 2,
                                                                 std::cout);
 
     // Since PMVS requires contiguous camera index, and that some views can have some missing poses,
@@ -77,7 +77,7 @@ bool exportToPMVSFormat(
 
     // Export valid views as Projective Cameras:
     for(Views::const_iterator iter = sfm_data.getViews().begin();
-      iter != sfm_data.getViews().end(); ++iter, ++my_progress_bar)
+      iter != sfm_data.getViews().end(); ++iter, ++progressDisplay)
     {
       const View * view = iter->second.get();
       if (!sfm_data.isPoseAndIntrinsicDefined(view))
@@ -109,7 +109,7 @@ bool exportToPMVSFormat(
     // Export (calibrated) views as undistorted images
     Image<RGBColor> image, image_ud;
     for(Views::const_iterator iter = sfm_data.getViews().begin();
-      iter != sfm_data.getViews().end(); ++iter, ++my_progress_bar)
+      iter != sfm_data.getViews().end(); ++iter, ++progressDisplay)
     {
       const View * view = iter->second.get();
       if (!sfm_data.isPoseAndIntrinsicDefined(view))

--- a/src/software/export/main_exportTracks.cpp
+++ b/src/software/export/main_exportTracks.cpp
@@ -17,6 +17,7 @@
 #include <aliceVision/track/tracksUtils.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
@@ -26,7 +27,6 @@
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
@@ -169,7 +169,8 @@ int aliceVision_main(int argc, char ** argv)
 
   // for each pair, export the matches
   fs::create_directory(outputFolder);
-  boost::progress_display myProgressBar( (viewCount*(viewCount-1)) / 2.0 , std::cout, "Export pairwise tracks\n");
+  auto myProgressBar = system::createConsoleProgressDisplay((viewCount*(viewCount-1)) / 2.0,
+                                                            std::cout, "Export pairwise tracks\n");
 
   for(std::size_t I = 0; I < viewCount; ++I)
   {

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -25,7 +25,6 @@
 #include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 #include <boost/program_options.hpp> 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -25,7 +25,6 @@
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <string>
 #include <fstream>

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
@@ -15,7 +16,6 @@
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -113,7 +113,8 @@ bool prepareDenseScene(const SfMData& sfmData,
                             "Choose '.exr' file type if you want AliceVision custom metadata");
 
   // export data
-  boost::progress_display progressBar(viewIds.size(), std::cout, "Exporting Scene Undistorted Images\n");
+  auto progressBar = system::createConsoleProgressDisplay(viewIds.size(), std::cout,
+                                                          "Exporting Scene Undistorted Images\n");
 
   // for exposure correction
   const double medianCameraExposure = sfmData.getMedianCameraExposureSetting().getExposure();

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -113,8 +113,8 @@ bool prepareDenseScene(const SfMData& sfmData,
                             "Choose '.exr' file type if you want AliceVision custom metadata");
 
   // export data
-  auto progressBar = system::createConsoleProgressDisplay(viewIds.size(), std::cout,
-                                                          "Exporting Scene Undistorted Images\n");
+  auto progressDisplay = system::createConsoleProgressDisplay(viewIds.size(), std::cout,
+                                                              "Exporting Scene Undistorted Images\n");
 
   // for exposure correction
   const double medianCameraExposure = sfmData.getMedianCameraExposureSetting().getExposure();
@@ -269,7 +269,7 @@ bool prepareDenseScene(const SfMData& sfmData,
     }
 
     #pragma omp critical
-    ++progressBar;
+    ++progressDisplay;
   }
 
   return true;

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -22,7 +22,6 @@
 #include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 #include <boost/program_options.hpp> 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>

--- a/src/software/pipeline/main_rigLocalization.cpp
+++ b/src/software/pipeline/main_rigLocalization.cpp
@@ -22,7 +22,6 @@
 #include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>
-#include <boost/progress.hpp>
 #include <boost/program_options.hpp> 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>

--- a/src/software/utils/main_rigTransform.cpp
+++ b/src/software/utils/main_rigTransform.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 
-#include <boost/progress.hpp>
 
 #include <iostream>
 #include <string>

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -389,9 +389,9 @@ bool ColorHarmonizationEngineGlobal::Process()
   std::cout << "\n\nThere is :\n" << set_indeximage.size() << " images to transform." << std::endl;
 
   //-> convert solution to gain offset and creation of the LUT per image
-  auto my_progress_bar = system::createConsoleProgressDisplay(set_indeximage.size(), std::cout);
+  auto progressDisplay = system::createConsoleProgressDisplay(set_indeximage.size(), std::cout);
   for (std::set<size_t>::const_iterator iterSet = set_indeximage.begin();
-    iterSet != set_indeximage.end(); ++iterSet, ++my_progress_bar)
+    iterSet != set_indeximage.end(); ++iterSet, ++progressDisplay)
   {
     const size_t imaNum = *iterSet;
     typedef Eigen::Matrix<double, 256, 1> Vec256;

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -8,6 +8,7 @@
 #include "colorHarmonizeEngineGlobal.hpp"
 #include "software/utils/sfmHelper/sfmIOHelper.hpp"
 
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
@@ -29,8 +30,6 @@
 #include <aliceVision/colorHarmonization/GainOffsetConstraintBuilder.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
-
-#include <boost/progress.hpp>
 
 #include <numeric>
 #include <iomanip>
@@ -390,7 +389,7 @@ bool ColorHarmonizationEngineGlobal::Process()
   std::cout << "\n\nThere is :\n" << set_indeximage.size() << " images to transform." << std::endl;
 
   //-> convert solution to gain offset and creation of the LUT per image
-  boost::progress_display my_progress_bar( set_indeximage.size() );
+  auto my_progress_bar = system::createConsoleProgressDisplay(set_indeximage.size(), std::cout);
   for (std::set<size_t>::const_iterator iterSet = set_indeximage.begin();
     iterSet != set_indeximage.end(); ++iterSet, ++my_progress_bar)
   {


### PR DESCRIPTION
Currently progress is displayed directly via `boost::progress_display`. This will become non-optimal once it's possible to use aliceVision as a library, as it would be impossible to control this from the including application.

This PR is the first step in addressing this: there is now a separate API for displaying progress. Right now the behavior does not change at all. Long term plan is to introduce another API from which code would retrieve instances of `ProgressDisplay` class. This way application would have full control over whether and how to display progress. One of the more interesting options is to not display anything, but pass the information about the current progress as numbers, so that calling application could expose them as a progress bar on a GUI.