### PR TITLE
Make DisplayProgress class thread safe

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1886,7 +1886,6 @@ void DelaunayGraphCut::fillGraph(double nPixelSizeBehind, bool labatutWeights, b
     {
         if(i % progressStep == 0)
         {
-#pragma omp critical
             ++progressDisplay;
         }
 

--- a/src/aliceVision/localization/VoctreeLocalizer.cpp
+++ b/src/aliceVision/localization/VoctreeLocalizer.cpp
@@ -373,10 +373,7 @@ bool VoctreeLocalizer::initDatabase(const std::string & vocTreeFilepath,
         _regionsPerView.getData()[id_view][descType] = std::move(filteredRegions);
       }
     }
-#pragma omp critical
-    {
-      ++progressDisplay;
-    }
+    ++progressDisplay;
   }
   return true;
 }

--- a/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
@@ -86,11 +86,7 @@ void robustModelEstimation(
 
       }
     }
-
-#pragma omp critical
-    {
-      ++progressDisplay;
-    }
+    ++progressDisplay;
   }
 }
 

--- a/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_cascadeHashing.cpp
+++ b/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_cascadeHashing.cpp
@@ -143,7 +143,6 @@ void Match
       if (!regionsPerView.viewExist(J)
           || regionsI.Type_id() != regionsJ.Type_id())
       {
-        #pragma omp critical
         ++progressDisplay;
         continue;
       }

--- a/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_generic.cpp
+++ b/src/aliceVision/matchingImageCollection/ImageCollectionMatcher_generic.cpp
@@ -78,7 +78,6 @@ void ImageCollectionMatcher_generic::Match(
       if (regionsJ.RegionCount() == 0
           || regionsI.Type_id() != regionsJ.Type_id())
       {
-        #pragma omp critical
         ++progressDisplay;
         continue;
       }

--- a/src/aliceVision/sfm/FrustumFilter.cpp
+++ b/src/aliceVision/sfm/FrustumFilter.cpp
@@ -83,11 +83,7 @@ PairSet FrustumFilter::getFrustumIntersectionPairs() const
           pairs.insert(std::make_pair(viewIds[i], viewIds[j]));
         }
       }
-      // Progress bar update
-      #pragma omp critical
-      {
-        ++progressDisplay;
-      }
+      ++progressDisplay;
     }
   }
   return pairs;

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
@@ -414,10 +414,7 @@ void GlobalSfMTranslationAveragingSolver::ComputePutativeTranslation_EdgesCovera
     for (int k = 0; k < vec_edges.size(); ++k)
     {
       const myEdge & edge = vec_edges[k];
-      #pragma omp critical
-      {
-        ++progressDisplay;
-      }
+      ++progressDisplay;
       if (m_mutexSet.count(edge) == 0 && m_mutexSet.size() != vec_edges.size())
       {
         // Find the triplets that support the given edge

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -453,10 +453,7 @@ void ReconstructionEngine_globalSfM::Compute_Relative_Rotations(rotationAveragin
   // Compute the relative pose from pairwise point matches:
   for (int i = 0; i < poseWiseMatches.size(); ++i)
   {
-    #pragma omp critical
-    {
-      ++progressDisplay;
-    }
+    ++progressDisplay;
     {
       PoseWiseMatches::const_iterator iter (poseWiseMatches.begin());
       std::advance(iter, i);

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1257,7 +1257,6 @@ bool ReconstructionEngine_sequentialSfM::getBestInitialImagePairs(std::vector<Pa
     matching::PairwiseMatches::const_iterator iter = _pairwiseMatches->begin();
     std::advance(iter, i);
     
-#pragma omp critical
     ++progressDisplay;
     
     const Pair current_pair = iter->first;

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -188,8 +188,7 @@ void StructureEstimationFromKnownPoses::filter(
   {
     #pragma omp single nowait
     {
-      #pragma omp critical
-      {++progressDisplay;}
+      ++progressDisplay;
 
       const graph::Triplet & triplet = *it;
       const IndexT I = triplet.i, J = triplet.j , K = triplet.k;

--- a/src/aliceVision/sfm/sfmTriangulation.cpp
+++ b/src/aliceVision/sfm/sfmTriangulation.cpp
@@ -45,7 +45,6 @@ void StructureComputation_blind::triangulate(sfmData::SfMData& sfmData, std::mt1
     {
       if (_bConsoleVerbose)
       {
-        #pragma omp critical
         ++(progressDisplay);
       }
       // Triangulate each landmark
@@ -131,7 +130,6 @@ void StructureComputation_robust::robust_triangulation(sfmData::SfMData& sfmData
     {
       if (_bConsoleVerbose)
       {
-        #pragma omp critical
         ++(progressDisplay);
       }
       Vec3 X;

--- a/src/aliceVision/sfmData/colorize.cpp
+++ b/src/aliceVision/sfmData/colorize.cpp
@@ -119,10 +119,7 @@ void colorizeTracks(SfMData& sfmData)
         landmark.rgb = image(pt.y(), pt.x());
       }
 
-#pragma omp critical
-      {
-        progressDisplay += viewCardinal.landmarks.size();
-      }
+      progressDisplay += viewCardinal.landmarks.size();
     }
   }
 }

--- a/src/aliceVision/system/ProgressDisplay.cpp
+++ b/src/aliceVision/system/ProgressDisplay.cpp
@@ -6,6 +6,7 @@
 
 #include "ProgressDisplay.hpp"
 #include <boost/progress.hpp>
+#include <mutex>
 
 namespace aliceVision {
 namespace system {
@@ -43,11 +44,13 @@ public:
 
     void increment(unsigned long count) override
     {
+        std::lock_guard<std::mutex> lock{_mutex};
         _display += count;
     }
 
     unsigned long count() override
     {
+        std::lock_guard<std::mutex> lock{_mutex};
         return _display.count();
     }
 
@@ -57,6 +60,7 @@ public:
     }
 
 private:
+    std::mutex _mutex;
     boost::progress_display _display;
 };
 

--- a/src/aliceVision/system/ProgressDisplay.hpp
+++ b/src/aliceVision/system/ProgressDisplay.hpp
@@ -40,21 +40,25 @@ public:
         _impl->restart(expectedCount);
     }
 
+    // Thread safe with respect to other calls to operator++ and to calls to count()
     void operator++()
     {
         _impl->increment(1);
     }
 
+    // Thread safe with respect to other calls to operator++ and to calls to count()
     void operator+=(unsigned long increment)
     {
         _impl->increment(increment);
     }
 
+    // Thread safe with respect to calls to operator++
     unsigned long count()
     {
         return _impl->count();
     }
 
+    // Thread safe
     unsigned long expectedCount()
     {
         return _impl->expectedCount();

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -268,7 +268,6 @@ bool prepareDenseScene(const SfMData& sfmData,
       }
     }
 
-    #pragma omp critical
     ++progressDisplay;
   }
 


### PR DESCRIPTION
The class is very often used in multithreaded contexts, so it makes sense to make it thread safe to avoid repeated locking code.