### PR TITLE
Consistently use divideRoundUp() for integer division with rounding up

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1049,7 +1049,7 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
     // and iterate to fuse points until we get the right amount of points.
 
     // unsigned long nbValidDepths = computeNumberOfAllPoints(mp, 0);
-    // int stepPts = std::ceil((double)nbValidDepths / (double)maxPoints);
+    // int stepPts = divideRoundUp(nbValidDepths, maxPoints);
     std::size_t nbPixels = 0;
     for(const auto& imgParams: _mp.getImagesParams())
     {

--- a/src/aliceVision/matching/matchesFiltering.cpp
+++ b/src/aliceVision/matching/matchesFiltering.cpp
@@ -74,10 +74,10 @@ void matchesGridFiltering(const aliceVision::feature::Regions& lRegions,
                           const aliceVision::Pair& indexImagePair,
                           aliceVision::matching::IndMatches& outMatches, size_t gridSize)
 {
-    const size_t leftCellWidth = std::ceil(lImgSize.first / (float)gridSize);
-    const size_t leftCellHeight = std::ceil(lImgSize.second / (float)gridSize);
-    const size_t rightCellWidth = std::ceil(rImgSize.first / (float)gridSize);
-    const size_t rightCellHeight = std::ceil(rImgSize.second / (float)gridSize);
+    const size_t leftCellWidth = divideRoundUp(lImgSize.first, gridSize);
+    const size_t leftCellHeight = divideRoundUp(lImgSize.second, gridSize);
+    const size_t rightCellWidth = divideRoundUp(rImgSize.first, gridSize);
+    const size_t rightCellHeight = divideRoundUp(rImgSize.second, gridSize);
 
     std::vector<aliceVision::matching::IndMatches> completeGrid(gridSize * gridSize * 2);
     // Reserve all cells

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -333,8 +333,8 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
     ALICEVISION_LOG_DEBUG("nbAtlasMax: " << nbAtlasMax);
 
     // Add rounding to have a uniform repartition between chunks (avoid a small chunk at the end)
-    const int nChunks = std::ceil(nbAtlas / double(nbAtlasMax));
-    nbAtlasMax = std::ceil(nbAtlas / double(nChunks));
+    const int nChunks = divideRoundUp(nbAtlas, nbAtlasMax);
+    nbAtlasMax = divideRoundUp(nbAtlas, nChunks);
     ALICEVISION_LOG_DEBUG("nChunks: " << nChunks);
     ALICEVISION_LOG_INFO("nbAtlasMax (after rounding): " << nbAtlasMax);
 

--- a/src/aliceVision/panorama/boundingBox.hpp
+++ b/src/aliceVision/panorama/boundingBox.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <aliceVision/numeric/numeric.hpp>
 #include <algorithm>
 #include <stdint.h>
 #include <cmath>
@@ -56,8 +57,8 @@ struct BoundingBox
 
         int leftBounded = int(std::floor(double(left) / double(gridSize))) * int(gridSize);
         int topBounded = int(std::floor(double(top) / double(gridSize))) * int(gridSize);
-        int widthBounded = int(std::ceil(double(right - leftBounded + 1) / double(gridSize))) * int(gridSize);
-        int heightBounded = int(std::ceil(double(bottom - topBounded + 1) / double(gridSize))) * int(gridSize);
+        int widthBounded = divideRoundUp<int>(right - leftBounded + 1, gridSize) * int(gridSize);
+        int heightBounded = divideRoundUp<int>(bottom - topBounded + 1, gridSize) * int(gridSize);
 
         left = leftBounded;
         top = topBounded;

--- a/src/aliceVision/panorama/panoramaMap.cpp
+++ b/src/aliceVision/panorama/panoramaMap.cpp
@@ -172,7 +172,7 @@ bool PanoramaMap::getIntersectionsList(std::vector<BoundingBox> & intersections,
 bool PanoramaMap::optimizeChunks(std::vector<std::vector<IndexT>> & chunks, int chunkSize) {
 
     int countViews = _map.size();
-    int countChunks =  int(std::ceil(double(countViews) / double(chunkSize)));
+    int countChunks = divideRoundUp(countViews, chunkSize);
 
     chunks.clear();
     chunks.resize(countChunks);

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -652,7 +652,7 @@ int aliceVision_main(int argc, char** argv)
             return EXIT_FAILURE;
         }
 
-        int countIterations = int(std::ceil(double(viewsCount) / double(rangeSize)));
+        int countIterations = divideRoundUp(viewsCount, rangeSize);
        
         if(rangeIteration >= countIterations)
         {

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -266,7 +266,7 @@ int aliceVision_main(int argc, char** argv)
 
         if(maxPanoramaWidth > 0 && panoramaSize.first > maxPanoramaWidth)
         {
-            downscaleFactor = std::ceil(panoramaSize.first / double(maxPanoramaWidth));
+            downscaleFactor = divideRoundUp(panoramaSize.first, maxPanoramaWidth);
         }
 
         ALICEVISION_LOG_INFO("Input panorama size is " << panoramaSize.first << "x" << panoramaSize.second);


### PR DESCRIPTION
This PR cleans up the cases where integer division with routing up was intended by reusing `divideRoundUp()`. Differently from https://github.com/alicevision/AliceVision/pull/1254, this PR does not improve any problematic behavior.