### PR TITLE
[image] Fix deprecated use of oiio computePixelStats()

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -463,8 +463,7 @@ void readImageNoFloat(const std::string& path,
 
 bool containsHalfFloatOverflow(const oiio::ImageBuf& image)
 {
-    oiio::ImageBufAlgo::PixelStats stats;
-    oiio::ImageBufAlgo::computePixelStats(stats, image);
+    auto stats = oiio::ImageBufAlgo::computePixelStats(image);
 
     for(auto maxValue: stats.max)
     {


### PR DESCRIPTION
Old overload has been deprecated since oiio 1.9.4. The minimum OpenImageIO version is 2.1.0 so we can replace the old overload unconditionally.


