### PR TITLE
Add support for TBB multi-threading backend in addition to OpenMP

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ option(ALICEVISION_BUILD_COVERAGE "Enable code coverage generation (gcc only)" O
 trilean_option(ALICEVISION_BUILD_DOC "Build AliceVision documentation" AUTO)
 
 trilean_option(ALICEVISION_USE_OPENMP "Enable OpenMP parallelization" ON)
+trilean_option(ALICEVISION_USE_TBB "Enable tbb parallelization" OFF)
 trilean_option(ALICEVISION_USE_CCTAG "Enable CCTAG markers" AUTO)
 trilean_option(ALICEVISION_USE_APRILTAG "Enable AprilTag markers" AUTO)
 trilean_option(ALICEVISION_USE_POPSIFT "Enable GPU SIFT implementation" AUTO)
@@ -264,6 +265,21 @@ if(ALICEVISION_HAVE_OPENMP)
     else()
     list(APPEND ALICEVISION_LIBRARY_DEPENDENCIES gomp)
     endif()
+  endif()
+endif()
+
+# ==============================================================================
+# oneTBB
+# ==============================================================================
+set(ALICEVISION_HAVE_TBB 0)
+if(ALICEVISION_USE_TBB STREQUAL "OFF")
+else() # ON OR AUTO
+  find_package(TBB)
+  if(TBB_FOUND)
+    set(ALICEVISION_HAVE_TBB 1)
+  elseif(ALICEVISION_USE_TBB STREQUAL "ON")
+    set(ALICEVISION_HAVE_TBB 0)
+    message(SEND_ERROR "Failed to find TBB.")
   endif()
 endif()
 
@@ -904,6 +920,7 @@ message("** Build MeshSDFilter: " ${ALICEVISION_HAVE_MESHSDFILTER})
 message("** Build Alembic exporter: " ${ALICEVISION_HAVE_ALEMBIC})
 message("** Enable code coverage generation: " ${ALICEVISION_BUILD_COVERAGE})
 message("** Enable OpenMP parallelization: " ${ALICEVISION_HAVE_OPENMP})
+message("** Enable TBB parallelization: " ${ALICEVISION_HAVE_TBB})
 message("** Use CUDA: " ${ALICEVISION_HAVE_CUDA})
 message("** Use OpenCV SIFT features: " ${ALICEVISION_HAVE_OCVSIFT})
 message("** Use PopSift feature extractor: " ${ALICEVISION_HAVE_POPSIFT})

--- a/src/aliceVision/camera/cameraUndistortImage.hpp
+++ b/src/aliceVision/camera/cameraUndistortImage.hpp
@@ -9,6 +9,7 @@
 
 #include <aliceVision/config.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/Sampler.hpp>
 #include <aliceVision/camera/cameraCommon.hpp>
@@ -64,9 +65,8 @@ void UndistortImage(
     image_ud.resize(widthRoi, heightRoi, true, fillcolor);
     const image::Sampler2d<image::SamplerLinear> sampler;
     
-    
-    #pragma omp parallel for
-    for(int j = 0; j < heightRoi; ++j)
+    system::parallelFor(0, heightRoi, [&](int j)
+    {
         for(int i = 0; i < widthRoi; ++i)
         {       
             const Vec2 undisto_pix(i + xOffset, j + yOffset); 
@@ -77,6 +77,7 @@ void UndistortImage(
             if(imageIn.Contains(disto_pix(1), disto_pix(0)))
                 image_ud(j, i) = sampler(imageIn, disto_pix(1), disto_pix(0));
         }
+    });
   }
 }
 

--- a/src/aliceVision/depthMap/Refine.cpp
+++ b/src/aliceVision/depthMap/Refine.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/gpu/gpu.hpp>
 
 #include <aliceVision/depthMap/RefineParams.hpp>
@@ -189,14 +190,13 @@ void Refine::refineAndFuseDepthSimMap(const DepthSimMap& depthSimMapSgmUpscale, 
 
             const StaticVector<DepthSim>& dsm = dataMaps[i]->_dsm;
 
-#pragma omp parallel for
-            for(int y = 0; y < hPartHeight; y++)
+            system::parallelFor(0, hPartHeight, [&](int y)
             {
                 for(int x = 0; x < w; x++)
                 {
                     (*dataMapHPart)[y * w + x] = dsm[(y + hPart * hPartHeightGlob) * w + x];
                 }
-            }
+            });
 
             dataMapsHPart.push_back(dataMapHPart);
         }
@@ -209,14 +209,13 @@ void Refine::refineAndFuseDepthSimMap(const DepthSimMap& depthSimMapSgmUpscale, 
                                                   dataMapsHPart, 
                                                   _refineParams);
 
-#pragma omp parallel for
-        for(int y = 0; y < hPartHeight; ++y)
+        system::parallelFor(0, hPartHeight, [&](int y)
         {
             for(int x = 0; x < w; ++x)
             {
                 out_depthSimMapRefinedFused._dsm[(y + hPart * hPartHeightGlob) * w + x] = depthSimMapFusedHPart[y * w + x];
             }
-        }
+        });
 
         deleteAllPointers(dataMapsHPart);
     }

--- a/src/aliceVision/depthMap/Refine.cpp
+++ b/src/aliceVision/depthMap/Refine.cpp
@@ -6,7 +6,6 @@
 
 #include "Refine.hpp"
 
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/ParallelFor.hpp>

--- a/src/aliceVision/depthMap/Sgm.cpp
+++ b/src/aliceVision/depthMap/Sgm.cpp
@@ -6,7 +6,6 @@
 
 #include "Sgm.hpp"
 
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/gpu/gpu.hpp>

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -21,7 +21,6 @@
 #include <aliceVision/image/imageAlgo.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/ParallelFor.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 
 #include "nanoflann.hpp"
 

--- a/src/aliceVision/fuseCut/VoxelsGrid.cpp
+++ b/src/aliceVision/fuseCut/VoxelsGrid.cpp
@@ -11,7 +11,6 @@
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/fuseCut/delaunayGraphCutTypes.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 
 #include <boost/filesystem.hpp>
 

--- a/src/aliceVision/hdr/DebevecCalibrate.cpp
+++ b/src/aliceVision/hdr/DebevecCalibrate.cpp
@@ -7,7 +7,6 @@
 #include "DebevecCalibrate.hpp"
 #include "sampling.hpp"
 
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>

--- a/src/aliceVision/hdr/GrossbergCalibrate.cpp
+++ b/src/aliceVision/hdr/GrossbergCalibrate.cpp
@@ -8,7 +8,6 @@
 #include "QuadProg++.hpp"
 #include "sampling.hpp"
 #include <Eigen/Dense>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <cassert>
 #include <iostream>

--- a/src/aliceVision/hdr/LaguerreBACalibration.cpp
+++ b/src/aliceVision/hdr/LaguerreBACalibration.cpp
@@ -7,7 +7,6 @@
 #include "LaguerreBACalibration.hpp"
 #include "sampling.hpp"
 
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 #include <Eigen/Dense>

--- a/src/aliceVision/hdr/hdrMerge.cpp
+++ b/src/aliceVision/hdr/hdrMerge.cpp
@@ -13,7 +13,7 @@
 
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
-
+#include <aliceVision/system/ParallelFor.hpp>
 
 namespace aliceVision {
 namespace hdr {
@@ -72,8 +72,7 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
   rgbCurve weightLongestExposure = weight;
   weightLongestExposure.freezeFirstPartValues();
 
-  #pragma omp parallel for
-  for(int y = 0; y < height; ++y)
+  system::parallelFor<int>(0, height, [&](int y)
   {
     for(int x = 0; x < width; ++x)
     {
@@ -140,7 +139,7 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
         radianceColor(channel) = wsum / std::max(0.001, wdiv) * targetCameraExposure;
       }
     }
-  }
+  });
 }
 
 void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfColor> > &images,
@@ -170,8 +169,7 @@ void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfC
 
     image::Image<float> isPixelClamped(width, height);
 
-#pragma omp parallel for
-    for (int y = 0; y < height; ++y)
+    system::parallelFor<int>(0, height, [&](int y)
     {
         for (int x = 0; x < width; ++x)
         {
@@ -194,13 +192,12 @@ void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfC
             }
             isPixelClamped(y, x) /= 3.0;
         }
-    }
+    });
 
     image::Image<float> isPixelClamped_g(width, height);
     image::ImageGaussianFilter(isPixelClamped, 1.0f, isPixelClamped_g, 3, 3);
 
-#pragma omp parallel for
-    for (int y = 0; y < height; ++y)
+    system::parallelFor<int>(0, height, [&](int y)
     {
         for (int x = 0; x < width; ++x)
         {
@@ -218,7 +215,7 @@ void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfC
                 }
             }
         }
-    }
+    });
 }
 
 } // namespace hdr

--- a/src/aliceVision/hdr/hdrMerge.cpp
+++ b/src/aliceVision/hdr/hdrMerge.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <fstream>
 
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ParallelFor.hpp>
 

--- a/src/aliceVision/hdr/sampling.cpp
+++ b/src/aliceVision/hdr/sampling.cpp
@@ -6,7 +6,6 @@
 
 #include "sampling.hpp"
 
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ParallelFor.hpp>
 

--- a/src/aliceVision/image/diffusion.hpp
+++ b/src/aliceVision/image/diffusion.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <aliceVision/config.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/ParallelFor.hpp>
 
 #include <vector>

--- a/src/aliceVision/image/diffusion.hpp
+++ b/src/aliceVision/image/diffusion.hpp
@@ -9,6 +9,7 @@
 
 #include <aliceVision/config.hpp>
 #include <aliceVision/alicevision_omp.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 #include <vector>
 
