### PR TITLE
[sift] Remove dependency on glibc memcpy

### DIFF
--- a/src/nonFree/sift/vl/host.h
+++ b/src/nonFree/sift/vl/host.h
@@ -659,7 +659,7 @@ vl_swap_host_big_endianness_2 (void *dst, void* src)
 }
 
 /* Linux: limit glibc to old versions for compatibility */
-#if defined(VL_COMPILER_GNUC) & defined(VL_OS_LINUX) & ! defined(__DOXYGEN__)
+#if defined(VL_COMPILER_GNUC) & defined(VL_OS_LINUX) & ! defined(__DOXYGEN__) & ! defined(ANDROID)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 #endif
 


### PR DESCRIPTION
Pinning to an old memcpy symver only makes sense on regular Linux, not Android.
