### PR TITLE
Draft: Update vcpkg dependency for Windows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -104,7 +104,7 @@ jobs:
       # tripletPath: '${{ github.workspace }}\..\vcpkg\triplets\community\x64-windows-release.cmake'
       BUILD_TYPE: Release
       CTEST_OUTPUT_ON_FAILURE: 1
-      COMMIT_ID: 467509eb8fe938de3e5f85a6cb1b72edacb2284c
+      COMMIT_ID: 34f072dfcb8b9356e6ed2c74947f87390ddb2706
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -115,7 +115,7 @@ jobs:
         # Uses a specific version of vcpkg with a fix on OpenEXR/Imath portfiles
         run: |
           cd ..
-          git clone https://github.com/alicevision/vcpkg.git
+          git clone https://github.com/p12tic/vcpkg.git
           cd vcpkg
           git checkout ${{ env.COMMIT_ID }}
           cd ${{ github.workspace }}


### PR DESCRIPTION
This PR just checks whether https://github.com/alicevision/vcpkg/pull/4 passes CI on Windows.