### PR TITLE
Don't use deprecated filesystem copy options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ Dependencies
 AliceVision depends on external libraries:
 
 * [Assimp >= 5.0.0](https://github.com/assimp/assimp)
-* [Boost >= 1.73.0](https://www.boost.org)
+* [Boost >= 1.74.0](https://www.boost.org)
 * [Ceres >= 1.10.0](https://github.com/ceres-solver/ceres-solver)
 * [Eigen >= 3.3.4](https://gitlab.com/libeigen/eigen)
 * [Geogram >= 1.7.5](https://gforge.inria.fr/frs/?group_id=5833)

--- a/src/software/convert/main_convertFloatDescriptorToUchar.cpp
+++ b/src/software/convert/main_convertFloatDescriptorToUchar.cpp
@@ -114,7 +114,8 @@ int aliceVision_main( int argc, char** argv )
     if(ext == ".feat")
     {
       // just copy the file into the output folder
-      fs::copy_file(iterator->path(), fs::path(outputFolder)/fs::path(filename), fs::copy_option::overwrite_if_exists);
+      fs::copy_file(iterator->path(), fs::path(outputFolder) / fs::path(filename),
+                    fs::copy_options::overwrite_existing);
       
       ++countFeat;
     }

--- a/src/software/pipeline/main_distortionCalibration.cpp
+++ b/src/software/pipeline/main_distortionCalibration.cpp
@@ -621,7 +621,7 @@ int aliceVision_main(int argc, char* argv[])
             }
 
             fs::copy_file(lensGridFilepath, fs::path(outputPath) / fs::path(lensGridFilepath).filename(),
-                          fs::copy_option::overwrite_if_exists);
+                          fs::copy_options::overwrite_existing);
 
             const std::string checkerImagePath =
                 (fs::path(outputPath) / fs::path(lensGridFilepath).stem()).string() + "_checkerboard.exr";


### PR DESCRIPTION
This PR introduces usage of `boost::filesystem::copy_options` instead of deprecated equivalent.

The new API has been introduced in Boost 1.74 and follows C++17 more closely.

Boost dependency has been bumped to 1.74. This is harmless because users will either use system Boost, which is 1.74 on both Debian stable (bullseye) and Ubuntu 22.04 LTS, or compile from source on older systems or RHEL which already has older Boost anyway. Therefore bumping the requirement is harmless.

I don't think we should upgrade to even newer boost because this would force even more libraries to be recompiled from source and included into AliceVision install prefix when developing even on relatively new systems.