### PR TITLE
[system] Fix deprecated uses of boost::progress_display

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ Dependencies
 AliceVision depends on external libraries:
 
 * [Assimp >= 5.0.0](https://github.com/assimp/assimp)
-* [Boost >= 1.70.0](https://www.boost.org)
+* [Boost >= 1.72.0](https://www.boost.org)
 * [Ceres >= 1.10.0](https://github.com/ceres-solver/ceres-solver)
 * [Eigen >= 3.3.4](https://gitlab.com/libeigen/eigen)
 * [Geogram >= 1.7.5](https://gforge.inria.fr/frs/?group_id=5833)

--- a/src/aliceVision/system/ProgressDisplay.cpp
+++ b/src/aliceVision/system/ProgressDisplay.cpp
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "ProgressDisplay.hpp"
-#include <boost/progress.hpp>
+#include <boost/timer/progress_display.hpp>
 #include <mutex>
 
 namespace aliceVision {
@@ -61,7 +61,7 @@ public:
 
 private:
     std::mutex _mutex;
-    boost::progress_display _display;
+    boost::timer::progress_display _display;
 };
 
 

--- a/src/aliceVision/system/ProgressDisplay.hpp
+++ b/src/aliceVision/system/ProgressDisplay.hpp
@@ -26,7 +26,7 @@ public:
  * This is a generic API to display progress bars. Depending on implementation different
  * destinations for display data may be used. Currently only console output is supported.
  *
- * The API is essentially the same as boost::progress_display
+ * The API is essentially the same as boost::timer::progress_display
  *
  * For ease of use value semantics are exposed.
  */


### PR DESCRIPTION
The new boost::timer::progress_display API has been available since Boost 1.72 and the old API was deprecated at the same time. This PR also bumps boost requirement to 1.72.