### PR TITLE
[bugfix] fix getColmapCompatibleViews 

### DIFF
--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 
 
 alicevision_add_test(middlebury_test.cpp
-        NAME "middlebury"
+        NAME "sfmDataIO_middlebury"
         LINKS aliceVision_sfmData
         aliceVision_numeric
         aliceVision_sfmDataIO

--- a/src/aliceVision/sfmDataIO/colmap.cpp
+++ b/src/aliceVision/sfmDataIO/colmap.cpp
@@ -77,7 +77,7 @@ CompatibleList getColmapCompatibleViews(const sfmData::SfMData& sfmData)
         {
             continue;
         }
-        if(compatibleIntrinsics.find(view->getIntrinsicId()) != compatibleViews.end())
+        if(compatibleIntrinsics.count(view->getIntrinsicId()) > 0)
         {
             compatibleViews.insert(viewID);
         }


### PR DESCRIPTION
In the code of `compatibleIntrinsics()`, in order to check if an element belongs to the vector, `find()` was used and compared to the `.end()` of a different vector. (self-facepalm).
This made the unit test fail (only) on windows. Why that was not failing on Linux, it's a big mystery.

Incidentally it fixes the name of the unit test for middlebury, which was missing the proper module prefix
