### PR TITLE
(trivial) Avoid repeated calls to std::min() or std::max()

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1622,7 +1622,7 @@ DelaunayGraphCut::GeometryIntersection DelaunayGraphCut::rayIntersectTriangle(co
     const double BCSize = (*B - *C).size();
     const double ACSize = (*A - *C).size();
 
-    const double marginEpsilon = std::min(std::min(ABSize, BCSize), ACSize) * epsilonFactor;
+    const double marginEpsilon = std::min({ABSize, BCSize, ACSize}) * epsilonFactor;
     const double ambiguityEpsilon = (ABSize + BCSize + ACSize) / 3.0 * 1.0e-2;
 
     Point3d tempIntersectPt;

--- a/src/aliceVision/fuseCut/OctreeTracks.cpp
+++ b/src/aliceVision/fuseCut/OctreeTracks.cpp
@@ -493,7 +493,7 @@ OctreeTracks::OctreeTracks(const Point3d* voxel_, mvsUtils::MultiViewParams* mp_
     minNumOfConsistentCams = _mp.userParams.get<int>("filter.minNumOfConsistentCams", 2);
     simWspThr = (float)_mp.userParams.get<double>("LargeScale.simWspThr", -0.0f);
 
-    int maxNumSubVoxs = std::max(std::max(numSubVoxsX, numSubVoxsY), numSubVoxsZ);
+    int maxNumSubVoxs = std::max({numSubVoxsX, numSubVoxsY, numSubVoxsZ});
     size_ = 2;
     while(size_ < maxNumSubVoxs)
     {

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -1297,17 +1297,17 @@ Point3d Mesh::computeTriangleCenterOfGravity(int idTri) const
 double Mesh::computeTriangleMaxEdgeLength(int idTri) const
 {
     const Mesh::triangle& t = tris[idTri];
-    return std::max(std::max((pts[t.v[0]] - pts[t.v[1]]).size(),
-                             (pts[t.v[1]] - pts[t.v[2]]).size()),
-                             (pts[t.v[2]] - pts[t.v[0]]).size());
+    return std::max({(pts[t.v[0]] - pts[t.v[1]]).size(),
+                     (pts[t.v[1]] - pts[t.v[2]]).size(),
+                     (pts[t.v[2]] - pts[t.v[0]]).size()});
 }
 
 double Mesh::computeTriangleMinEdgeLength(int idTri) const
 {
     const Mesh::triangle& t = tris[idTri];
-    return std::min(std::min((pts[t.v[0]] - pts[t.v[1]]).size(),
-                             (pts[t.v[1]] - pts[t.v[2]]).size()),
-                             (pts[t.v[2]] - pts[t.v[0]]).size());
+    return std::min({(pts[t.v[0]] - pts[t.v[1]]).size(),
+                     (pts[t.v[1]] - pts[t.v[2]]).size(),
+                     (pts[t.v[2]] - pts[t.v[0]]).size()});
 }
 
 void Mesh::computeNormalsForPts(StaticVector<Point3d>& out_nms)

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -560,8 +560,12 @@ void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
                     // compute the Bottom-Left minima of the current UDIM for [0,1] range remapping
                     Point2d udimBL;
                     StaticVector<Point2d>& uvCoords = mesh->uvCoords;
-                    udimBL.x = std::floor(std::min(std::min(uvCoords[triangleUvIds[0]].x, uvCoords[triangleUvIds[1]].x), uvCoords[triangleUvIds[2]].x));
-                    udimBL.y = std::floor(std::min(std::min(uvCoords[triangleUvIds[0]].y, uvCoords[triangleUvIds[1]].y), uvCoords[triangleUvIds[2]].y));
+                    udimBL.x = std::floor(std::min({uvCoords[triangleUvIds[0]].x,
+                                                    uvCoords[triangleUvIds[1]].x,
+                                                    uvCoords[triangleUvIds[2]].x}));
+                    udimBL.y = std::floor(std::min({uvCoords[triangleUvIds[0]].y,
+                                                    uvCoords[triangleUvIds[1]].y,
+                                                    uvCoords[triangleUvIds[2]].y}));
 
                     for(int k = 0; k < 3; ++k)
                     {
@@ -579,10 +583,10 @@ void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
                     // min values: floor(value)
                     // max values: ceil(value)
                     Pixel LU, RD;
-                    LU.x = static_cast<int>(std::floor(std::min(std::min(triPixs[0].x, triPixs[1].x), triPixs[2].x)));
-                    LU.y = static_cast<int>(std::floor(std::min(std::min(triPixs[0].y, triPixs[1].y), triPixs[2].y)));
-                    RD.x = static_cast<int>(std::ceil(std::max(std::max(triPixs[0].x, triPixs[1].x), triPixs[2].x)));
-                    RD.y = static_cast<int>(std::ceil(std::max(std::max(triPixs[0].y, triPixs[1].y), triPixs[2].y)));
+                    LU.x = static_cast<int>(std::floor(std::min({triPixs[0].x, triPixs[1].x, triPixs[2].x})));
+                    LU.y = static_cast<int>(std::floor(std::min({triPixs[0].y, triPixs[1].y, triPixs[2].y})));
+                    RD.x = static_cast<int>(std::ceil(std::max({triPixs[0].x, triPixs[1].x, triPixs[2].x})));
+                    RD.y = static_cast<int>(std::ceil(std::max({triPixs[0].y, triPixs[1].y, triPixs[2].y})));
 
                     // sanity check: clamp values to [0; textureSide]
                     int texSide = static_cast<int>(texParams.textureSide);
@@ -1319,8 +1323,12 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
         // compute the Bottom-Left minima of the current UDIM for [0,1] range remapping
         Point2d udimBL;
         StaticVector<Point2d>& uvCoords = mesh->uvCoords;
-        udimBL.x = std::floor(std::min(std::min(uvCoords[triangleUvIds[0]].x, uvCoords[triangleUvIds[1]].x),uvCoords[triangleUvIds[2]].x));
-        udimBL.y = std::floor(std::min(std::min(uvCoords[triangleUvIds[0]].y, uvCoords[triangleUvIds[1]].y),uvCoords[triangleUvIds[2]].y));
+        udimBL.x = std::floor(std::min({uvCoords[triangleUvIds[0]].x,
+                                        uvCoords[triangleUvIds[1]].x,
+                                        uvCoords[triangleUvIds[2]].x}));
+        udimBL.y = std::floor(std::min({uvCoords[triangleUvIds[0]].y,
+                                        uvCoords[triangleUvIds[1]].y,
+                                        uvCoords[triangleUvIds[2]].y}));
 
         for(int k = 0; k < 3; k++)
         {
@@ -1339,10 +1347,10 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
         // min values: floor(value)
         // max values: ceil(value)
         Pixel LU, RD;
-        LU.x = static_cast<int>(std::floor(std::min(std::min(triPixs[0].x, triPixs[1].x), triPixs[2].x)));
-        LU.y = static_cast<int>(std::floor(std::min(std::min(triPixs[0].y, triPixs[1].y), triPixs[2].y)));
-        RD.x = static_cast<int>(std::ceil(std::max(std::max(triPixs[0].x, triPixs[1].x), triPixs[2].x)));
-        RD.y = static_cast<int>(std::ceil(std::max(std::max(triPixs[0].y, triPixs[1].y), triPixs[2].y)));
+        LU.x = static_cast<int>(std::floor(std::min({triPixs[0].x, triPixs[1].x, triPixs[2].x})));
+        LU.y = static_cast<int>(std::floor(std::min({triPixs[0].y, triPixs[1].y, triPixs[2].y})));
+        RD.x = static_cast<int>(std::ceil(std::max({triPixs[0].x, triPixs[1].x, triPixs[2].x})));
+        RD.y = static_cast<int>(std::ceil(std::max({triPixs[0].y, triPixs[1].y, triPixs[2].y})));
 
         // sanity check: clamp values to [0; textureSide]
         int texSide = static_cast<int>(texParams.textureSide);

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -610,7 +610,7 @@ StaticVector<int> MultiViewParams::findNearestCamsFromLandmarks(int rc, int nbNe
   qsort(&ids[0], ids.size(), sizeof(SortedId), qsortCompareSortedIdDesc);
 
   // ensure the ideal number of target cameras is not superior to the actual number of cameras
-  const int maxTc = std::min(std::min(getNbCameras(), nbNearestCams), static_cast<int>(ids.size()));
+  const int maxTc = std::min({getNbCameras(), nbNearestCams, static_cast<int>(ids.size())});
   out.reserve(maxTc);
 
   for(int i = 0; i < maxTc; ++i)

--- a/src/aliceVision/mvsUtils/common.cpp
+++ b/src/aliceVision/mvsUtils/common.cpp
@@ -410,8 +410,9 @@ StaticVector<Point3d>* lineSegmentHexahedronIntersection(const Point3d& linePoin
 void triangleRectangleIntersection(Point3d& A, Point3d& B, Point3d& C, const MultiViewParams& mp, int rc,
                                                      Point2d P[4], StaticVector<Point3d>& out)
 {
-    const double maxd =
-        std::max(std::max((mp.CArr[rc] - A).size(), (mp.CArr[rc] - B).size()), (mp.CArr[rc] - C).size()) * 1000.0f;
+    const double maxd = std::max({(mp.CArr[rc] - A).size(),
+                                  (mp.CArr[rc] - B).size(),
+                                  (mp.CArr[rc] - C).size()}) * 1000.0f;
 
     out.reserve(40);
 


### PR DESCRIPTION
These functions have overloads accepting std::initializer_list argument which does not introduce performance overheads.
