### PR TITLE
[sift] Build static libraries, not shared

### DIFF
--- a/src/nonFree/sift/CMakeLists.txt
+++ b/src/nonFree/sift/CMakeLists.txt
@@ -1,5 +1,5 @@
 # libs should be static
-set(BUILD_SHARED_LIBS ON)
+set(BUILD_SHARED_LIBS OFF)
 
 # use PIC code for link into shared lib
 if(UNIX)


### PR DESCRIPTION
This seems to be an oversight in
b40d54f0fef12d0bac5dd3dd854d8777958e5e0b, as there's no need to build the library as a shared library.

Also note the comment above the changed line.
