### PR TITLE
[CMake] Increase function count limit in object files on MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,12 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   AddCompilerFlag("-Werror=return-local-addr")
 endif()
 
+# MSVC has a limit of around 65k functions in an object file by default. This is already exceeded
+# in debug mode, thus the following is needed to increase the limit.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  AddCompilerFlag("/bigobj")
+endif()
+
 # Eigen requires overaligned buffers for maximum efficiency (e.g. on AVX512 buffers may need to
 # be aligned to 64 bytes). AliceVision currently does not support this. Fortunately this is fixed
 # in C++17. While we can't upgrade to C++17 just yet, some compilers support overaligned


### PR DESCRIPTION
This should fix https://github.com/alicevision/AliceVision/issues/1261 but I haven't tested as I don't have a Windows machine with AliceVision build environment already present.

By default MSVC has a limit of 65k functions in an object file which we hit in debug builds. `/bigobj` compile option bumps the limit to 4 billion.

cc @fabiencastan 