### PR TITLE
Update vcpkg dependency for Windows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,7 @@ jobs:
       # tripletPath: '${{ github.workspace }}\..\vcpkg\triplets\community\x64-windows-release.cmake'
       BUILD_TYPE: Release
       CTEST_OUTPUT_ON_FAILURE: 1
-      COMMIT_ID: 467509eb8fe938de3e5f85a6cb1b72edacb2284c
+      COMMIT_ID: 8e8a3d7c1a6f7f587b486663b1e814911e6f2342
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR just checks whether https://github.com/alicevision/vcpkg/pull/5 passes CI on Windows.