### PR TITLE
Fix ceres-solver deprecations

### DIFF
--- a/src/aliceVision/calibration/distortionEstimation.cpp
+++ b/src/aliceVision/calibration/distortionEstimation.cpp
@@ -8,6 +8,7 @@
 
 #include <ceres/ceres.h>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/CeresUtils.hpp>
 
 
 namespace aliceVision {
@@ -243,8 +244,13 @@ bool estimate(std::shared_ptr<camera::Pinhole> & cameraToEstimate, Statistics & 
     }
     else
     {
-        ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(2, {1});   
+#if ALICEVISION_CERES_HAS_MANIFOLD
+        auto* subsetManifold = new ceres::SubsetManifold(2, {1});
+        problem.SetManifold(scale, subsetManifold);
+#else
+        ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(2, {1});
         problem.SetParameterization(scale, subsetParameterization);
+#endif
     }
 
     //Add off center parameter
@@ -286,8 +292,13 @@ bool estimate(std::shared_ptr<camera::Pinhole> & cameraToEstimate, Statistics & 
 
         if (!constantDistortions.empty())
         {
-            ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(countDistortionParams, constantDistortions);   
+#if ALICEVISION_CERES_HAS_MANIFOLD
+            auto* subsetManifold = new ceres::SubsetManifold(countDistortionParams, constantDistortions);
+            problem.SetManifold(distortionParameters, subsetManifold);
+#else
+            ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(countDistortionParams, constantDistortions);
             problem.SetParameterization(distortionParameters, subsetParameterization);
+#endif
         }
     }
     
@@ -388,8 +399,13 @@ bool estimate(std::shared_ptr<camera::Pinhole> & cameraToEstimate, Statistics & 
     }
     else
     {
-        ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(2, {1});   
+#if ALICEVISION_CERES_HAS_MANIFOLD
+        auto* subsetManifold = new ceres::SubsetManifold(2, {1});
+        problem.SetManifold(scale, subsetManifold);
+#else
+        ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(2, {1});
         problem.SetParameterization(scale, subsetParameterization);
+#endif
     }
     
 
@@ -432,8 +448,13 @@ bool estimate(std::shared_ptr<camera::Pinhole> & cameraToEstimate, Statistics & 
         
         if (!constantDistortions.empty())
         {
-            ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(countDistortionParams, constantDistortions);   
+#if ALICEVISION_CERES_HAS_MANIFOLD
+            auto* subsetManifold = new ceres::SubsetManifold(countDistortionParams, constantDistortions);
+            problem.SetManifold(distortionParameters, subsetManifold);
+#else
+            ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(countDistortionParams, constantDistortions);
             problem.SetParameterization(distortionParameters, subsetParameterization);
+#endif
         }
     }
     

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -530,8 +530,13 @@ void BundleAdjustmentCeres::addExtrinsicsToProblem(const sfmData::SfMData& sfmDa
     // subset parametrization
     if(!constantExtrinsic.empty())
     {
+#if ALICEVISION_CERES_HAS_MANIFOLD
+      auto* subsetManifold = new ceres::SubsetManifold(6, constantExtrinsic);
+      problem.SetManifold(poseBlockPtr, subsetManifold);
+#else
       ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(6, constantExtrinsic);
       problem.SetParameterization(poseBlockPtr, subsetParameterization);
+#endif
     }
 
     _statistics.addState(EParameter::POSE, EParameterState::REFINED);

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/sfm/ResidualErrorConstraintFunctor.hpp>
 #include <aliceVision/sfm/ResidualErrorRotationPriorFunctor.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/utils/CeresUtils.hpp>
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/camera/Equidistant.hpp>
@@ -30,48 +31,48 @@ namespace sfm {
 using namespace aliceVision::camera;
 using namespace aliceVision::geometry;
 
-class IntrinsicsParameterization : public ceres::LocalParameterization {
+class IntrinsicsManifold : public utils::CeresManifold {
  public:
-  explicit IntrinsicsParameterization(size_t parametersSize, double focalRatio, bool lockFocal, bool lockFocalRatio, bool lockCenter, bool lockDistortion)
-  : _globalSize(parametersSize),
+  explicit IntrinsicsManifold(size_t parametersSize, double focalRatio, bool lockFocal, bool lockFocalRatio, bool lockCenter, bool lockDistortion)
+  : _ambientSize(parametersSize),
     _focalRatio(focalRatio),
     _lockFocal(lockFocal),
     _lockFocalRatio(lockFocalRatio),
     _lockCenter(lockCenter),
     _lockDistortion(lockDistortion)
   {
-    _distortionSize = _globalSize - 4;
-    _localSize = 0;
+    _distortionSize = _ambientSize - 4;
+    _tangentSize = 0;
 
     if (!_lockFocal)
     {
       if (_lockFocalRatio)
       {
-        _localSize += 1;
+        _tangentSize += 1;
       }
       else
       {
-        _localSize += 2;
+        _tangentSize += 2;
       }
     }
 
     if (!_lockCenter)
     {
-      _localSize += 2;
+      _tangentSize += 2;
     }
 
     if (!_lockDistortion)
     {
-      _localSize += _distortionSize;
+      _tangentSize += _distortionSize;
     }
   }
 
-  virtual ~IntrinsicsParameterization() = default;
+  virtual ~IntrinsicsManifold() = default;
 
 
   bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
   {
-    for (int i = 0; i < _globalSize; i++)
+    for (int i = 0; i < _ambientSize; i++)
     {
       x_plus_delta[i] = x[i];
     }
@@ -115,9 +116,9 @@ class IntrinsicsParameterization : public ceres::LocalParameterization {
     return true;
   }
 
-  bool ComputeJacobian(const double* x, double* jacobian) const override
+  bool PlusJacobian(const double* x, double* jacobian) const override
   {    
-    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobian, GlobalSize(), LocalSize());
+    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobian, AmbientSize(), TangentSize());
 
     J.fill(0);
 
@@ -160,20 +161,28 @@ class IntrinsicsParameterization : public ceres::LocalParameterization {
     return true;
   }
 
-  int GlobalSize() const override 
-  {
-    return _globalSize;
+  bool Minus(const double* y, const double* x, double* delta) const override {
+    throw std::invalid_argument("IntrinsicsManifold::Minus() should never be called");
   }
 
-  int LocalSize() const override 
+  bool MinusJacobian(const double* x, double* jacobian) const override {
+    throw std::invalid_argument("IntrinsicsManifold::MinusJacobian() should never be called");
+  }
+
+  int AmbientSize() const override
+  {
+    return _ambientSize;
+  }
+
+  int TangentSize() const override
   { 
-    return _localSize; 
+    return _tangentSize;
   }
 
  private:
   size_t _distortionSize;
-  size_t _globalSize;
-  size_t _localSize;
+  size_t _ambientSize;
+  size_t _tangentSize;
   double _focalRatio;
   bool _lockFocal;
   bool _lockFocalRatio;
@@ -699,8 +708,13 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
     }
 
     
-    IntrinsicsParameterization * subsetParameterization = new IntrinsicsParameterization(intrinsicBlock.size(), focalRatio, lockFocal, lockRatio, lockCenter, lockDistortion);
-    problem.SetParameterization(intrinsicBlockPtr, subsetParameterization);
+    IntrinsicsManifold* subsetManifold = new IntrinsicsManifold(intrinsicBlock.size(), focalRatio,
+                                                                lockFocal, lockRatio, lockCenter, lockDistortion);
+#if ALICEVISION_CERES_HAS_MANIFOLD
+    problem.SetManifold(intrinsicBlockPtr, subsetManifold);
+#else
+    problem.SetParameterization(intrinsicBlockPtr, new utils::ManifoldToParameterizationWrapper(subsetManifold));
+#endif
 
     _statistics.addState(EParameter::INTRINSIC, EParameterState::REFINED);
   }

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
@@ -412,7 +412,11 @@ void BundleAdjustmentPanoramaCeres::addExtrinsicsToProblem(const sfmData::SfMDat
     double* poseBlockPtr = poseBlock.data();
 
     /*Define rotation parameterization*/
-    problem.AddParameterBlock(poseBlockPtr, 9, new SO3::LocalParameterization);
+#if ALICEVISION_CERES_HAS_MANIFOLD
+    problem.AddParameterBlock(poseBlockPtr, 9, new SO3::Manifold);
+#else
+    problem.AddParameterBlock(poseBlockPtr, 9, new utils::ManifoldToParameterizationWrapper(new SO3::Manifold));
+#endif
 
     // keep the camera extrinsics constants
     if(cameraPose.isLocked() || isConstant || !refineRotation)

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
@@ -7,6 +7,7 @@
 
 #include <aliceVision/sfm/BundleAdjustmentPanoramaCeres.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/utils/CeresUtils.hpp>
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/sfm/ResidualErrorRotationPriorFunctor.hpp>
@@ -559,8 +560,13 @@ void BundleAdjustmentPanoramaCeres::addIntrinsicsToProblem(const sfmData::SfMDat
 
     if(!constantIntrinisc.empty())
     {
+#if ALICEVISION_CERES_HAS_MANIFOLD
+      auto* subsetManifold = new ceres::SubsetManifold(intrinsicBlock.size(), constantIntrinisc);
+      problem.SetManifold(intrinsicBlockPtr, subsetManifold);
+#else
       ceres::SubsetParameterization* subsetParameterization = new ceres::SubsetParameterization(intrinsicBlock.size(), constantIntrinisc);
       problem.SetParameterization(intrinsicBlockPtr, subsetParameterization);
+#endif
     }
 
     _statistics.addState(EParameter::INTRINSIC, EParameterState::REFINED);

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -27,9 +27,10 @@ namespace sfm {
 using namespace aliceVision::camera;
 using namespace aliceVision::geometry;
 
-class IntrinsicsManifold : public utils::CeresManifold {
+class IntrinsicsManifoldSymbolic : public utils::CeresManifold {
  public:
-  explicit IntrinsicsManifold(size_t parametersSize, double focalRatio, bool lockFocal, bool lockFocalRatio, bool lockCenter, bool lockDistortion)
+  explicit IntrinsicsManifoldSymbolic(size_t parametersSize, double focalRatio, bool lockFocal,
+                                      bool lockFocalRatio, bool lockCenter, bool lockDistortion)
   : _ambientSize(parametersSize),
     _focalRatio(focalRatio),
     _lockFocal(lockFocal),
@@ -63,7 +64,7 @@ class IntrinsicsManifold : public utils::CeresManifold {
     }
   }
 
-  virtual ~IntrinsicsManifold() = default;
+  virtual ~IntrinsicsManifoldSymbolic() = default;
 
 
   bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
@@ -672,7 +673,7 @@ void BundleAdjustmentSymbolicCeres::addIntrinsicsToProblem(const sfmData::SfMDat
       lockDistortion = true;
     }
 
-    IntrinsicsManifold* subsetManifold = new IntrinsicsManifold(intrinsicBlock.size(), focalRatio,
+    IntrinsicsManifoldSymbolic* subsetManifold = new IntrinsicsManifoldSymbolic(intrinsicBlock.size(), focalRatio,
                                                                 lockFocal, lockRatio, lockCenter, lockDistortion);
 #if ALICEVISION_CERES_HAS_MANIFOLD
     problem.SetManifold(intrinsicBlockPtr, subsetManifold);

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -296,7 +296,12 @@ void BundleAdjustmentSymbolicCeres::addPose(const sfmData::CameraPose& cameraPos
 
   if (refineRotation && refineTranslation)
   {
-    problem.SetParameterization(poseBlockPtr, new SE3::LocalParameterization(refineRotation, refineTranslation));
+#if ALICEVISION_CERES_HAS_MANIFOLD
+    problem.SetManifold(poseBlockPtr, new SE3::Manifold(refineRotation, refineTranslation));
+#else
+    problem.SetParameterization(poseBlockPtr, new utils::ManifoldToParameterizationWrapper(
+                                    new SE3::Manifold(refineRotation, refineTranslation)));
+#endif
   }
   else
   {

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/camera/Equidistant.hpp>
+#include <aliceVision/utils/CeresUtils.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -26,48 +27,48 @@ namespace sfm {
 using namespace aliceVision::camera;
 using namespace aliceVision::geometry;
 
-class IntrinsicsParameterization : public ceres::LocalParameterization {
+class IntrinsicsManifold : public utils::CeresManifold {
  public:
-  explicit IntrinsicsParameterization(size_t parametersSize, double focalRatio, bool lockFocal, bool lockFocalRatio, bool lockCenter, bool lockDistortion)
-  : _globalSize(parametersSize),
+  explicit IntrinsicsManifold(size_t parametersSize, double focalRatio, bool lockFocal, bool lockFocalRatio, bool lockCenter, bool lockDistortion)
+  : _ambientSize(parametersSize),
     _focalRatio(focalRatio),
     _lockFocal(lockFocal),
     _lockFocalRatio(lockFocalRatio),
     _lockCenter(lockCenter),
     _lockDistortion(lockDistortion)
   {
-    _distortionSize = _globalSize - 4;
-    _localSize = 0;
+    _distortionSize = _ambientSize - 4;
+    _tangentSize = 0;
 
     if (!_lockFocal)
     {
       if (_lockFocalRatio)
       {
-        _localSize += 1;
+        _tangentSize += 1;
       }
       else
       {
-        _localSize += 2;
+        _tangentSize += 2;
       }
     }
 
     if (!_lockCenter)
     {
-      _localSize += 2;
+      _tangentSize += 2;
     }
 
     if (!_lockDistortion)
     {
-      _localSize += _distortionSize;
+      _tangentSize += _distortionSize;
     }
   }
 
-  virtual ~IntrinsicsParameterization() = default;
+  virtual ~IntrinsicsManifold() = default;
 
 
   bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
   {
-    for (int i = 0; i < _globalSize; i++)
+    for (int i = 0; i < _ambientSize; i++)
     {
       x_plus_delta[i] = x[i];
     }
@@ -111,9 +112,9 @@ class IntrinsicsParameterization : public ceres::LocalParameterization {
     return true;
   }
 
-  bool ComputeJacobian(const double* x, double* jacobian) const override
+  bool PlusJacobian(const double* x, double* jacobian) const override
   {    
-    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobian, GlobalSize(), LocalSize());
+    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobian, AmbientSize(), TangentSize());
 
     J.fill(0);
 
@@ -156,20 +157,28 @@ class IntrinsicsParameterization : public ceres::LocalParameterization {
     return true;
   }
 
-  int GlobalSize() const override 
-  {
-    return _globalSize;
+  bool Minus(const double* y, const double* x, double* delta) const override {
+    throw std::invalid_argument("IntrinsicsManifold::Minus() should never be called");
   }
 
-  int LocalSize() const override 
+  bool MinusJacobian(const double* x, double* jacobian) const override {
+    throw std::invalid_argument("IntrinsicsManifold::MinusJacobian() should never be called");
+  }
+
+  int AmbientSize() const override
+  {
+    return _ambientSize;
+  }
+
+  int TangentSize() const override
   { 
-    return _localSize; 
+    return _tangentSize;
   }
 
  private:
   size_t _distortionSize;
-  size_t _globalSize;
-  size_t _localSize;
+  size_t _ambientSize;
+  size_t _tangentSize;
   double _focalRatio;
   bool _lockFocal;
   bool _lockFocalRatio;
@@ -658,8 +667,13 @@ void BundleAdjustmentSymbolicCeres::addIntrinsicsToProblem(const sfmData::SfMDat
       lockDistortion = true;
     }
 
-    IntrinsicsParameterization * subsetParameterization = new IntrinsicsParameterization(intrinsicBlock.size(), focalRatio, lockFocal, lockRatio, lockCenter, lockDistortion);
-    problem.SetParameterization(intrinsicBlockPtr, subsetParameterization);
+    IntrinsicsManifold* subsetManifold = new IntrinsicsManifold(intrinsicBlock.size(), focalRatio,
+                                                                lockFocal, lockRatio, lockCenter, lockDistortion);
+#if ALICEVISION_CERES_HAS_MANIFOLD
+    problem.SetManifold(intrinsicBlockPtr, subsetManifold);
+#else
+    problem.SetParameterization(intrinsicBlockPtr, new utils::ManifoldToParameterizationWrapper(subsetManifold));
+#endif
 
     _statistics.addState(EParameter::INTRINSIC, EParameterState::REFINED);
   }

--- a/src/aliceVision/sfm/liealgebra.hpp
+++ b/src/aliceVision/sfm/liealgebra.hpp
@@ -333,7 +333,7 @@ inline Eigen::Matrix2d expm(double algebra){
 }
 
 
-class LocalParameterization : public ceres::LocalParameterization {
+class Manifold : public utils::CeresManifold {
 public:
   bool Plus(const double* x, const double* delta, double* x_plus_delta) const override {
 
@@ -347,7 +347,7 @@ public:
     return true;
   }
 
-  bool ComputeJacobian(const double * x, double* jacobian) const override {
+  bool PlusJacobian(const double * x, double* jacobian) const override {
 
     Eigen::Map<Eigen::Matrix<double, 4, 1>> J(jacobian);
 
@@ -359,11 +359,19 @@ public:
     return true;
   }
 
-  int GlobalSize() const override {
+  bool Minus(const double* y, const double* x, double* delta) const override {
+    throw std::invalid_argument("SO3::Manifold::Minus() should never be called");
+  }
+
+  bool MinusJacobian(const double* x, double* jacobian) const override {
+    throw std::invalid_argument("SO3::Manifold::MinusJacobian() should never be called");
+  }
+
+  int AmbientSize() const override {
     return 4;
   }
 
-  int LocalSize() const override {
+  int TangentSize() const override {
     return 1;
   }
 };

--- a/src/aliceVision/sfm/liealgebra.hpp
+++ b/src/aliceVision/sfm/liealgebra.hpp
@@ -238,9 +238,9 @@ inline Eigen::Matrix4d expm(const Eigen::Matrix<double, 6, 1> & algebra){
 }
 
 
-class LocalParameterization : public ceres::LocalParameterization {
+class Manifold : public utils::CeresManifold {
 public:
-  LocalParameterization(bool refineRotation, bool refineTranslation) :
+  Manifold(bool refineRotation, bool refineTranslation) :
   _refineRotation(refineRotation), 
   _refineTranslation(refineTranslation)
   {
@@ -259,7 +259,7 @@ public:
     return true;
   }
 
-  bool ComputeJacobian(const double * x, double* jacobian) const override {
+  bool PlusJacobian(const double * x, double* jacobian) const override {
 
     Eigen::Map<Eigen::Matrix<double, 16, 6, Eigen::RowMajor>> J(jacobian);
     Eigen::Map<const Eigen::Matrix<double, 4, 4, Eigen::RowMajor>> T(x);
@@ -288,11 +288,19 @@ public:
     return true;
   }
 
-  int GlobalSize() const override {
+  bool Minus(const double* y, const double* x, double* delta) const override {
+    throw std::invalid_argument("SE3::Manifold::Minus() should never be called");
+  }
+
+  bool MinusJacobian(const double* x, double* jacobian) const override {
+    throw std::invalid_argument("SE3::Manifold::MinusJacobian() should never be called");
+  }
+
+  int AmbientSize() const override {
     return 16;
   }
 
-  int LocalSize() const override {
+  int TangentSize() const override {
     return 6;
   }
 

--- a/src/aliceVision/sfm/liealgebra.hpp
+++ b/src/aliceVision/sfm/liealgebra.hpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 #include <unsupported/Eigen/KroneckerProduct>
+#include <aliceVision/utils/CeresUtils.hpp>
 #include <ceres/ceres.h>
 
 namespace aliceVision {
@@ -142,9 +143,9 @@ inline Eigen::Matrix<double, 3, 9, Eigen::RowMajor> dlogmdr(const Eigen::Matrix3
     return dpdmat * scale + resnoscale * dscaledmat;
 }
 
-class LocalParameterization : public ceres::LocalParameterization {
+class Manifold : public utils::CeresManifold {
  public:
-  ~LocalParameterization() override = default;
+  ~Manifold() override = default;
 
   bool Plus(const double* x, const double* delta, double* x_plus_delta) const override {
  
@@ -170,7 +171,7 @@ class LocalParameterization : public ceres::LocalParameterization {
     return true;
   }
 
-  bool ComputeJacobian(const double* /*x*/, double* jacobian) const override {
+  bool PlusJacobian(const double* /*x*/, double* jacobian) const override {
     
     Eigen::Map<Eigen::Matrix<double, 9, 3, Eigen::RowMajor>> J(jacobian);
     //Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> R(x);
@@ -187,9 +188,17 @@ class LocalParameterization : public ceres::LocalParameterization {
     return true;
   }
 
-  int GlobalSize() const override { return 9; }
+  bool Minus(const double* y, const double* x, double* delta) const override {
+    throw std::invalid_argument("SO3::Manifold::Minus() should never be called");
+  }
 
-  int LocalSize() const override { return 3; }
+  bool MinusJacobian(const double* x, double* jacobian) const override {
+    throw std::invalid_argument("SO3::Manifold::MinusJacobian() should never be called");
+  }
+
+  int AmbientSize() const override { return 9; }
+
+  int TangentSize() const override { return 3; }
 };
 
 }

--- a/src/aliceVision/utils/CeresUtils.hpp
+++ b/src/aliceVision/utils/CeresUtils.hpp
@@ -1,0 +1,72 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2022 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <ceres/ceres.h>
+#include <memory>
+
+namespace aliceVision {
+namespace utils {
+
+// We can remove this wrapper once we can use ceres-solver 2.1 and newer. We can't do so right now
+// because ceres-solver 2.1 breaks with GCC 6.x and older due to
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+#define ALICEVISION_CERES_HAS_MANIFOLD ((CERES_VERSION_MAJOR * 100 + CERES_VERSION_MINOR) >= 201)
+
+#if ALICEVISION_CERES_HAS_MANIFOLD
+using CeresManifold = ceres::Manifold;
+#else
+class CeresManifold {
+public:
+    virtual ~CeresManifold() = default;
+    virtual int AmbientSize() const = 0;
+    virtual int TangentSize() const = 0;
+    virtual bool Plus(const double* x,
+                      const double* delta,
+                      double* x_plus_delta) const = 0;
+    virtual bool PlusJacobian(const double* x, double* jacobian) const = 0;
+    virtual bool Minus(const double* y,
+                       const double* x,
+                       double* y_minus_x) const = 0;
+    virtual bool MinusJacobian(const double* x, double* jacobian) const = 0;
+};
+
+class ManifoldToParameterizationWrapper : public ceres::LocalParameterization
+{
+public:
+    // takes ownership of manifold
+    ManifoldToParameterizationWrapper(CeresManifold* manifold) : _manifold{manifold} {}
+
+    ~ManifoldToParameterizationWrapper() override = default;
+
+    bool Plus(const double* x, const double* delta, double* x_plus_delta) const override
+    {
+        return _manifold->Plus(x, delta, x_plus_delta);
+    }
+
+    bool ComputeJacobian(const double* x, double* jacobian) const override
+    {
+        return _manifold->PlusJacobian(x, jacobian);
+    }
+
+    int GlobalSize() const override
+    {
+        return _manifold->AmbientSize();
+    }
+
+    int LocalSize() const override
+    {
+        return _manifold->TangentSize();
+    }
+
+private:
+    std::unique_ptr<CeresManifold> _manifold;
+};
+#endif
+
+} // namespace utils
+} // namespace aliceVision


### PR DESCRIPTION
ceres-solver deprecated `LocalParameterization` in favor of `Manifold` in v2.1. v2.2 will not contain `LocalParameterization` anymore. This PR bumps ceres-solver dependency to at least v2.1 which has been released on 2022-03-28.

This PR also fixes an ODR violation that was caused by two local classes named `alicevision::sfm::IntrinsicsManifold` present in two different translation units.