### PR TITLE
[cmake] Add clp dependencies to AliceVisionConfig.cmake.in

### DIFF
--- a/src/cmake/AliceVisionConfig.cmake.in
+++ b/src/cmake/AliceVisionConfig.cmake.in
@@ -103,6 +103,13 @@ if(BOOST_NO_CXX11)
  add_definitions(-DBOOST_NO_CXX11_SCOPED_ENUMS)
 endif()
 
+set(ALICEVISION_BUILD_SFM @ALICEVISION_BUILD_SFM@)
+if(ALICEVISION_BUILD_SFM)
+  find_package(CoinUtils REQUIRED)
+  find_package(Clp REQUIRED)
+  find_package(Osi REQUIRED)
+endif()
+
 # propagate other building options
 set(ALICEVISION_HAVE_OPENGV @ALICEVISION_HAVE_OPENGV@)
 set(ALICEVISION_HAVE_ALEMBIC @ALICEVISION_HAVE_ALEMBIC@)


### PR DESCRIPTION
This is required for packages that use AliceVision as dependency to be able to build in cases they themselves don't depend on clp. In such situation CMake doesn't know about CoinUtils, Osi and Clp packages when parsing dependencies of AliceVision and the build fails.

This problem has been introduced by https://github.com/alicevision/AliceVision/pull/1237.