### PR TITLE
Cleanup image metadata reading

### DIFF
--- a/src/aliceVision/depthMap/DepthSimMap.cpp
+++ b/src/aliceVision/depthMap/DepthSimMap.cpp
@@ -6,6 +6,7 @@
 
 #include "DepthSimMap.hpp"
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/mvsData/Color.hpp>
@@ -421,7 +422,7 @@ void DepthSimMap::save(const std::string& customSuffix, bool useStep1) const
     const int width = _mp.getWidth(_rc) / scaleStep;
     const int height = _mp.getHeight(_rc) / scaleStep;
 
-    oiio::ParamValueList metadata = imageIO::getMetadataFromMap(_mp.getMetadata(_rc));
+    auto metadata = image::getMetadataFromMap(_mp.getMetadata(_rc));
     metadata.push_back(oiio::ParamValue("AliceVision:downscale", _mp.getDownscaleFactor(_rc) * scaleStep));
 
     double s = scaleStep;

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -300,7 +300,7 @@ bool Fuser::filterDepthMapsRC(int rc, int minNumOfModals, int minNumOfModalsWSP2
           ++nbDepthValues;
     }
 
-    oiio::ParamValueList metadata = imageIO::getMetadataFromMap(_mp.getMetadata(rc));
+    auto metadata = image::getMetadataFromMap(_mp.getMetadata(rc));
     metadata.push_back(oiio::ParamValue("AliceVision:nbDepthValues", oiio::TypeDesc::INT32, 1, &nbDepthValues));
     metadata.push_back(oiio::ParamValue("AliceVision:downscale", _mp.getDownscaleFactor(rc)));
     metadata.push_back(oiio::ParamValue("AliceVision:CArr", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::VEC3), 1, _mp.CArr[rc].m));

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -5,6 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Fuser.hpp"
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/mvsData/geometry.hpp>
@@ -35,8 +36,7 @@ unsigned long computeNumberOfAllPoints(const mvsUtils::MultiViewParams& mp, int 
     for(int rc = 0; rc < mp.ncams; rc++)
     {
         const std::string filename = mvsUtils::getFileNameFromIndex(mp, rc, mvsUtils::EFileType::depthMap, scale);
-        oiio::ParamValueList metadata;
-        imageIO::readImageMetadata(filename, metadata);
+        const auto metadata = image::readImageMetadata(filename);
         int nbDepthValues = metadata.get_int("AliceVision:nbDepthValues", -1);
 
         if(nbDepthValues < 0)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -221,6 +221,16 @@ oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>
   return metadata;
 }
 
+std::map<std::string, std::string> getMapFromMetadata(const oiio::ParamValueList& metadata)
+{
+    std::map<std::string, std::string> metadataMap;
+
+    for (const auto& param : metadata)
+        metadataMap.emplace(param.name().string(), param.get_string());
+
+    return metadataMap;
+}
+
 oiio::ParamValueList readImageMetadata(const std::string& path, int& width, int& height)
 {
   std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path));
@@ -259,9 +269,7 @@ oiio::ParamValueList readImageMetadata(const std::string& path)
 void readImageMetadata(const std::string& path, int& width, int& height, std::map<std::string, std::string>& metadata)
 {
   oiio::ParamValueList oiioMetadadata = readImageMetadata(path, width, height);
-
-  for(const auto& param : oiioMetadadata)
-    metadata.emplace(param.name().string(), param.get_string());
+  metadata = getMapFromMetadata(oiioMetadadata);
 }
 
 void readImageSize(const std::string& path, int& width, int& height)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -257,13 +257,6 @@ oiio::ParamValueList readImageMetadata(const std::string& path)
     return readImageSpec(path).extra_attribs;
 }
 
