### PR TITLE
Add OnePlus 8 Pro to the sensor database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4422,6 +4422,9 @@ OnePlus;Oneplus A6003;5.5;devicespecifications
 OnePlus;Oneplus A6010;5.5;devicespecifications
 OnePlus;Oneplus A6013;5.5;devicespecifications
 OnePlus;OnePlus HD1913;6.4;usercontribution
+OnePlus;OnePlus LE2120;8.96;devicespecifications
+OnePlus;OnePlus LE2123;8.96;devicespecifications
+OnePlus;OnePlus LE2125;8.96;devicespecifications
 OnePlus;OnePlus Nord;6.4;kimovil
 Oneplus;Oneplus One;4.69;devicespecifications
 Oneplus;Oneplus X;4.69;devicespecifications


### PR DESCRIPTION
Add sensor database entries for the OnePlus 8 Pro model numbers.  These are regional variations of the device, which all have the same camera.