### PR TITLE
Optimize distortion calibration by 1.25x for certain problems

### DIFF
--- a/src/aliceVision/calibration/distortionEstimation.cpp
+++ b/src/aliceVision/calibration/distortionEstimation.cpp
@@ -44,19 +44,11 @@ public:
         const double cangle = cos(angle);
         const double sangle = sin(angle);
 
-        const int distortionSize = _camera->getDistortionParams().size();
-
         //Read parameters and update camera
+        auto distortionSize = _camera->getDistortionParamsSize();
         _camera->setScale({parameter_scale[0], parameter_scale[1]});
         _camera->setOffset({parameter_center[0], parameter_center[1]});
-        std::vector<double> cameraDistortionParams = _camera->getDistortionParams();
-
-        for (int idParam = 0; idParam < distortionSize; idParam++)
-        {
-            cameraDistortionParams[idParam] = parameter_disto[idParam];
-        }
-        _camera->setDistortionParams(cameraDistortionParams);
-
+        _camera->setDistortionParamsFn([&](auto index) { return parameter_disto[index]; });
 
         //Estimate measure
         const Vec2 cpt = _camera->ima2cam(_pt);
@@ -149,18 +141,11 @@ public:
         const double* parameter_center = parameters[1];
         const double* parameter_disto = parameters[2];
 
-        const int distortionSize = _camera->getDistortionParams().size();
-
         //Read parameters and update camera
+        auto distortionSize = _camera->getDistortionParamsSize();
         _camera->setScale({parameter_scale[0], parameter_scale[1]});
         _camera->setOffset({parameter_center[0], parameter_center[1]});
