### PR TITLE
Upgrade ceres-solver dependency to 2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ endif()
 set(CERES_TARGET ceres)
 ExternalProject_Add(${CERES_TARGET}
        GIT_REPOSITORY https://github.com/ceres-solver/ceres-solver
-       GIT_TAG 31008453fe979f947e594df15a7e254d6631881b  # 2021/10/06
+       GIT_TAG 2.1.0
        PREFIX ${BUILD_DIR}
        BUILD_IN_SOURCE 0
        BUILD_ALWAYS 0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ AliceVision depends on external libraries:
 
 * [Assimp >= 5.0.0](https://github.com/assimp/assimp)
 * [Boost >= 1.72.0](https://www.boost.org)
-* [Ceres >= 1.10.0](https://github.com/ceres-solver/ceres-solver)
+* [Ceres >= 2.1.0](https://github.com/ceres-solver/ceres-solver)
 * [Eigen >= 3.3.4](https://gitlab.com/libeigen/eigen)
 * [Geogram >= 1.7.5](https://gforge.inria.fr/frs/?group_id=5833)
 * [OpenEXR >= 2.5](https://github.com/AcademySoftwareFoundation/openexr)


### PR DESCRIPTION
This PR extracts part of https://github.com/alicevision/AliceVision/pull/1249 so that docker images with upgraded dependency can be rebuilt without breaking the CI even temporarily.