### PR TITLE
[sfmDataIO] Missing fstream include

### DIFF
--- a/src/aliceVision/sfmDataIO/colmap.cpp
+++ b/src/aliceVision/sfmDataIO/colmap.cpp
@@ -11,6 +11,7 @@
 #include <boost/filesystem.hpp>
 
 #include <sstream>
+#include <fstream>
 
 namespace fs = boost::filesystem;
 


### PR DESCRIPTION
Missing include in colmap.cpp

Does not build on some computers under centOS