### PR TITLE
Merge EImageFileType and EImageColorSpace enums from image and imageIO modules

### DIFF
--- a/src/aliceVision/depthMap/DepthSimMap.cpp
+++ b/src/aliceVision/depthMap/DepthSimMap.cpp
@@ -392,7 +392,8 @@ void DepthSimMap::saveToImage(const std::string& filename, float simThr) const
 
         oiio::ParamValueList metadata;
         using namespace imageIO;
-        writeImage(filename, bufferWidth, _h, colorBuffer, EImageQuality::LOSSLESS, OutputFileColorSpace(EImageColorSpace::NO_CONVERSION), metadata);
+        writeImage(filename, bufferWidth, _h, colorBuffer, EImageQuality::LOSSLESS,
+                   OutputFileColorSpace(image::EImageColorSpace::NO_CONVERSION), metadata);
     }
     catch (...)
     {
@@ -459,8 +460,12 @@ void DepthSimMap::save(const std::string& customSuffix, bool useStep1) const
     metadata.push_back(oiio::ParamValue("AliceVision:nbDepthValues", oiio::TypeDesc::INT32, 1, &nbDepthValues));
 
     using namespace imageIO;
-    writeImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::depthMap, _scale, customSuffix), width, height, depthMap.getDataWritable(), EImageQuality::LOSSLESS, OutputFileColorSpace(EImageColorSpace::NO_CONVERSION), metadata);
-    writeImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::simMap, _scale, customSuffix), width, height, simMap.getDataWritable(), imageIO::EImageQuality::OPTIMIZED, OutputFileColorSpace(EImageColorSpace::NO_CONVERSION), metadata);
+    writeImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::depthMap, _scale, customSuffix),
+               width, height, depthMap.getDataWritable(), EImageQuality::LOSSLESS,
+               OutputFileColorSpace(image::EImageColorSpace::NO_CONVERSION), metadata);
+    writeImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::simMap, _scale, customSuffix),
+               width, height, simMap.getDataWritable(), imageIO::EImageQuality::OPTIMIZED,
+               OutputFileColorSpace(image::EImageColorSpace::NO_CONVERSION), metadata);
 }
 
 void DepthSimMap::load(int fromScale)
@@ -471,8 +476,10 @@ void DepthSimMap::load(int fromScale)
     StaticVector<float> simMap;
 
     using namespace imageIO;
-    readImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::depthMap, fromScale), width, height, depthMap.getDataWritable(), EImageColorSpace::NO_CONVERSION);
-    readImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::simMap, fromScale), width, height, simMap.getDataWritable(), EImageColorSpace::NO_CONVERSION);
+    readImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::depthMap, fromScale),
+              width, height, depthMap.getDataWritable(), image::EImageColorSpace::NO_CONVERSION);
+    readImage(getFileNameFromIndex(_mp, _rc, mvsUtils::EFileType::simMap, fromScale),
+              width, height, simMap.getDataWritable(), image::EImageColorSpace::NO_CONVERSION);
 
     initFromDepthMapAndSimMap(&depthMap, &simMap, fromScale);
 }