-// Warning: type conversion problems from string to param value, we may lose some metadata with string maps
-void readImageMetadata(const std::string& path, int& width, int& height, std::map<std::string, std::string>& metadata)
-{
-  oiio::ParamValueList oiioMetadadata = readImageMetadata(path, width, height);
-  metadata = getMapFromMetadata(oiioMetadadata);
-}
-
 void readImageSize(const std::string& path, int& width, int& height)
 {
     const auto spec = readImageSpec(path);

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -147,6 +147,13 @@ std::istream& operator>>(std::istream& in, EStorageDataType& dataType);
 oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>& metadataMap);
 
 /**
+ * @brief convert an oiio::ParamValueList into metadata string map
+ * @param[in] metadata An instance of oiio::ParamValueList
+ * @return std::map Metadata string map
+ */
+std::map<std::string, std::string> getMapFromMetadata(const oiio::ParamValueList& metadata);
+
+/**
  * @brief extract metadata from an image for a given path
  * @param[in] path The given path to the image
  * @param[out] width The image header width

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -151,6 +151,7 @@ oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>
  * @param[in] metadata An instance of oiio::ParamValueList
  * @return std::map Metadata string map
  */
+// Warning: type conversion problems from string to param value, we may lose some metadata with string maps
 std::map<std::string, std::string> getMapFromMetadata(const oiio::ParamValueList& metadata);
 
 /**
@@ -175,15 +176,6 @@ oiio::ParamValueList readImageMetadata(const std::string& path);
  * @return imageSpec Specification describing the image
  */
 oiio::ImageSpec readImageSpec(const std::string& path);
-
-/**
- * @brief extract metadata from an image for a given path
- * @param[in] path The given path to the image
- * @param[out] width The image header width
- * @param[out] height The image header height
- * @param[out] metadata All metadata find in the image
- */
-void readImageMetadata(const std::string& path, int& width, int& height, std::map<std::string, std::string>& metadata);
 
 /**
  * @brief return the size of the image for a given path

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -170,6 +170,13 @@ oiio::ParamValueList readImageMetadata(const std::string& path, int& width, int&
 oiio::ParamValueList readImageMetadata(const std::string& path);
 
 /**
+ * @brief extract entire image specification from an image for a given path
+ * @param[in] path The given path to the image
+ * @return imageSpec Specification describing the image
+ */
+oiio::ImageSpec readImageSpec(const std::string& path);
+
+/**
  * @brief extract metadata from an image for a given path
  * @param[in] path The given path to the image
  * @param[out] width The image header width

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -178,19 +178,6 @@ void readImageSpec(const std::string& path,
   in->close();
 }
 
-void readImageMetadata(const std::string& path, oiio::ParamValueList& metadata)
-{
-  ALICEVISION_LOG_DEBUG("[IO] Read Image Metadata: " << path);
-  std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path));
-
-  if(!in)
-    throw std::runtime_error("Can't find/open image file '" + path + "'.");
-
-  metadata = in->spec().extra_attribs;
-
-  in->close();
-}
-
 bool isSupportedUndistortFormat(const std::string &ext)
 {
   static const std::array<std::string, 6> supportedExtensions = {".jpg", ".jpeg", ".png",  ".tif", ".tiff", ".exr"};

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -158,26 +158,6 @@ oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>
   return metadata;
 }
 
-void readImageSpec(const std::string& path,
-                   int& width,
-                   int& height,
-                   int& nchannels)
-{
-  ALICEVISION_LOG_DEBUG("[IO] Read Image Spec: " << path);
-  std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path));
-
-  if(!in)
-    throw std::runtime_error("Can't find/open image file '" + path + "'.");
-
-  const oiio::ImageSpec &spec = in->spec();
-
-  width = spec.width;
-  height = spec.height;
-  nchannels = spec.nchannels;
-
-  in->close();
-}
-
 bool isSupportedUndistortFormat(const std::string &ext)
 {
   static const std::array<std::string, 6> supportedExtensions = {".jpg", ".jpeg", ".png",  ".tif", ".tiff", ".exr"};

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -150,14 +150,6 @@ std::istream& operator>>(std::istream& in, EImageFileType& imageFileType)
   return in;
 }
 
-oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>& metadataMap)
-{
-  oiio::ParamValueList metadata;
-  for(const auto& metadataPair : metadataMap)
-    metadata.push_back(oiio::ParamValue(metadataPair.first, metadataPair.second));
-  return metadata;
-}
-
 bool isSupportedUndistortFormat(const std::string &ext)
 {
   static const std::array<std::string, 6> supportedExtensions = {".jpg", ".jpeg", ".png",  ".tif", ".tiff", ".exr"};

--- a/src/aliceVision/mvsData/imageIO.hpp
+++ b/src/aliceVision/mvsData/imageIO.hpp
@@ -119,13 +119,6 @@ std::ostream& operator<<(std::ostream& os, EImageQuality imageQuality);
 std::istream& operator>>(std::istream& in, EImageQuality& imageQuality);
 
 /**
- * @brief convert a metadata string map into an oiio::ParamValueList
- * @param[in] metadataMap string map
- * @return oiio::ParamValueList
- */
-oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>& metadataMap);
-
-/**
  * @brief get informations about each image file type
  * @return String
  */