@@ -102,11 +103,11 @@ void ImageFEDCentralCPPThread( const Image & src , const Image & diff , const ty
   std::vector< int > range;
   SplitRange( 1 , (int) ( src.rows() - 1 ) , nb_thread , range ) ;
 
-  #pragma omp parallel for schedule(dynamic)
-  for( int i = 1 ; i < static_cast<int>(range.size()) ; ++i )
+  system::parallelFor<int>(1, range.size(), system::ParallelSettings().setDynamicScheduling(),
+                           [&](int i)
   {
     ImageFEDCentral( src, diff, half_t, out, range[i-1] , range[i]) ;
-  }
+  });
 }
 
 /**

--- a/src/aliceVision/image/warping.hpp
+++ b/src/aliceVision/image/warping.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <aliceVision/config.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 namespace aliceVision{
 namespace image{
@@ -34,14 +35,13 @@ void Warp(const Image &im, const Mat3 & H, Image &out)
 
   const Sampler2d<SamplerLinear> sampler;
   for (int j = 0; j < hOut; ++j)
-    #pragma omp parallel for
-    for (int i = 0; i < wOut; ++i)
+    system::parallelFor(0, wOut, [&](int i)
     {
       double xT = i, yT = j;
       if (ApplyH_AndCheckOrientation(H, xT, yT)
           && im.Contains(yT,xT))
         out(j,i) = sampler(im, (float)yT, (float)xT);
-    }
+    });
 }
 
 }; // namespace image

--- a/src/aliceVision/imageMatching/ImageMatching.cpp
+++ b/src/aliceVision/imageMatching/ImageMatching.cpp
@@ -6,6 +6,7 @@
 
 #include "ImageMatching.hpp"
 #include <aliceVision/voctree/databaseIO.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 namespace aliceVision {
 namespace imageMatching {
@@ -272,8 +273,8 @@ void generateFromVoctree(PairList& allMatches,
     }
 
     // query each document
-#pragma omp parallel for
-    for (ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(descriptorsFiles.size()); ++i)
+    system::parallelFor<std::ptrdiff_t>(0, descriptorsFiles.size(), system::ParallelSettings(),
+                                        [&](auto i)
     {
         auto itA = descriptorsFiles.cbegin();
         std::advance(itA, i);
@@ -307,7 +308,7 @@ void generateFromVoctree(PairList& allMatches,
         {
             imgMatches.push_back(m.id);
         }
-    }
+    });
 }
 
 void conditionVocTree(const std::string& treeName, bool withWeights,

--- a/src/aliceVision/matching/ArrayMatcher_bruteForce.hpp
+++ b/src/aliceVision/matching/ArrayMatcher_bruteForce.hpp
@@ -11,6 +11,7 @@
 #include <aliceVision/matching/ArrayMatcher.hpp>
 #include <aliceVision/feature/metric.hpp>
 #include <aliceVision/stl/indexedSort.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 #include <aliceVision/config.hpp>
 
@@ -124,8 +125,8 @@ class ArrayMatcher_bruteForce  : public ArrayMatcher<Scalar, Metric>
     pvec_distances->resize(nbQuery * NN);
     pvec_indices->resize(nbQuery * NN);
 
-    #pragma omp parallel for schedule(dynamic)
-    for (int queryIndex=0; queryIndex < nbQuery; ++queryIndex) 
+    system::parallelFor(0, nbQuery, system::ParallelSettings().setDynamicScheduling(),
+                        [&](int queryIndex)
     {
       std::vector<DistanceType> vec_distance((*memMapping).rows(), 0.0);
       const Scalar * queryPtr = mat_query.row(queryIndex).data();
@@ -148,7 +149,7 @@ class ArrayMatcher_bruteForce  : public ArrayMatcher<Scalar, Metric>
         (*pvec_distances)[queryIndex*NN+i] = packet_vec[i].val;
         (*pvec_indices)[queryIndex*NN+i] = IndMatch(queryIndex, packet_vec[i].index);
       }
-    }
+    });
     return true;
   };
 

--- a/src/aliceVision/matching/ArrayMatcher_kdtreeFlann.hpp
+++ b/src/aliceVision/matching/ArrayMatcher_kdtreeFlann.hpp
@@ -9,7 +9,6 @@
 
 #include <aliceVision/matching/ArrayMatcher.hpp>
 #include <aliceVision/config.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 
 #include "flann/flann.hpp"
 

--- a/src/aliceVision/matching/kvld/kvld.cpp
+++ b/src/aliceVision/matching/kvld/kvld.cpp
@@ -19,6 +19,7 @@
 #include <numeric>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/config.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 using namespace aliceVision;
 using namespace aliceVision::image;
@@ -38,8 +39,7 @@ ImageScale::ImageScale( const Image< float >& I, double r )
   GradAndNorm( I, angles[ 0 ], magnitudes[ 0 ] );
   ratios[ 0 ] = 1;
   
-  #pragma omp parallel for
-  for( int k = 1; k < number; k++ )
+  system::parallelFor(1, number, [&](int k)
   {
     Image< float > I2;
     double ratio = 1 * pow( step, k );
@@ -56,7 +56,7 @@ ImageScale::ImageScale( const Image< float >& I, double r )
     }
     GradAndNorm( I2,angles[ k ], magnitudes[ k ] );
     ratios[ k ] = ratio;
-  }
+  });
 }
 
 void ImageScale::GradAndNorm( const Image< float >& I, Image< float >& angle, Image< float >& m )
@@ -66,8 +66,7 @@ void ImageScale::GradAndNorm( const Image< float >& I, Image< float >& angle, Im
   angle.fill( 0 );
   m.fill( 0 );
   
-  #pragma omp parallel for
-  for( int y = 1; y < I.Height() - 1; y++ )
+  system::parallelFor(1, I.Height() - 1, [&](int y)
   {
     for( int x = 1; x < I.Width() - 1; x++ )
     {
@@ -78,7 +77,7 @@ void ImageScale::GradAndNorm( const Image< float >& I, Image< float >& angle, Im
         angle( y, x ) = -1;
       m( y, x ) = std::hypot(gx, gy);
     }
-  }
+  });
 }
 
 int ImageScale::getIndex( const double r )const

--- a/src/aliceVision/mesh/MeshEnergyOpt.cpp
+++ b/src/aliceVision/mesh/MeshEnergyOpt.cpp
@@ -6,6 +6,7 @@
 
 #include "MeshEnergyOpt.hpp"
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -29,8 +30,7 @@ void MeshEnergyOpt::computeLaplacianPtsParallel(StaticVector<Point3d>& out_lapPt
     out_lapPts.resize_with(pts.size(), Point3d(0.0f, 0.0f, 0.f));
     int nlabpts = 0;
 
-#pragma omp parallel for
-    for(int i = 0; i < pts.size(); i++)
+    system::parallelFor(0, pts.size(), [&](int i)
     {
         Point3d lapPt;
         if(getLaplacianSmoothingVector(i, lapPt))
@@ -38,7 +38,7 @@ void MeshEnergyOpt::computeLaplacianPtsParallel(StaticVector<Point3d>& out_lapPt
             out_lapPts[i] = lapPt;
             nlabpts++;
         }
-    }
+    });
 }
 
 void MeshEnergyOpt::updateGradientParallel(float lambda, const Point3d& LU,
@@ -52,8 +52,7 @@ void MeshEnergyOpt::updateGradientParallel(float lambda, const Point3d& LU,
     newPts.reserve(pts.size());
     newPts.push_back_arr(&pts);
 
-#pragma omp parallel for
-    for(int i = 0; i < pts.size(); ++i)
+    system::parallelFor(0, pts.size(), [&](int i)
     {
         if( ptsCanMove.empty() || ptsCanMove[i] )
         {
@@ -68,7 +67,7 @@ void MeshEnergyOpt::updateGradientParallel(float lambda, const Point3d& LU,
                 }
             }
         }
-    }
+    });
 
     pts.clear();
     pts.swap(newPts);

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -10,8 +10,7 @@
 
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/MemoryInfo.hpp>
-#include <aliceVision/image/io.hpp>
-#include <aliceVision/image/pixelTypes.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/mvsData/geometry.hpp>
 #include <aliceVision/mvsData/Pixel.hpp>
@@ -555,8 +554,7 @@ void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
                 ALICEVISION_LOG_INFO("      - band " << band + 1 << ": " << trianglesId.size() << " triangles.");
 
                 // for each triangle
-                #pragma omp parallel for
-                for(int ti = 0; ti < trianglesId.size(); ++ti)
+                system::parallelFor<int>(0, trianglesId.size(), [&](int ti)
                 {
                     const unsigned int triangleId = std::get<0>(trianglesId[ti]);
                     const float triangleScore = texParams.useScore ? std::get<1>(trianglesId[ti]) : 1.0f;
@@ -649,7 +647,7 @@ void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
                            }
                        }
                     }
-                }
+                });
             }
         }
     }
@@ -1317,8 +1315,7 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
     const auto& triangles = _atlases[atlasID];
 
     // iterate over atlas' triangles
-#pragma omp parallel for
-    for(int ti = 0; ti < triangles.size(); ++ti)
+    system::parallelFor<int>(0, triangles.size(), [&](int ti)
     {
         const unsigned int triangleId = triangles[ti];
         //  const Point3d __triangleNormal_ = me->computeTriangleNormal(triangleId).normalize();
@@ -1432,7 +1429,7 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
                 }
             }
         }
-    }
+    });
 
     // Save Normal Map
     if(bumpMappingParams.bumpType == EBumpMappingType::Normal && bumpMappingParams.bumpMappingFileType != image::EImageFileType::NONE)

--- a/src/aliceVision/multiview/rotationAveraging/l2.cpp
+++ b/src/aliceVision/multiview/rotationAveraging/l2.cpp
@@ -7,7 +7,6 @@
 
 #include "aliceVision/multiview/rotationAveraging/l2.hpp"
 #include <aliceVision/config.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 #include <vector>

--- a/src/aliceVision/multiview/translationAveraging/solverL1Soft.cpp
+++ b/src/aliceVision/multiview/translationAveraging/solverL1Soft.cpp
@@ -10,7 +10,6 @@
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/config.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 #include "ceres/ceres.h"

--- a/src/aliceVision/multiview/translationAveraging/solverL2Chordal.cpp
+++ b/src/aliceVision/multiview/translationAveraging/solverL2Chordal.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/multiview/translationAveraging/common.hpp>
 #include <aliceVision/multiview/translationAveraging/solver.hpp>
 #include <aliceVision/config.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 #include "ceres/ceres.h"

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -11,7 +11,6 @@
 #include <aliceVision/sfm/ResidualErrorRotationPriorFunctor.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/utils/CeresUtils.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/camera/Equidistant.hpp>
 

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <aliceVision/types.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/sfm/BundleAdjustment.hpp>
 #include <aliceVision/sfm/LocalBundleAdjustmentGraph.hpp>
 #include <aliceVision/numeric/numeric.hpp>

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
@@ -8,7 +8,6 @@
 #include <aliceVision/sfm/BundleAdjustmentPanoramaCeres.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/utils/CeresUtils.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/sfm/ResidualErrorRotationPriorFunctor.hpp>
 

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.hpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <aliceVision/types.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/sfm/BundleAdjustment.hpp>
 #include <aliceVision/sfm/LocalBundleAdjustmentGraph.hpp>
 

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -7,7 +7,6 @@
 
 #include <aliceVision/sfm/BundleAdjustmentSymbolicCeres.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/camera/Equidistant.hpp>
 #include <aliceVision/utils/CeresUtils.hpp>

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.hpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <aliceVision/types.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/sfm/BundleAdjustment.hpp>
 #include <aliceVision/sfm/LocalBundleAdjustmentGraph.hpp>
 #include <aliceVision/numeric/numeric.hpp>

--- a/src/aliceVision/sfm/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundleAdjustment_test.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/sfm/sfm.hpp>
 #include <aliceVision/camera/cameraCommon.hpp>
 #include <aliceVision/multiview/NViewDataSet.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 #include <cmath>
 #include <cstdio>
@@ -340,13 +341,12 @@ track::TracksPerView getTracksPerViews(const SfMData& sfmData)
   }
 
   // sort tracks Ids in each view
-  #pragma omp parallel for
-  for(int i = 0; i < tracksPerView.size(); ++i)
+  system::parallelFor<int>(0, tracksPerView.size(), [&](int i)
   {
     track::TracksPerView::iterator it = tracksPerView.begin();
     std::advance(it, i);
     std::sort(it->second.begin(), it->second.end());
-  }
+  });
 
   return tracksPerView;
 }

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
@@ -28,7 +28,6 @@
 #include <aliceVision/multiview/translationAveraging/solver.hpp>
 #include <aliceVision/sfm/pipeline/global/TranslationTripletKernelACRansac.hpp>
 #include <aliceVision/config.hpp>
-#include <aliceVision/alicevision_omp.hpp>
 
 #include <aliceVision/utils/Histogram.hpp>
 

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
@@ -745,8 +745,6 @@ void ReconstructionEngine_panorama::Compute_Relative_Rotations(rotationAveraging
               }
           }
       }
-
-      // #pragma omp critical
       {
         // Add the relative rotation to the relative 'rotation' pose graph
         using namespace aliceVision::rotationAveraging;

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -7,6 +7,7 @@
 
 #include "regionsIO.hpp"
 
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <boost/filesystem.hpp>
 
@@ -163,8 +164,7 @@ bool loadFeaturesPerDescPerView(std::vector<std::vector<std::unique_ptr<feature:
     std::vector<std::unique_ptr<feature::Regions>>& featuresPerView = featuresPerDescPerView.at(descIdx);
     featuresPerView.resize(viewIds.size());
 
-#pragma omp parallel for
-    for(int viewIdx = 0; viewIdx < viewIds.size(); ++viewIdx)
+    system::parallelFor<int>(0, viewIds.size(), [&](int viewIdx)
     {
       try
       {
@@ -174,7 +174,7 @@ bool loadFeaturesPerDescPerView(std::vector<std::vector<std::unique_ptr<feature:
       {
         loadingSuccess = false;
       }
-    }
+    });
   }
 
   return loadingSuccess;

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -81,91 +81,94 @@ void StructureEstimationFromKnownPoses::match(const SfMData& sfmData,
   auto progressDisplay = system::createConsoleProgressDisplay(pairs.size(), std::cout,
     "Compute pairwise fundamental guided matching:\n" );
 
-  #pragma omp parallel
-  for (PairSet::const_iterator it = pairs.begin(); it != pairs.end(); ++it)
-  {
-    #pragma omp single nowait
+    std::mutex matchesMutex;
+    system::parallelLoop([&](auto& manager)
     {
-    // --
-    // Perform GUIDED MATCHING
-    // --
-    // Use the computed model to check valid correspondences
-    // - by considering geometric error and descriptor distance ratio.
+        for (PairSet::const_iterator it = pairs.begin(); it != pairs.end(); ++it)
+        {
+            manager.submit([&, it]()
+            {
+                // --
+                // Perform GUIDED MATCHING
+                // --
+                // Use the computed model to check valid correspondences
+                // - by considering geometric error and descriptor distance ratio.
 
-    const View * viewL = sfmData.getViews().at(it->first).get();
-    const Pose3 poseL = sfmData.getPose(*viewL).getTransform();
-    const Intrinsics::const_iterator iterIntrinsicL = sfmData.getIntrinsics().find(viewL->getIntrinsicId());
-    const View * viewR = sfmData.getViews().at(it->second).get();
-    const Pose3 poseR = sfmData.getPose(*viewR).getTransform();
-    const Intrinsics::const_iterator iterIntrinsicR = sfmData.getIntrinsics().find(viewR->getIntrinsicId());
+                const View * viewL = sfmData.getViews().at(it->first).get();
+                const Pose3 poseL = sfmData.getPose(*viewL).getTransform();
+                const Intrinsics::const_iterator iterIntrinsicL = sfmData.getIntrinsics().find(viewL->getIntrinsicId());
+                const View * viewR = sfmData.getViews().at(it->second).get();
+                const Pose3 poseR = sfmData.getPose(*viewR).getTransform();
+                const Intrinsics::const_iterator iterIntrinsicR = sfmData.getIntrinsics().find(viewR->getIntrinsicId());
 
-    if (sfmData.getIntrinsics().count(viewL->getIntrinsicId()) != 0 ||
-        sfmData.getIntrinsics().count(viewR->getIntrinsicId()) != 0)
-    {
-      std::shared_ptr<IntrinsicBase> camL = iterIntrinsicL->second;
-      std::shared_ptr<camera::Pinhole> pinHoleCamL = std::dynamic_pointer_cast<camera::Pinhole>(camL);
-      if (!pinHoleCamL) {
-        ALICEVISION_LOG_ERROR("Camera is not pinhole in match");
-      }
+                if (sfmData.getIntrinsics().count(viewL->getIntrinsicId()) != 0 ||
+                    sfmData.getIntrinsics().count(viewR->getIntrinsicId()) != 0)
+                {
+                    std::shared_ptr<IntrinsicBase> camL = iterIntrinsicL->second;
+                    std::shared_ptr<camera::Pinhole> pinHoleCamL = std::dynamic_pointer_cast<camera::Pinhole>(camL);
+                    if (!pinHoleCamL) {
+                        ALICEVISION_LOG_ERROR("Camera is not pinhole in match");
+                    }
 
-      std::shared_ptr<IntrinsicBase> camR = iterIntrinsicR->second;
-      std::shared_ptr<camera::Pinhole> pinHoleCamR = std::dynamic_pointer_cast<camera::Pinhole>(camR);
-      if (!pinHoleCamL) {
-        ALICEVISION_LOG_ERROR("Camera is not pinhole in match");
-      }
-      
-      const Mat34 P_L = pinHoleCamL->getProjectiveEquivalent(poseL);
-      const Mat34 P_R = pinHoleCamR->getProjectiveEquivalent(poseR);
+                    std::shared_ptr<IntrinsicBase> camR = iterIntrinsicR->second;
+                    std::shared_ptr<camera::Pinhole> pinHoleCamR = std::dynamic_pointer_cast<camera::Pinhole>(camR);
+                    if (!pinHoleCamL) {
+                        ALICEVISION_LOG_ERROR("Camera is not pinhole in match");
+                    }
 
-      const Mat3 F_lr = F_from_P(P_L, P_R);
-      std::vector<feature::EImageDescriberType> commonDescTypes = regionsPerView.getCommonDescTypes(*it);
-      
-      matching::MatchesPerDescType allImagePairMatches;
-      for(feature::EImageDescriberType descType: commonDescTypes)
-      {
-        std::vector<matching::IndMatch> matches;
+                    const Mat34 P_L = pinHoleCamL->getProjectiveEquivalent(poseL);
+                    const Mat34 P_R = pinHoleCamR->getProjectiveEquivalent(poseR);
+
+                    const Mat3 F_lr = F_from_P(P_L, P_R);
+                    std::vector<feature::EImageDescriberType> commonDescTypes = regionsPerView.getCommonDescTypes(*it);
+
+                    matching::MatchesPerDescType allImagePairMatches;
+                    for (feature::EImageDescriberType descType: commonDescTypes)
+                    {
+                        std::vector<matching::IndMatch> matches;
 #ifdef ALICEVISION_EXHAUSTIVE_MATCHING
-          matching::guidedMatching
-          <Mat3, multiview::relativePose::FundamentalEpipolarDistanceError>
-          (
-            F_lr,
-            iterIntrinsicL->second.get(),
-            regionsPerView.getRegions(it->first, descType),
-            iterIntrinsicR->second.get(),
-            regionsPerView.getRegions(it->second, descType),
-            // descType,
-            Square(thresholdF), Square(0.8),
-            matches
-          );
-      #else
-        const Vec3 epipole2  = epipole_from_P(P_R, poseL);
+                        matching::guidedMatching
+                        <Mat3, multiview::relativePose::FundamentalEpipolarDistanceError>
+                        (
+                            F_lr,
+                            iterIntrinsicL->second.get(),
+                            regionsPerView.getRegions(it->first, descType),
+                            iterIntrinsicR->second.get(),
+                            regionsPerView.getRegions(it->second, descType),
+                            // descType,
+                            Square(thresholdF), Square(0.8),
+                            matches
+                        );
+#else
+                        const Vec3 epipole2  = epipole_from_P(P_R, poseL);
 
-        //const feature::Regions& regions = regionsPerView.getRegions(it->first);
-        matching::guidedMatchingFundamentalFast<multiview::relativePose::FundamentalEpipolarDistanceError>
-          (
-            F_lr,
-            epipole2,
-            iterIntrinsicL->second.get(),
-            regionsPerView.getRegions(it->first, descType),
-            iterIntrinsicR->second.get(),
-            regionsPerView.getRegions(it->second, descType),
-            iterIntrinsicR->second->w(), iterIntrinsicR->second->h(),
-            //descType,
-            Square(geometricErrorMax), Square(0.8),
-            matches
-          );
-      #endif
-         allImagePairMatches[descType] = matches;
-      }
+                        //const feature::Regions& regions = regionsPerView.getRegions(it->first);
+                        matching::guidedMatchingFundamentalFast<multiview::relativePose::FundamentalEpipolarDistanceError>
+                        (
+                            F_lr,
+                            epipole2,
+                            iterIntrinsicL->second.get(),
+                            regionsPerView.getRegions(it->first, descType),
+                            iterIntrinsicR->second.get(),
+                            regionsPerView.getRegions(it->second, descType),
+                            iterIntrinsicR->second->w(), iterIntrinsicR->second->h(),
+                            //descType,
+                            Square(geometricErrorMax), Square(0.8),
+                            matches
+                        );
+#endif
+                        allImagePairMatches[descType] = matches;
+                    }
 
-      #pragma omp critical
-      {
-        ++progressDisplay;
-        _putativeMatches[*it] = allImagePairMatches;
-      }
-    }
-    }
-  }
+                    ++progressDisplay;
+                    {
+                        std::lock_guard<std::mutex> lock{matchesMutex};
+                        _putativeMatches[*it] = allImagePairMatches;
+                    }
+                }
+            });
+        }
+    });
 }
 
 /// Filter inconsistent correspondences by using 3-view correspondences on view triplets
@@ -183,79 +186,82 @@ void StructureEstimationFromKnownPoses::filter(
 
   auto progressDisplay = system::createConsoleProgressDisplay(triplets.size(), std::cout,
     "Per triplet tracks validation (discard spurious correspondences):\n" );
-  #pragma omp parallel
-  for( Triplets::const_iterator it = triplets.begin(); it != triplets.end(); ++it)
-  {
-    #pragma omp single nowait
+
+    std::mutex tripleMatchesMutex;
+    system::parallelLoop([&](auto& manager)
     {
-      ++progressDisplay;
-
-      const graph::Triplet & triplet = *it;
-      const IndexT I = triplet.i, J = triplet.j , K = triplet.k;
-
-      track::TracksMap map_tracksCommon;
-      track::TracksBuilder tracksBuilder;
-      {
-        matching::PairwiseMatches map_matchesIJK;
-        if (_putativeMatches.count(std::make_pair(I,J)))
-          map_matchesIJK.insert(*_putativeMatches.find(std::make_pair(I,J)));
-
-        if (_putativeMatches.count(std::make_pair(I,K)))
-          map_matchesIJK.insert(*_putativeMatches.find(std::make_pair(I,K)));
-
-        if (_putativeMatches.count(std::make_pair(J,K)))
-          map_matchesIJK.insert(*_putativeMatches.find(std::make_pair(J,K)));
-
-        if (map_matchesIJK.size() >= 2) {
-          tracksBuilder.build(map_matchesIJK);
-          tracksBuilder.filter(true,3, false);
-          tracksBuilder.exportToSTL(map_tracksCommon);
-        }
-
-        // Triangulate the tracks
-        for (track::TracksMap::const_iterator iterTracks = map_tracksCommon.begin();
-          iterTracks != map_tracksCommon.end(); ++iterTracks) {
-          {
-            const track::Track & subTrack = iterTracks->second;
-            multiview::Triangulation trianObj;
-            for (auto iter = subTrack.featPerView.begin(); iter != subTrack.featPerView.end(); ++iter)
+        for (Triplets::const_iterator it = triplets.begin(); it != triplets.end(); ++it)
+        {
+            manager.submit([&, it]
             {
-              const size_t imaIndex = iter->first;
-              const size_t featIndex = iter->second;
-              const View * view = sfmData.getViews().at(imaIndex).get();
-              
-              std::shared_ptr<camera::IntrinsicBase> cam = sfmData.getIntrinsics().at(view->getIntrinsicId());
-              std::shared_ptr<camera::Pinhole> camPinHole = std::dynamic_pointer_cast<camera::Pinhole>(cam);
-              if (!camPinHole) {
-                ALICEVISION_LOG_ERROR("Camera is not pinhole in filter");
-                continue;
-              }
+                ++progressDisplay;
 
-              const Pose3 pose = sfmData.getPose(*view).getTransform();
-              const Vec2 pt = regionsPerView.getRegions(imaIndex, subTrack.descType).GetRegionPosition(featIndex);
-              trianObj.add(camPinHole->getProjectiveEquivalent(pose), cam->get_ud_pixel(pt));
-            }
-            const Vec3 Xs = trianObj.compute();
-            if (trianObj.minDepth() > 0 && trianObj.error()/(double)trianObj.size() < 4.0)
-            // TODO: Add an angular check ?
-            {
-              #pragma omp critical
-              {
-                track::Track::FeatureIdPerView::const_iterator iterI, iterJ, iterK;
-                iterI = iterJ = iterK = subTrack.featPerView.begin();
-                std::advance(iterJ,1);
-                std::advance(iterK,2);
+                const graph::Triplet & triplet = *it;
+                const IndexT I = triplet.i, J = triplet.j , K = triplet.k;
 
-                _tripletMatches[std::make_pair(I,J)][subTrack.descType].emplace_back(iterI->second, iterJ->second);
-                _tripletMatches[std::make_pair(J,K)][subTrack.descType].emplace_back(iterJ->second, iterK->second);
-                _tripletMatches[std::make_pair(I,K)][subTrack.descType].emplace_back(iterI->second, iterK->second);
-              }
-            }
-          }
+                track::TracksMap map_tracksCommon;
+                track::TracksBuilder tracksBuilder;
+                {
+                    matching::PairwiseMatches map_matchesIJK;
+                    if (_putativeMatches.count(std::make_pair(I,J)))
+                        map_matchesIJK.insert(*_putativeMatches.find(std::make_pair(I,J)));
+
+                    if (_putativeMatches.count(std::make_pair(I,K)))
+                        map_matchesIJK.insert(*_putativeMatches.find(std::make_pair(I,K)));
+
+                    if (_putativeMatches.count(std::make_pair(J,K)))
+                        map_matchesIJK.insert(*_putativeMatches.find(std::make_pair(J,K)));
+
+                    if (map_matchesIJK.size() >= 2) {
+                        tracksBuilder.build(map_matchesIJK);
+                        tracksBuilder.filter(true,3, false);
+                        tracksBuilder.exportToSTL(map_tracksCommon);
+                    }
+
+                    // Triangulate the tracks
+                    for (track::TracksMap::const_iterator iterTracks = map_tracksCommon.begin();
+                         iterTracks != map_tracksCommon.end(); ++iterTracks) {
+                        {
+                            const track::Track & subTrack = iterTracks->second;
+                            multiview::Triangulation trianObj;
+                            for (auto iter = subTrack.featPerView.begin(); iter != subTrack.featPerView.end(); ++iter)
+                            {
+                                const size_t imaIndex = iter->first;
+                                const size_t featIndex = iter->second;
+                                const View * view = sfmData.getViews().at(imaIndex).get();
+
+                                std::shared_ptr<camera::IntrinsicBase> cam = sfmData.getIntrinsics().at(view->getIntrinsicId());
+                                std::shared_ptr<camera::Pinhole> camPinHole = std::dynamic_pointer_cast<camera::Pinhole>(cam);
+                                if (!camPinHole) {
+                                    ALICEVISION_LOG_ERROR("Camera is not pinhole in filter");
+                                    continue;
+                                }
+
+                                const Pose3 pose = sfmData.getPose(*view).getTransform();
+                                const Vec2 pt = regionsPerView.getRegions(imaIndex, subTrack.descType).GetRegionPosition(featIndex);
+                                trianObj.add(camPinHole->getProjectiveEquivalent(pose), cam->get_ud_pixel(pt));
+                            }
+                            const Vec3 Xs = trianObj.compute();
+                            if (trianObj.minDepth() > 0 && trianObj.error()/(double)trianObj.size() < 4.0)
+                            // TODO: Add an angular check ?
+                            {
+                                std::lock_guard<std::mutex> lock{tripleMatchesMutex};
+                                track::Track::FeatureIdPerView::const_iterator iterI, iterJ, iterK;
+                                iterI = iterJ = iterK = subTrack.featPerView.begin();
+                                std::advance(iterJ,1);
+                                std::advance(iterK,2);
+
+                                _tripletMatches[std::make_pair(I,J)][subTrack.descType].emplace_back(iterI->second, iterJ->second);
+                                _tripletMatches[std::make_pair(J,K)][subTrack.descType].emplace_back(iterJ->second, iterK->second);
+                                _tripletMatches[std::make_pair(I,K)][subTrack.descType].emplace_back(iterI->second, iterK->second);
+                            }
+                        }
+                    }
+                }
+            });
         }
-      }
-    }
-  }
+    });
+
   // Clear putatives matches since they are no longer required
   matching::PairwiseMatches().swap(_putativeMatches);
 }

--- a/src/aliceVision/sfmData/colorize.cpp
+++ b/src/aliceVision/sfmData/colorize.cpp
@@ -6,7 +6,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "colorize.hpp"
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/stl/indexedSort.hpp>
 #include <aliceVision/stl/mapUtils.hpp>

--- a/src/aliceVision/sfmData/colorize.cpp
+++ b/src/aliceVision/sfmData/colorize.cpp
@@ -11,6 +11,7 @@
 #include <aliceVision/stl/indexedSort.hpp>
 #include <aliceVision/stl/mapUtils.hpp>
 #include <aliceVision/image/io.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 
 #include <map>
@@ -99,8 +100,7 @@ void colorizeTracks(SfMData& sfmData)
   std::shuffle(unsortedIndexes.begin(), unsortedIndexes.end(), rng);
 
   // landmark colorization
-#pragma omp parallel for
-  for(int i = 0; i < unsortedIndexes.size(); ++i)
+  system::parallelFor<int>(0, unsortedIndexes.size(), [&](int i)
   {
     const ViewInfo& viewCardinal = sortedViewsCardinal.at(unsortedIndexes.at(i));
     if(!viewCardinal.landmarks.empty())
@@ -121,7 +121,7 @@ void colorizeTracks(SfMData& sfmData)
 
       progressDisplay += viewCardinal.landmarks.size();
     }
-  }
+  });
 }
 
 } // namespace sfm

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -7,6 +7,7 @@
 #include "jsonIO.hpp"
 #include <aliceVision/camera/camera.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 
@@ -568,8 +569,7 @@ bool loadJSON(sfmData::SfMData& sfmData, const std::string& filename, ESfMData p
       }
 
       // update incomplete views
-      #pragma omp parallel for
-      for(int i = 0; i < incompleteViews.size(); ++i)
+      system::parallelFor<int>(0, incompleteViews.size(), [&](int i)
       {
         sfmData::View& v = incompleteViews.at(i);
 
@@ -591,7 +591,7 @@ bool loadJSON(sfmData::SfMData& sfmData, const std::string& filename, ESfMData p
           v.setHeight(intrinsics->h());
         }
         updateIncompleteView(incompleteViews.at(i), viewIdMethod, viewIdRegex);
-      }
+      });
 
       // copy complete views in the SfMData views map
       for(const sfmData::View& view : incompleteViews)

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -6,6 +6,10 @@ set(system_files_headers
   system.hpp
   Timer.hpp
   Logger.hpp
+  ParallelFor.hpp
+  ParallelismBackend.hpp
+  ParallelismBackendOpenMP.hpp
+  ParallelSettings.hpp
   ProgressDisplay.hpp
   nvtx.hpp
 )
@@ -16,6 +20,8 @@ set(system_files_sources
   MemoryInfo.cpp
   Timer.cpp
   Logger.cpp
+  ParallelismBackend.cpp
+  ParallelismBackendOpenMP.cpp
   ProgressDisplay.cpp
   nvtx.cpp
 )

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -1,3 +1,10 @@
+if(ALICEVISION_HAVE_TBB)
+  set(system_files_headers_tbb ParallelismBackendTBB.hpp)
+  set(system_files_sources_tbb ParallelismBackendTBB.cpp)
+  set(system_tbb_library TBB::tbb)
+  set(system_tbb_definitions "-DALICEVISION_HAVE_TBB=1")
+endif()
+
 # Headers
 set(system_files_headers
   cpu.hpp
@@ -9,6 +16,7 @@ set(system_files_headers
   ParallelFor.hpp
   ParallelismBackend.hpp
   ParallelismBackendOpenMP.hpp
+  ${system_files_headers_tbb}
   ParallelSettings.hpp
   ProgressDisplay.hpp
   nvtx.hpp
@@ -22,6 +30,7 @@ set(system_files_sources
   Logger.cpp
   ParallelismBackend.cpp
   ParallelismBackendOpenMP.cpp
+  ${system_files_sources_tbb}
   ProgressDisplay.cpp
   nvtx.cpp
 )
@@ -38,6 +47,9 @@ alicevision_add_library(aliceVision_system
     ${ALICEVISION_NVTX_LIBRARY}
   PRIVATE_LINKS
     Boost::boost
+    ${system_tbb_library}
+  PRIVATE_DEFINITIONS
+    ${system_tbb_definitions}
 )
 
 alicevision_add_test(Logger_test.cpp NAME "system_Logger" LINKS aliceVision_system)

--- a/src/aliceVision/system/ParallelFor.hpp
+++ b/src/aliceVision/system/ParallelFor.hpp
@@ -1,0 +1,121 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ParallelSettings.hpp"
+#include "ParallelismBackend.hpp"
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <functional>
+#include <type_traits>
+
+namespace aliceVision {
+namespace system {
+
+void parallelForImpl(std::int64_t lowerBound, std::int64_t upperBound,
+                     ParallelSettings settings, const std::function<void(std::int64_t)>& callback);
+
+template<class Integral, class F>
+void parallelBlockedFor(Integral lowerBound, Integral upperBound, ParallelSettings settings,
+                        F&& callback)
+{
+    static_assert(std::is_integral<Integral>::value, "Range must be of an integral type");
+    static_assert(!(std::is_unsigned<Integral>::value && sizeof(Integral) >= sizeof(std::int64_t)),
+                  "std::uint64_t and similar large unsigned types are not supported for iteration");
+
+    getCurrentParallelismBackend().parallelFor(lowerBound, upperBound, settings,
+                                               [&](std::int64_t lowerBound, std::int64_t upperBound,
+                                                   int threadNumberInTeam)
+    {
+        callback(static_cast<Integral>(lowerBound), static_cast<Integral>(upperBound));
+    });
+}
+
+template<class Integral, class F>
+void parallelBlockedFor(Integral lowerBound, Integral upperBound, F&& callback)
+{
+    parallelBlockedFor(lowerBound, upperBound, ParallelSettings(), callback);
+}
+
+template<class Integral, class F>
+void parallelFor(Integral lowerBound, Integral upperBound, ParallelSettings settings, F&& callback)
+{
+    parallelBlockedFor(lowerBound, upperBound, settings,
+                       [&](Integral lowerBound, Integral upperBound)
+    {
+        for (Integral i = lowerBound; i < upperBound; ++i)
+        {
+            callback(static_cast<Integral>(i));
+        }
+    });
+}
+
+template<class Integral, class F>
+void parallelFor(Integral lowerBound, Integral upperBound, F&& callback)
+{
+    parallelFor(lowerBound, upperBound, ParallelSettings(), callback);
+}
+
+template<class Integral, class Array, class F>
+void parallelForWithPerThreadData(Integral lowerBound, Integral upperBound, Array& perThreadArray,
+                                  ParallelSettings settings, F&& callback)
+{
+    static_assert(std::is_integral<Integral>::value, "Range must be of an integral type");
+    static_assert(!(std::is_unsigned<Integral>::value && sizeof(Integral) >= sizeof(std::int64_t)),
+                  "std::uint64_t and similar large unsigned types are not supported for iteration");
+
+    getCurrentParallelismBackend().parallelFor(lowerBound, upperBound, settings,
+                                               [&](std::int64_t lowerBound, std::int64_t upperBound,
+                                                   int threadNumberInTeam)
+    {
+        auto& perThreadData = perThreadArray[threadNumberInTeam];
+        for (std::int64_t i = lowerBound; i < upperBound; ++i)
+        {
+            callback(static_cast<Integral>(i), perThreadData);
+        }
+    });
+}
+
+/** This is a more flexible parallel loop implementation which can work on any iterable.
+    It is not specified whether the loop iteration is performed by one or more threads, except that
+    any functions submitted to IParallelLoopManager::submit() are executed once for each iteration
+    of the loop.
+
+    The intended usage is as follows:
+
+    parallelLoop([&](IParallelLoopManager& mgr)
+    {
+        for (auto it = container.begin(); it != container.end(); ++it)
+        {
+            // note that iterator must be copied
+            mgr.submit([it, &]()
+            {
+                // do stuff
+            });
+        }
+    }
+*/
+inline void parallelLoop(ParallelSettings settings,
+                         const std::function<void(IParallelLoopManager&)>& callback)
+{
+    getCurrentParallelismBackend().parallelLoop(settings, callback);
+}
+
+inline void parallelLoop(const std::function<void(IParallelLoopManager&)>& callback)
+{
+    parallelLoop(ParallelSettings(), callback);
+}
+
+inline int getMaxParallelThreadCount()
+{
+    return getCurrentParallelismBackend().getMaxThreadCount();
+}
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ParallelSettings.hpp
+++ b/src/aliceVision/system/ParallelSettings.hpp
@@ -1,0 +1,58 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+namespace aliceVision {
+namespace system {
+
+class ParallelSettings {
+public:
+    static constexpr unsigned ANY_THREAD_COUNT = 0;
+
+    ParallelSettings() = default;
+
+    ParallelSettings& setThreadCount(unsigned count)
+    {
+        _threadCount = count;
+        return *this;
+    }
+
+    // Corresponds to #pragma omp parallel for schedule(dynamic)
+    // TODO: this may be eventually be removed once parallelFor supports nested loops natively
+    // better.
+    ParallelSettings& setDynamicScheduling()
+    {
+        _isDynamic = true;
+        return *this;
+    }
+
+    ParallelSettings& setEnableMultithreading(bool enable)
+    {
+        _enableMultithreading = enable;
+        return *this;
+    }
+
+    ParallelSettings& setEnableNested(bool enable)
+    {
+        _enableNested = enable;
+        return *this;
+    }
+
+    bool isDynamicScheduling() const { return _isDynamic; }
+    unsigned threadCount() const { return _threadCount; }
+    bool enableMultithreading() const { return _enableMultithreading; }
+    bool isNestedEnabled() const { return _enableNested; }
+
+private:
+    unsigned _threadCount = ANY_THREAD_COUNT;
+    bool _isDynamic = false;
+    bool _enableMultithreading = true;
+    bool _enableNested = false;
+};
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ParallelismBackend.cpp
+++ b/src/aliceVision/system/ParallelismBackend.cpp
@@ -1,0 +1,42 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ParallelFor.hpp"
+#include "ParallelismBackendOpenMP.hpp"
+
+#if ALICEVISION_HAVE_TBB
+#include "ParallelismBackendTBB.hpp"
+#endif
+
+namespace aliceVision {
+namespace system {
+
+IParallelLoopManager::~IParallelLoopManager() = default;
+
+ParallelLoopManagerSingleThread::ParallelLoopManagerSingleThread() = default;
+ParallelLoopManagerSingleThread::~ParallelLoopManagerSingleThread() = default;
+
+void ParallelLoopManagerSingleThread::submit(const std::function<void()>& callback)
+{
+    callback();
+}
+
+IParallelismBackend::~IParallelismBackend() = default;
+
+IParallelismBackend& getCurrentParallelismBackend()
+{
+#if ALICEVISION_HAVE_TBB
+    static tbb::task_arena taskArena;
+    static ParallelismBackendTBB backend{taskArena};
+    return backend;
+#else
+    static ParallelismBackendOpenMP backend;
+    return backend;
+#endif
+}
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ParallelismBackend.hpp
+++ b/src/aliceVision/system/ParallelismBackend.hpp
@@ -1,0 +1,54 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ParallelSettings.hpp"
+#include <functional>
+#include <memory>
+
+namespace aliceVision {
+namespace system {
+
+class IParallelLoopManager
+{
+public:
+    virtual ~IParallelLoopManager();
+    virtual void submit(const std::function<void()>& callback) = 0;
+};
+
+class ParallelLoopManagerSingleThread : public IParallelLoopManager
+{
+public:
+    ParallelLoopManagerSingleThread();
+    ~ParallelLoopManagerSingleThread() override;
+
+    void submit(const std::function<void()>& callback) override;
+};
+
+
+class IParallelismBackend
+{
+public:
+    // lower bound, upper bound, thread number in team
+    using ParallelForCallback = std::function<void (std::int64_t, std::int64_t, int)>;
+
+    virtual ~IParallelismBackend();
+
+    virtual void parallelFor(std::int64_t lowerBound, std::int64_t upperBound,
+                             ParallelSettings settings,
+                             const ParallelForCallback& callback) = 0;
+
+    virtual void parallelLoop(ParallelSettings settings,
+                              const std::function<void(IParallelLoopManager&)>& callback) = 0;
+
+    virtual int getMaxThreadCount() const = 0;
+};
+
+IParallelismBackend& getCurrentParallelismBackend();
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ParallelismBackendOpenMP.cpp
+++ b/src/aliceVision/system/ParallelismBackendOpenMP.cpp
@@ -1,0 +1,132 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ParallelismBackendOpenMP.hpp"
+#include <aliceVision/alicevision_omp.hpp>
+#include <algorithm>
+#include <stdexcept>
+
+namespace aliceVision {
+namespace system {
+
+ParallelLoopManagerOpenMP::ParallelLoopManagerOpenMP() = default;
+
+ParallelLoopManagerOpenMP::~ParallelLoopManagerOpenMP() = default;
+
+void ParallelLoopManagerOpenMP::submit(const std::function<void()>& callback)
+{
+#pragma omp single nowait
+    callback();
+}
+
+ParallelismBackendOpenMP::~ParallelismBackendOpenMP() = default;
+
+void ParallelismBackendOpenMP::parallelFor(std::int64_t lowerBound, std::int64_t upperBound,
+                                           ParallelSettings settings,
+                                           const ParallelForCallback& callback)
+{
+    if (!settings.enableMultithreading())
+    {
+        callback(lowerBound, upperBound, 0);
+        return;
+    }
+
+#define PARALLEL_FOR_LOOP_BODY                                                                  \
+    for (int i = 0; i < blockCount; ++i)                                                        \
+    {                                                                                           \
+        auto blockLowerBound = lowerBound + static_cast<std::int64_t>(itemsPerBlock * i);       \
+        auto blockUpperBound = lowerBound + static_cast<std::int64_t>(itemsPerBlock * (i + 1)); \
+        if (i == blockCount - 1) {                                                              \
+            blockUpperBound = upperBound;                                                       \
+        }                                                                                       \
+        callback(blockLowerBound, blockUpperBound, omp_get_thread_num());                       \
+    }
+
+    bool anyThreadCount = settings.threadCount() == ParallelSettings::ANY_THREAD_COUNT;
+
+    std::int64_t maxBlockCount = upperBound - lowerBound;
+    int blockCount = anyThreadCount
+            ? omp_get_max_threads()
+            : std::min<int>(omp_get_max_threads(), settings.threadCount());
+
+    if (settings.isNestedEnabled())
+    {
+        omp_set_nested(1);
+    }
+
+    if (settings.isDynamicScheduling())
+    {
+        // Dynamic scheduling, the tasks difficulty varies, so they are scheduled dynamically.
+        // We achieve this by splitting each block of work items into 4 and letting OpenMP to
+        // do dynamic scheduling.
+        blockCount = std::min<std::int64_t>(maxBlockCount, blockCount * 4);
+        double itemsPerBlock = static_cast<double>(upperBound - lowerBound) / blockCount;
+
+        if (anyThreadCount)
+        {
+#pragma omp parallel for schedule(dynamic)
+            PARALLEL_FOR_LOOP_BODY
+        }
+        else
+        {
+#pragma omp parallel for schedule(dynamic) num_threads(settings.threadCount())
+            PARALLEL_FOR_LOOP_BODY
+        }
+    }
+    else
+    {
+        double itemsPerBlock = static_cast<double>(upperBound - lowerBound) / blockCount;
+        // Static scheduling, each thread gets the same amount of work items
+        if (anyThreadCount)
+        {
+#pragma omp parallel for
+            PARALLEL_FOR_LOOP_BODY
+        }
+        else
+        {
+#pragma omp parallel for num_threads(settings.threadCount())
+            PARALLEL_FOR_LOOP_BODY
+        }
+    }
+#undef PARALLEL_FOR_LOOP_BODY
+}
+
+void ParallelismBackendOpenMP::parallelLoop(ParallelSettings settings,
+                                            const std::function<void(IParallelLoopManager&)>& callback)
+{
+    if (!settings.enableMultithreading())
+    {
+        ParallelLoopManagerSingleThread manager;
+        callback(manager);
+        return;
+    }
+
+    ParallelLoopManagerOpenMP manager;
+    if (settings.isDynamicScheduling())
+    {
+        throw std::invalid_argument("Dynamic scheduling is not supported in parallelLoop()");
+    }
+
+    bool anyThreadCount = settings.threadCount() == ParallelSettings::ANY_THREAD_COUNT;
+    if (anyThreadCount)
+    {
+#pragma omp parallel
+        callback(manager);
+    }
+    else
+    {
+#pragma omp parallel num_threads(settings.threadCount())
+        callback(manager);
+    }
+}
+
+int ParallelismBackendOpenMP::getMaxThreadCount() const
+{
+    return omp_get_max_threads();
+}
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ParallelismBackendOpenMP.hpp
+++ b/src/aliceVision/system/ParallelismBackendOpenMP.hpp
@@ -1,0 +1,39 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ParallelismBackend.hpp"
+
+namespace aliceVision {
+namespace system {
+
+class ParallelLoopManagerOpenMP : public IParallelLoopManager
+{
+public:
+    ParallelLoopManagerOpenMP();
+    ~ParallelLoopManagerOpenMP() override;
+
+    void submit(const std::function<void()>& callback) override;
+};
+
+class ParallelismBackendOpenMP : public IParallelismBackend
+{
+public:
+    ~ParallelismBackendOpenMP() override;
+
+    void parallelFor(std::int64_t lowerBound, std::int64_t upperBound,
+                     ParallelSettings settings,
+                     const ParallelForCallback& callback) override;
+
+    void parallelLoop(ParallelSettings settings,
+                      const std::function<void(IParallelLoopManager&)>& callback) override;
+
+    int getMaxThreadCount() const override;
+};
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ParallelismBackendTBB.cpp
+++ b/src/aliceVision/system/ParallelismBackendTBB.cpp
@@ -1,0 +1,173 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ParallelismBackendTBB.hpp"
+#include <mutex>
+#include <stdexcept>
+
+namespace aliceVision {
+namespace system {
+
+ParallelLoopManagerTBB::ParallelLoopManagerTBB(std::atomic<std::int64_t>* sharedCounter) :
+    _sharedCounter{sharedCounter}
+{
+}
+
+ParallelLoopManagerTBB::~ParallelLoopManagerTBB() = default;
+
+void ParallelLoopManagerTBB::submit(const std::function<void()>& callback)
+{
+    // Note that there are no dependent memory operations, thus relaxed ordering is fine.
+    auto sharedCounterValue = _sharedCounter->load(std::memory_order_relaxed);
+    if (_thisThreadCounter < sharedCounterValue)
+    {
+        // Current thread is catching up
+        _thisThreadCounter++;
+        return;
+    }
+
+    // The current thread has made farthest progress and could take a task by increasing the
+    // shared counter.
+    while (!_sharedCounter->compare_exchange_weak(sharedCounterValue, sharedCounterValue + 1,
+                                                  std::memory_order_relaxed,
+                                                  std::memory_order_relaxed))
+    {
+        if (_thisThreadCounter < sharedCounterValue)
+        {
+            // Another thread increased the shared counter in the mean time, which means the
+            // current thread is catching up again.
+            _thisThreadCounter++;
+            return;
+        }
+    }
+
+    // _sharedCounter has been successfully incremented, do the work
+    _thisThreadCounter++;
+    callback();
+}
+
+ParallelismBackendTBB::ParallelismBackendTBB(tbb::task_arena& taskArena) :
+    _taskArena{taskArena}
+{}
+
+ParallelismBackendTBB::~ParallelismBackendTBB() = default;
+
+void ParallelismBackendTBB::parallelFor(std::int64_t lowerBound, std::int64_t upperBound,
+                                        ParallelSettings settings,
+                                        const ParallelForCallback& callback)
+{
+    if (!settings.enableMultithreading())
+    {
+        callback(lowerBound, upperBound, 0);
+        return;
+    }
+
+
+#define PARALLEL_FOR_LOOP_BODY                                                                  \
+    for (int i = 0; i < blockCount; ++i)                                                        \
+    {                                                                                           \
+        auto blockLowerBound = lowerBound + static_cast<std::int64_t>(itemsPerBlock * i);       \
+        auto blockUpperBound = lowerBound + static_cast<std::int64_t>(itemsPerBlock * (i + 1)); \
+        if (i == blockCount - 1) {                                                              \
+            blockUpperBound = upperBound;                                                       \
+        }                                                                                       \
+        callback(blockLowerBound, blockUpperBound, omp_get_thread_num());                       \
+    }
+
+    bool anyThreadCount = settings.threadCount() == ParallelSettings::ANY_THREAD_COUNT;
+
+    std::int64_t maxBlockCount = upperBound - lowerBound;
+    int blockCount = anyThreadCount
+            ? _taskArena.max_concurrency()
+            : std::min<int>(_taskArena.max_concurrency(), settings.threadCount());
+
+    if (settings.isDynamicScheduling())
+    {
+        // Dynamic scheduling, the tasks difficulty varies, so they are scheduled dynamically.
+        // We achieve this by splitting each block of work items into 4 and letting TBB to
+        // do dynamic scheduling.
+        blockCount = std::min<std::int64_t>(maxBlockCount, blockCount * 4);
+    }
+    double itemsPerBlock = static_cast<double>(upperBound - lowerBound) / blockCount;
+
+    tbb::task_group group;
+
+    for (int i = 0; i < blockCount; ++i)
+    {
+        // Note that we use enqueue() on task_arena and defer() on task_group instead of just
+        // calling run() on task_group which would be the most obvious choice. This is because
+        // the call group.wait() below confusingly will wait not just for this task group, but
+        // also other active task groups. Using enqueue() avoids this problem.
+        _taskArena.enqueue(group.defer([&, i]()
+        {
+            auto blockLowerBound = lowerBound + static_cast<std::int64_t>(itemsPerBlock * i);
+            auto blockUpperBound = lowerBound + static_cast<std::int64_t>(itemsPerBlock * (i + 1));
+            if (i == blockCount - 1) {
+                blockUpperBound = upperBound;
+            }
+            callback(blockLowerBound, blockUpperBound,
+                     tbb::this_task_arena::current_thread_index());
+        }));
+    }
+    group.wait();
+}
+
+void ParallelismBackendTBB::parallelLoop(ParallelSettings settings,
+                                         const std::function<void(IParallelLoopManager&)>& callback)
+{
+    if (!settings.enableMultithreading())
+    {
+        ParallelLoopManagerSingleThread manager;
+        callback(manager);
+        return;
+    }
+
+    if (settings.isDynamicScheduling())
+    {
+        throw std::invalid_argument("Dynamic scheduling is not supported in parallelLoop()");
+    }
+
+    // This will be shared with other threads. Add padding to avoid false sharing.
+    constexpr int cacheLineSize = 128;
+    struct {
+        char pad0[cacheLineSize];
+        std::atomic<std::int64_t> sharedCounter;
+        char pad1[cacheLineSize];
+    } sharedCounterStorage;
+
+    sharedCounterStorage.sharedCounter = 0;
+
+    bool anyThreadCount = settings.threadCount() == ParallelSettings::ANY_THREAD_COUNT;
+    int threadCount = anyThreadCount
+            ? _taskArena.max_concurrency()
+            : std::min<int>(settings.threadCount(), _taskArena.max_concurrency());
+
+    std::vector<ParallelLoopManagerTBB> loopManagers;
+    loopManagers.reserve(threadCount);
+    for (int i = 0; i < threadCount; ++i)
+    {
+        loopManagers.emplace_back(&sharedCounterStorage.sharedCounter);
+    }
+
+    tbb::task_group group;
+    for (int i = 0; i < threadCount; ++i)
+    {
+        // See note near _taskArena.enqueue call in parallelFor()
+        _taskArena.enqueue(group.defer([&, i]()
+        {
+            callback(loopManagers[i]);
+        }));
+    }
+    group.wait();
+}
+
+int ParallelismBackendTBB::getMaxThreadCount() const
+{
+    return _taskArena.max_concurrency();
+}
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/system/ParallelismBackendTBB.hpp
+++ b/src/aliceVision/system/ParallelismBackendTBB.hpp
@@ -1,0 +1,54 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ParallelismBackend.hpp"
+#include <tbb/tbb.h>
+#include <tbb/task_arena.h>
+#include <atomic>
+
+namespace aliceVision {
+namespace system {
+
+constexpr int CACHE_LINE_SIZE = 128;
+
+class ParallelLoopManagerTBB : public IParallelLoopManager
+{
+public:
+    ParallelLoopManagerTBB(std::atomic<std::int64_t>* sharedCounter);
+    ~ParallelLoopManagerTBB() override;
+
+    void submit(const std::function<void()>& callback) override;
+private:
+    std::atomic<std::int64_t>* _sharedCounter = nullptr;
+    std::int64_t _thisThreadCounter = 0;
+
+    // Avoid false sharing with _thisThreadCounter of other threads.
+    char pad[CACHE_LINE_SIZE - sizeof(_sharedCounter) - sizeof(_thisThreadCounter)];
+};
+
+class ParallelismBackendTBB : public IParallelismBackend
+{
+public:
+    ParallelismBackendTBB(tbb::task_arena& taskArena);
+    ~ParallelismBackendTBB() override;
+
+    void parallelFor(std::int64_t lowerBound, std::int64_t upperBound,
+                     ParallelSettings settings,
+                     const ParallelForCallback& callback) override;
+
+    void parallelLoop(ParallelSettings settings,
+                      const std::function<void(IParallelLoopManager&)>& callback) override;
+
+    int getMaxThreadCount() const override;
+
+private:
+    tbb::task_arena& _taskArena;
+};
+
+} // namespace system
+} // namespace aliceVision

--- a/src/aliceVision/track/tracksUtils.cpp
+++ b/src/aliceVision/track/tracksUtils.cpp
@@ -7,6 +7,7 @@
 
 #include "tracksUtils.hpp"
 
+#include <aliceVision/system/ParallelFor.hpp>
 #include <iterator>
 
 
@@ -185,13 +186,12 @@ void computeTracksPerView(const TracksMap& tracks, TracksPerView& tracksPerView)
   }
 
   // sort tracks Ids in each view
-#pragma omp parallel for
-  for(int i = 0; i < tracksPerView.size(); ++i)
+  system::parallelFor<int>(0, tracksPerView.size(), [&](int i)
   {
     TracksPerView::iterator it = tracksPerView.begin();
     std::advance(it, i);
     std::sort(it->second.begin(), it->second.end());
-  }
+  });
 }
 
 void getTracksIdVector(const TracksMap& tracks,

--- a/src/aliceVision/voctree/Database.cpp
+++ b/src/aliceVision/voctree/Database.cpp
@@ -82,7 +82,6 @@ void Database::sanityCheck(std::size_t N, std::map<std::size_t, DocMatches>& mat
   // query allocate the whole memory
   auto display = system::createConsoleProgressDisplay(database_.size(), std::cout);
   
-  //#pragma omp parallel for default(none) shared(database_)
   for(const auto &doc : database_)
   {
     std::vector<DocMatch> m;

--- a/src/aliceVision/voctree/SimpleKmeans.hpp
+++ b/src/aliceVision/voctree/SimpleKmeans.hpp
@@ -9,7 +9,6 @@
 #include "distance.hpp"
 #include "DefaultAllocator.hpp"
 
-#include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ParallelFor.hpp>
 

--- a/src/aliceVision/voctree/VocabularyTree.hpp
+++ b/src/aliceVision/voctree/VocabularyTree.hpp
@@ -15,6 +15,7 @@
 
 #include <aliceVision/types.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 #include <stdint.h>
 #include <vector>
@@ -230,12 +231,11 @@ std::vector<Word> VocabularyTree<Feature, Distance, FeatureAllocator>::quantize(
   std::vector<Word> imgVisualWords(features.size(), 0);
 
   // quantize the features
-  #pragma omp parallel for
-  for(ptrdiff_t j = 0; j < static_cast<ptrdiff_t>(features.size()); ++j)
+  system::parallelFor<std::ptrdiff_t>(0, features.size(), [&](std::ptrdiff_t j)
   {
     // store the visual word associated to the feature in the temporary list
     imgVisualWords[j] = quantize<DescriptorT>(features[j]);
-  }
+  });
 
   // add the vector to the documents
   return imgVisualWords;

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -7,6 +7,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/AlembicExporter.hpp>
@@ -283,8 +284,7 @@ int aliceVision_main(int argc, char** argv)
           // UV Map: Undistort
           {
               // flip and normalize as UVMap
-    #pragma omp parallel for
-              for(int y = 0; y < int(intrinsic.h()); ++y)
+              system::parallelFor<int>(0, intrinsic.h(), [&](int y)
               {
                   for(int x = 0; x < int(intrinsic.w()); ++x)
                   {
@@ -295,7 +295,7 @@ int aliceVision_main(int argc, char** argv)
                       image_dist(y, x).r() = float((disto_pix[0]) / (intrinsic.w() - 1));
                       image_dist(y, x).g() = float((intrinsic.h() - 1 - disto_pix[1]) / (intrinsic.h() - 1));
                   }
-              }
+              });
 
               const std::string dstImage =
                   (undistortedImagesFolderPath / (std::to_string(intrinsicPair.first) + "_UVMap_Undistort." +
@@ -306,8 +306,7 @@ int aliceVision_main(int argc, char** argv)
           // UV Map: Distort
           {
               // flip and normalize as UVMap
-    #pragma omp parallel for
-              for(int y = 0; y < int(intrinsic.h()); ++y)
+              system::parallelFor<int>(0, intrinsic.h(), [&](int y)
               {
                   for(int x = 0; x < int(intrinsic.w()); ++x)
                   {
@@ -318,7 +317,7 @@ int aliceVision_main(int argc, char** argv)
                       image_dist(y, x).r() = float((undisto_pix[0]) / (intrinsic.w() - 1));
                       image_dist(y, x).g() = float((intrinsic.h() - 1 - undisto_pix[1]) / (intrinsic.h() - 1));
                   }
-              }
+              });
 
               const std::string dstImage =
                   (undistortedImagesFolderPath / (std::to_string(intrinsicPair.first) + "_UVMap_Distort." +

--- a/src/software/pipeline/main_imageMasking.cpp
+++ b/src/software/pipeline/main_imageMasking.cpp
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
 
     bool useDepthMap = !depthMapExp.empty() || !depthMapFolder.empty();
 
-    // #pragma omp parallel for
+    // system::parallelFor(0, size, [&](int i)
     for(int i = 0; i < size; ++i)
     {
         const auto& item = std::next(viewPairItBegin, rangeStart + i);

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -20,6 +20,7 @@
 // System
 #include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 
 // Reading command line options
 #include <boost/program_options.hpp>
@@ -354,13 +355,12 @@ bool processImage(const PanoramaMap & panoramaMap, const std::string & composite
     oiio::ParamValueList srcMetadata = image::readImageMetadata(firstImagePath);
     colorSpace = srcMetadata.get_string("AliceVision:ColorSpace", "Linear");
 
-    #pragma omp parallel for
-    for (int posCurrent = 0; posCurrent < overlappingViews.size(); posCurrent++)
+    system::parallelFor<int>(0, overlappingViews.size(), [&](int posCurrent)
     {
         IndexT viewCurrent = overlappingViews[posCurrent];
         if (hasFailed)
         {
-            continue;
+            return;
         }
 
         ALICEVISION_LOG_INFO("Processing input " << posCurrent << "/" << overlappingViews.size());
@@ -370,12 +370,12 @@ bool processImage(const PanoramaMap & panoramaMap, const std::string & composite
         std::vector<BoundingBox> currentBoundingBoxes;
         if (!panoramaMap.getIntersectionsList(intersections, currentBoundingBoxes, referenceBoundingBox, viewCurrent))
         {
-            continue;
+            return;
         }
 
         if (intersections.empty())
         {
-            continue;
+            return;
         }
 
         ALICEVISION_LOG_TRACE("Effective processing");
@@ -450,7 +450,7 @@ bool processImage(const PanoramaMap & panoramaMap, const std::string & composite
                 continue;
             }
         }
-    }
+    });
 
     if (hasFailed) 
     {
@@ -717,7 +717,7 @@ int aliceVision_main(int argc, char** argv)
     if(maxThreads > 0)
         omp_set_num_threads(std::min(omp_get_max_threads(), maxThreads));
 
-    //#pragma omp parallel for
+    // system::parallelFor<std::int64_t>(0, chunk.size(), [&](std::size_t posReference)
     for (std::size_t posReference = 0; posReference < chunk.size(); posReference++)
     {
         ALICEVISION_LOG_INFO("processing input region " << posReference + 1 << "/" << chunk.size());

--- a/src/software/utils/main_voctreeCreation.cpp
+++ b/src/software/utils/main_voctreeCreation.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/voctree/descriptorLoader.hpp>
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/system/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
@@ -169,12 +170,12 @@ int aliceVision_main(int argc, char** argv)
     // allocate as many visual words as the number of the features in the image
     imgVisualWords.resize(descRead[i], 0);
 
-    #pragma omp parallel for
-    for(ptrdiff_t j = 0; j < static_cast<ptrdiff_t>(descRead[i]); ++j)
+    system::parallelFor<std::ptrdiff_t>(0, descRead[i], [&](std::ptrdiff_t j)
     {
       //	store the visual word associated to the feature in the temporary list
       imgVisualWords[j] = builder.tree().quantize(descriptors[ j + offset ]);
-    }
+    });
+
     aliceVision::voctree::SparseHistogram histo;
     aliceVision::voctree::computeSparseHistogram(imgVisualWords, histo);
     // add the vector to the documents

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -8,6 +8,7 @@
 #include "colorHarmonizeEngineGlobal.hpp"
 #include "software/utils/sfmHelper/sfmIOHelper.hpp"
 
+#include <aliceVision/system/ParallelFor.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
@@ -416,8 +417,7 @@ bool ColorHarmonizationEngineGlobal::Process()
     Image< RGBColor > image_c;
     readImage( _fileNames[ imaNum ], image_c , image::EImageColorSpace::LINEAR);
 
-    #pragma omp parallel for
-    for( int j = 0; j < image_c.Height(); ++j )
+    system::parallelFor(0, image_c.Height(), [&](int j)
     {
       for( int i = 0; i < image_c.Width(); ++i )
       {
@@ -425,7 +425,7 @@ bool ColorHarmonizationEngineGlobal::Process()
         image_c(j, i)[1] = clamp(vec_map_lut[1][image_c(j, i)[1]], 0., 255.);
         image_c(j, i)[2] = clamp(vec_map_lut[2][image_c(j, i)[2]], 0., 255.);
       }
-    }
+    });
 
     const std::string out_folder = (fs::path(_outputDirectory) / (vec_selectionMethod[ _selectionMethod ] + "_" + vec_harmonizeMethod[ harmonizeMethod ])).string();
     if(!fs::exists(out_folder))


### PR DESCRIPTION
Currently AliceVision uses OpenMP as the only multi-threading backend. This is problematic due to multiple reasons.

 - OpenMP support is not uniform among compilers. In particular, Apple mobile platforms do not support OpenMP. As a result, the performance of the algorithms is as much as 8 times lower than possible.

 - OpenMP critical sections are global. That is, all `#pragma omp critical` lock the same global mutex. As a consequence it is inefficient to run multiple instances of the same parallelized aliceVision algorithm because these instances will share the same mutex even though data races are possible only among threads running single instance of the algorithm. Ideally each instance would have its own mutex.

 - It is not possible to efficiently integrate third-party libraries that use another multi-threading framework because OpenMP assumes that it is the only user of the CPU. As a result, the CPU will be oversubscribed which leads to poor performance. Note that as currently used OpenMP will oversubscribe the CPU all by itself even right now if multiple instances of the same parallelized algorithm are invoked in parallel.

This PR takes inspiration from OpenCV to hide the usage of multi-threading framework behind an API. This will eventually allow supporting multiple multi-threading frameworks. For more details in how it works in OpenCV, see this [document](https://docs.opencv.org/4.x/de/d55/group__core__parallel__backend.html).

This PR implements the following:
 - Migrate off OpenMP synchronization primitives to standard mutexes, atomics and `boost::atomic_ref` (once we can use C++20 we can migrate to `std::atomic_ref`).
 - Move `pragma omp parallel` uses behind an interface exposing `system::parallelFor` and `system::parallelLoop` functions instead.
 - Implement support for multiple underlying multi-threading backends
 - Implement support for oneTBB library as the underlying multi-threading backend.

As a result the OpenMP code can be converted as follows. For example:
```
#pragma omp parallel for
for (int i = 10; i < size; ++i)
{
    doStuff(i);
}
```
Equivalent implementation of this loop using `system::parallelFor` is the following:

```
system::parallelFor(10, size, [&](int i)
{
    doStuff(i);
});
```

As a result, the performance has been improved in several cases where libgomp implementation of OpenMP currently doesn't handle well (many requests to parallelize relatively small problems). This reduces the need for PRs like https://github.com/alicevision/AliceVision/pull/1277 as the multithreading runtime handles a wider variety of tasks. For example, before #1277, the this PR made the following tests faster running on a machine with AMD 2990WX with disabled turbo boost:
 - `test_voctree_vocabularyTreeBuild`: before ~5.1-7s (extremely variable), after ~1.4s 
 - `test_voctree_kmeans`: before ~5.8-10s (extremely variable), after ~4.7s 
 - `test_sfm_sequentialSfM`: before ~1.7s, after ~1.5s

The PR is split into a large number of commits to allow easy bisection in case a bug slips through. As a result the risk of the PR is low as any bugs will be easily diagnosed and fixed.