--- a/src/aliceVision/depthMap/depthMap.cpp
+++ b/src/aliceVision/depthMap/depthMap.cpp
@@ -73,7 +73,7 @@ void estimateAndRefineDepthMaps(int cudaDeviceIndex, mvsUtils::MultiViewParams& 
     computeScaleStepSgmParams(mp, sgmParams);
 
     // load images from files into RAM
-    mvsUtils::ImagesCache<ImageRGBAf> ic(mp, imageIO::EImageColorSpace::LINEAR);
+    mvsUtils::ImagesCache<ImageRGBAf> ic(mp, image::EImageColorSpace::LINEAR);
 
     // load stuff on GPU memory and creates multi-level images and computes gradients
     PlaneSweepingCuda cps(cudaDeviceIndex, ic, mp, sgmParams.scale);
@@ -115,7 +115,7 @@ void computeNormalMaps(int cudaDeviceIndex, mvsUtils::MultiViewParams& mp, const
     const float gammaP = 1.0f;
     const int wsh = 3;
 
-    mvsUtils::ImagesCache<ImageRGBAf> ic(mp, EImageColorSpace::LINEAR);
+    mvsUtils::ImagesCache<ImageRGBAf> ic(mp, image::EImageColorSpace::LINEAR);
     PlaneSweepingCuda cps(cudaDeviceIndex, ic, mp, 1);
 
     NormalMapping* mapping = cps.createNormalMapping();
@@ -129,13 +129,16 @@ void computeNormalMaps(int cudaDeviceIndex, mvsUtils::MultiViewParams& mp, const
             std::vector<float> depthMap;
             int w = 0;
             int h = 0;
-            readImage(getFileNameFromIndex(mp, rc, mvsUtils::EFileType::depthMap, 0), w, h, depthMap, EImageColorSpace::NO_CONVERSION);
+            readImage(getFileNameFromIndex(mp, rc, mvsUtils::EFileType::depthMap, 0), w, h, depthMap,
+                      image::EImageColorSpace::NO_CONVERSION);
 
             std::vector<ColorRGBf> normalMap;
             normalMap.resize(mp.getWidth(rc) * mp.getHeight(rc));
 
             cps.computeNormalMap(mapping, depthMap, normalMap, rc, 1, gammaC, gammaP, wsh);
-            writeImage(normalMapFilepath, mp.getWidth(rc), mp.getHeight(rc), normalMap, EImageQuality::LOSSLESS, OutputFileColorSpace(EImageColorSpace::NO_CONVERSION));
+            writeImage(normalMapFilepath, mp.getWidth(rc), mp.getHeight(rc), normalMap,
+                       EImageQuality::LOSSLESS,
+                       OutputFileColorSpace(image::EImageColorSpace::NO_CONVERSION));
         }
     }
     cps.deleteNormalMapping(mapping);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -300,7 +300,8 @@ void createVerticesWithVisibilities(const StaticVector<int>& cams, std::vector<P
         int width, height;
         {
             const std::string depthMapFilepath = getFileNameFromIndex(mp, c, mvsUtils::EFileType::depthMap, 0);
-            imageIO::readImage(depthMapFilepath, width, height, depthMap, imageIO::EImageColorSpace::NO_CONVERSION);
+            imageIO::readImage(depthMapFilepath, width, height, depthMap,
+                               image::EImageColorSpace::NO_CONVERSION);
             if(depthMap.empty())
             {
                 ALICEVISION_LOG_WARNING("Empty depth map: " << depthMapFilepath);
@@ -312,7 +313,8 @@ void createVerticesWithVisibilities(const StaticVector<int>& cams, std::vector<P
             // else init with a constant value.
             if(boost::filesystem::exists(simMapFilepath))
             {
-                imageIO::readImage(simMapFilepath, wTmp, hTmp, simMap, imageIO::EImageColorSpace::NO_CONVERSION);
+                imageIO::readImage(simMapFilepath, wTmp, hTmp, simMap,
+                                   image::EImageColorSpace::NO_CONVERSION);
                 if(wTmp != width || hTmp != height)
                     throw std::runtime_error("Similarity map size doesn't match the depth map size: " + simMapFilepath +
                                              ", " + depthMapFilepath);
@@ -950,7 +952,8 @@ void DelaunayGraphCut::addMaskHelperPoints(const Point3d voxel[8], const StaticV
             int width, height;
             {
                 const std::string depthMapFilepath = getFileNameFromIndex(_mp, c, mvsUtils::EFileType::depthMap, 0);
-                imageIO::readImage(depthMapFilepath, width, height, depthMap, imageIO::EImageColorSpace::NO_CONVERSION);
+                imageIO::readImage(depthMapFilepath, width, height, depthMap,
+                                   image::EImageColorSpace::NO_CONVERSION);
                 if(depthMap.empty())
                 {
                     ALICEVISION_LOG_WARNING("Empty depth map: " << depthMapFilepath);
@@ -1091,7 +1094,7 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
             int width, height;
             {
                 const std::string depthMapFilepath = getFileNameFromIndex(_mp, c, mvsUtils::EFileType::depthMap, 0);
-                imageIO::readImage(depthMapFilepath, width, height, depthMap, imageIO::EImageColorSpace::NO_CONVERSION);
+                imageIO::readImage(depthMapFilepath, width, height, depthMap, image::EImageColorSpace::NO_CONVERSION);
                 if(depthMap.empty())
                 {
                     ALICEVISION_LOG_WARNING("Empty depth map: " << depthMapFilepath);
@@ -1103,7 +1106,7 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
                 // else init with a constant value.
                 if(boost::filesystem::exists(simMapFilepath))
                 {
-                    imageIO::readImage(simMapFilepath, wTmp, hTmp, simMap, imageIO::EImageColorSpace::NO_CONVERSION);
+                    imageIO::readImage(simMapFilepath, wTmp, hTmp, simMap, image::EImageColorSpace::NO_CONVERSION);
                     if(wTmp != width || hTmp != height)
                         throw std::runtime_error("Wrong sim map dimensions: " + simMapFilepath);
                     {
@@ -1124,7 +1127,7 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
                 if(boost::filesystem::exists(nmodMapFilepath))
                 {
                     imageIO::readImage(nmodMapFilepath, wTmp, hTmp, numOfModalsMap,
-                                       imageIO::EImageColorSpace::NO_CONVERSION);
+                                       image::EImageColorSpace::NO_CONVERSION);
                     if(wTmp != width || hTmp != height)
                         throw std::runtime_error("Wrong nmod map dimensions: " + nmodMapFilepath);
                 }

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -47,7 +47,9 @@ unsigned long computeNumberOfAllPoints(const mvsUtils::MultiViewParams& mp, int 
 
             ALICEVISION_LOG_WARNING("Can't find or invalid 'nbDepthValues' metadata in '" << filename << "'. Recompute the number of valid values.");
 
-            imageIO::readImage(mvsUtils::getFileNameFromIndex(mp, rc, mvsUtils::EFileType::depthMap, scale), width, height, depthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
+            imageIO::readImage(mvsUtils::getFileNameFromIndex(mp, rc, mvsUtils::EFileType::depthMap, scale),
+                               width, height, depthMap.getDataWritable(),
+                               image::EImageColorSpace::NO_CONVERSION);
             // no need to transpose for this operation
             for(int i = 0; i < sizeOfStaticVector<float>(&depthMap); ++i)
                 nbDepthValues += static_cast<unsigned long>(depthMap[i] > 0.0f);
@@ -164,8 +166,12 @@ bool Fuser::filterGroupsRC(int rc, float pixToleranceFactor, int pixSizeBall, in
     {
         int width, height;
 
-        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, 1), width, height, depthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
-        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::simMap, 1), width, height, simMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
+        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, 1),
+                           width, height, depthMap.getDataWritable(),
+                           image::EImageColorSpace::NO_CONVERSION);
+        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::simMap, 1),
+                           width, height, simMap.getDataWritable(),
+                           image::EImageColorSpace::NO_CONVERSION);
     }
 
     std::vector<unsigned char> numOfModalsMap(w * h, 0);
@@ -193,7 +199,9 @@ bool Fuser::filterGroupsRC(int rc, float pixToleranceFactor, int pixSizeBall, in
 
         {
             int width, height;
-            imageIO::readImage(getFileNameFromIndex(_mp, tc, mvsUtils::EFileType::depthMap, 1), width, height, tcdepthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
+            imageIO::readImage(getFileNameFromIndex(_mp, tc, mvsUtils::EFileType::depthMap, 1),
+                               width, height, tcdepthMap.getDataWritable(),
+                               image::EImageColorSpace::NO_CONVERSION);
         }
 
         if(!tcdepthMap.empty())
@@ -220,7 +228,9 @@ bool Fuser::filterGroupsRC(int rc, float pixToleranceFactor, int pixSizeBall, in
 
     {
         using namespace imageIO;
-        writeImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap), w, h, numOfModalsMap, EImageQuality::LOSSLESS, OutputFileColorSpace(EImageColorSpace::NO_CONVERSION));
+        writeImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap), w, h,
+                   numOfModalsMap, EImageQuality::LOSSLESS,
+                   OutputFileColorSpace(image::EImageColorSpace::NO_CONVERSION));
     }
 
     delete numOfPtsMap;
@@ -261,9 +271,12 @@ bool Fuser::filterDepthMapsRC(int rc, int minNumOfModals, int minNumOfModalsWSP2
     {
         int width, height;
 
-        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, 1), width, height, depthMap, imageIO::EImageColorSpace::NO_CONVERSION);
-        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::simMap, 1), width, height, simMap, imageIO::EImageColorSpace::NO_CONVERSION);
-        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap), width, height, numOfModalsMap, imageIO::EImageColorSpace::NO_CONVERSION);
+        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, 1),
+                           width, height, depthMap, image::EImageColorSpace::NO_CONVERSION);
+        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::simMap, 1),
+                           width, height, simMap, image::EImageColorSpace::NO_CONVERSION);
+        imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap),
+                           width, height, numOfModalsMap, image::EImageColorSpace::NO_CONVERSION);
     }
 
     int nbDepthValues = 0;
@@ -318,8 +331,12 @@ bool Fuser::filterDepthMapsRC(int rc, int minNumOfModals, int minNumOfModalsWSP2
     }
 
     using namespace imageIO;
-    writeImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, 0), w, h, depthMap, EImageQuality::LOSSLESS, OutputFileColorSpace(EImageColorSpace::NO_CONVERSION), metadata);
-    writeImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::simMap, 0), w, h, simMap, EImageQuality::OPTIMIZED, OutputFileColorSpace(EImageColorSpace::NO_CONVERSION), metadata);
+    writeImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, 0), w, h, depthMap,
+               EImageQuality::LOSSLESS,
+               OutputFileColorSpace(image::EImageColorSpace::NO_CONVERSION), metadata);
+    writeImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::simMap, 0), w, h, simMap,
+               EImageQuality::OPTIMIZED,
+               OutputFileColorSpace(image::EImageColorSpace::NO_CONVERSION), metadata);
 
     ALICEVISION_LOG_DEBUG(rc << " solved.");
     mvsUtils::printfElapsedTime(t1);
@@ -346,7 +363,9 @@ float Fuser::computeAveragePixelSizeInHexahedron(Point3d* hexah, int step, int s
 
         {
             int width, height;
-            imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, scale), width, height, rcdepthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
+            imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, scale),
+                               width, height, rcdepthMap.getDataWritable(),
+                               image::EImageColorSpace::NO_CONVERSION);
         }
 
         for(int y = 0; y < h; y++)
@@ -444,7 +463,9 @@ void Fuser::divideSpaceFromDepthMaps(Point3d* hexah, float& minPixSize)
         {
             int width, height;
 
-            imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, scale), width, height, depthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
+            imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, scale),
+                               width, height, depthMap.getDataWritable(),
+                               image::EImageColorSpace::NO_CONVERSION);
         }
 
         for(int i = 0; i < sizeOfStaticVector<float>(&depthMap); i += stepPts)
@@ -488,7 +509,9 @@ void Fuser::divideSpaceFromDepthMaps(Point3d* hexah, float& minPixSize)
         {
             int width, height;
 
-            imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, scale), width, height, depthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
+            imageIO::readImage(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::depthMap, scale),
+                               width, height, depthMap.getDataWritable(),
+                               image::EImageColorSpace::NO_CONVERSION);
         }
 
         for(int i = 0; i < depthMap.size(); i += stepPts)
