### PR TITLE
[image] Use build-time ALICEVISION_ROOT as fallback to env variable

### DIFF
--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -42,6 +42,8 @@ alicevision_add_library(aliceVision_image
     Boost::filesystem
   PRIVATE_INCLUDE_DIRS
     ${OPENEXR_INCLUDE_DIR}
+  PRIVATE_DEFINITIONS
+    -DALICEVISION_DEFAULT_ROOT=${CMAKE_INSTALL_PREFIX}
 )
 
 # Install config.ocio

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -18,6 +18,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/preprocessor/stringize.hpp>
 
 #include <cstring>
 #include <stdexcept>
@@ -1125,7 +1126,13 @@ std::string getAliceVisionRoot()
     if (!aliceVisionRootOverride.empty())
         return aliceVisionRootOverride;
     const char* value = std::getenv("ALICEVISION_ROOT");
-    return value ? value : "";
+    if (value)
+        return value;
+#ifdef ALICEVISION_DEFAULT_ROOT
+    return BOOST_PP_STRINGIZE(ALICEVISION_DEFAULT_ROOT);
+#else
+    return "";
+#endif
 }
 
 std::string getAliceVisionOCIOConfig()


### PR DESCRIPTION
This still allows to override ALICEVISION_ROOT, but will avoid the need to set the environment variable in a cases when the prefix is known beforehand.

