### PR TITLE
(trivial) Drop code catering to old OpenImageIO versions

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -229,16 +229,6 @@ oiio::ParamValueList readImageMetadata(const std::string& path, int& width, int&
   if(!in)
     throw std::runtime_error("Can't find/open image file '" + path + "'.");
 
-#if OIIO_VERSION <= (10000 * 2 + 100 * 0 + 8) // OIIO_VERSION <= 2.0.8
-  const std::string formatStr = in->format_name();
-  if(formatStr == "raw")
-  {
-    // For the RAW plugin: override colorspace as linear (as the content is linear with sRGB primaries but declared as sRGB)
-    spec.attribute("oiio:ColorSpace", "Linear");
-    ALICEVISION_LOG_TRACE("OIIO workaround: RAW input image " << path << " is in Linear.");
-  }
-#endif
-
   width = spec.width;
   height = spec.height;
 
@@ -332,12 +322,7 @@ void readImage(const std::string& path,
   configSpec.attribute("raw:use_camera_wb", (imageReadOptions.applyWhiteBalance?1:0)); // white balance correction
   // use_camera_matrix: Whether to use the embedded color profile, if it is present: 0=never, 1 (default)=only for DNG files, 3=always
   configSpec.attribute("raw:use_camera_matrix", 3); // use embeded color profile
-#if OIIO_VERSION <= (10000 * 2 + 100 * 0 + 8) // OIIO_VERSION <= 2.0.8
-  // In old versions of oiio, there was no Linear option
-  configSpec.attribute("raw:ColorSpace", "sRGB"); // use colorspace sRGB
-#else
   configSpec.attribute("raw:ColorSpace", "Linear"); // use linear colorspace with sRGB primaries
-#endif
 
   oiio::ImageBuf inBuf(path, 0, 0, NULL, &configSpec);
 

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -222,12 +222,7 @@ void readImage(const std::string& path,
     configSpec.attribute("raw:auto_bright", 0);       // don't want exposure correction
     configSpec.attribute("raw:use_camera_wb", 1);     // want white balance correction
     configSpec.attribute("raw:use_camera_matrix", 3); // want to use embeded color profile
-#if OIIO_VERSION <= (10000 * 2 + 100 * 0 + 8) // OIIO_VERSION <= 2.0.8
-    // In these previous versions of oiio, there was no Linear option
-    configSpec.attribute("raw:ColorSpace", "sRGB");   // want colorspace sRGB
-#else
     configSpec.attribute("raw:ColorSpace", "Linear");   // want linear colorspace with sRGB primaries
-#endif
 
     oiio::ImageBuf inBuf(path, 0, 0, NULL, &configSpec);
 
@@ -236,25 +231,7 @@ void readImage(const std::string& path,
     if(!inBuf.initialized())
         throw std::runtime_error("Cannot find/open image file '" + path + "'.");
 
-#if OIIO_VERSION <= (10000 * 2 + 100 * 0 + 8) // OIIO_VERSION <= 2.0.8
-    // Workaround for bug in RAW colorspace management in previous versions of OIIO:
-    //     When asking sRGB we got sRGB primaries with linear gamma,
-    //     but oiio::ColorSpace was wrongly set to sRGB.
-    oiio::ImageSpec inSpec = inBuf.spec();
-    if(inSpec.get_string_attribute("oiio:ColorSpace", "") == "sRGB")
-    {
-        const auto in = oiio::ImageInput::open(path, nullptr);
-        const std::string formatStr = in->format_name();
-        if(formatStr == "raw")
-        {
-            // For the RAW plugin: override colorspace as linear (as the content is linear with sRGB primaries but declared as sRGB)
-            inSpec.attribute("oiio:ColorSpace", "Linear");
-            ALICEVISION_LOG_TRACE("OIIO workaround: RAW input image " << path << " is in Linear.");
-        }
-    }
-#else
     const oiio::ImageSpec& inSpec = inBuf.spec();
-#endif
 
     // check picture channels number
     if (inSpec.nchannels == 0)

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -293,7 +293,6 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
         image.swap(rescaled);
     }
     
-    #if OIIO_VERSION >= (10000 * 2 + 100 * 0 + 0) // OIIO_VERSION >= 2.0.0
     if (pParams.contrast != 1.0f)
     {
         image::Image<image::RGBAfColor> filtered(image.Width(), image.Height());
@@ -303,7 +302,6 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 
         image.swap(filtered);
     }
-    #endif
     if (pParams.medianFilter >= 3)
     {
         image::Image<image::RGBAfColor> filtered(image.Width(), image.Height());


### PR DESCRIPTION
Minimum OpenImageIO version is 2.1.0 which means macros checking for older versions are no longer needed.

