### PR TITLE
Remove uses of features removed from C++17 standard

### DIFF
--- a/src/aliceVision/hdr/sampling.cpp
+++ b/src/aliceVision/hdr/sampling.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/system/Logger.hpp>
 
 #include <OpenImageIO/imagebufalgo.h>
+#include <random>
 
 
 namespace aliceVision {
@@ -416,12 +417,15 @@ bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, c
         }
     }
 
+    std::random_device randomDevice;
+    std::mt19937 rng(randomDevice());
+
     for (auto & item : counters)
     {
         if (item.second.size() > params.maxCountSample)
         {
             // Shuffle and ignore the exceeding samples
-            std::random_shuffle(item.second.begin(), item.second.end());
+            std::shuffle(item.second.begin(), item.second.end(), rng);
             item.second.resize(params.maxCountSample);
         }
 
@@ -469,6 +473,9 @@ void Sampling::analyzeSource(std::vector<ImageSample> & samples, int channelQuan
         }
     }
 
+    std::random_device randomDevice;
+    std::mt19937 rng(randomDevice());
+
     for (auto & item : _positions)
     {
         // TODO: expose as parameters
@@ -476,7 +483,7 @@ void Sampling::analyzeSource(std::vector<ImageSample> & samples, int channelQuan
         if(item.second.size() > maxSamples)
         {
             // Shuffle and ignore the exceeding samples
-            std::random_shuffle(item.second.begin(), item.second.end());
+            std::shuffle(item.second.begin(), item.second.end(), rng);
             item.second.resize(500);
         }
     }
@@ -488,6 +495,9 @@ void Sampling::filter(size_t maxTotalPoints)
     size_t limitPerGroup = 510;
     size_t total_points = maxTotalPoints + 1;
 
+    std::random_device randomDevice;
+    std::mt19937 rng(randomDevice());
+
     while (total_points > maxTotalPoints)
     {
         limitPerGroup = limitPerGroup - 10;
@@ -498,7 +508,7 @@ void Sampling::filter(size_t maxTotalPoints)
             if (item.second.size() > limitPerGroup)
             {
                 // Shuffle and ignore the exceeding samples
-                std::random_shuffle(item.second.begin(), item.second.end());
+                std::shuffle(item.second.begin(), item.second.end(), rng);
                 item.second.resize(limitPerGroup);
             }
 

--- a/src/aliceVision/mvsUtils/MultiViewParams.hpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.hpp
@@ -210,7 +210,8 @@ public:
         const Matrix3x4& p34 = camArr.at(index); // projection matrix (3x4) scale = getDownscaleFactor()
         const int downscale = getDownscaleFactor(index);
         p44.assign(p34.m, p34.m + 12);
-        std::transform(p44.begin(), p44.begin() + 8, p44.begin(), std::bind1st(std::multiplies<double>(),downscale));
+        std::transform(p44.begin(), p44.begin() + 8, p44.begin(),
+                       [&](double p){ return p * downscale; });
         p44.push_back(0);
         p44.push_back(0);
         p44.push_back(0);

--- a/src/aliceVision/sfmData/colorize.cpp
+++ b/src/aliceVision/sfmData/colorize.cpp
@@ -15,6 +15,7 @@
 #include <boost/progress.hpp>
 
 #include <map>
+#include <random>
 #include <vector>
 #include <functional>
 namespace aliceVision {
@@ -89,10 +90,13 @@ void colorizeTracks(SfMData& sfmData)
       break;
   }
 
+  std::random_device randomDevice;
+  std::mt19937 rng(randomDevice());
+
   // create an unsorted index container
   std::vector<int> unsortedIndexes(sortedViewsCardinal.size()) ;
   std::iota(std::begin(unsortedIndexes), std::end(unsortedIndexes), 0);
-  std::random_shuffle(unsortedIndexes.begin(), unsortedIndexes.end());
+  std::shuffle(unsortedIndexes.begin(), unsortedIndexes.end(), rng);
 
   // landmark colorization
 #pragma omp parallel for

--- a/src/aliceVision/track/TracksBuilder.cpp
+++ b/src/aliceVision/track/TracksBuilder.cpp
@@ -156,7 +156,7 @@ void TracksBuilder::filter(bool clearForks, std::size_t minTrackLength, bool mul
   }
 
   std::for_each(set_classToErase.begin(), set_classToErase.end(),
-    std::bind1st(std::mem_fun(&UnionFindObject::eraseClass), _d->tracksUF.get()));
+                [&](int toErase){ _d->tracksUF->eraseClass(toErase); });
 }
 
 bool TracksBuilder::exportToStream(std::ostream& os)

