### PR TITLE
(trivial) Cleanup std::pow usages

### DIFF
--- a/src/aliceVision/mvsUtils/common.cpp
+++ b/src/aliceVision/mvsUtils/common.cpp
@@ -528,9 +528,9 @@ bool isPointInHexahedron(const Point3d& p, const Point3d* hexah)
 
 double computeHexahedronVolume(const Point3d* hexah)
 {
-  const double w = std::sqrt(std::pow(hexah[1].x - hexah[0].x, 2));
-  const double h = std::sqrt(std::pow(hexah[3].y - hexah[0].y, 2));
-  const double l = std::sqrt(std::pow(hexah[4].z - hexah[0].z, 2));
+  const double w = std::abs(hexah[1].x - hexah[0].x);
+  const double h = std::abs(hexah[3].y - hexah[0].y);
+  const double l = std::abs(hexah[4].z - hexah[0].z);
 
   return (l * w * h);
 }

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -524,10 +524,9 @@ void ReconstructionEngine_globalSfM::Compute_Relative_Rotations(rotationAveragin
 
       RelativePoseInfo relativePose_info;
       // Compute max authorized error as geometric mean of camera plane tolerated residual error
-      relativePose_info.initial_residual_tolerance = std::pow(
+      relativePose_info.initial_residual_tolerance = std::sqrt(
         cam_I->imagePlaneToCameraPlaneError(2.5) *
-        cam_J->imagePlaneToCameraPlaneError(2.5),
-        1./2.);
+        cam_J->imagePlaneToCameraPlaneError(2.5));
 
       // Since we use normalized features, we will use unit image size and intrinsic matrix:
       const std::pair<size_t, size_t> imageSize(1., 1.);

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
@@ -611,7 +611,8 @@ void ReconstructionEngine_panorama::Compute_Relative_Rotations(rotationAveraging
 
       RelativePoseInfo relativePose_info;
       // Compute max authorized error as geometric mean of camera plane tolerated residual error
-      relativePose_info.initial_residual_tolerance = std::pow(cam_I->imagePlaneToCameraPlaneError(2.5) * cam_J->imagePlaneToCameraPlaneError(2.5), 1./2.);
+      relativePose_info.initial_residual_tolerance =
+              std::sqrt(cam_I->imagePlaneToCameraPlaneError(2.5) * cam_J->imagePlaneToCameraPlaneError(2.5));
 
       // Since we use normalized features, we will use unit image size and intrinsic matrix:
       const std::pair<size_t, size_t> imageSize(1., 1.);
@@ -631,7 +632,8 @@ void ReconstructionEngine_panorama::Compute_Relative_Rotations(rotationAveraging
         case RELATIVE_ROTATION_FROM_H:
         {
           RelativeRotationInfo relativeRotation_info;
-          relativeRotation_info._initialResidualTolerance = std::pow(cam_I->imagePlaneToCameraPlaneError(2.5) * cam_J->imagePlaneToCameraPlaneError(2.5), 1./2.);
+          relativeRotation_info._initialResidualTolerance =
+                  std::sqrt(cam_I->imagePlaneToCameraPlaneError(2.5) * cam_J->imagePlaneToCameraPlaneError(2.5));
           
           if(!robustRelativeRotation_fromH(x1, x2, imageSize, imageSize, _randomNumberGenerator, relativeRotation_info))
           {
@@ -648,7 +650,8 @@ void ReconstructionEngine_panorama::Compute_Relative_Rotations(rotationAveraging
         case RELATIVE_ROTATION_FROM_R:
         {
           RelativeRotationInfo relativeRotation_info;
-          relativeRotation_info._initialResidualTolerance = std::pow(cam_I->imagePlaneToCameraPlaneError(2.5) * cam_J->imagePlaneToCameraPlaneError(2.5), 1./2.);
+          relativeRotation_info._initialResidualTolerance =
+                  std::sqrt(cam_I->imagePlaneToCameraPlaneError(2.5) * cam_J->imagePlaneToCameraPlaneError(2.5));
           
           if(!robustRelativeRotation_fromR(x1, x2, imageSize, imageSize, _randomNumberGenerator, relativeRotation_info))
           {


### PR DESCRIPTION
In a couple of places `std::pow` was used where `std::sqrt` would suffice. In another place `std::pow` and `std::sqrt` pair could be replaced with `std::abs`.