### PR TITLE
[github] Append to vcpkg cache key to expire broken CI cache

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -181,6 +181,9 @@ jobs:
           # doNotCache: true
           # Ensure the vcpkg artifacts are cached, they are generated in the 'CMAKE_BINARY_DIR/vcpkg_installed' directory.
           additionalCachedPaths: ${{ env.buildDir }}/vcpkg_installed
+          # This is used to unbreak cached artifacts if for some reason dependencies fail to build,
+          # the action does not notice it and saves broken artifacts.
+          appendedCacheKey: cache1
 
       - name: vcpkg - Display installed packages
         run:


### PR DESCRIPTION
Hopefully this fixes the CI on Windows. Current failures fail due to missing include file from boost which exists in the release that we use, so I assume the file was not installed for some reason, the CI did not notice this failure and stored broken artifacts into cache.