### PR TITLE
[image] Introduce a function to retrieve ALICEVISION_ROOT

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -509,15 +509,13 @@ void writeImage(const std::string& path,
   }
   else if((imageColorSpace != EImageColorSpace::LINEAR) && (imageColorSpace != EImageColorSpace::NO_CONVERSION)) // ACES or ACEScg
   {
-      char const* val = getenv("ALICEVISION_ROOT");
-      if (val == NULL)
+      const auto& root = getAliceVisionRoot();
+      if (root.empty())
       {
           throw std::runtime_error("ALICEVISION_ROOT is not defined, OCIO config file cannot be accessed.");
       }
-      std::string configOCIOFilePath = std::string(val);
-      configOCIOFilePath.append("/share/aliceVision/config.ocio");
 
-      oiio::ColorConfig colorConfig(configOCIOFilePath);
+      oiio::ColorConfig colorConfig(root + "/share/aliceVision/config.ocio");
       oiio::ImageBufAlgo::colorconvert(colorspaceBuf, *outBuf, "Linear",
                                        (imageColorSpace != EImageColorSpace::ACES) ? "aces" : "ACEScg", true, "", "",
                                        &colorConfig);
@@ -717,6 +715,21 @@ bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& mas
         }
     }
     return false;
+}
+
+static std::string aliceVisionRootOverride;
+
+std::string getAliceVisionRoot()
+{
+    if (!aliceVisionRootOverride.empty())
+        return aliceVisionRootOverride;
+    const char* value = std::getenv("ALICEVISION_ROOT");
+    return value ? value : "";
+}
+
+void setAliceVisionRootOverride(const std::string& value)
+{
+    aliceVisionRootOverride = value;
 }
 
 }  // namespace image

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -509,13 +509,13 @@ void writeImage(const std::string& path,
   }
   else if((imageColorSpace != EImageColorSpace::LINEAR) && (imageColorSpace != EImageColorSpace::NO_CONVERSION)) // ACES or ACEScg
   {
-      const auto& root = getAliceVisionRoot();
-      if (root.empty())
+      const auto colorConfigPath = getAliceVisionOCIOConfig();
+      if (colorConfigPath.empty())
       {
           throw std::runtime_error("ALICEVISION_ROOT is not defined, OCIO config file cannot be accessed.");
       }
 
-      oiio::ColorConfig colorConfig(root + "/share/aliceVision/config.ocio");
+      oiio::ColorConfig colorConfig(colorConfigPath);
       oiio::ImageBufAlgo::colorconvert(colorspaceBuf, *outBuf, "Linear",
                                        (imageColorSpace != EImageColorSpace::ACES) ? "aces" : "ACEScg", true, "", "",
                                        &colorConfig);
@@ -725,6 +725,13 @@ std::string getAliceVisionRoot()
         return aliceVisionRootOverride;
     const char* value = std::getenv("ALICEVISION_ROOT");
     return value ? value : "";
+}
+
+std::string getAliceVisionOCIOConfig()
+{
+    if (!getAliceVisionRoot().empty())
+        return getAliceVisionRoot() + "/share/aliceVision/config.ocio";
+    return {};
 }
 
 void setAliceVisionRootOverride(const std::string& value)

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -275,5 +275,15 @@ struct ColorTypeInfo<RGBAfColor>
 bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& masksFolders,
                  const IndexT viewId, const std::string & srcImage);
 
+/**
+ * Returns the value of ALICEVISION_ROOT environmental variable, or empty string if it is not
+ * defined. The returned value can be overridden by `setAliceVisionRootOverride` if needed, for
+ * example in tests.
+ */
+// TODO: use std::optional when the C++ standard version is upgraded to C++17
+std::string getAliceVisionRoot();
+
+void setAliceVisionRootOverride(const std::string& value);
+
 }  // namespace image
 }  // namespace aliceVision

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -283,6 +283,9 @@ bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& mas
 // TODO: use std::optional when the C++ standard version is upgraded to C++17
 std::string getAliceVisionRoot();
 
+/// Returns path to OpenColorIO config that is shipped with aliceVision
+std::string getAliceVisionOCIOConfig();
+
 void setAliceVisionRootOverride(const std::string& value);
 
 }  // namespace image

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -318,15 +318,14 @@ int aliceVision_main(int argc, char **argv)
   std::vector<sensorDB::Datasheet> sensorDatabase;
   if (sensorDatabasePath.empty())
   {
-      char const* val = getenv("ALICEVISION_ROOT");
-      if (val == NULL)
+      const auto root = image::getAliceVisionRoot();
+      if (root.empty())
       {
           ALICEVISION_LOG_WARNING("ALICEVISION_ROOT is not defined, default sensor database cannot be accessed.");
       }
       else
       {
-          sensorDatabasePath = std::string(val);
-          sensorDatabasePath.append("/share/aliceVision/cameraSensors.db");
+          sensorDatabasePath = root + "/share/aliceVision/cameraSensors.db";
       }
   }
 


### PR DESCRIPTION
This allows to override the returned value if needed, e.g. in tests. Idea comes from this comment: https://github.com/alicevision/AliceVision/pull/1170#discussion_r990088525