@@ -763,8 +786,12 @@ std::string generateTempPtsSimsFiles(const std::string& tmpDir, mvsUtils::MultiV
             {
                 int width, height;
 
-                imageIO::readImage(getFileNameFromIndex(mp, rc, mvsUtils::EFileType::depthMap, scale), width, height, depthMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
-                imageIO::readImage(getFileNameFromIndex(mp, rc, mvsUtils::EFileType::simMap, scale), width, height, simMap.getDataWritable(), imageIO::EImageColorSpace::NO_CONVERSION);
+                imageIO::readImage(getFileNameFromIndex(mp, rc, mvsUtils::EFileType::depthMap, scale),
+                                   width, height, depthMap.getDataWritable(),
+                                   image::EImageColorSpace::NO_CONVERSION);
+                imageIO::readImage(getFileNameFromIndex(mp, rc, mvsUtils::EFileType::simMap, scale),
+                                   width, height, simMap.getDataWritable(),
+                                   image::EImageColorSpace::NO_CONVERSION);
             }
 
             if(addRandomNoise)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -36,6 +36,8 @@ std::string EImageColorSpace_informations()
            EImageColorSpace_enumToString(EImageColorSpace::SRGB) + ", " +
            EImageColorSpace_enumToString(EImageColorSpace::ACES) + ", " +
            EImageColorSpace_enumToString(EImageColorSpace::ACEScg) + ", " +
+           EImageColorSpace_enumToString(EImageColorSpace::LAB) + ", " +
+           EImageColorSpace_enumToString(EImageColorSpace::XYZ) + ", " +
            EImageColorSpace_enumToString(EImageColorSpace::NO_CONVERSION);
 }
 
@@ -53,6 +55,10 @@ EImageColorSpace EImageColorSpace_stringToEnum(const std::string& dataType)
         return EImageColorSpace::ACES;
     if(type == "acescg")
         return EImageColorSpace::ACEScg;
+    if(type == "lab")
+        return EImageColorSpace::LAB;
+    if(type == "xyz")
+        return EImageColorSpace::XYZ;
     if(type == "no_conversion")
         return EImageColorSpace::NO_CONVERSION;
 
@@ -73,10 +79,29 @@ std::string EImageColorSpace_enumToString(const EImageColorSpace dataType)
             return "aces";
         case EImageColorSpace::ACEScg:
             return "acescg";
+        case EImageColorSpace::LAB:
+            return "lab";
+        case EImageColorSpace::XYZ:
+            return "xyz";
         case EImageColorSpace::NO_CONVERSION:
             return "no_conversion";
     }
     throw std::out_of_range("Invalid EImageColorSpace enum");
+}
+
+std::string EImageColorSpace_enumToOIIOString(const EImageColorSpace colorSpace)
+{
+     // WARNING: string should match with OIIO definitions or implemented conversion
+    switch(colorSpace)
+    {
+        case EImageColorSpace::SRGB: return "sRGB";
+        case EImageColorSpace::LINEAR: return "Linear";
+        case EImageColorSpace::LAB: return "LAB";
+        case EImageColorSpace::XYZ: return "XYZ";
+        default: ;
+    }
+    throw std::out_of_range("No string defined for EImageColorSpace to OIIO conversion: " +
+                            std::to_string(int(colorSpace)));
 }
 
 std::ostream& operator<<(std::ostream& os, EImageColorSpace dataType)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -122,6 +122,7 @@ std::string EImageFileType_enumToString(const EImageFileType imageFileType)
     case EImageFileType::PNG:   return "png";
     case EImageFileType::TIFF:  return "tif";
     case EImageFileType::EXR:   return "exr";
+    case EImageFileType::NONE:  return "none";
   }
   throw std::out_of_range("Invalid EImageType enum");
 }

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -49,7 +49,8 @@ enum class EImageFileType
   JPEG,
   PNG,
   TIFF,
