### PR TITLE
Extract some code out of pipeline executables to reusable modules (part 2)

### DIFF
--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -39,6 +39,7 @@ alicevision_add_library(aliceVision_sfmDataIO
   SOURCES ${sfmDataIO_files_headers} ${sfmDataIO_files_sources}
   PUBLIC_LINKS
     aliceVision_sfmData
+    aliceVision_sensorDB
     Boost::filesystem
   PRIVATE_LINKS
     aliceVision_image

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -292,5 +292,23 @@ bool extractNumberFromFileStem(const std::string& imagePathStem, IndexT& number,
     return containsNumber;
 }
 
+bool viewHasDefinedIntrinsic(const sfmData::SfMData& sfmData, const sfmData::View& view)
+{
+    auto intrinsicId = view.getIntrinsicId();
+    if (intrinsicId == UndefinedIndexT)
+        return false;
+
+
+    auto* intrinsicBase = sfmData.getIntrinsicPtr(view.getIntrinsicId());
+    auto* intrinsic = dynamic_cast<const camera::Pinhole*>(intrinsicBase);
+    if (intrinsic == nullptr)
+        return false;
+
+    if (intrinsic->getFocalLengthPixX() <= 0)
+        return false;
+
+    return true;
+}
+
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -310,5 +310,43 @@ bool viewHasDefinedIntrinsic(const sfmData::SfMData& sfmData, const sfmData::Vie
     return true;
 }
 
+
+std::string EGroupCameraFallback_enumToString(EGroupCameraFallback strategy)
+{
+    switch(strategy)
+    {
+    case EGroupCameraFallback::GLOBAL:
+        return "global";
+    case EGroupCameraFallback::FOLDER:
+        return "folder";
+    case EGroupCameraFallback::IMAGE:
+        return "image";
+    }
+    throw std::out_of_range("Invalid GroupCameraFallback type Enum: " + std::to_string(int(strategy)));
+}
+
+EGroupCameraFallback EGroupCameraFallback_stringToEnum(const std::string& strategy)
+{
+    if (strategy == "global")
+        return EGroupCameraFallback::GLOBAL;
+    if (strategy == "folder")
+        return EGroupCameraFallback::FOLDER;
+    if (strategy == "image")
+        return EGroupCameraFallback::IMAGE;
+    throw std::out_of_range("Invalid GroupCameraFallback type string " + strategy);
+}
+
+std::ostream& operator<<(std::ostream& os, EGroupCameraFallback s)
+{
+    return os << EGroupCameraFallback_enumToString(s);
+}
+
+std::istream& operator>>(std::istream& in, EGroupCameraFallback& s)
+{
+    std::string token;
+    in >> token;
+    s = EGroupCameraFallback_stringToEnum(token);
+    return in;
+}
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -113,5 +113,16 @@ bool extractNumberFromFileStem(const std::string& imagePathStem, IndexT& number,
 
 bool viewHasDefinedIntrinsic(const sfmData::SfMData& sfmData, const sfmData::View& view);
 
+
+enum class EGroupCameraFallback {
+    GLOBAL,
+    FOLDER,
+    IMAGE
+};
+
+std::string EGroupCameraFallback_enumToString(EGroupCameraFallback strategy);
+EGroupCameraFallback EGroupCameraFallback_stringToEnum(const std::string& strategy);
+std::ostream& operator<<(std::ostream& os, EGroupCameraFallback s);
+std::istream& operator>>(std::istream& in, EGroupCameraFallback& s);
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmData/View.hpp>
 #include <aliceVision/camera/cameraCommon.hpp>
 #include <aliceVision/camera/IntrinsicBase.hpp>
@@ -109,6 +110,8 @@ std::vector<std::string> viewPathsFromFolders(const sfmData::View& view, const s
 * @return true if the image filename (stripped of its extension) contains a number
 */
 bool extractNumberFromFileStem(const std::string& imagePathStem, IndexT& number, std::string& prefix, std::string& suffix);
+
+bool viewHasDefinedIntrinsic(const sfmData::SfMData& sfmData, const sfmData::View& view);
 
 } // namespace sfmDataIO
 } // namespace aliceVision

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -471,22 +471,11 @@ int aliceVision_main(int argc, char **argv)
     const double diag24x36 = std::sqrt(36.0 * 36.0 + 24.0 * 24.0);
     camera::EIntrinsicInitMode intrinsicInitMode = camera::EIntrinsicInitMode::UNKNOWN;
 
-    // check if the view intrinsic is already defined
-    if(intrinsicId != UndefinedIndexT)
+    if (sfmDataIO::viewHasDefinedIntrinsic(sfmData, view))
     {
-      camera::IntrinsicBase* intrinsicBase = sfmData.getIntrinsicPtr(view.getIntrinsicId());
-      camera::Pinhole* intrinsic = dynamic_cast<camera::Pinhole*>(intrinsicBase);
-      if(intrinsic != nullptr)
-      {
-        if(intrinsic->getFocalLengthPixX() > 0)
-        {
-          // the view intrinsic is initialized
-          boost::atomic_ref<std::size_t>(completeViewCount)++;
-
-          // don't need to build a new intrinsic
-          continue;
-        }
-      }
+        // don't need to build a new intrinsic
+        boost::atomic_ref<std::size_t>(completeViewCount)++;
+        continue;
     }
 
     // try to find in the sensor width in the database

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -87,51 +87,6 @@ bool listFiles(const std::string& folderOrFile,
   return false;
 }
 
-enum class EGroupCameraFallback {
-    GLOBAL,
-    FOLDER,
-    IMAGE
-};
-
-inline std::string EGroupCameraFallback_enumToString(EGroupCameraFallback strategy)
-{
-  switch(strategy)
-  {
-    case EGroupCameraFallback::GLOBAL:
-      return "global";
-    case EGroupCameraFallback::FOLDER:
-      return "folder";
-    case EGroupCameraFallback::IMAGE:
-      return "image";
-  }
-  throw std::out_of_range("Invalid GroupCameraFallback type Enum: " + std::to_string(int(strategy)));
-}
-
-inline EGroupCameraFallback EGroupCameraFallback_stringToEnum(const std::string& strategy)
-{
-  if(strategy == "global")
-    return EGroupCameraFallback::GLOBAL;
-  if(strategy == "folder")
-    return EGroupCameraFallback::FOLDER;
-  if(strategy == "image")
-    return EGroupCameraFallback::IMAGE;
-  throw std::out_of_range("Invalid GroupCameraFallback type string " + strategy);
-}
-
-inline std::ostream& operator<<(std::ostream& os, EGroupCameraFallback s)
-{
-    return os << EGroupCameraFallback_enumToString(s);
-}
-
-inline std::istream& operator>>(std::istream& in, EGroupCameraFallback& s)
-{
-    std::string token;
-    in >> token;
-    s = EGroupCameraFallback_stringToEnum(token);
-    return in;
-}
-
-
 /**
  * @brief Create the description of an input image dataset for AliceVision toolsuite
  * - Export a SfMData file with View & Intrinsic data

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -471,7 +471,12 @@ int aliceVision_main(int argc, char **argv)
     const double diag24x36 = std::sqrt(36.0 * 36.0 + 24.0 * 24.0);
     camera::EIntrinsicInitMode intrinsicInitMode = camera::EIntrinsicInitMode::UNKNOWN;
 
-    if (sfmDataIO::viewHasDefinedIntrinsic(sfmData, view))
+    bool hasDefinedIntrinsic = false;
+    #pragma omp critical
+    {
+        hasDefinedIntrinsic = sfmDataIO::viewHasDefinedIntrinsic(sfmData, view);
+    }
+    if (hasDefinedIntrinsic)
     {
         // don't need to build a new intrinsic
         boost::atomic_ref<std::size_t>(completeViewCount)++;


### PR DESCRIPTION
This PR moves code out of cameraInit executable to aliceVision libraries that can be linked into other executables which in turn allows code reuse.

The `Extract ...` commits only move code around reindenting it to 4-space indents in the process.

The last commit changes how warning reporting is done in cameraInit. This can be potentially be reused in external code now too.

In this PR 3 race conditions have been identified and fixed.

This PR is a followup to https://github.com/alicevision/AliceVision/pull/1270 and is filled separately because it solves a more complicated case.