### PR TITLE
[stl] Don't escape a forward slash

### DIFF
--- a/src/aliceVision/stl/regex.hpp
+++ b/src/aliceVision/stl/regex.hpp
@@ -13,7 +13,7 @@ namespace aliceVision {
 inline std::regex simpleFilterToRegex(const std::string& simpleFilter)
 {
     std::string filterToRegex = simpleFilter;
-    filterToRegex = std::regex_replace(filterToRegex, std::regex("\/"), std::string("\\\/"));
+    filterToRegex = std::regex_replace(filterToRegex, std::regex("/"), std::string("\\/"));
     filterToRegex = std::regex_replace(filterToRegex, std::regex("\\*"), std::string(".*"));
     filterToRegex = std::regex_replace(filterToRegex, std::regex("\\?"), std::string("."));
     filterToRegex = std::regex_replace(filterToRegex, std::regex("\\@"), std::string("[0-9]+")); // one @ correspond to one or more digits


### PR DESCRIPTION
This fixes "unknown escape sequence: '\/'" warning.

To verify that behavior is identical, run the following:

```
#include <iostream>

int main()
{
    std::cout << "\/" << "\n" << "\\\/" << "\n";
    std::cout << "/" << "\n" << "\\/" << "\n";
}
```