--- a/src/dependencies/flann/src/cpp/flann/algorithms/kdtree_index.h
+++ b/src/dependencies/flann/src/cpp/flann/algorithms/kdtree_index.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <cassert>
 #include <cstring>
+#include <random>
 #include <stdarg.h>
 
 #include "flann/general.h"
@@ -251,6 +252,9 @@ protected:
      */
     void buildIndexImpl()
     {
+        std::random_device randomDevice;
+        std::mt19937 rng(randomDevice());
+
         // Create a permutable array of indices to the input vectors.
     	std::vector<int> ind(size_);
         for (size_t i = 0; i < size_; ++i) {
@@ -264,7 +268,7 @@ protected:
         /* Construct the randomized trees. */
         for (int i = 0; i < trees_; i++) {
             /* Randomize the order of vectors to allow for unbiased sampling. */
-            std::random_shuffle(ind.begin(), ind.end());
+            std::shuffle(ind.begin(), ind.end(), rng);
             tree_roots_[i] = divideTree(&ind[0], int(size_) );
         }
         delete[] mean_;

--- a/src/dependencies/flann/src/cpp/flann/util/lsh_table.h
+++ b/src/dependencies/flann/src/cpp/flann/util/lsh_table.h
@@ -38,6 +38,8 @@
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
+#include <random>
+
 #include <limits.h>
 // TODO as soon as we use C++0x, use the code in USE_UNORDERED_MAP
 #if USE_UNORDERED_MAP
@@ -357,6 +359,9 @@ private:
 template<>
 inline LshTable<unsigned char>::LshTable(unsigned int feature_size, unsigned int subsignature_size)
 {
+    std::random_device randomDevice;
+    std::mt19937 rng(randomDevice());
+
     initialize(subsignature_size);
     // Allocate the mask
     mask_ = std::vector<size_t>((size_t)ceil((float)(feature_size * sizeof(char)) / (float)sizeof(size_t)), 0);
@@ -364,7 +369,7 @@ inline LshTable<unsigned char>::LshTable(unsigned int feature_size, unsigned int
     // A bit brutal but fast to code
     std::vector<size_t> indices(feature_size * CHAR_BIT);
     for (size_t i = 0; i < feature_size * CHAR_BIT; ++i) indices[i] = i;
-    std::random_shuffle(indices.begin(), indices.end());
+    std::shuffle(indices.begin(), indices.end(), rng);
 
     // Generate a random set of order of subsignature_size_ bits
     for (unsigned int i = 0; i < key_size_; ++i) {

--- a/src/dependencies/flann/src/cpp/flann/util/random.h
+++ b/src/dependencies/flann/src/cpp/flann/util/random.h
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstddef>
+#include <random>
 #include <vector>
 
 #include "flann/general.h"
@@ -110,14 +111,16 @@ public:
      */
     void init(int n)
     {
-        static RandomGenerator generator;
+        std::random_device randomDevice;
+        std::mt19937 rng(randomDevice());
+
         // create and initialize an array of size n
         vals_.resize(n);
         size_ = n;
         for (int i = 0; i < size_; ++i) vals_[i] = i;
 
         // shuffle the elements in the array
-        std::random_shuffle(vals_.begin(), vals_.end(), generator);
+        std::shuffle(vals_.begin(), vals_.end(), rng);
 
         counter_ = 0;
     }


### PR DESCRIPTION
This fixes build on compilers (e.g. Apple Clang) that follow the C++ standard by the letter. 