-  EXR
+  EXR,
+  NONE
 };
 
 /**

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -31,12 +31,15 @@ enum class EImageColorSpace
   SRGB,
   ACES,
   ACEScg,
+  LAB,
+  XYZ,
   NO_CONVERSION
 };
 
 std::string EImageColorSpace_informations();
 EImageColorSpace EImageColorSpace_stringToEnum(const std::string& dataType);
 std::string EImageColorSpace_enumToString(const EImageColorSpace dataType);
+std::string EImageColorSpace_enumToOIIOString(const EImageColorSpace colorSpace);
 std::ostream& operator<<(std::ostream& os, EImageColorSpace dataType);
 std::istream& operator>>(std::istream& in, EImageColorSpace& dataType);
 

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -285,7 +285,8 @@ void Texturing::updateAtlases()
 }
 
 void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
-                                 const boost::filesystem::path& outPath, imageIO::EImageFileType textureFileType)
+                                 const boost::filesystem::path& outPath,
+                                 image::EImageFileType textureFileType)
 {
     // Ensure that contribution levels do not contain 0 and are sorted (as each frequency band contributes to lower bands).
     auto& m = texParams.multiBandNbContrib;
@@ -369,7 +370,10 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
 }
 
 void Texturing::generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
-                                const std::vector<size_t>& atlasIDs, mvsUtils::ImagesCache<ImageRGBf>& imageCache, const bfs::path& outPath, imageIO::EImageFileType textureFileType)
+                                       const std::vector<size_t>& atlasIDs,
+                                       mvsUtils::ImagesCache<ImageRGBf>& imageCache,
+                                       const bfs::path& outPath,
+                                       image::EImageFileType textureFileType)
 {
     if(atlasIDs.size() > _atlases.size())
         throw std::runtime_error("Invalid atlas IDs ");
@@ -759,7 +763,7 @@ void Texturing::generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp,
 
 
 void Texturing::writeTexture(AccuImage& atlasTexture, const std::size_t atlasID, const boost::filesystem::path &outPath,
-                             imageIO::EImageFileType textureFileType, const int level)
+                             image::EImageFileType textureFileType, const int level)
 {
     unsigned int outTextureSide = texParams.textureSide;
     // WARNING: we modify the "imgCount" to apply the padding (to avoid the creation of a new buffer)
@@ -889,7 +893,7 @@ void Texturing::writeTexture(AccuImage& atlasTexture, const std::size_t atlasID,
         std::swap(resizedColorBuffer, atlasTexture.img);
     }
 
-    const std::string textureName = "texture_" + std::to_string(1001 + atlasID) + (level < 0 ? "" : "_" + std::to_string(level)) + "." + imageIO::EImageFileType_enumToString(textureFileType); // starts at '1001' for UDIM compatibility
+    const std::string textureName = "texture_" + std::to_string(1001 + atlasID) + (level < 0 ? "" : "_" + std::to_string(level)) + "." + image::EImageFileType_enumToString(textureFileType); // starts at '1001' for UDIM compatibility
     bfs::path texturePath = outPath / textureName;
     ALICEVISION_LOG_INFO("  - Writing texture file: " << texturePath.string());
 
@@ -1021,7 +1025,7 @@ void Texturing::unwrap(mvsUtils::MultiViewParams& mp, EUnwrapMethod method)
 
 void Texturing::saveAs(const bfs::path& dir, const std::string& basename, 
     EFileType meshFileType, 
-    imageIO::EImageFileType textureFileType,
+    image::EImageFileType textureFileType,
     const BumpMappingParams& bumpMappingParams)
 {
     const std::string meshFileTypeStr = EFileType_enumToString(meshFileType);
@@ -1050,7 +1054,7 @@ void Texturing::saveAs(const bfs::path& dir, const std::string& basename,
     {      
         // starts at '1001' for UDIM compatibility
         const std::size_t textureId = 1001 + atlasId;
-        const std::string texturePath = "texture_" + std::to_string(textureId) + "." + imageIO::EImageFileType_enumToString(textureFileType);
+        const std::string texturePath = "texture_" + std::to_string(textureId) + "." + image::EImageFileType_enumToString(textureFileType);
 
         //Set material for this atlas
         const aiVector3D valcolor(0.6, 0.6, 0.6);
@@ -1068,26 +1072,26 @@ void Texturing::saveAs(const bfs::path& dir, const std::string& basename,
         scene.mMaterials[atlasId]->AddProperty(&texName, AI_MATKEY_NAME);
 
         // Color Mapping
-        if(textureFileType != imageIO::EImageFileType::NONE)
+        if(textureFileType != image::EImageFileType::NONE)
         {
             const aiString texFile(texturePath);
             scene.mMaterials[atlasId]->AddProperty(&texFile, AI_MATKEY_TEXTURE_DIFFUSE(0));
         }
 
         // Displacement Mapping
-        if(bumpMappingParams.displacementFileType != imageIO::EImageFileType::NONE)
+        if(bumpMappingParams.displacementFileType != image::EImageFileType::NONE)
         {
             const aiString texFileHeightMap("Displacement_" + std::to_string(textureId) + "." +EImageFileType_enumToString(bumpMappingParams.bumpMappingFileType));
             scene.mMaterials[atlasId]->AddProperty(&texFileHeightMap, AI_MATKEY_TEXTURE_DISPLACEMENT(0));
         }
         
         // Bump Mapping
-        if(bumpMappingParams.bumpType == EBumpMappingType::Normal && bumpMappingParams.bumpMappingFileType != imageIO::EImageFileType::NONE)
+        if(bumpMappingParams.bumpType == EBumpMappingType::Normal && bumpMappingParams.bumpMappingFileType != image::EImageFileType::NONE)
         {
             const aiString texFileNormalMap("Normal_" + std::to_string(textureId) + "." + EImageFileType_enumToString(bumpMappingParams.bumpMappingFileType));
             scene.mMaterials[atlasId]->AddProperty(&texFileNormalMap, AI_MATKEY_TEXTURE_NORMALS(0));
         }
-        else if(bumpMappingParams.bumpType == EBumpMappingType::Height && bumpMappingParams.bumpMappingFileType != imageIO::EImageFileType::NONE)
+        else if(bumpMappingParams.bumpType == EBumpMappingType::Height && bumpMappingParams.bumpMappingFileType != image::EImageFileType::NONE)
         {
             const aiString texFileHeightMap("Bump_" + std::to_string(textureId) + "." + EImageFileType_enumToString(bumpMappingParams.displacementFileType));
             scene.mMaterials[atlasId]->AddProperty(&texFileHeightMap, AI_MATKEY_TEXTURE_HEIGHT(0));
@@ -1416,7 +1420,7 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
     }
 
     // Save Normal Map
-    if(bumpMappingParams.bumpType == EBumpMappingType::Normal && bumpMappingParams.bumpMappingFileType != imageIO::EImageFileType::NONE)
+    if(bumpMappingParams.bumpType == EBumpMappingType::Normal && bumpMappingParams.bumpMappingFileType != image::EImageFileType::NONE)
     {
         unsigned int outTextureSide = texParams.textureSide;
         // downscale texture if required
@@ -1451,7 +1455,7 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
     }
 
     // Save Height Maps
-    if(bumpMappingParams.bumpMappingFileType != imageIO::EImageFileType::NONE || bumpMappingParams.displacementFileType != imageIO::EImageFileType::NONE)
+    if(bumpMappingParams.bumpMappingFileType != image::EImageFileType::NONE || bumpMappingParams.displacementFileType != image::EImageFileType::NONE)
     {
         unsigned int outTextureSide = texParams.textureSide;
         if(texParams.downscale > 1)
@@ -1466,7 +1470,7 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
 
         // Height maps are only in .EXR at this time, so this will never be executed.
         // 
-        //if(bumpMappingParams.bumpMappingFileType != imageIO::EImageFileType::EXR)
+        //if(bumpMappingParams.bumpMappingFileType != image::EImageFileType::EXR)
         //{
         //    // Y: [-1, 0, +1] => [0, 128, 255]
         //    for(unsigned int i = 0; i < heightMap.size(); ++i)
@@ -1483,7 +1487,7 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
             imageIO::writeImage(bumpMapPath.string(), outTextureSide, outTextureSide, heightMap, imageIO::EImageQuality::OPTIMIZED, outputColorSpace);
         }
         // Save Displacement Map
-        if(bumpMappingParams.displacementFileType != imageIO::EImageFileType::NONE)
+        if(bumpMappingParams.displacementFileType != image::EImageFileType::NONE)
         {
             const std::string dispName = "Displacement_" + std::to_string(1001 + atlasID) + "." + EImageFileType_enumToString(bumpMappingParams.displacementFileType);
             bfs::path dispMapPath = outPath / dispName;

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -305,7 +305,7 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
     }
     std::partial_sum(m.begin(), m.end(), m.begin());
 
-    ALICEVISION_LOG_INFO("Texturing in " + imageIO::EImageColorSpace_enumToString(texParams.processColorspace) + " colorspace.");
+    ALICEVISION_LOG_INFO("Texturing in " + image::EImageColorSpace_enumToString(texParams.processColorspace) + " colorspace.");
     mvsUtils::ImagesCache<ImageRGBf> imageCache(mp, texParams.processColorspace, texParams.correctEV);
     imageCache.setCacheSize(2);
     ALICEVISION_LOG_INFO("Images loaded from cache with: " + ECorrectEV_enumToString(texParams.correctEV));
@@ -754,7 +754,7 @@ void Texturing::generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp,
     toGeoMesh(*mesh, geoSparseMesh);
     GEO::compute_normals(geoSparseMesh);
 
-    mvsUtils::ImagesCache<ImageRGBf> imageCache(mp, imageIO::EImageColorSpace::NO_CONVERSION);
+    mvsUtils::ImagesCache<ImageRGBf> imageCache(mp, image::EImageColorSpace::NO_CONVERSION);
     
     for(size_t atlasID = 0; atlasID < _atlases.size(); ++atlasID)
         _generateNormalAndHeightMaps(mp, denseMeshAABB, geoSparseMesh, atlasID, imageCache, outPath, bumpMappingParams);
@@ -898,7 +898,7 @@ void Texturing::writeTexture(AccuImage& atlasTexture, const std::size_t atlasID,
     ALICEVISION_LOG_INFO("  - Writing texture file: " << texturePath.string());
 
     using namespace imageIO;
-    OutputFileColorSpace colorspace(texParams.processColorspace, EImageColorSpace::AUTO);
+    OutputFileColorSpace colorspace(texParams.processColorspace, image::EImageColorSpace::AUTO);
     writeImage(texturePath.string(), atlasTexture.img, EImageQuality::OPTIMIZED, colorspace);
 }
 
@@ -1450,7 +1450,8 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
         bfs::path normalMapPath = outPath / name;
         ALICEVISION_LOG_INFO("Writing normal map: " << normalMapPath.string());
 
-        imageIO::OutputFileColorSpace outputColorSpace(imageIO::EImageColorSpace::NO_CONVERSION,imageIO::EImageColorSpace::NO_CONVERSION);
+        imageIO::OutputFileColorSpace outputColorSpace(image::EImageColorSpace::NO_CONVERSION,
+                                                       image::EImageColorSpace::NO_CONVERSION);
         imageIO::writeImage(normalMapPath.string(), outTextureSide, outTextureSide, normalMap, imageIO::EImageQuality::OPTIMIZED, outputColorSpace);
     }
 
@@ -1478,7 +1479,7 @@ void Texturing::_generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp
         //}
 
         // Save Bump Map
-        imageIO::OutputFileColorSpace outputColorSpace(imageIO::EImageColorSpace::AUTO);
+        imageIO::OutputFileColorSpace outputColorSpace(image::EImageColorSpace::AUTO);
         if(bumpMappingParams.bumpType == EBumpMappingType::Height)
         {
             const std::string bumpName = "Bump_" + std::to_string(1001 + atlasID) + "." + EImageFileType_enumToString(bumpMappingParams.bumpMappingFileType);

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -89,7 +89,7 @@ struct TexturingParams
     double angleHardThreshold = 90.0; //< 0.0 to disable angle hard threshold filtering
 
     image::EImageFileType textureFileType = image::EImageFileType::NONE;
-    imageIO::EImageColorSpace processColorspace = imageIO::EImageColorSpace::SRGB; // colorspace for the texturing internal computation
+    image::EImageColorSpace processColorspace = image::EImageColorSpace::SRGB; // colorspace for the texturing internal computation
     mvsUtils::ECorrectEV correctEV{mvsUtils::ECorrectEV::NO_CORRECTION};
 
     bool forceVisibleByAllVertices = false; //< triangle visibility is based on the union of vertices visiblity

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/mvsData/imageIO.hpp>
 #include <aliceVision/mvsData/Point2d.hpp>
 #include <aliceVision/mvsData/Point3d.hpp>
@@ -64,8 +65,8 @@ std::ostream& operator<<(std::ostream& os, EBumpMappingType meshFileType);
 
 struct BumpMappingParams
 {
-    imageIO::EImageFileType bumpMappingFileType = imageIO::EImageFileType::NONE;
-    imageIO::EImageFileType displacementFileType = imageIO::EImageFileType::NONE;
+    image::EImageFileType bumpMappingFileType = image::EImageFileType::NONE;
+    image::EImageFileType displacementFileType = image::EImageFileType::NONE;
 
     EBumpMappingType bumpType = EBumpMappingType::Normal;
 };
@@ -87,7 +88,7 @@ struct TexturingParams
     double bestScoreThreshold = 0.1; //< 0.0 to disable filtering based on threshold to relative best score
     double angleHardThreshold = 90.0; //< 0.0 to disable angle hard threshold filtering
 
-    imageIO::EImageFileType textureFileType = imageIO::EImageFileType::NONE;
+    image::EImageFileType textureFileType = image::EImageFileType::NONE;
     imageIO::EImageColorSpace processColorspace = imageIO::EImageColorSpace::SRGB; // colorspace for the texturing internal computation
     mvsUtils::ECorrectEV correctEV{mvsUtils::ECorrectEV::NO_CORRECTION};
 
@@ -190,12 +191,14 @@ public:
 
     /// Generate texture files for all texture atlases
     void generateTextures(const mvsUtils::MultiViewParams& mp,
-                          const bfs::path &outPath, imageIO::EImageFileType textureFileType = imageIO::EImageFileType::PNG);
+                          const bfs::path &outPath,
+                          image::EImageFileType textureFileType = image::EImageFileType::PNG);
 
     /// Generate texture files for the given sub-set of texture atlases
     void generateTexturesSubSet(const mvsUtils::MultiViewParams& mp,
                          const std::vector<size_t>& atlasIDs, mvsUtils::ImagesCache<ImageRGBf>& imageCache,
-                         const bfs::path &outPath, imageIO::EImageFileType textureFileType = imageIO::EImageFileType::PNG);
+                                const bfs::path &outPath,
+                                image::EImageFileType textureFileType = image::EImageFileType::PNG);
 
     void generateNormalAndHeightMaps(const mvsUtils::MultiViewParams& mp, const Mesh& denseMesh,
                                      const bfs::path& outPath, const mesh::BumpMappingParams& bumpMappingParams);
@@ -206,12 +209,12 @@ public:
 
     ///Fill holes and write texture files for the given texture atlas
     void writeTexture(AccuImage& atlasTexture, const std::size_t atlasID, const bfs::path& outPath,
-                      imageIO::EImageFileType textureFileType, const int level);
+                      image::EImageFileType textureFileType, const int level);
 
     /// Save textured mesh as an OBJ + MTL file
     void saveAs(const bfs::path& dir, const std::string& basename,
                 aliceVision::mesh::EFileType meshFileType = aliceVision::mesh::EFileType::OBJ,
-                imageIO::EImageFileType textureFileType = imageIO::EImageFileType::EXR,
+                image::EImageFileType textureFileType = image::EImageFileType::EXR,
                 const BumpMappingParams& bumpMappingParams = BumpMappingParams());
 };
 

--- a/src/aliceVision/mvsData/CMakeLists.txt
+++ b/src/aliceVision/mvsData/CMakeLists.txt
@@ -40,6 +40,7 @@ alicevision_add_library(aliceVision_mvsData
   SOURCES ${mvsData_files_headers} ${mvsData_files_sources}
   PUBLIC_LINKS
     aliceVision_system
+    aliceVision_numeric
     ZLIB::ZLIB
     Boost::filesystem
     Boost::boost

--- a/src/aliceVision/mvsData/imageAlgo.cpp
+++ b/src/aliceVision/mvsData/imageAlgo.cpp
@@ -109,9 +109,11 @@ void processImage(oiio::ImageBuf& dst, const oiio::ImageBuf& src, std::function<
     processImage(dst, pixelFunc);
 }
 
-void colorconvert(oiio::ImageBuf& imgBuf, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace)
+void colorconvert(oiio::ImageBuf& imgBuf, image::EImageColorSpace fromColorSpace,
+                  image::EImageColorSpace toColorSpace)
 {
     using namespace imageIO;
+    using image::EImageColorSpace;
 
     if(fromColorSpace == toColorSpace)
         return;
@@ -168,7 +170,8 @@ void colorconvert(oiio::ImageBuf& imgBuf, imageIO::EImageColorSpace fromColorSpa
     ALICEVISION_LOG_TRACE("Convert image from " << EImageColorSpace_enumToString(fromColorSpace) << " to " << EImageColorSpace_enumToString(toColorSpace));
 }
 
-void colorconvert(ImageRGBf& image, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace)
+void colorconvert(ImageRGBf& image, image::EImageColorSpace fromColorSpace,
+                  image::EImageColorSpace toColorSpace)
 {
     oiio::ImageSpec imageSpec(image.width(), image.height(), 3, oiio::TypeDesc::FLOAT);
     std::vector<ColorRGBf>& buffer = image.data();
@@ -177,7 +180,8 @@ void colorconvert(ImageRGBf& image, imageIO::EImageColorSpace fromColorSpace, im
     colorconvert(imageBuf, fromColorSpace, toColorSpace);
 }
 
-void colorconvert(ImageRGBAf& image, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace)
+void colorconvert(ImageRGBAf& image, image::EImageColorSpace fromColorSpace,
+                  image::EImageColorSpace toColorSpace)
 {
     oiio::ImageSpec imageSpec(image.width(), image.height(), 4, oiio::TypeDesc::FLOAT);
     std::vector<ColorRGBAf>& buffer = image.data();
@@ -186,7 +190,8 @@ void colorconvert(ImageRGBAf& image, imageIO::EImageColorSpace fromColorSpace, i
     colorconvert(imageBuf, fromColorSpace, toColorSpace);
 }
 
-void colorconvert(oiio::ImageBuf& dst, const oiio::ImageBuf& src, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace)
+void colorconvert(oiio::ImageBuf& dst, const oiio::ImageBuf& src,
+                  image::EImageColorSpace fromColorSpace, image::EImageColorSpace toColorSpace)
 {
     dst.copy(src);
     colorconvert(dst, fromColorSpace, toColorSpace);

--- a/src/aliceVision/mvsData/imageAlgo.cpp
+++ b/src/aliceVision/mvsData/imageAlgo.cpp
@@ -120,7 +120,8 @@ void colorconvert(oiio::ImageBuf& imgBuf, imageIO::EImageColorSpace fromColorSpa
     {
         if(fromColorSpace == EImageColorSpace::SRGB)
             oiio::ImageBufAlgo::colorconvert(imgBuf, imgBuf,
-                                             EImageColorSpace_enumToString(EImageColorSpace::SRGB), EImageColorSpace_enumToString(EImageColorSpace::LINEAR));
+                                             EImageColorSpace_enumToOIIOString(EImageColorSpace::SRGB),
+                                             EImageColorSpace_enumToOIIOString(EImageColorSpace::LINEAR));
         else if(fromColorSpace == EImageColorSpace::XYZ)
             processImage(imgBuf, &XYZtoRGB);
         else if(fromColorSpace == EImageColorSpace::LAB)
@@ -133,7 +134,8 @@ void colorconvert(oiio::ImageBuf& imgBuf, imageIO::EImageColorSpace fromColorSpa
         else if(fromColorSpace == EImageColorSpace::LAB)
             processImage(imgBuf, &LABtoRGB);
         oiio::ImageBufAlgo::colorconvert(imgBuf, imgBuf,
-                                         EImageColorSpace_enumToString(EImageColorSpace::LINEAR), EImageColorSpace_enumToString(EImageColorSpace::SRGB));
+                                         EImageColorSpace_enumToOIIOString(EImageColorSpace::LINEAR),
+                                         EImageColorSpace_enumToOIIOString(EImageColorSpace::SRGB));
     }
     else if(toColorSpace == EImageColorSpace::XYZ)
     {
@@ -142,7 +144,8 @@ void colorconvert(oiio::ImageBuf& imgBuf, imageIO::EImageColorSpace fromColorSpa
         else if(fromColorSpace == EImageColorSpace::SRGB)
         {
             oiio::ImageBufAlgo::colorconvert(imgBuf, imgBuf,
-                                             EImageColorSpace_enumToString(EImageColorSpace::SRGB), EImageColorSpace_enumToString(EImageColorSpace::LINEAR));
+                                             EImageColorSpace_enumToOIIOString(EImageColorSpace::SRGB),
+                                             EImageColorSpace_enumToOIIOString(EImageColorSpace::LINEAR));
             processImage(imgBuf, &RGBtoXYZ);
         }
         else if(fromColorSpace == EImageColorSpace::LAB)
@@ -155,7 +158,8 @@ void colorconvert(oiio::ImageBuf& imgBuf, imageIO::EImageColorSpace fromColorSpa
         else if(fromColorSpace == EImageColorSpace::SRGB)
         {
             oiio::ImageBufAlgo::colorconvert(imgBuf, imgBuf,
-                                             EImageColorSpace_enumToString(EImageColorSpace::SRGB), EImageColorSpace_enumToString(EImageColorSpace::LINEAR));
+                                             EImageColorSpace_enumToOIIOString(EImageColorSpace::SRGB),
+                                             EImageColorSpace_enumToOIIOString(EImageColorSpace::LINEAR));
             processImage(imgBuf, &RGBtoLAB);
         }
         else if(fromColorSpace == EImageColorSpace::XYZ)

--- a/src/aliceVision/mvsData/imageAlgo.hpp
+++ b/src/aliceVision/mvsData/imageAlgo.hpp
@@ -39,10 +39,14 @@ void LABtoRGB(oiio::ImageBuf::Iterator<float>& pixel);
 void processImage(oiio::ImageBuf& image, std::function<void(oiio::ImageBuf::Iterator<float>&)> pixelFunc);
 void processImage(oiio::ImageBuf& dst, const oiio::ImageBuf& src, std::function<void(oiio::ImageBuf::Iterator<float>&)> pixelFunc);
 
-void colorconvert(oiio::ImageBuf& image, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace);
-void colorconvert(ImageRGBf& image, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace);
-void colorconvert(ImageRGBAf& image, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace);
-void colorconvert(oiio::ImageBuf& dst, const oiio::ImageBuf& src, imageIO::EImageColorSpace fromColorSpace, imageIO::EImageColorSpace toColorSpace);
+void colorconvert(oiio::ImageBuf& image, image::EImageColorSpace fromColorSpace,
+                  image::EImageColorSpace toColorSpace);
+void colorconvert(ImageRGBf& image, image::EImageColorSpace fromColorSpace,
+                  image::EImageColorSpace toColorSpace);
+void colorconvert(ImageRGBAf& image, image::EImageColorSpace fromColorSpace,
+                  image::EImageColorSpace toColorSpace);
+void colorconvert(oiio::ImageBuf& dst, const oiio::ImageBuf& src,
+                  image::EImageColorSpace fromColorSpace, image::EImageColorSpace toColorSpace);
 
 /**
  * @brief transpose a given image buffer

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -41,13 +41,27 @@ std::string EImageColorSpace_enumToString(const EImageColorSpace colorSpace)
 {
     switch(colorSpace)
     {
-    case EImageColorSpace::SRGB: return "sRGB"; // WARNING: string should match with OIIO definitions or implemented conversion
+    case EImageColorSpace::SRGB: return "sRGB";
     case EImageColorSpace::LINEAR: return "Linear";
     case EImageColorSpace::LAB: return "LAB";
     case EImageColorSpace::XYZ: return "XYZ";
     default: ;
     }
     throw std::out_of_range("No string defined for EImageColorSpace: " + std::to_string(int(colorSpace)));
+}
+
+std::string EImageColorSpace_enumToOIIOString(const EImageColorSpace colorSpace)
+{
+    switch(colorSpace)
+    {
+        case EImageColorSpace::SRGB: return "sRGB"; // WARNING: string should match with OIIO definitions or implemented conversion
+        case EImageColorSpace::LINEAR: return "Linear";
+        case EImageColorSpace::LAB: return "LAB";
+        case EImageColorSpace::XYZ: return "XYZ";
+        default: ;
+    }
+    throw std::out_of_range("No string defined for EImageColorSpace to OIIO conversion: " +
+                            std::to_string(int(colorSpace)));
 }
 
 EImageColorSpace EImageColorSpace_stringToEnum(const std::string& colorspace)

--- a/src/aliceVision/mvsData/imageIO.cpp
+++ b/src/aliceVision/mvsData/imageIO.cpp
@@ -102,54 +102,6 @@ std::istream& operator>>(std::istream& in, EImageQuality& imageQuality)
   return in;
 }
 
-std::string EImageFileType_informations()
-{
-  return "Image file type :\n"
-         "* jpg \n"
-         "* png \n"
-         "* tif \n"
-         "* exr (half)";
-}
-
-EImageFileType EImageFileType_stringToEnum(const std::string& imageFileType)
-{
-  std::string type = imageFileType;
-  std::transform(type.begin(), type.end(), type.begin(), ::tolower); //tolower
-
-  if(type == "jpg" || type == "jpeg") return EImageFileType::JPEG;
-  if(type == "png")                   return EImageFileType::PNG;
-  if(type == "tif" || type == "tiff") return EImageFileType::TIFF;
-  if(type == "exr")                   return EImageFileType::EXR;
-
-  throw std::out_of_range("Invalid image file type : " + imageFileType);
-}
-
-std::string EImageFileType_enumToString(const EImageFileType imageFileType)
-{
-  switch(imageFileType)
-  {
-    case EImageFileType::JPEG:  return "jpg";
-    case EImageFileType::PNG:   return "png";
-    case EImageFileType::TIFF:  return "tif";
-    case EImageFileType::EXR:   return "exr";
-    case EImageFileType::NONE:  return "none";
-  }
-  throw std::out_of_range("Invalid EImageType enum");
-}
-
-std::ostream& operator<<(std::ostream& os, EImageFileType imageFileType)
-{
-  return os << EImageFileType_enumToString(imageFileType);
-}
-
-std::istream& operator>>(std::istream& in, EImageFileType& imageFileType)
-{
-  std::string token;
-  in >> token;
-  imageFileType = EImageFileType_stringToEnum(token);
-  return in;
-}
-
 oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>& metadataMap)
 {
   oiio::ParamValueList metadata;

--- a/src/aliceVision/mvsData/imageIO.hpp
+++ b/src/aliceVision/mvsData/imageIO.hpp
@@ -68,6 +68,7 @@ enum class EImageQuality
 };
 
 std::string EImageColorSpace_enumToString(const EImageColorSpace colorSpace);
+std::string EImageColorSpace_enumToOIIOString(const EImageColorSpace colorSpace);
 EImageColorSpace EImageColorSpace_stringToEnum(const std::string& colorspace);
 
 /**

--- a/src/aliceVision/mvsData/imageIO.hpp
+++ b/src/aliceVision/mvsData/imageIO.hpp
@@ -24,18 +24,6 @@ using ImageRGBAf = Image<ColorRGBAf>;
 namespace imageIO {
 
 /**
- * @brief Available image file types for pipeline output
- */
-enum class EImageFileType
-{
-  JPEG,
-  PNG,
-  TIFF,
-  EXR,
-  NONE
-};
-
-/**
  * @brief Available image color space for pipeline input / output
  */
 enum class EImageColorSpace
