### PR TITLE
Add support for Xiaomi Redmi K30 Pro Zoom Edition in cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -7104,6 +7104,7 @@ Xiaomi;m2007j20cg;7.4;devicespecifications
 Xiaomi;Mi A1;5.11;devicespecifications
 Xiaomi;Mi A3;6.4;devicespecifications
 Xiaomi;MI 9;6.4;devicespecifications
+Xiaomi;Redmi K30 Pro Zoom Edition;7.4;devicespecifications
 Xiaomi;Xiaomi Mi 3;4.69;devicespecifications
 Xiaomi;Xiaomi Mi 3 TD;4.69;devicespecifications
 Xiaomi;Xiaomi Mi 4;4.69;devicespecifications


### PR DESCRIPTION
This pull request adds support for Xiaomi Redmi K30 Pro Zoom Edition in `cameraSensors.db`.
This Android phone matches information from [here](https://www.devicespecifications.com/en/model/39385339).
The main camera sensor is Sony IMX686.

Sensor width = 9248 px * 0.8 µm / 1000 = 7.4 mm