-        std::vector<double> cameraDistortionParams = _camera->getDistortionParams();
-
-        for (int idParam = 0; idParam < distortionSize; idParam++)
-        {
-            cameraDistortionParams[idParam] = parameter_disto[idParam];
-        }
-        _camera->setDistortionParams(cameraDistortionParams);
+        _camera->setDistortionParamsFn([&](auto index) { return parameter_disto[index]; });
 
         //Estimate measure
         const Vec2 cpt = _camera->ima2cam(_ptUndistorted);

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -346,6 +346,12 @@ public:
   virtual std::vector<double> getParams() const = 0;
 
   /**
+   * @brief Get count of intrinsic parameters
+   * @return the number of intrinsic parameters
+   */
+  virtual std::size_t getParamsSize() const = 0;
+
+  /**
    * @brief Update intrinsic parameters
    * @param[in] intrinsic parameters
    * @return true if done

--- a/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
@@ -81,6 +81,13 @@ public:
     return cam2ima(addDistortion(ima2cam(p)));
   }
 
+  std::size_t getDistortionParamsSize() const
+  {
+    if (_pDistortion == nullptr)
+        return 0;
+    return _pDistortion->getParameters().size();
+  }
+
   std::vector<double> getDistortionParams() const
   {
     if (!hasDistortion()) {
@@ -121,6 +128,30 @@ public:
     }
   }
 
+  template<class F>
+  void setDistortionParamsFn(std::size_t count, F&& callback)
+  {
+    if (_pDistortion == nullptr)
+    {
+        if (count != 0)
+        {
+            throwSetDistortionParamsCountError(0, count);
+        }
+        return;
+    }
+
+    auto& params = _pDistortion->getParameters();
+    if (params.size() != count)
+    {
+        throwSetDistortionParamsCountError(params.size(), count);
+    }
+
+    for (std::size_t i = 0; i < params.size(); ++i)
+    {
+        params[i] = callback(i);
+    }
+  }
+
   // Data wrapper for non linear optimization (get data)
   std::vector<double> getParams() const override
   {
@@ -132,6 +163,16 @@ public:
     }
 
     return params;
+  }
+
+  std::size_t getParamsSize() const override
+  {
+    std::size_t size = 4;
+    if (hasDistortion())
+    {
+      size += _pDistortion->getParameters().size();
+    }
+    return size;
   }
 
   // Data wrapper for non linear optimization (update from data)

--- a/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
@@ -110,6 +110,19 @@ public:
     }
   }
 
+  template<class F>
+  void setDistortionParamsFn(F&& callback)
+  {
+    if (_pDistortion == nullptr)
+        return;
+
+    auto& params = _pDistortion->getParameters();
+    for (std::size_t i = 0; i < params.size(); ++i)
+    {
+        params[i] = callback(i);
+    }
+  }
+
   // Data wrapper for non linear optimization (get data)
   std::vector<double> getParams() const override
   {

--- a/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
@@ -99,9 +99,7 @@ public:
 
     if (distortionParams.size() != expected)
     {
-        std::stringstream s;
-        s << "IntrinsicsScaleOffsetDisto::setDistortionParams: wrong number of distortion parameters (expected: " << expected << ", given:" << distortionParams.size() << ").";
-        throw std::runtime_error(s.str());
+        throwSetDistortionParamsCountError(expected, distortionParams.size());
     }
 
     if (_pDistortion)
@@ -221,6 +219,15 @@ public:
   ~IntrinsicsScaleOffsetDisto() override = default;
 
 protected:
+  void throwSetDistortionParamsCountError(std::size_t expected, std::size_t received)
+  {
+      std::stringstream s;
+      s << "IntrinsicsScaleOffsetDisto::setDistortionParams*: "
+        << "wrong number of distortion parameters (expected: "
+        << expected << ", given:" << received << ").";
+      throw std::runtime_error(s.str());
+  }
+
   std::shared_ptr<Distortion> _pDistortion;
 };
 

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
@@ -88,7 +88,7 @@ public:
 
     _intrinsic->setScale({parameter_intrinsics[0], parameter_intrinsics[1]});
     _intrinsic->setOffset({parameter_intrinsics[2], parameter_intrinsics[3]});
-    _intrinsic->setDistortionParams({parameter_intrinsics[4], parameter_intrinsics[5], parameter_intrinsics[6]});
+    _intrinsic->setDistortionParamsFn(3, [&](auto index) { return parameter_intrinsics[4 + index]; });
 
     Eigen::Matrix3d R = jRo * iRo.transpose();
     geometry::Pose3 T(R, Vec3({0,0,0}));

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
@@ -167,14 +167,14 @@ public:
     _intrinsic->setScale({parameter_intrinsics[0], parameter_intrinsics[1]});
     _intrinsic->setOffset({parameter_intrinsics[2], parameter_intrinsics[3]});
 
-    std::vector<double> distortion_params;
-    size_t params_size = _intrinsic->getParams().size();
-    size_t disto_size = _intrinsic->getDistortionParams().size();
+    size_t params_size = _intrinsic->getParamsSize();
+    size_t disto_size = _intrinsic->getDistortionParamsSize();
     size_t offset = params_size - disto_size;
-    for (size_t index = offset; index < params_size; index++) {
-      distortion_params.push_back(parameter_intrinsics[index]);
-    }
-    _intrinsic->setDistortionParams(distortion_params);
+
+    _intrinsic->setDistortionParamsFn(disto_size, [&](auto index)
+    {
+        return parameter_intrinsics[offset + index];
+    });
 
     Eigen::Matrix3d R = jRo * iRo.transpose();
     geometry::Pose3 T(R, Vec3({0,0,0}));


### PR DESCRIPTION
I've accidentally noticed that distortion calibration takes a lot of time in `std::vector` operations. Closer inspection revealed that we're copying data unnecessarily when setting distortion parameters. This PR optimizes this operation by giving the caller an option to supply a callback with which appropriate number of parameters will be initialized with all the usual error checking.

On a machine with AMD 2990WX (with turbo boost disabled) this PR improves the run-time of `test_calibration_distortion` test from ~3.9s to ~3.1s.