--- a/src/aliceVision/mvsData/imageIO.hpp
+++ b/src/aliceVision/mvsData/imageIO.hpp
@@ -162,15 +162,6 @@ std::ostream& operator<<(std::ostream& os, EImageFileType imageFileType);
 std::istream& operator>>(std::istream& in, EImageFileType& imageFileType);
 
 /**
- * @brief read image dimension from a given path
- * @param[in] path The given path to the image
- * @param[out] width The image width
- * @param[out] height The image height
- * @param[out] nchannels The image channel number
- */
-void readImageSpec(const std::string& path, int& width, int& height, int& nchannels);
-
-/**
  * @brief Test if the extension is supported for undistorted images.
  * @param[in] ext The extension with the dot (eg ".png")
  * @return \p true if the extension is supported.

--- a/src/aliceVision/mvsData/imageIO.hpp
+++ b/src/aliceVision/mvsData/imageIO.hpp
@@ -171,13 +171,6 @@ std::istream& operator>>(std::istream& in, EImageFileType& imageFileType);
 void readImageSpec(const std::string& path, int& width, int& height, int& nchannels);
 
 /**
- * @brief read image metadata from a given path
- * @param[in] path The given path to the image
- * @param[out] metadata The image metadata
- */
-void readImageMetadata(const std::string& path, oiio::ParamValueList& metadata);
-
-/**
  * @brief Test if the extension is supported for undistorted images.
  * @param[in] ext The extension with the dot (eg ".png")
  * @return \p true if the extension is supported.

--- a/src/aliceVision/mvsUtils/CMakeLists.txt
+++ b/src/aliceVision/mvsUtils/CMakeLists.txt
@@ -17,6 +17,7 @@ set(mvsUtils_files_sources
 alicevision_add_library(aliceVision_mvsUtils
   SOURCES ${mvsUtils_files_headers} ${mvsUtils_files_sources}
   PUBLIC_LINKS
+    aliceVision_image
     aliceVision_numeric
     aliceVision_multiview
     aliceVision_mvsData

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -7,6 +7,7 @@
 #include "MultiViewParams.hpp"
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/mvsData/geometry.hpp>
 #include <aliceVision/mvsData/Matrix3x4.hpp>
 #include <aliceVision/mvsData/Pixel.hpp>
@@ -122,7 +123,7 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
         const bool fileExists = fs::exists(imgParams.path);
         if(fileExists)
         {
-            imageIO::readImageMetadata(imgParams.path, metadata);
+            metadata = image::readImageMetadata(imgParams.path);
             scaleIt = metadata.find("AliceVision:downscale");
             pIt = metadata.find("AliceVision:P");
         }
@@ -653,8 +654,7 @@ StaticVector<int> MultiViewParams::findCamsWhichIntersectsHexahedron(const Point
     tcams.reserve(getNbCameras());
     for(int rc = 0; rc < getNbCameras(); rc++)
     {
-        oiio::ParamValueList metadata;
-        imageIO::readImageMetadata(getImagePath(rc), metadata);
+        const auto metadata = image::readImageMetadata(getImagePath(rc));
 
         const float minDepth = metadata.get_float("AliceVision:minDepth", -1);
         const float maxDepth = metadata.get_float("AliceVision:maxDepth", -1);

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -137,8 +137,8 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
         else if(fileExists)
         {
             // use image dimension
-            int w, h, channels;
-            imageIO::readImageSpec(imgParams.path, w, h, channels);
+            int w, h;
+            image::readImageSize(imgParams.path, w, h);
             const int widthScale = imgParams.width / w;
             const int heightScale = imgParams.height / h;
 

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -6,6 +6,7 @@
 
 #include "fileIO.hpp"
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/mvsUtils/MultiViewParams.hpp>
 #include <aliceVision/mvsData/imageAlgo.hpp>
@@ -340,8 +341,7 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
         imageIO::readImage(path, img, imageIO::EImageColorSpace::LINEAR);
         checkImageSize();
 
-        oiio::ParamValueList metadata;
-        imageIO::readImageMetadata(path, metadata);
+        const auto metadata = image::readImageMetadata(path);
 
         float exposureCompensation = metadata.get_float("AliceVision:EVComp", -1);
 

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -31,16 +31,14 @@ void updateIncompleteView(sfmData::View& view, EViewIdMethod viewIdMethod, const
     return;
 
   int width, height;
-  std::map<std::string, std::string> metadata;
-
-  image::readImageMetadata(view.getImagePath(), width, height, metadata);
+  const auto metadata = image::readImageMetadata(view.getImagePath(), width, height);
 
   view.setWidth(width);
   view.setHeight(height);
 
   // reset metadata
   if(view.getMetadata().empty())
-    view.setMetadata(metadata);
+    view.setMetadata(image::getMapFromMetadata(metadata));
 
   // Reset viewId
   if(view.getViewId() == UndefinedIndexT)

--- a/src/samples/texturing/main_evcorrection.cpp
+++ b/src/samples/texturing/main_evcorrection.cpp
@@ -96,12 +96,13 @@ int main(int argc, char **argv)
         if(fs::is_regular_file(filePath)) 
         { 
             int w, h; 
-            std::map<std::string, std::string> metadata; 
             const IndexT id_view = c, id_pose = c, id_intrinsic = 0, rigId = 0, subPoseId = 0; 
  
-            image::readImageMetadata(filePath.string(), w, h, metadata); 
+            const auto metadata = image::readImageMetadata(filePath.string(), w, h);
  
-            sfm_data.views[c] = std::make_shared<sfmData::View>(filePath.string(), id_view, id_intrinsic, id_pose, w, h, rigId, subPoseId, metadata); 
+            sfm_data.views[c] = std::make_shared<sfmData::View>(filePath.string(), id_view, id_intrinsic,
+                                                                id_pose, w, h, rigId, subPoseId,
+                                                                image::getMapFromMetadata(metadata));
  
             ++c; 
         } 

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -292,7 +292,7 @@ int aliceVision_main(int argc, char** argv)
         // Load mask
         const std::string maskPath = (fs::path(warpingFolder) / (std::to_string(viewId) + "_mask.exr")).string();
         int width, height;
-        image::readImageMetadata(maskPath, width, height);
+        image::readImageSize(maskPath, width, height);
         width /= downscaleFactor;
         height /= downscaleFactor;
 


### PR DESCRIPTION
This PR removes a couple of functions from mvsData that do the same thing as functions in image module. Additionally, `readImageSpec` function has been introduced and all functions were redefined in terms of it, which makes them simplier (no need to define additional variables just to satisfy an interface like before). Finally, there is now a way to get whatever attributes needed without writing any more getter functions.

The objective is to have a single place for all metadata access.

The new `readImageSpec()` function is not strictly necessary. However, there was `void readImageSpec(const std::string& path, int& width, int& height, int& nchannels);` overload before, so given that `nchannels` was needed at least at some point in the past, it seems logical to expose the underlying OIIO ImageSpec without restrictions to satisfy similar accesses in the future.