@@ -124,42 +112,6 @@ std::istream& operator>>(std::istream& in, EImageQuality& imageQuality);
  * @return oiio::ParamValueList
  */
 oiio::ParamValueList getMetadataFromMap(const std::map<std::string, std::string>& metadataMap);
-
-/**
- * @brief get informations about each image file type
- * @return String
- */
-std::string EImageFileType_informations();
-
-/**
- * @brief returns the EImageFileType enum from a string.
- * @param[in] imageFileType the input string.
- * @return the associated EImageFileType enum.
- */
-EImageFileType EImageFileType_stringToEnum(const std::string& imageFileType);
-
-/**
- * @brief converts an EImageFileType enum to a string.
- * @param[in] imageFileType the EImageFileType enum to convert.
- * @return the string associated to the EImageFileType enum.
- */
-std::string EImageFileType_enumToString(const EImageFileType imageFileType);
-
-/**
- * @brief write an EImageFileType enum into a stream by converting it to a string.
- * @param[in] os the stream where to write the imageType.
- * @param[in] imageFileType the EImageFileType enum to write.
- * @return the modified stream.
- */
-std::ostream& operator<<(std::ostream& os, EImageFileType imageFileType);
-
-/**
- * @brief read a EImageFileType enum from a stream.
- * @param[in] in the stream from which the enum is read.
- * @param[out] imageFileType the EImageFileType enum read from the stream.
- * @return the modified stream without the read enum.
- */
-std::istream& operator>>(std::istream& in, EImageFileType& imageFileType);
 
 /**
  * @brief read image dimension from a given path

--- a/src/aliceVision/mvsData/imageIO.hpp
+++ b/src/aliceVision/mvsData/imageIO.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include <string>
-
+#include <aliceVision/image/io.hpp>
 #include <OpenImageIO/paramlist.h>
+#include <string>
 
 namespace oiio = OIIO;
 
@@ -23,34 +23,20 @@ using ImageRGBAf = Image<ColorRGBAf>;
 
 namespace imageIO {
 
-/**
- * @brief Available image color space for pipeline input / output
- */
-enum class EImageColorSpace
-{
-  AUTO,
-  LINEAR,
-  SRGB,
-  LAB,
-  XYZ,
-  NO_CONVERSION
-};
-
-
 struct OutputFileColorSpace
 {
-    EImageColorSpace from{EImageColorSpace::LINEAR};
-    EImageColorSpace to{EImageColorSpace::AUTO};
+    image::EImageColorSpace from{image::EImageColorSpace::LINEAR};
+    image::EImageColorSpace to{image::EImageColorSpace::AUTO};
 
-    OutputFileColorSpace(EImageColorSpace from_, EImageColorSpace to_)
+    OutputFileColorSpace(image::EImageColorSpace from_, image::EImageColorSpace to_)
         : from(from_)
         , to(to_)
     {
     }
     /// @brief Assumes that @p from is LINEAR
-    explicit OutputFileColorSpace(EImageColorSpace to_)
+    explicit OutputFileColorSpace(image::EImageColorSpace to_)
     {
-        if(to_ == EImageColorSpace::NO_CONVERSION)
+        if(to_ == image::EImageColorSpace::NO_CONVERSION)
             to = from;
         else
             to = to_;
@@ -66,10 +52,6 @@ enum class EImageQuality
   OPTIMIZED,
   LOSSLESS
 };
-
-std::string EImageColorSpace_enumToString(const EImageColorSpace colorSpace);
-std::string EImageColorSpace_enumToOIIOString(const EImageColorSpace colorSpace);
-EImageColorSpace EImageColorSpace_stringToEnum(const std::string& colorspace);
 
 /**
  * @brief get informations about each image quality
@@ -145,14 +127,20 @@ bool isSupportedUndistortFormat(const std::string &ext);
  * @param[out] buffer The output image buffer
  * @param[in] image color space
  */
-void readImage(const std::string& path, int& width, int& height, std::vector<unsigned char>& buffer, EImageColorSpace toColorSpace);
-void readImage(const std::string& path, int& width, int& height, std::vector<unsigned short>& buffer, EImageColorSpace toColorSpace);
-void readImage(const std::string& path, int& width, int& height, std::vector<rgb>& buffer, EImageColorSpace toColorSpace);
-void readImage(const std::string& path, int& width, int& height, std::vector<float>& buffer, EImageColorSpace toColorSpace);
-void readImage(const std::string& path, int& width, int& height, std::vector<ColorRGBf>& buffer, EImageColorSpace toColorSpace);
-void readImage(const std::string& path, int& width, int& height, std::vector<ColorRGBAf>& buffer, EImageColorSpace toColorSpace);
-void readImage(const std::string& path, ImageRGBf& image, EImageColorSpace toColorSpace);
-void readImage(const std::string& path, ImageRGBAf& image, EImageColorSpace toColorSpace);
+void readImage(const std::string& path, int& width, int& height, std::vector<unsigned char>& buffer,
+               image::EImageColorSpace toColorSpace);
+void readImage(const std::string& path, int& width, int& height, std::vector<unsigned short>& buffer,
+               image::EImageColorSpace toColorSpace);
+void readImage(const std::string& path, int& width, int& height, std::vector<rgb>& buffer,
+               image::EImageColorSpace toColorSpace);
+void readImage(const std::string& path, int& width, int& height, std::vector<float>& buffer,
+               image::EImageColorSpace toColorSpace);
+void readImage(const std::string& path, int& width, int& height, std::vector<ColorRGBf>& buffer,
+               image::EImageColorSpace toColorSpace);
+void readImage(const std::string& path, int& width, int& height, std::vector<ColorRGBAf>& buffer,
+               image::EImageColorSpace toColorSpace);
+void readImage(const std::string& path, ImageRGBf& image, image::EImageColorSpace toColorSpace);
+void readImage(const std::string& path, ImageRGBAf& image, image::EImageColorSpace toColorSpace);
 
 /**
  * @brief write an image with a given path and buffer

--- a/src/aliceVision/mvsUtils/ImagesCache.cpp
+++ b/src/aliceVision/mvsUtils/ImagesCache.cpp
@@ -26,7 +26,8 @@ std::string ECorrectEV_enumToString(const ECorrectEV correctEV)
 
 
 template<typename Image>
-ImagesCache<Image>::ImagesCache(const MultiViewParams& mp, imageIO::EImageColorSpace colorspace, ECorrectEV correctEV)
+ImagesCache<Image>::ImagesCache(const MultiViewParams& mp, image::EImageColorSpace colorspace,
+                                ECorrectEV correctEV)
   : _mp(mp)
   , _colorspace(colorspace)
   , _correctEV(correctEV)
@@ -40,7 +41,8 @@ ImagesCache<Image>::ImagesCache(const MultiViewParams& mp, imageIO::EImageColorS
 }
 
 template<typename Image>
-ImagesCache<Image>::ImagesCache(const MultiViewParams& mp, imageIO::EImageColorSpace colorspace, std::vector<std::string>& imagesNames
+ImagesCache<Image>::ImagesCache(const MultiViewParams& mp, image::EImageColorSpace colorspace,
+                                std::vector<std::string>& imagesNames
                         , ECorrectEV correctEV)
   : _mp(mp)
   , _colorspace(colorspace)

--- a/src/aliceVision/mvsUtils/ImagesCache.hpp
+++ b/src/aliceVision/mvsUtils/ImagesCache.hpp
@@ -53,12 +53,17 @@ private:
 
     std::list<std::future<void>> _asyncObjects;
 
-    imageIO::EImageColorSpace _colorspace{imageIO::EImageColorSpace::AUTO};
+    image::EImageColorSpace _colorspace{image::EImageColorSpace::AUTO};
     ECorrectEV _correctEV{ECorrectEV::NO_CORRECTION};
 
 public:
-    ImagesCache( const MultiViewParams& mp, imageIO::EImageColorSpace colorspace, ECorrectEV correctEV = ECorrectEV::NO_CORRECTION);
-    ImagesCache( const MultiViewParams& mp, imageIO::EImageColorSpace colorspace, std::vector<std::string>& imagesNames, ECorrectEV correctEV = ECorrectEV::NO_CORRECTION);
+    ImagesCache(const MultiViewParams& mp, image::EImageColorSpace colorspace,
+                ECorrectEV correctEV = ECorrectEV::NO_CORRECTION);
+
+    ImagesCache(const MultiViewParams& mp, image::EImageColorSpace colorspace,
+                std::vector<std::string>& imagesNames,
+                ECorrectEV correctEV = ECorrectEV::NO_CORRECTION);
+
     void initIC( std::vector<std::string>& imagesNames );
     void setCacheSize(int nbPreload);
     void setCorrectEV(const ECorrectEV correctEV) { _correctEV = correctEV; }

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -314,7 +314,8 @@ Matrix3x4 load3x4MatrixFromFile(std::istream& in)
 }
 
 template<class Image>
-void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Image& img, imageIO::EImageColorSpace colorspace, ECorrectEV correctEV)
+void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Image& img,
+               image::EImageColorSpace colorspace, ECorrectEV correctEV)
 {
     // check image size
     auto checkImageSize = [&path, &mp, camId, &img](){
@@ -337,7 +338,7 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
     // if exposure correction, apply it in linear colorspace and then convert colorspace
     else
     {
-        imageIO::readImage(path, img, imageIO::EImageColorSpace::LINEAR);
+        imageIO::readImage(path, img, image::EImageColorSpace::LINEAR);
         checkImageSize();
 
         oiio::ParamValueList metadata;
@@ -357,7 +358,7 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
             for(int pix = 0; pix < img.size(); ++pix)
                 img[pix] = img[pix] * exposureCompensation;
 
-            imageAlgo::colorconvert(img, imageIO::EImageColorSpace::LINEAR, colorspace);
+            imageAlgo::colorconvert(img, image::EImageColorSpace::LINEAR, colorspace);
         }
     }
 
@@ -373,8 +374,10 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
     }
 }
 
-template void loadImage<ImageRGBf>(const std::string& path, const MultiViewParams& mp, int camId, ImageRGBf& img, imageIO::EImageColorSpace colorspace, ECorrectEV correctEV);
-template void loadImage<ImageRGBAf>(const std::string& path, const MultiViewParams& mp, int camId, ImageRGBAf& img, imageIO::EImageColorSpace colorspace, ECorrectEV correctEV);
+template void loadImage<ImageRGBf>(const std::string& path, const MultiViewParams& mp, int camId,
+                                   ImageRGBf& img, image::EImageColorSpace colorspace, ECorrectEV correctEV);
+template void loadImage<ImageRGBAf>(const std::string& path, const MultiViewParams& mp, int camId,
+                                    ImageRGBAf& img, image::EImageColorSpace colorspace, ECorrectEV correctEV);
 
 } // namespace mvsUtils
 } // namespace aliceVision

--- a/src/aliceVision/mvsUtils/fileIO.hpp
+++ b/src/aliceVision/mvsUtils/fileIO.hpp
@@ -35,7 +35,7 @@ Matrix3x4 load3x4MatrixFromFile(std::istream& in);
 
 template<class Image>
 void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Image& img,
-    imageIO::EImageColorSpace colorspace, ECorrectEV correctEV);
+               image::EImageColorSpace colorspace, ECorrectEV correctEV);
 
 } // namespace mvsUtils
 } // namespace aliceVision

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -53,7 +53,7 @@ int aliceVision_main(int argc, char* argv[])
 
     std::string outputFolder;
     std::string imagesFolder;
-    std::string processColorspaceName = imageIO::EImageColorSpace_enumToString(imageIO::EImageColorSpace::SRGB);
+    std::string processColorspaceName = image::EImageColorSpace_enumToString(image::EImageColorSpace::SRGB);
     bool flipNormals = false;
     bool correctEV = false;
 
@@ -182,7 +182,7 @@ int aliceVision_main(int argc, char* argv[])
     GEO::initialize();
 
     texParams.visibilityRemappingMethod = mesh::EVisibilityRemappingMethod_stringToEnum(visibilityRemappingMethod);
-    texParams.processColorspace = imageIO::EImageColorSpace_stringToEnum(processColorspaceName);
+    texParams.processColorspace = image::EImageColorSpace_stringToEnum(processColorspaceName);
 
     texParams.correctEV = mvsUtils::ECorrectEV::NO_CORRECTION;
     if(correctEV) { texParams.correctEV = mvsUtils::ECorrectEV::APPLY_CORRECTION; }

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -62,8 +62,8 @@ int aliceVision_main(int argc, char* argv[])
     std::string visibilityRemappingMethod = mesh::EVisibilityRemappingMethod_enumToString(texParams.visibilityRemappingMethod);
 
     mesh::BumpMappingParams bumpMappingParams;
-    imageIO::EImageFileType normalFileType;
-    imageIO::EImageFileType heightFileType;
+    image::EImageFileType normalFileType;
+    image::EImageFileType heightFileType;
 
     po::options_description allParams("AliceVision texturing");
 
@@ -89,14 +89,14 @@ int aliceVision_main(int argc, char* argv[])
             "Texture downscale factor")
         ("outputMeshFileType", po::value<aliceVision::mesh::EFileType>(&outputMeshFileType)->default_value(aliceVision::mesh::EFileType::OBJ),
             "output mesh file type")
-        ("colorMappingFileType", po::value<imageIO::EImageFileType>(&texParams.textureFileType)->default_value(texParams.textureFileType),
-          imageIO::EImageFileType_informations().c_str())(
-        "heightFileType", po::value<imageIO::EImageFileType>(&heightFileType)->default_value(imageIO::EImageFileType::NONE),
-            imageIO::EImageFileType_informations().c_str())
-        ("normalFileType", po::value<imageIO::EImageFileType>(&normalFileType)->default_value(imageIO::EImageFileType::NONE),
-            imageIO::EImageFileType_informations().c_str())
-        ("displacementMappingFileType", po::value<imageIO::EImageFileType>(&bumpMappingParams.displacementFileType)->default_value(bumpMappingParams.displacementFileType),
-            imageIO::EImageFileType_informations().c_str())
+        ("colorMappingFileType", po::value<image::EImageFileType>(&texParams.textureFileType)->default_value(texParams.textureFileType),
+          image::EImageFileType_informations().c_str())
+        ("heightFileType", po::value<image::EImageFileType>(&heightFileType)->default_value(image::EImageFileType::NONE),
+            image::EImageFileType_informations().c_str())
+        ("normalFileType", po::value<image::EImageFileType>(&normalFileType)->default_value(image::EImageFileType::NONE),
+            image::EImageFileType_informations().c_str())
+        ("displacementMappingFileType", po::value<image::EImageFileType>(&bumpMappingParams.displacementFileType)->default_value(bumpMappingParams.displacementFileType),
+            image::EImageFileType_informations().c_str())
         ("bumpType", po::value<mesh::EBumpMappingType>(&bumpMappingParams.bumpType)->default_value(bumpMappingParams.bumpType),
             "Use HeightMap for displacement or bump mapping")
         ("unwrapMethod", po::value<std::string>(&unwrapMethod)->default_value(unwrapMethod),
@@ -254,7 +254,7 @@ int aliceVision_main(int argc, char* argv[])
     }
 
     // generate diffuse textures
-    if(!inputMeshFilepath.empty() && !sfmDataFilename.empty() && texParams.textureFileType != imageIO::EImageFileType::NONE)
+    if(!inputMeshFilepath.empty() && !sfmDataFilename.empty() && texParams.textureFileType != image::EImageFileType::NONE)
     {
         ALICEVISION_LOG_INFO("Generate textures.");
         mesh.generateTextures(mp, outputFolder, texParams.textureFileType);
@@ -262,8 +262,8 @@ int aliceVision_main(int argc, char* argv[])
 
 
     if(!inputRefMeshFilepath.empty() && !inputMeshFilepath.empty() &&
-       (bumpMappingParams.bumpMappingFileType != imageIO::EImageFileType::NONE ||
-        bumpMappingParams.displacementFileType != imageIO::EImageFileType::NONE))
+       (bumpMappingParams.bumpMappingFileType != image::EImageFileType::NONE ||
+        bumpMappingParams.displacementFileType != image::EImageFileType::NONE))
     {
         ALICEVISION_LOG_INFO("Generate height and normal maps.");
 


### PR DESCRIPTION
We currently have two enums in different modules that do the same thing. This PR merges them.

Behavior should remain the same except that the code in many cases supports only a subset of EImageColorSpace depending on whether it was originally written to target imageIO::EImageColorSpace or image::EImageColorSpace.

The only potential change is that the default colorspace names are now lowercase in cases where imageIO::EImageColorSpace was used before. While AliceVision ignores the case when parsing colorspace, this could affect external tools.

To preserve conversions to strings as expected by OIIO, a separate function has been introduced.