### PR TITLE
[sensorDB] update sensor data from websites

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -168,6 +168,10 @@ Allview;Allview X4 Soul Lite;4.71;devicespecifications
 Allview;Allview X4 Soul mini;4.69;devicespecifications
 Allview;Allview X4 Soul Style;4.71;devicespecifications
 Allview;Allview X4 Xtreme;4.71;devicespecifications
+Apple;Apple iPhone 11;4.8;imaging-resource
+Apple;Apple iPhone 4;4.5;imaging-resource
+Apple;Apple iPhone 4S;4.5;imaging-resource
+Apple;Apple iPhone 8 Plus;4.8;imaging-resource
 Apple;iPad 3;4.54;usercontribution
 Apple;iPad mini 4;3.6;devicespecifications
 Apple;iPhone 11 Pro;5.75;usercontribution
@@ -178,20 +182,20 @@ Apple;iPhone 13 Pro;7.76;dpreview
 Apple;iPhone 13 Pro Max;7.76;dpreview
 Apple;iPhone 3G;3.56;vfxcamdb
 Apple;iPhone 3GS;3.6;vfxcamdb
-Apple;iPhone 4;4.54;imaging-resource,devicespecifications
-Apple;iPhone 4S;4.54;imaging-resource,devicespecifications,vfxcamdb
+Apple;iPhone 4;4.54;devicespecifications,imaging-resource
+Apple;iPhone 4S;4.54;devicespecifications,imaging-resource,vfxcamdb
 Apple;iPhone 5;4.54;devicespecifications,vfxcamdb
 Apple;iPhone 5c;4.54;devicespecifications
 Apple;iPhone 5s;4.89;devicespecifications
-Apple;iPhone 6;4.89;phonearena,devicespecifications
-Apple;iPhone 6 Plus;4.89;phonearena,devicespecifications
-Apple;iPhone 6s;4.89;phonearena,devicespecifications
-Apple;iPhone 6s Plus;4.89;phonearena,devicespecifications
+Apple;iPhone 6;4.89;devicespecifications,phonearena
+Apple;iPhone 6 Plus;4.89;devicespecifications,phonearena
+Apple;iPhone 6s;4.89;devicespecifications,phonearena
+Apple;iPhone 6s Plus;4.89;devicespecifications,phonearena
 Apple;iPhone 7;4.89;phonearena
 Apple;iPhone 7 Plus;4.89;phonearena
 Apple;iPhone 8;4.89;phonearena
 Apple;iPhone 8 Plus;4.89;imaging-resource,phonearena
-Apple;iPhone SE;4.89;phonearena,devicespecifications
+Apple;iPhone SE;4.89;devicespecifications,phonearena
 Apple;iPhone X;4.89;phonearena
 Apple;iPhone XR;5.60;dpreview
 Apple;iPhone XS;5.60;dpreview
@@ -220,8 +224,6 @@ ARRI;ARRI Alexa SXT Plus;28.25;usercontribution
 ARRI;ARRI ALEXA SXT W;28.25;ARRI
 ARRI;ARRI Alexa XT;23.76;usercontribution
 ARRI;ARRI AMIRA;26.40;ARRI
-ARRI;ARRI AMIRA;28.17;ARRI
-ARRI;ARRI AMIRA Live;26.40;ARRI
 ARRI;ARRI AMIRA Live;26.40;ARRI
 Asus;Asus 2016;4.69;devicespecifications
 Asus;Asus Google Nexus 7;2.46;devicespecifications
@@ -512,51 +514,53 @@ Bq mobile;Bq mobile BQ-5504 Strike Selfie Max;4.69;devicespecifications
 Bq mobile;Bq mobile BQ-5508L Next LTE;3.67;devicespecifications
 Bq mobile;Bq mobile BQ-6001L Jumbo;4.69;devicespecifications
 Bravis;Bravis S500 Diamond;3.67;devicespecifications
+Canon;Canon  EOS-1D X Mark II;36.0;dxomark
+Canon;Canon  EOS-1D X Mark III;36.0;dxomark
 Canon;Canon 550D;22.3;usercontribution
 Canon;Canon Canon IXUS 185;5.33;usercontribution
 Canon;Canon Digital IXUS;5.33;digicamdb
-Canon;Canon Digital IXUS 100 IS;6.17;dpreview,digicamdb
+Canon;Canon Digital IXUS 100 IS;6.17;digicamdb,dpreview
 Canon;Canon Digital IXUS 110 IS;6.16;digicamdb
 Canon;Canon Digital IXUS 120 IS;6.16;digicamdb
 Canon;Canon Digital IXUS 200 IS;6.16;digicamdb
 Canon;Canon Digital IXUS 30;5.744;dpreview
-Canon;Canon Digital IXUS 300;5.312;dpreview,digicamdb
-Canon;Canon Digital IXUS 330;5.312;dpreview,digicamdb
-Canon;Canon Digital IXUS 40;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 400;7.144;dpreview,digicamdb
-Canon;Canon Digital IXUS 430;7.144;dpreview,digicamdb
-Canon;Canon Digital IXUS 50;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 500;7.144;dpreview,digicamdb
+Canon;Canon Digital IXUS 300;5.312;digicamdb,dpreview
+Canon;Canon Digital IXUS 330;5.312;digicamdb,dpreview
+Canon;Canon Digital IXUS 40;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 400;7.144;digicamdb,dpreview
+Canon;Canon Digital IXUS 430;7.144;digicamdb,dpreview
+Canon;Canon Digital IXUS 50;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 500;7.144;digicamdb,dpreview
 Canon;Canon Digital IXUS 55;5.744;dpreview
-Canon;Canon Digital IXUS 60;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 65;5.744;dpreview,digicamdb
+Canon;Canon Digital IXUS 60;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 65;5.744;digicamdb,dpreview
 Canon;Canon Digital IXUS 70;5.744;dpreview
 Canon;Canon DIGITAL IXUS 700;7.144;digicamdb
 Canon;Canon Digital IXUS 75;5.744;dpreview
 Canon;Canon DIGITAL IXUS 750;7.144;digicamdb
-Canon;Canon Digital IXUS 80 IS;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 800 IS;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 85 IS;6.17;dpreview,digicamdb
-Canon;Canon Digital IXUS 850 IS;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 860 IS;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 870 IS;6.17;dpreview,digicamdb
-Canon;Canon Digital IXUS 90 IS;6.17;dpreview,digicamdb
-Canon;Canon Digital IXUS 900 Ti;7.144;dpreview,digicamdb
-Canon;Canon Digital IXUS 95 IS;6.17;dpreview,digicamdb
-Canon;Canon Digital IXUS 950 IS;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS 960 IS;7.44;dpreview,digicamdb
-Canon;Canon Digital IXUS 970 IS;6.17;dpreview,digicamdb
-Canon;Canon Digital IXUS 980 IS;7.44;dpreview,digicamdb
+Canon;Canon Digital IXUS 80 IS;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 800 IS;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 85 IS;6.17;digicamdb,dpreview
+Canon;Canon Digital IXUS 850 IS;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 860 IS;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 870 IS;6.17;digicamdb,dpreview
+Canon;Canon Digital IXUS 90 IS;6.17;digicamdb,dpreview
+Canon;Canon Digital IXUS 900 Ti;7.144;digicamdb,dpreview
+Canon;Canon Digital IXUS 95 IS;6.17;digicamdb,dpreview
+Canon;Canon Digital IXUS 950 IS;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS 960 IS;7.44;digicamdb,dpreview
+Canon;Canon Digital IXUS 970 IS;6.17;digicamdb,dpreview
+Canon;Canon Digital IXUS 980 IS;7.44;digicamdb,dpreview
 Canon;Canon Digital IXUS 990 IS;6.16;digicamdb
-Canon;Canon Digital IXUS i;5.744;dpreview,digicamdb
+Canon;Canon Digital IXUS i;5.744;digicamdb,dpreview
 Canon;Canon Digital IXUS i Zoom;5.75;digicamdb
 Canon;Canon Digital IXUS i5;5.744;dpreview
-Canon;Canon Digital IXUS i7;5.744;dpreview,digicamdb
-Canon;Canon Digital IXUS II;5.312;dpreview,digicamdb
-Canon;Canon Digital IXUS IIs;5.312;dpreview,digicamdb
+Canon;Canon Digital IXUS i7;5.744;digicamdb,dpreview
+Canon;Canon Digital IXUS II;5.312;digicamdb,dpreview
+Canon;Canon Digital IXUS IIs;5.312;digicamdb,dpreview
 Canon;Canon Digital IXUS V;5.312;dpreview
-Canon;Canon Digital IXUS v2;5.312;dpreview,digicamdb
-Canon;Canon Digital IXUS v3;5.312;dpreview,digicamdb
+Canon;Canon Digital IXUS v2;5.312;digicamdb,dpreview
+Canon;Canon Digital IXUS v3;5.312;digicamdb,dpreview
 Canon;Canon Digital IXUS Wireless;5.744;dpreview
 Canon;Canon ELPH 100 HS;6.17;dpreview
 Canon;Canon ELPH 115 IS;6.17;dpreview
@@ -570,12 +574,12 @@ Canon;Canon ELPH 300 HS;6.17;dpreview
 Canon;Canon ELPH 310 HS;6.17;dpreview
 Canon;Canon ELPH 500 HS;6.17;dpreview
 Canon;Canon ELPH 520 HS;6.17;dpreview
-Canon;Canon EOS 1000D;22.2;dpreview,digicamdb,dxomark
-Canon;Canon EOS 100D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 10D;22.7;dpreview,digicamdb,dxomark
-Canon;Canon EOS 1100D;22.2;dpreview,digicamdb,dxomark
-Canon;Canon EOS 1200D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 1300D;22.3;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon EOS 1000D;22.2;digicamdb,dpreview,dxomark
+Canon;Canon EOS 100D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 10D;22.7;digicamdb,dpreview,dxomark
+Canon;Canon EOS 1100D;22.2;digicamdb,dpreview,dxomark
+Canon;Canon EOS 1200D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 1300D;22.3;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon EOS 1D Mark II;29.0;dxomark
 Canon;Canon EOS 1D Mark II N;28.7;dxomark
 Canon;Canon EOS 1D Mark III;28.7;dxomark
@@ -586,49 +590,52 @@ Canon;Canon EOS 1Ds;35.8;dxomark
 Canon;Canon EOS 1Ds Mark II;36.0;dxomark
 Canon;Canon EOS 1Ds Mark III;36.0;dxomark
 Canon;Canon EOS 1Dx;36.0;dxomark
-Canon;Canon EOS 2000D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 200D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 20D;22.5;dpreview,digicamdb,dxomark
-Canon;Canon EOS 20Da;22.5;dpreview,digicamdb
-Canon;Canon EOS 300D;22.7;dpreview,digicamdb,dxomark
-Canon;Canon EOS 30D;22.5;dpreview,digicamdb,dxomark
-Canon;Canon EOS 350D;22.2;dpreview,digicamdb,dxomark
-Canon;Canon EOS 4000D;22.3;dpreview,digicamdb,dxomark
-Canon;Canon EOS 400D;22.2;dpreview,digicamdb,dxomark
-Canon;Canon EOS 400D DIGITAL;22.2;dpreview,digicamdb,dxomark
+Canon;Canon EOS 2000D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 200D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 20D;22.5;digicamdb,dpreview,dxomark
+Canon;Canon EOS 20Da;22.5;digicamdb,dpreview
+Canon;Canon EOS 250D;22.3;dxomark
+Canon;Canon EOS 300D;22.7;digicamdb,dpreview,dxomark
+Canon;Canon EOS 30D;22.5;digicamdb,dpreview,dxomark
+Canon;Canon EOS 350D;22.2;digicamdb,dpreview,dxomark
+Canon;Canon EOS 4000D;22.3;digicamdb,dpreview,dxomark
+Canon;Canon EOS 400D;22.2;digicamdb,dpreview,dxomark
+Canon;Canon EOS 400D DIGITAL;22.2;digicamdb,dpreview,dxomark
 Canon;Canon EOS 400D Rebel XTi;22.2;imaging-resource
-Canon;Canon EOS 40D;22.2;dpreview,digicamdb
-Canon;Canon EOS 450D;22.2;dpreview,digicamdb,dxomark
-Canon;Canon EOS 500D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 50D;22.3;dpreview,digicamdb,dxomark
-Canon;Canon EOS 550D;22.3;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon EOS 40D;22.2;digicamdb,dpreview
+Canon;Canon EOS 450D;22.2;digicamdb,dpreview,dxomark
+Canon;Canon EOS 500D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 50D;22.3;digicamdb,dpreview,dxomark
+Canon;Canon EOS 550D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 550D pre production;22.3;dxomark
 Canon;Canon EOS 5D;36.0;dpreview,dxomark
-Canon;Canon EOS 5D Mark II;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 5D Mark III;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 5D Mark IV;36.0;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon EOS 5D Mark II;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 5D Mark III;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 5D Mark IV;36.0;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon EOS 5D mk II;36.00;usercontribution
 Canon;Canon EOS 5D mk III;36.00;usercontribution
 Canon;Canon EOS 5D mk IV;36.00;usercontribution
-Canon;Canon EOS 5DS;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 5DS R;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 600D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 60D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 60Da;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS 650D;22.3;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon EOS 5DS;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 5DS R;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 600D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 60D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 60Da;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS 650D;22.3;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon EOS 6D;36.0;dpreview,dxomark
-Canon;Canon EOS 6D Mark II;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 700D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 70D;22.5;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 750D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 760D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 77D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 7D;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 7D;22.30;usercontribution
-Canon;Canon EOS 7D Mark II;22.4;dpreview,digicamdb,dxomark
+Canon;Canon EOS 6D Mark II;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 700D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 70D;22.5;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 750D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 760D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 77D;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 7D;22.30;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 7D Mark II;22.4;digicamdb,dpreview,dxomark
 Canon;Canon EOS 8000D;22.3;digicamdb
-Canon;Canon EOS 800D;22.3;digicamdb,imaging-resource,dxomark
-Canon;Canon EOS 80D;22.5;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon EOS 800D;22.3;digicamdb,dxomark,imaging-resource
+Canon;Canon EOS 80D;22.5;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS 850D;22.3;digicamdb
 Canon;Canon EOS 9000D;22.3;digicamdb
+Canon;Canon EOS 90D;22.3;dxomark
 Canon;Canon EOS C100;24.60;usercontribution
 Canon;Canon EOS C100 mk II;24.60;usercontribution
 Canon;Canon EOS C200;24.40;usercontribution
@@ -639,18 +646,21 @@ Canon;Canon EOS C500 mk II;38.10;usercontribution
 Canon;Canon EOS C70;26.20;usercontribution
 Canon;Canon EOS C700;28.90;usercontribution
 Canon;Canon EOS C700 FF;38.10;usercontribution
-Canon;Canon EOS D30;22.7;dpreview,digicamdb
-Canon;Canon EOS D60;22.7;dpreview,digicamdb
-Canon;Canon EOS Digital Rebel;22.7;dpreview,digicamdb
+Canon;Canon EOS D30;22.7;digicamdb,dpreview
+Canon;Canon EOS D60;22.7;digicamdb,dpreview
+Canon;Canon EOS Digital Rebel;22.7;digicamdb,dpreview
 Canon;Canon EOS Digital Rebel XS;22.2;digicamdb
 Canon;Canon EOS Digital Rebel XSi;22.2;digicamdb
-Canon;Canon EOS Digital Rebel XT;22.2;dpreview,digicamdb
-Canon;Canon EOS Digital Rebel XTi;22.2;dpreview,digicamdb
+Canon;Canon EOS Digital Rebel XT;22.2;digicamdb,dpreview
+Canon;Canon EOS Digital Rebel XTi;22.2;digicamdb,dpreview
 Canon;Canon EOS Kiss Digital;22.7;digicamdb
 Canon;Canon EOS Kiss Digital N;22.2;digicamdb
 Canon;Canon EOS Kiss Digital X;22.2;digicamdb
 Canon;Canon EOS Kiss F;22.2;digicamdb
-Canon;Canon EOS Kiss M;22.3;dpreview,digicamdb
+Canon;Canon EOS Kiss M;22.3;digicamdb,dpreview
+Canon;Canon EOS Kiss M2;22.3;digicamdb
+Canon;Canon EOS Kiss X10;22.3;digicamdb
+Canon;Canon EOS Kiss X10i;22.3;digicamdb
 Canon;Canon EOS Kiss X2;22.2;digicamdb
 Canon;Canon EOS Kiss X3;22.3;digicamdb
 Canon;Canon EOS Kiss X4;22.3;digicamdb
@@ -665,83 +675,95 @@ Canon;Canon EOS Kiss X8i;22.3;digicamdb
 Canon;Canon EOS Kiss X9;22.3;digicamdb
 Canon;Canon EOS Kiss X90;22.3;digicamdb
 Canon;Canon EOS Kiss X9i;22.3;digicamdb
-Canon;Canon EOS M;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS M10;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS M100;22.3;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon EOS M;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS M10;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS M100;22.3;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon EOS M2;22.3;dxomark
-Canon;Canon EOS M3;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS M5;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS M50;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS M50m2;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS M6;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS M6 Mark II;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS R;36.0;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS R3;36.00;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS R5;36.0;dpreview,digicamdb,imaging-resource
+Canon;Canon EOS M200;22.3;dxomark
+Canon;Canon EOS M3;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS M5;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS M50;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS M50 II;22.3;digicamdb
+Canon;Canon EOS M50 Mark II;22.3;dpreview
+Canon;Canon EOS M50m2;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS M6;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS M6 Mark II;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS R;36.0;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS R10;22.3;digicamdb
+Canon;Canon EOS R3;36.00;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS R5;36.0;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS R5 C;36.0;imaging-resource
 Canon;Canon EOS R6;35.9;devicespecifications,digicamdb
-Canon;Canon EOS Rebel SL1;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel SL2;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T1i;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T2i;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T3;22.2;dpreview,digicamdb
-Canon;Canon EOS Rebel T3i;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T4i;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T5;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T5i;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T6;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T6i;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T6s;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T7;22.3;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS Rebel T7i;22.3;dpreview,digicamdb,imaging-resource
+Canon;Canon EOS R6 II;36.0;dpreview
+Canon;Canon EOS R6 Mark II;36.0;imaging-resource
+Canon;Canon EOS R7;22.3;imaging-resource
+Canon;Canon EOS Ra;36.0;dpreview
+Canon;Canon EOS Rebel SL1;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel SL2;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel SL3;22.3;digicamdb
+Canon;Canon EOS Rebel T1i;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T2i;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T3;22.2;digicamdb,dpreview
+Canon;Canon EOS Rebel T3i;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T4i;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T5;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T5i;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T6;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T6i;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T6s;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T7;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T7i;22.3;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS Rebel T8i;22.3;digicamdb
 Canon;Canon EOS Rebel XS;22.2;dpreview
 Canon;Canon EOS Rebel XSi;22.2;dpreview
-Canon;Canon EOS RP;35.9;dpreview,digicamdb,imaging-resource
+Canon;Canon EOS RP;35.9;digicamdb,dpreview,imaging-resource
 Canon;Canon EOS XS;22.2;imaging-resource
 Canon;Canon EOS XSi;22.2;imaging-resource
-Canon;Canon EOS-1D;28.7;dpreview,digicamdb
-Canon;Canon EOS-1D C;36.0;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS-1D Mark II;28.7;dpreview,digicamdb
-Canon;Canon EOS-1D Mark II N;28.7;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS-1D Mark III;28.7;dpreview,digicamdb
-Canon;Canon EOS-1D Mark IV;27.9;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS-1D X;36.0;dpreview,digicamdb,imaging-resource
-Canon;Canon EOS-1D X Mark II;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon EOS-1Ds;35.8;dpreview,digicamdb
-Canon;Canon EOS-1Ds Mark II;36.0;dpreview,digicamdb
-Canon;Canon EOS-1Ds Mark III;36.0;dpreview,digicamdb,imaging-resource
+Canon;Canon EOS-1D;28.7;digicamdb,dpreview
+Canon;Canon EOS-1D C;36.0;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS-1D Mark II;28.7;digicamdb,dpreview
+Canon;Canon EOS-1D Mark II N;28.7;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS-1D Mark III;28.7;digicamdb,dpreview
+Canon;Canon EOS-1D Mark IV;27.9;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS-1D X;36.0;digicamdb,dpreview,imaging-resource
+Canon;Canon EOS-1D X Mark II;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon EOS-1D X Mark III;36.0;digicamdb
+Canon;Canon EOS-1Ds;35.8;digicamdb,dpreview
+Canon;Canon EOS-1Ds Mark II;36.0;digicamdb,dpreview
+Canon;Canon EOS-1Ds Mark III;36.0;digicamdb,dpreview,imaging-resource
 Canon;Canon IXUS 1000 HS;6.16;digicamdb
 Canon;Canon IXUS 105;6.16;digicamdb
 Canon;Canon IXUS 107;6.16;usercontribution
-Canon;Canon IXUS 1100 HS;6.17;dpreview,digicamdb
-Canon;Canon IXUS 115 HS;6.17;dpreview,digicamdb
+Canon;Canon IXUS 1100 HS;6.17;digicamdb,dpreview
+Canon;Canon IXUS 115 HS;6.17;digicamdb,dpreview
 Canon;Canon IXUS 125 HS;6.16;digicamdb
 Canon;Canon IXUS 127 HS;6.17;usercontribution
 Canon;Canon IXUS 130;6.16;digicamdb
 Canon;Canon IXUS 132;6.16;digicamdb
 Canon;Canon IXUS 132 HS;6.17;dpreview
 Canon;Canon IXUS 135;6.16;digicamdb
-Canon;Canon IXUS 140;6.17;dpreview,digicamdb
-Canon;Canon IXUS 145;6.17;dpreview,digicamdb
-Canon;Canon IXUS 150;6.17;dpreview,digicamdb
-Canon;Canon IXUS 155;6.17;dpreview,digicamdb
-Canon;Canon IXUS 160;6.17;dpreview,digicamdb
-Canon;Canon IXUS 165;6.17;dpreview,digicamdb
-Canon;Canon IXUS 170;6.17;dpreview,digicamdb
+Canon;Canon IXUS 140;6.17;digicamdb,dpreview
+Canon;Canon IXUS 145;6.17;digicamdb,dpreview
+Canon;Canon IXUS 150;6.17;digicamdb,dpreview
+Canon;Canon IXUS 155;6.17;digicamdb,dpreview
+Canon;Canon IXUS 160;6.17;digicamdb,dpreview
+Canon;Canon IXUS 165;6.17;digicamdb,dpreview
+Canon;Canon IXUS 170;6.17;digicamdb,dpreview
 Canon;Canon IXUS 175;6.16;digicamdb
 Canon;Canon IXUS 180;6.16;digicamdb
 Canon;Canon IXUS 210;6.16;digicamdb
-Canon;Canon IXUS 220 HS;6.17;dpreview,digicamdb
+Canon;Canon IXUS 220 HS;6.17;digicamdb,dpreview
 Canon;Canon IXUS 220HS;6.16;usercontribution
-Canon;Canon IXUS 230 HS;6.17;dpreview,digicamdb
+Canon;Canon IXUS 230 HS;6.17;digicamdb,dpreview
 Canon;Canon IXUS 240 HS;6.16;digicamdb
-Canon;Canon IXUS 255 HS;6.17;dpreview,digicamdb
-Canon;Canon IXUS 265 HS;6.17;dpreview,digicamdb
-Canon;Canon IXUS 275 HS;6.17;dpreview,digicamdb
+Canon;Canon IXUS 255 HS;6.17;digicamdb,dpreview
+Canon;Canon IXUS 265 HS;6.17;digicamdb,dpreview
+Canon;Canon IXUS 275 HS;6.17;digicamdb,dpreview
 Canon;Canon IXUS 285 HS;6.16;digicamdb
-Canon;Canon IXUS 300 HS;6.17;dpreview,digicamdb
-Canon;Canon IXUS 310 HS;6.17;dpreview,digicamdb
-Canon;Canon IXUS 500 HS;6.17;dpreview,digicamdb
-Canon;Canon IXUS 510 HS;6.17;dpreview,digicamdb
+Canon;Canon IXUS 300 HS;6.17;digicamdb,dpreview
+Canon;Canon IXUS 310 HS;6.17;digicamdb,dpreview
+Canon;Canon IXUS 500 HS;6.17;digicamdb,dpreview
+Canon;Canon IXUS 510 HS;6.17;digicamdb,dpreview
 Canon;Canon IXY 1;6.16;digicamdb
 Canon;Canon IXY 100F;6.16;digicamdb
 Canon;Canon IXY 10S;6.16;digicamdb
@@ -815,146 +837,149 @@ Canon;Canon IXY DIGITAL L2;5.75;digicamdb
 Canon;Canon IXY Digital L3;5.744;dpreview
 Canon;Canon IXY DIGITAL L4;5.75;digicamdb
 Canon;Canon IXY DIGITAL WIRELESS;5.75;digicamdb
-Canon;Canon PowerShot 350;4.8;dpreview,digicamdb
-Canon;Canon PowerShot 600;4.8;dpreview,digicamdb
-Canon;Canon PowerShot A10;5.312;dpreview,digicamdb
+Canon;Canon PowerShot 350;4.8;digicamdb,dpreview
+Canon;Canon PowerShot 600;4.8;digicamdb,dpreview
+Canon;Canon PowerShot A10;5.312;digicamdb,dpreview
 Canon;Canon Powershot A100;4.544;usercontribution
-Canon;Canon PowerShot A1000 IS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot A1000 IS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon Powershot A1100 IS;6.16;usercontribution
 Canon;Canon Powershot A1200;6.16;usercontribution
-Canon;Canon PowerShot A1300;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A1400;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A20;5.312;dpreview,digicamdb
+Canon;Canon PowerShot A1300;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A1400;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A20;5.312;digicamdb,dpreview
 Canon;Canon Powershot A200;4.544;usercontribution
-Canon;Canon PowerShot A2000 IS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot A2000 IS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon Powershot A2100 IS;6.16;usercontribution
 Canon;Canon Powershot A2200;6.16;usercontribution
-Canon;Canon PowerShot A2300;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A2400 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A2500;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot A2300;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A2400 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A2500;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot A2600;6.16;digicamdb,imaging-resource
-Canon;Canon PowerShot A30;5.312;dpreview,digicamdb
-Canon;Canon PowerShot A300;5.312;dpreview,digicamdb
+Canon;Canon PowerShot A30;5.312;digicamdb,dpreview
+Canon;Canon PowerShot A300;5.312;digicamdb,dpreview
 Canon;Canon Powershot A3000 IS;6.16;usercontribution
-Canon;Canon PowerShot A310;5.312;dpreview,digicamdb
+Canon;Canon PowerShot A310;5.312;digicamdb,dpreview
 Canon;Canon Powershot A3100 IS;6.16;usercontribution
 Canon;Canon Powershot A3200 IS;6.16;usercontribution
 Canon;Canon Powershot A3300 IS;6.16;usercontribution
-Canon;Canon PowerShot A3400 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A3500 IS;6.17;dpreview,digicamdb
-Canon;Canon PowerShot A40;5.312;dpreview,digicamdb
-Canon;Canon PowerShot A400;4.544;dpreview,digicamdb
-Canon;Canon PowerShot A4000 IS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot A3400 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A3500 IS;6.17;digicamdb,dpreview
+Canon;Canon PowerShot A40;5.312;digicamdb,dpreview
+Canon;Canon PowerShot A400;4.544;digicamdb,dpreview
+Canon;Canon PowerShot A4000 IS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon Powershot A410;4.544;usercontribution
 Canon;Canon Powershot A420;4.8;usercontribution
-Canon;Canon PowerShot A430;4.8;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A450;4.8;dpreview,digicamdb
-Canon;Canon PowerShot A460;4.8;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A470;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A480;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A490;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A495;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A5;4.8;dpreview,digicamdb
-Canon;Canon PowerShot A5 Zoom;4.8;dpreview,digicamdb
-Canon;Canon PowerShot A50;4.8;dpreview,digicamdb
+Canon;Canon PowerShot A430;4.8;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A450;4.8;digicamdb,dpreview
+Canon;Canon PowerShot A460;4.8;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A470;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A480;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A490;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A495;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A5;4.8;digicamdb,dpreview
+Canon;Canon PowerShot A5 Zoom;4.8;digicamdb,dpreview
+Canon;Canon PowerShot A50;4.8;digicamdb,dpreview
 Canon;Canon Powershot A510;5.33;usercontribution
-Canon;Canon PowerShot A520;5.744;dpreview,digicamdb
-Canon;Canon PowerShot A530;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A540;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A550;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A560;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A570 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A580;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A590 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A60;5.312;dpreview,digicamdb
+Canon;Canon PowerShot A520;5.744;digicamdb,dpreview
+Canon;Canon PowerShot A530;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A540;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A550;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A560;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A570 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A580;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A590 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A60;5.312;digicamdb,dpreview
 Canon;Canon Powershot A610;7.144;usercontribution
-Canon;Canon PowerShot A620;7.144;dpreview,digicamdb
-Canon;Canon PowerShot A630;7.144;dpreview,digicamdb
-Canon;Canon PowerShot A640;7.144;dpreview,digicamdb
-Canon;Canon PowerShot A650 IS;7.44;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A70;5.312;dpreview,digicamdb
-Canon;Canon PowerShot A700;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A710 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A720 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A75;5.312;dpreview,digicamdb
+Canon;Canon PowerShot A620;7.144;digicamdb,dpreview
+Canon;Canon PowerShot A630;7.144;digicamdb,dpreview
+Canon;Canon PowerShot A640;7.144;digicamdb,dpreview
+Canon;Canon PowerShot A650 IS;7.44;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A70;5.312;digicamdb,dpreview
+Canon;Canon PowerShot A700;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A710 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A720 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A75;5.312;digicamdb,dpreview
 Canon;Canon Powershot A80;7.144;usercontribution
-Canon;Canon PowerShot A800;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A810;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot A85;5.312;dpreview,digicamdb
-Canon;Canon PowerShot A95;7.144;dpreview,digicamdb
-Canon;Canon PowerShot D10;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot D20;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot D30;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot E1;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot A800;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A810;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot A85;5.312;digicamdb,dpreview
+Canon;Canon PowerShot A95;7.144;digicamdb,dpreview
+Canon;Canon PowerShot D10;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot D20;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot D30;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot E1;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot ELPH 100 HS;6.16;digicamdb,imaging-resource
 Canon;Canon PowerShot ELPH 110 HS;6.16;digicamdb,imaging-resource
+Canon;Canon PowerShot ELPH 110HS;6.17;dpreview
 Canon;Canon PowerShot ELPH 115 IS;6.16;digicamdb
 Canon;Canon PowerShot ELPH 120 IS;6.16;digicamdb
 Canon;Canon PowerShot ELPH 130 IS;6.16;digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 135;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 140 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 150 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 160;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot ELPH 135;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 140 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 150 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 160;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot ELPH 165 IS;6.16;digicamdb
-Canon;Canon PowerShot ELPH 170 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 180;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 190 IS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot ELPH 170 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 180;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 190 IS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot ELPH 300 HS;6.16;digicamdb,imaging-resource
 Canon;Canon PowerShot ELPH 310 HS;6.16;digicamdb,imaging-resource
 Canon;Canon PowerShot ELPH 320 HS;6.16;digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 330 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 340 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 350 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot ELPH 360 HS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot ELPH 330 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 340 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 350 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot ELPH 360 HS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot ELPH 500 HS;6.16;digicamdb,imaging-resource
 Canon;Canon PowerShot ELPH 510 HS;6.16;digicamdb,imaging-resource
 Canon;Canon PowerShot ELPH 520 HS;6.16;digicamdb,imaging-resource
 Canon;Canon PowerShot Elph 530 HS;6.16;digicamdb
 Canon;Canon Powershot G1;7.144;usercontribution
-Canon;Canon PowerShot G1 X;18.7;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot G1 X Mark II;18.7;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot G1 X Mark III;22.3;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot G10;7.44;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot G11;7.44;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot G12;7.44;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon PowerShot G1 X;18.7;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot G1 X Mark II;18.7;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot G1 X Mark III;22.3;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot G10;7.44;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot G11;7.44;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot G12;7.44;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon Powershot G15;7.44;dxomark
-Canon;Canon PowerShot G16;7.44;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon PowerShot G16;7.44;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon PowerShot G1X;18.7;dxomark
 Canon;Canon Powershot G2;7.144;usercontribution
 Canon;Canon Powershot G3;7.144;usercontribution
-Canon;Canon PowerShot G3 X;13.2;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon PowerShot G3 X;13.2;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon Powershot G5;7.144;usercontribution
-Canon;Canon PowerShot G5 X;13.2;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon PowerShot G5 X;13.2;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon PowerShot G5 X Mark II;13.2;usercontribution
-Canon;Canon PowerShot G6;7.144;dpreview,digicamdb
-Canon;Canon PowerShot G7;7.144;dpreview,digicamdb
-Canon;Canon PowerShot G7 X;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot G7 X Mark II;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot G9;7.44;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot G6;7.144;digicamdb,dpreview
+Canon;Canon PowerShot G7;7.144;digicamdb,dpreview
+Canon;Canon PowerShot G7 X;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot G7 X Mark II;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot G7 X Mark III;13.2;dxomark
+Canon;Canon PowerShot G9;7.44;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot G9 X;13.2;dpreview,imaging-resource
-Canon;Canon PowerShot G9 X Mark II;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot N;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot G9 X Mark II;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot IXUS 125 HS;6.17;dpreview
+Canon;Canon PowerShot N;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot N Facebook ready;6.17;dpreview
-Canon;Canon PowerShot N100;7.44;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot N100;7.44;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot N2;6.16;digicamdb,imaging-resource
-Canon;Canon PowerShot Pro1;8.8;dpreview,digicamdb
-Canon;Canon PowerShot Pro70;6.4;dpreview,digicamdb
-Canon;Canon PowerShot Pro90 IS;7.144;dpreview,digicamdb
-Canon;Canon PowerShot S1 IS;5.312;dpreview,digicamdb
+Canon;Canon PowerShot Pro1;8.8;digicamdb,dpreview
+Canon;Canon PowerShot Pro70;6.4;digicamdb,dpreview
+Canon;Canon PowerShot Pro90 IS;7.144;digicamdb,dpreview
+Canon;Canon PowerShot S1 IS;5.312;digicamdb,dpreview
 Canon;Canon Powershot S10;6.4;usercontribution
-Canon;Canon PowerShot S100;7.44;dpreview,digicamdb,imaging-resource,dxomark
+Canon;Canon PowerShot S100;7.44;digicamdb,dpreview,dxomark,imaging-resource
 Canon;Canon PowerShot S100 DIGITAL ELPH;5.33;digicamdb
 Canon;Canon PowerShot S100 Digital IXUS;5.33;usercontribution
 Canon;Canon Powershot S110;7.44;dxomark
 Canon;Canon PowerShot S110 DIGITAL ELPH;5.33;digicamdb
-Canon;Canon PowerShot S120;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot S2 IS;5.744;dpreview,digicamdb
+Canon;Canon PowerShot S120;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot S2 IS;5.744;digicamdb,dpreview
 Canon;Canon Powershot S20;7.144;usercontribution
 Canon;Canon PowerShot S200;7.44;dpreview
 Canon;Canon PowerShot S200 DIGITAL ELPH;5.33;digicamdb
 Canon;Canon PowerShot S230;5.312;dpreview
 Canon;Canon PowerShot S230 DIGITAL ELPH;5.33;digicamdb
-Canon;Canon PowerShot S3 IS;5.744;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot S3 IS;5.744;digicamdb,dpreview,imaging-resource
 Canon;Canon Powershot S30;7.144;usercontribution
 Canon;Canon PowerShot S300;5.312;dpreview
 Canon;Canon PowerShot S300 DIGITAL ELPH;5.33;digicamdb
@@ -963,97 +988,98 @@ Canon;Canon PowerShot S330 DIGITAL ELPH;5.33;digicamdb
 Canon;Canon Powershot S40;7.144;usercontribution
 Canon;Canon PowerShot S400;7.144;dpreview
 Canon;Canon PowerShot S400 DIGITAL ELPH;7.11;digicamdb
-Canon;Canon PowerShot S410;7.144;dpreview,digicamdb
+Canon;Canon PowerShot S410;7.144;digicamdb,dpreview
 Canon;Canon Powershot S45;7.144;usercontribution
-Canon;Canon PowerShot S5 IS;5.744;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot S5 IS;5.744;digicamdb,dpreview,imaging-resource
 Canon;Canon Powershot S50;7.144;usercontribution
-Canon;Canon PowerShot S500;7.144;dpreview,digicamdb
-Canon;Canon PowerShot S60;7.144;dpreview,digicamdb
-Canon;Canon PowerShot S70;7.144;dpreview,digicamdb
+Canon;Canon PowerShot S500;7.144;digicamdb,dpreview
+Canon;Canon PowerShot S60;7.144;digicamdb,dpreview
+Canon;Canon PowerShot S70;7.144;digicamdb,dpreview
 Canon;Canon Powershot S80;7.144;usercontribution
-Canon;Canon PowerShot S90;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot S95;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot SD10;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD100;5.312;dpreview,digicamdb
-Canon;Canon PowerShot SD1000;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD110;5.312;dpreview,digicamdb
-Canon;Canon PowerShot SD1100 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD1200 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD1300 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD1400 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD20;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD200;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD30;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD300;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD3500 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD40;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD400;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD4000 IS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot S90;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot S95;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot SD10;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD100;5.312;digicamdb,dpreview
+Canon;Canon PowerShot SD1000;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD110;5.312;digicamdb,dpreview
+Canon;Canon PowerShot SD1100 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD1200 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD1300 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD1400 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD20;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD200;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD30;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD300;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD3500 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD40;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD400;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD4000 IS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot SD430;5.8;imaging-resource
-Canon;Canon PowerShot SD430 Wireless;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD450;5.744;dpreview,digicamdb
-Canon;Canon PowerShot SD4500 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD500;7.144;dpreview,digicamdb
-Canon;Canon PowerShot SD550;7.144;dpreview,digicamdb
-Canon;Canon PowerShot SD600;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD630;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD700 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD750;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD770 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD780 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD790 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD800 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD850 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD870 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD880 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD890 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD900;7.144;dpreview,digicamdb
-Canon;Canon PowerShot SD940 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD950 IS;7.44;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD960 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD970 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD980 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SD990 IS;7.44;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX1 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX10 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX100 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX110 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX120 IS;5.744;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX130 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX150 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX160 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX170 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX20 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX200 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX210 IS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot SD430 Wireless;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD450;5.744;digicamdb,dpreview
+Canon;Canon PowerShot SD4500 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD500;7.144;digicamdb,dpreview
+Canon;Canon PowerShot SD550;7.144;digicamdb,dpreview
+Canon;Canon PowerShot SD600;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD630;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD700 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD750;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD770 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD780 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD790 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD800 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD850 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD870 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD880 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD890 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD900;7.144;digicamdb,dpreview
+Canon;Canon PowerShot SD940 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD950 IS;7.44;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD960 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD970 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD980 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SD990 IS;7.44;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX1 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX10 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX100 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX110 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX120 IS;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX130 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX150 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX160 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX170 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX20 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX200 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX210 IS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot SX220 HS;6.16;digicamdb,imaging-resource
-Canon;Canon PowerShot SX230 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX240 HS;6.17;dpreview,digicamdb
-Canon;Canon PowerShot SX260 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX270 HS;6.17;dpreview,digicamdb
-Canon;Canon PowerShot SX280 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX30 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX40 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX400 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX410 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX420 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX50 HS;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot SX500 IS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX510 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX520 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX530 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX540 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX60 HS;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Canon;Canon PowerShot SX600 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX610 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX620 HS;6.17;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot SX230 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX240 HS;6.17;digicamdb,dpreview
+Canon;Canon PowerShot SX260 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX270 HS;6.17;digicamdb,dpreview
+Canon;Canon PowerShot SX280 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX30 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX40 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX400 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX410 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX420 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX50 HS;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot SX500 IS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX510 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX520 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX530 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX540 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX60 HS;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Canon;Canon PowerShot SX600 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX610 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX620 HS;6.17;digicamdb,dpreview,imaging-resource
 Canon;Canon PowerShot SX70 HS;6.17;dpreview,imaging-resource
-Canon;Canon PowerShot SX700 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX710 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX720 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX730 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot SX740 HS;6.17;dpreview,digicamdb,imaging-resource
-Canon;Canon PowerShot TX1;5.744;dpreview,digicamdb,imaging-resource
+Canon;Canon PowerShot SX700 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX710 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX720 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX730 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot SX740 HS;6.17;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot TX1;5.744;digicamdb,dpreview,imaging-resource
+Canon;Canon PowerShot Zoom;4.8;dpreview
 Canon;Canon Pro90 IS;7.11;usercontribution
 Canon;Canon Rebel XS, Canon 1000D;22.2;imaging-resource
 Canon;Canon Rebel XSi, Canon 450D;22.2;imaging-resource
@@ -1084,8 +1110,8 @@ Casio;Casio EXILIM Card EX-S5;6.2;imaging-resource
 Casio;Casio EXILIM CARD EX-S600;5.8;imaging-resource
 Casio;Casio EXILIM CARD EX-S770;5.8;imaging-resource
 Casio;Casio EXILIM CARD EX-S880;5.8;imaging-resource
-Casio;Casio Exilim EX-10;7.44;dpreview,digicamdb
-Casio;Casio Exilim EX-100;7.44;dpreview,digicamdb
+Casio;Casio Exilim EX-10;7.44;digicamdb,dpreview
+Casio;Casio Exilim EX-100;7.44;digicamdb,dpreview
 Casio;Casio Exilim EX-100F;7.6;dxomark
 Casio;Casio EXILIM EX-FC100;6.16;usercontribution
 Casio;Casio EXILIM EX-FC150;6.16;imaging-resource
@@ -1112,42 +1138,42 @@ Casio;Casio Exilim EX-N10;6.16;digicamdb
 Casio;Casio Exilim EX-N20;6.16;digicamdb
 Casio;Casio Exilim EX-N5;6.16;digicamdb
 Casio;Casio Exilim EX-N50;6.16;digicamdb
-Casio;Casio Exilim EX-P505;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-P600;7.144;dpreview,digicamdb
-Casio;Casio Exilim EX-P700;7.144;dpreview,digicamdb
+Casio;Casio Exilim EX-P505;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-P600;7.144;digicamdb,dpreview
+Casio;Casio Exilim EX-P700;7.144;digicamdb,dpreview
 Casio;Casio EXILIM EX-S1;5.33;usercontribution
 Casio;Casio EXILIM EX-S10;6.16;usercontribution
-Casio;Casio Exilim EX-S100;4.544;dpreview,digicamdb
+Casio;Casio Exilim EX-S100;4.544;digicamdb,dpreview
 Casio;Casio EXILIM EX-S12;6.16;usercontribution
 Casio;Casio EXILIM EX-S2;7.11;usercontribution
-Casio;Casio Exilim EX-S20;5.312;dpreview,digicamdb
+Casio;Casio Exilim EX-S20;5.312;digicamdb,dpreview
 Casio;Casio EXILIM EX-S200;6.16;usercontribution
 Casio;Casio EXILIM EX-S3;7.144;usercontribution
 Casio;Casio EXILIM EX-S5;6.16;usercontribution
-Casio;Casio Exilim EX-S500;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-S600;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-S500;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-S600;5.744;digicamdb,dpreview
 Casio;Casio Exilim EX-S600d;5.744;dpreview
 Casio;Casio EXILIM EX-S7;6.16;imaging-resource
-Casio;Casio Exilim EX-S770;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-S770;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-S770D;5.75;usercontribution
 Casio;Casio EXILIM EX-S8;6.08;usercontribution
-Casio;Casio Exilim EX-S880;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-S880;5.744;digicamdb,dpreview
 Casio;Casio Exilim EX-TR10;6.16;digicamdb
 Casio;Casio EXILIM EX-TR100;6.16;usercontribution
 Casio;Casio Exilim EX-TR15;6.16;digicamdb
 Casio;Casio EXILIM EX-TR150;6.16;usercontribution
 Casio;Casio Exilim EX-TR50;7.44;dpreview
-Casio;Casio Exilim EX-V7;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-V8;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-V7;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-V8;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z1;6.16;usercontribution
-Casio;Casio Exilim EX-Z10;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z10;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z100;6.16;usercontribution
 Casio;Casio EXILIM EX-Z1000;7.144;usercontribution
 Casio;Casio EXILIM EX-Z1050;7.31;usercontribution
 Casio;Casio EXILIM EX-Z1080;7.31;usercontribution
-Casio;Casio Exilim EX-Z110;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z110;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z120;7.144;usercontribution
-Casio;Casio Exilim EX-Z1200 SR;7.44;dpreview,digicamdb
+Casio;Casio Exilim EX-Z1200 SR;7.44;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z150;5.75;usercontribution
 Casio;Casio EXILIM EX-Z16;6.16;imaging-resource
 Casio;Casio EXILIM EX-Z19;5.75;usercontribution
@@ -1158,57 +1184,57 @@ Casio;Casio EXILIM EX-Z2000;6.16;usercontribution
 Casio;Casio EXILIM EX-Z2300;6.16;usercontribution
 Casio;Casio EXILIM EX-Z25;6.16;usercontribution
 Casio;Casio EXILIM EX-Z250;5.75;usercontribution
-Casio;Casio Exilim EX-Z270;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z270;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z280;5.75;usercontribution
-Casio;Casio Exilim EX-Z29;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z3;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z30;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z29;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z3;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z30;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z300;6.16;usercontribution
 Casio;Casio EXILIM EX-Z3000;6.16;usercontribution
 Casio;Casio EXILIM EX-Z33;6.16;usercontribution
 Casio;Casio EXILIM EX-Z330;6.16;usercontribution
 Casio;Casio EXILIM EX-Z35;6.16;usercontribution
 Casio;Casio EXILIM EX-Z350;6.16;usercontribution
-Casio;Casio Exilim EX-Z4;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z40;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z4;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z40;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z400;6.16;usercontribution
 Casio;Casio EXILIM EX-Z450;6.16;usercontribution
-Casio;Casio Exilim EX-Z5;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z50;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z500;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z55;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z5;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z50;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z500;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z55;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z550;6.16;usercontribution
-Casio;Casio Exilim EX-Z57;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z57;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z6;5.75;usercontribution
 Casio;Casio EXILIM EX-Z60;7.11;usercontribution
 Casio;Casio EXILIM EX-Z600;5.75;usercontribution
 Casio;Casio EXILIM EX-Z65;5.75;usercontribution
 Casio;Casio EXILIM EX-Z7;5.75;usercontribution
-Casio;Casio Exilim EX-Z70;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z700;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z75;5.744;dpreview,digicamdb
-Casio;Casio Exilim EX-Z750;7.144;dpreview,digicamdb
-Casio;Casio Exilim EX-Z77;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z70;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z700;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z75;5.744;digicamdb,dpreview
+Casio;Casio Exilim EX-Z750;7.144;digicamdb,dpreview
+Casio;Casio Exilim EX-Z77;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z8;5.75;usercontribution
-Casio;Casio Exilim EX-Z80;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z80;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z800;6.16;usercontribution
-Casio;Casio Exilim EX-Z85;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z85;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z850;7.144;usercontribution
-Casio;Casio Exilim EX-Z9;5.744;dpreview,digicamdb
+Casio;Casio Exilim EX-Z9;5.744;digicamdb,dpreview
 Casio;Casio EXILIM EX-Z90;6.16;usercontribution
 Casio;Casio EXILIM EX-ZR10;6.16;imaging-resource
 Casio;Casio EXILIM EX-ZR100;6.16;imaging-resource
-Casio;Casio Exilim EX-ZR1000;6.17;dpreview,digicamdb
+Casio;Casio Exilim EX-ZR1000;6.17;digicamdb,dpreview
 Casio;Casio Exilim EX-ZR1100;6.16;digicamdb
 Casio;Casio EXILIM EX-ZR15;6.16;imaging-resource
 Casio;Casio EXILIM EX-ZR20;6.16;usercontribution
 Casio;Casio Exilim EX-ZR200;6.16;digicamdb
 Casio;Casio EXILIM EX-ZR300;6.16;usercontribution
 Casio;Casio Exilim EX-ZR3000;7.6;dxomark
-Casio;Casio Exilim EX-ZR400;6.17;dpreview,digicamdb
+Casio;Casio Exilim EX-ZR400;6.17;digicamdb,dpreview
 Casio;Casio Exilim EX-ZR5000;7.44;dpreview
-Casio;Casio Exilim EX-ZR700;6.17;dpreview,digicamdb
-Casio;Casio Exilim EX-ZR800;6.17;dpreview,digicamdb,dxomark
+Casio;Casio Exilim EX-ZR700;6.17;digicamdb,dpreview
+Casio;Casio Exilim EX-ZR800;6.17;digicamdb,dpreview,dxomark
 Casio;Casio Exilim EX-ZS10;6.16;digicamdb
 Casio;Casio EXILIM EX-ZS100;6.16;usercontribution
 Casio;Casio EXILIM EX-ZS12;6.16;usercontribution
@@ -1225,7 +1251,7 @@ Casio;Casio EXILIM Hi-Zoom EX-V8;5.8;imaging-resource
 Casio;Casio EXILIM Pro EX-F1;7.144;usercontribution
 Casio;Casio EXILIM Pro EX-F1 ;7.2;imaging-resource
 Casio;Casio EXILIM QV-R100;6.16;usercontribution
-Casio;Casio Exilim TRYX;6.17;dpreview,digicamdb
+Casio;Casio Exilim TRYX;6.17;digicamdb,dpreview
 Casio;Casio EXILIM Zoom EX-Z100 ;6.2;imaging-resource
 Casio;Casio EXILIM ZOOM EX-Z1000;7.2;imaging-resource
 Casio;Casio EXILIM Zoom EX-Z1050;7.4;imaging-resource
@@ -1258,34 +1284,34 @@ Casio;Casio EXILIM Zoom EX-Z85;5.8;imaging-resource
 Casio;Casio EXILIM ZOOM EX-Z850;7.2;imaging-resource
 Casio;Casio EXILIM Zoom EX-Z9;5.8;imaging-resource
 Casio;Casio EXILIM Zoom EX-Z90;6.2;imaging-resource
-Casio;Casio GV-10;4.544;dpreview,digicamdb
-Casio;Casio GV-20;4.544;dpreview,digicamdb
-Casio;Casio QV-2000UX;6.4;dpreview,digicamdb
-Casio;Casio QV-2100;5.312;dpreview,digicamdb
-Casio;Casio QV-2300UX;5.312;dpreview,digicamdb
-Casio;Casio QV-2400UX;5.312;dpreview,digicamdb
-Casio;Casio QV-2800UX;5.312;dpreview,digicamdb
-Casio;Casio QV-2900UX;5.312;dpreview,digicamdb
+Casio;Casio GV-10;4.544;digicamdb,dpreview
+Casio;Casio GV-20;4.544;digicamdb,dpreview
+Casio;Casio QV-2000UX;6.4;digicamdb,dpreview
+Casio;Casio QV-2100;5.312;digicamdb,dpreview
+Casio;Casio QV-2300UX;5.312;digicamdb,dpreview
+Casio;Casio QV-2400UX;5.312;digicamdb,dpreview
+Casio;Casio QV-2800UX;5.312;digicamdb,dpreview
+Casio;Casio QV-2900UX;5.312;digicamdb,dpreview
 Casio;Casio QV-300;4.8;digicamdb
-Casio;Casio QV-3000EX;7.144;dpreview,digicamdb
-Casio;Casio QV-3500EX;7.144;dpreview,digicamdb
-Casio;Casio QV-3EX;7.144;dpreview,digicamdb
-Casio;Casio QV-4000;7.144;dpreview,digicamdb
-Casio;Casio QV-5000SX;4.8;dpreview,digicamdb
-Casio;Casio QV-5500SX;4.8;dpreview,digicamdb
-Casio;Casio QV-5700;7.144;dpreview,digicamdb
+Casio;Casio QV-3000EX;7.144;digicamdb,dpreview
+Casio;Casio QV-3500EX;7.144;digicamdb,dpreview
+Casio;Casio QV-3EX;7.144;digicamdb,dpreview
+Casio;Casio QV-4000;7.144;digicamdb,dpreview
+Casio;Casio QV-5000SX;4.8;digicamdb,dpreview
+Casio;Casio QV-5500SX;4.8;digicamdb,dpreview
+Casio;Casio QV-5700;7.144;digicamdb,dpreview
 Casio;Casio QV-700;4.8;digicamdb
-Casio;Casio QV-7000SX;4.8;dpreview,digicamdb
+Casio;Casio QV-7000SX;4.8;digicamdb,dpreview
 Casio;Casio QV-770;4.8;digicamdb
-Casio;Casio QV-8000SX;4.8;dpreview,digicamdb
-Casio;Casio QV-R3;7.144;dpreview,digicamdb
-Casio;Casio QV-R4;7.144;dpreview,digicamdb
-Casio;Casio QV-R40;7.144;dpreview,digicamdb
-Casio;Casio QV-R41;7.144;dpreview,digicamdb
-Casio;Casio QV-R51;7.144;dpreview,digicamdb
+Casio;Casio QV-8000SX;4.8;digicamdb,dpreview
+Casio;Casio QV-R3;7.144;digicamdb,dpreview
+Casio;Casio QV-R4;7.144;digicamdb,dpreview
+Casio;Casio QV-R40;7.144;digicamdb,dpreview
+Casio;Casio QV-R41;7.144;digicamdb,dpreview
+Casio;Casio QV-R51;7.144;digicamdb,dpreview
 Casio;Casio QV-R52;7.11;digicamdb
-Casio;Casio QV-R61;7.144;dpreview,digicamdb
-Casio;Casio QV-R62;7.144;dpreview,digicamdb
+Casio;Casio QV-R61;7.144;digicamdb,dpreview
+Casio;Casio QV-R62;7.144;digicamdb,dpreview
 Casio;Casio TRYX;6.2;imaging-resource
 Casio;Casio XV-3;7.144;dpreview
 Cherry mobile;Cherry mobile Cosmos Force;4.69;devicespecifications
@@ -1350,9 +1376,9 @@ Concord;Concord Eye-Q Go LCD;6.4;digicamdb
 Concord;Concord Eye-Q Go Wireless;7.11;digicamdb
 Conquest;Conquest S8 2017 Edition;4.74;devicespecifications
 Contax;Contax i4R;5.33;digicamdb
-Contax;Contax N Digital;36.0;dpreview,digicamdb
+Contax;Contax N Digital;36.0;digicamdb,dpreview
 Contax;Contax SL300R T;5.33;digicamdb
-Contax;Contax TVS Digital;7.144;dpreview,digicamdb
+Contax;Contax TVS Digital;7.144;digicamdb,dpreview
 Contax;Contax U4R;5.33;digicamdb
 Coolpad;Coolpad 1S;4.69;devicespecifications
 Coolpad;Coolpad Cool Changer 1C;4.71;devicespecifications
@@ -1409,20 +1435,21 @@ Dexp;Dexp Ixion X355 Zenith;4.82;devicespecifications
 Dexp;Dexp Ixion XL 5;4.69;devicespecifications
 Dexp;Dexp Ixion XL140 Flash;3.67;devicespecifications
 Dexp;Dexp Ixion XL240 Triforce;3.6;devicespecifications
+DJI;DJI Phantom 4;6.3;dxomark
+DJI;DJI Phantom4 Pro;13.2;dxomark
 DJI;DJI Ronin 4D 6K;36.00;usercontribution
+DJI;DJI Zenmuse X4S;13.2;dxomark
+DJI;DJI Zenmuse X5S;17.3;dxomark
+DJI;DJI Zenmuse X7;23.5;dxomark
 DJI;FC1102;6.17;usercontribution
 DJI;FC2103;6.17;usercontribution
 DJI;FC220;6.17;usercontribution
-DJI;FC220;6.17;usercontribution
 DJI;FC300C;6.17;usercontribution
 DJI;FC300S;6.16;usercontribution
-DJI;FC300S;6.16;usercontribution
-DJI;FC300X;6.16;usercontribution
 DJI;FC300X;6.16;usercontribution
 DJI;FC300XW;6.17;usercontribution
 DJI;FC330;6.17;usercontribution
 DJI;FC3411;13.13;usercontribution
-DJI;FC350;6.17;usercontribution
 DJI;FC350;6.17;usercontribution
 DJI;FC550;17.3;usercontribution
 DJI;FC550RAW;17.3;usercontribution
@@ -1434,7 +1461,7 @@ DJI;FC6520;17.3;usercontribution
 DJI;FC6540;23.5;usercontribution
 DJI;FC7203;6.16;usercontribution
 DJI;FC7303;6.16;usercontribution
-DJI;MAVIC2-ENTERPRISE-ADVANCED;4.8
+DJI;MAVIC2-ENTERPRISE-ADVANCED;4.8;
 DJI;Mavic3;17.3;dji
 DJI;Phantom 4;6.3;dxomark
 DJI;Phantom 4 Pro;13.2;dxomark
@@ -1534,22 +1561,22 @@ Elephone;Elephone Vowney Lite;5.99;devicespecifications
 Energy sistem;Energy sistem Energy Phone Max 2+;4.69;devicespecifications
 Energy sistem;Energy sistem Energy Phone Pro 3;4.71;devicespecifications
 Epson;Epson L-500V;5.75;usercontribution
-Epson;Epson PhotoPC 3000 Zoom;7.144;dpreview,digicamdb
-Epson;Epson PhotoPC 3100 Zoom;7.144;dpreview,digicamdb
-Epson;Epson PhotoPC 500;4.8;dpreview,digicamdb
-Epson;Epson PhotoPC 550;4.8;dpreview,digicamdb
-Epson;Epson PhotoPC 600;4.8;dpreview,digicamdb
-Epson;Epson PhotoPC 650;4.8;dpreview,digicamdb
-Epson;Epson PhotoPC 700;4.8;dpreview,digicamdb
-Epson;Epson PhotoPC 750 Zoom;6.4;dpreview,digicamdb
-Epson;Epson PhotoPC 800;6.4;dpreview,digicamdb
-Epson;Epson PhotoPC 850 Zoom;6.4;dpreview,digicamdb
+Epson;Epson PhotoPC 3000 Zoom;7.144;digicamdb,dpreview
+Epson;Epson PhotoPC 3100 Zoom;7.144;digicamdb,dpreview
+Epson;Epson PhotoPC 500;4.8;digicamdb,dpreview
+Epson;Epson PhotoPC 550;4.8;digicamdb,dpreview
+Epson;Epson PhotoPC 600;4.8;digicamdb,dpreview
+Epson;Epson PhotoPC 650;4.8;digicamdb,dpreview
+Epson;Epson PhotoPC 700;4.8;digicamdb,dpreview
+Epson;Epson PhotoPC 750 Zoom;6.4;digicamdb,dpreview
+Epson;Epson PhotoPC 800;6.4;digicamdb,dpreview
+Epson;Epson PhotoPC 850 Zoom;6.4;digicamdb,dpreview
 Epson;Epson PhotoPC L-200;5.75;digicamdb
-Epson;Epson PhotoPC L-300;5.744;dpreview,digicamdb
-Epson;Epson PhotoPC L-400;5.744;dpreview,digicamdb
-Epson;Epson PhotoPC L-410;5.744;dpreview,digicamdb
-Epson;Epson PhotoPC L-500V;5.744;dpreview,digicamdb
-Epson;Epson R-D1;23.7;dpreview,digicamdb
+Epson;Epson PhotoPC L-300;5.744;digicamdb,dpreview
+Epson;Epson PhotoPC L-400;5.744;digicamdb,dpreview
+Epson;Epson PhotoPC L-410;5.744;digicamdb,dpreview
+Epson;Epson PhotoPC L-500V;5.744;digicamdb,dpreview
+Epson;Epson R-D1;23.7;digicamdb,dpreview
 Epson;Epson R-D1x;23.7;dpreview
 Epson;Epson R-D1xG;23.7;digicamdb
 Epson;Epson RD-1s;23.7;digicamdb
@@ -1611,71 +1638,71 @@ Fujifilm;Fujifilm A850;5.75;usercontribution
 Fujifilm;Fujifilm Bigjob HD-3W;5.75;digicamdb
 Fujifilm;Fujifilm Bigjob HD1;5.33;digicamdb
 Fujifilm;Fujifilm Digital Q1;6.4;digicamdb
-Fujifilm;Fujifilm DS-260HD;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm DS-300;8.8;dpreview,digicamdb
+Fujifilm;Fujifilm DS-260HD;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm DS-300;8.8;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix 1200;6.4;dpreview
-Fujifilm;Fujifilm FinePix 1300;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix 1300;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix 1400 Zoom;5.312;dpreview
 Fujifilm;Fujifilm FinePix 1400z;5.33;digicamdb
 Fujifilm;Fujifilm Finepix 1500;6.4;dpreview
 Fujifilm;Fujifilm FinePix 1700 Zoom;6.4;dpreview
-Fujifilm;Fujifilm FinePix 2300;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix 2400 Zoom;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix 2600 Zoom;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix 2300;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix 2400 Zoom;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix 2600 Zoom;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix 2650;5.312;dpreview
 Fujifilm;Fujifilm Finepix 2700;6.4;dpreview
-Fujifilm;Fujifilm FinePix 2800 Zoom;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix 2800 Zoom;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix 2900Z;6.4;dpreview
 Fujifilm;Fujifilm FinePix 30i;5.312;dpreview
 Fujifilm;Fujifilm FinePix 3800;5.312;dpreview
 Fujifilm;Fujifilm FinePix 40i;5.33;digicamdb
-Fujifilm;Fujifilm FinePix 4700 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix 4800 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix 4900 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix 50i;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix 6800 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix 6900 Zoom;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix 4700 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix 4800 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix 4900 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix 50i;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix 6800 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix 6900 Zoom;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix 700;6.4;dpreview
-Fujifilm;Fujifilm FinePix A100;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A101;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A120;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A150;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix A100;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A101;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A120;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A150;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix A160;6.16;digicamdb
-Fujifilm;Fujifilm FinePix A170;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix A170;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix A175;6.16;digicamdb
 Fujifilm;Fujifilm FinePix A180;6.16;digicamdb
 Fujifilm;Fujifilm FinePix A200;5.312;dpreview
-Fujifilm;Fujifilm FinePix A201;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A202;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A203;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A204;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix A201;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A202;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A203;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A204;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix A205 Zoom;5.312;dpreview
 Fujifilm;Fujifilm FinePix A205s;5.312;dpreview
-Fujifilm;Fujifilm FinePix A210 Zoom;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix A210 Zoom;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix A220;6.16;digicamdb
 Fujifilm;Fujifilm FinePix A225;6.16;digicamdb
 Fujifilm;Fujifilm FinePix A235;6.16;digicamdb
-Fujifilm;Fujifilm FinePix A303;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A310 Zoom;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A330;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A340;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A345 Zoom;5.744;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A350 Zoom;5.744;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix A303;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A310 Zoom;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A330;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A340;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A345 Zoom;5.744;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A350 Zoom;5.744;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix A400;5.8;imaging-resource
-Fujifilm;Fujifilm FinePix A400 Zoom;5.744;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix A400 Zoom;5.744;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix A500;5.8;imaging-resource
-Fujifilm;Fujifilm FinePix A500 Zoom;5.744;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix A500 Zoom;5.744;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix A510;5.75;digicamdb
 Fujifilm;Fujifilm FinePix A600;7.6;imaging-resource
-Fujifilm;Fujifilm FinePix A600 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix A610;5.744;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix A600 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix A610;5.744;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix A700;8.1;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix A800;8.0;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix A820;8.0;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix A800;8.0;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix A820;8.0;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix A825;8.0;digicamdb
 Fujifilm;Fujifilm FinePix A850;5.75;digicamdb
-Fujifilm;Fujifilm FinePix A900;8.0;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix A920;8.0;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix A900;8.0;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix A920;8.0;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix AV100;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix AV105;6.16;digicamdb
 Fujifilm;Fujifilm FinePix AV110;6.16;digicamdb
@@ -1684,9 +1711,9 @@ Fujifilm;Fujifilm FinePix AV140;6.16;digicamdb
 Fujifilm;Fujifilm FinePix AV150;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix AV180;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix AV200;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix AV205;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix AV205;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix AV250;6.16;digicamdb
-Fujifilm;Fujifilm FinePix AV255;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix AV255;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix AX200;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix AX205;6.16;digicamdb
 Fujifilm;Fujifilm FinePix AX230;6.16;digicamdb,imaging-resource
@@ -1696,116 +1723,116 @@ Fujifilm;Fujifilm FinePix AX280;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix AX300;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix AX305;6.16;digicamdb
 Fujifilm;Fujifilm FinePix AX350;6.16;digicamdb
-Fujifilm;Fujifilm FinePix AX355;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix AX355;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix AX500;6.16;digicamdb
 Fujifilm;Fujifilm FinePix AX550;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix AX650;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix E500 Zoom;5.744;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix E510 Zoom;5.744;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix E550 Zoom;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix E500 Zoom;5.744;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix E510 Zoom;5.744;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix E550 Zoom;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix E900;8.1;imaging-resource
-Fujifilm;Fujifilm FinePix E900 Zoom;8.0;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix E900 Zoom;8.0;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix EX-20;5.33;digicamdb
-Fujifilm;Fujifilm FinePix F10 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F100fd;8.0;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F11 Zoom;7.44;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix F10 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F100fd;8.0;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix F11 Zoom;7.44;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix F20;7.6;imaging-resource
-Fujifilm;Fujifilm FinePix F20 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F200EXR;8.0;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F20 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F200EXR;8.0;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F200EXR ;8.1;imaging-resource
 Fujifilm;Fujifilm FinePix F30;7.6;imaging-resource
-Fujifilm;Fujifilm FinePix F30 Zoom;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F30 Zoom;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F300EXR;6.4;dpreview
-Fujifilm;Fujifilm FinePix F305EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F31fd;7.44;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F401 Zoom;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F402;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F40fd;8.0;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F410 Zoom;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F420 Zoom;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F440 Zoom;5.744;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F450 Zoom;5.744;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F455 Zoom;5.744;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F305EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F31fd;7.44;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix F401 Zoom;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F402;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F40fd;8.0;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix F410 Zoom;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F420 Zoom;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F440 Zoom;5.744;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F450 Zoom;5.744;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F455 Zoom;5.744;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F45fd;8.0;digicamdb
 Fujifilm;Fujifilm FinePix F460;5.75;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix F470;5.8;imaging-resource
-Fujifilm;Fujifilm FinePix F470 Zoom;5.744;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F470 Zoom;5.744;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F47fd;8.0;digicamdb
 Fujifilm;Fujifilm FinePix F480;5.8;imaging-resource
-Fujifilm;Fujifilm FinePix F480 Zoom;5.744;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F480 Zoom;5.744;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F500 EXR;6.4;digicamdb
 Fujifilm;Fujifilm FinePix F500EXR;6.4;imaging-resource
 Fujifilm;Fujifilm FinePix F505 EXR;6.4;dpreview
-Fujifilm;Fujifilm FinePix F50fd;8.0;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F550 EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F550EXR;6.4;imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix F600 EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F600EXR;6.4;imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix F601 Zoom;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F50fd;8.0;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix F550 EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F550EXR;6.4;dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix F600 EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F600EXR;6.4;dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix F601 Zoom;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F605EXR;6.4;digicamdb
-Fujifilm;Fujifilm FinePix F60fd;8.0;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F610;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F60fd;8.0;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix F610;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F650;5.8;imaging-resource
-Fujifilm;Fujifilm FinePix F650 Zoom;5.744;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F660EXR;6.4;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F700;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F650 Zoom;5.744;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F660EXR;6.4;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix F700;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F70EXR;6.4;dpreview
-Fujifilm;Fujifilm FinePix F710;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F710;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F72EXR;6.4;digicamdb
-Fujifilm;Fujifilm FinePix F750EXR;6.4;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F75EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F770EXR;6.4;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix F800EXR;6.4;dpreview,digicamdb,imaging-resource,dxomark
+Fujifilm;Fujifilm FinePix F750EXR;6.4;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix F75EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F770EXR;6.4;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix F800EXR;6.4;digicamdb,dpreview,dxomark,imaging-resource
 Fujifilm;Fujifilm FinePix F80EXR;6.4;dpreview
-Fujifilm;Fujifilm FinePix F810 Zoom;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F810 Zoom;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix F850EXR;6.4;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix F85EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix F900EXR;6.4;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix HS10;6.16;digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix HS11;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix F85EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix F900EXR;6.4;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix HS10;6.16;digicamdb,dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix HS11;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix HS20 EXR;6.4;digicamdb
-Fujifilm;Fujifilm FinePix HS20EXR;6.4;imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix HS22 EXR;6.4;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix HS20EXR;6.4;dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix HS22 EXR;6.4;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix HS25 EXR;6.4;digicamdb
 Fujifilm;Fujifilm FinePix HS25EXR;6.4;imaging-resource
 Fujifilm;Fujifilm FinePix HS30 EXR;6.4;digicamdb
 Fujifilm;Fujifilm FinePix HS30EXR;6.4;dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix HS35 EXR;6.4;digicamdb
 Fujifilm;Fujifilm FinePix HS35EXR;6.4;dpreview,imaging-resource
-Fujifilm;Fujifilm FinePix HS50 EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix HS50EXR;6.4;imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix IS Pro;23.0;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix IS-1;8.0;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix J10;5.744;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix J100;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix HS50 EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix HS50EXR;6.4;dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix IS Pro;23.0;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix IS-1;8.0;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix J10;5.744;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix J100;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix J110w;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J12;5.75;digicamdb
-Fujifilm;Fujifilm FinePix J120;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix J120;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix J15;5.75;digicamdb
 Fujifilm;Fujifilm FinePix J150w;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix J20;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix J20;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix J20fd;6.2;imaging-resource
 Fujifilm;Fujifilm FinePix J210;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J22;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J25;6.16;digicamdb
-Fujifilm;Fujifilm FinePix J250;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix J250;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix J250W;6.2;imaging-resource
 Fujifilm;Fujifilm FinePix J26;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J27;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J28;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J29;6.16;digicamdb
-Fujifilm;Fujifilm FinePix J30;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix J30;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix J32;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J35;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J37;6.16;digicamdb
 Fujifilm;Fujifilm FinePix J38;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix J50;5.744;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix J50;5.744;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix JV100;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix JV105;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix JV105;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix JV110;6.16;digicamdb
-Fujifilm;Fujifilm FinePix JV150;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix JV150;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix JV200;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix JV205;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix JV205;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix JV250;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JV255;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JX200;6.16;digicamdb,imaging-resource
@@ -1814,55 +1841,55 @@ Fujifilm;Fujifilm FinePix JX210;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JX250;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix JX280;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix JX300;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix JX305;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix JX305;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix JX350;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix JX355;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix JX370;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix JX355;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix JX370;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix JX375;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JX400;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JX405;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JX420;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix JX500;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix JX500;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix JX520;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JX530;6.16;digicamdb
-Fujifilm;Fujifilm FinePix JX550;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix JX550;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix JX580;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix JX680;6.2;imaging-resource
 Fujifilm;Fujifilm FinePix JX700;6.16;digicamdb
-Fujifilm;Fujifilm FinePix JZ100;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix JZ200;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix JZ100;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix JZ200;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix JZ250;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix JZ300;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix JZ305;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix JZ305;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix JZ310;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JZ500;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JZ500 ;6.2;imaging-resource
-Fujifilm;Fujifilm FinePix JZ505;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix JZ505;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix JZ510;6.16;digicamdb
 Fujifilm;Fujifilm FinePix JZ700;6.16;digicamdb
-Fujifilm;Fujifilm FinePix M603;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix M603;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix PR21;6.4;digicamdb
-Fujifilm;Fujifilm FinePix Real 3D W1;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix Real 3D W3;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S1;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix S1 Pro;23.0;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S1000fd;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S100fs;8.8;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S1500;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix Real 3D W1;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix Real 3D W3;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S1;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix S1 Pro;23.0;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S1000fd;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix S100fs;8.8;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S1500;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S1500fd;6.2;imaging-resource
 Fujifilm;Fujifilm FinePix S1600;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix S1700;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S1730;6.16;digicamdb
-Fujifilm;Fujifilm FinePix S1770;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S1770;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S1800;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix S1850;6.16;digicamdb
-Fujifilm;Fujifilm FinePix S1880;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S1880;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S1900;6.16;digicamdb
-Fujifilm;Fujifilm FinePix S2 Pro;23.0;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S20 Pro;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S2 Pro;23.0;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S20 Pro;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S2000hd;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S200EXR;8.0;dpreview
-Fujifilm;Fujifilm FinePix S205EXR;8.0;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S205EXR;8.0;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S2500hd;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S2550hd;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S2600hd;6.16;digicamdb
@@ -1870,31 +1897,31 @@ Fujifilm;Fujifilm FinePix S2800hd;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S2900hd;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S2950;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix S2980;6.16;digicamdb
-Fujifilm;Fujifilm FinePix S2990;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S2990;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S3 Pro;23.0;dpreview,dxomark
 Fujifilm;Fujifilm FinePix S3 Pro UVIR;23.7;imaging-resource
-Fujifilm;Fujifilm FinePix S3000 Z;5.312;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S304;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S3000 Z;5.312;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S304;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S3200;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S3250;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S3250;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S3280;6.4;usercontribution
 Fujifilm;Fujifilm FinePix S3300;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S3350;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S3400;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S3450;6.16;digicamdb
-Fujifilm;Fujifilm FinePix S3500 Zoom;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S3500 Zoom;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S4000;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S4050;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S4200;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix S4050;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S4200;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix S4250WM;6.16;usercontribution
 Fujifilm;Fujifilm FinePix S4300;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S4400;6.16;digicamdb
-Fujifilm;Fujifilm FinePix S4500;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix S4500;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix S4600;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S4700;6.16;digicamdb
-Fujifilm;Fujifilm FinePix S4800;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S5 Pro;23.0;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix S5000 Zoom;5.312;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S4800;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix S5 Pro;23.0;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix S5000 Zoom;5.312;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S5100 Zoom;5.312;dpreview
 Fujifilm;Fujifilm FinePix S5200;5.8;imaging-resource
 Fujifilm;Fujifilm FinePix S5200 Zoom;5.744;dpreview
@@ -1905,102 +1932,106 @@ Fujifilm;Fujifilm FinePix S5600 Zoom;5.75;digicamdb
 Fujifilm;Fujifilm FinePix S5700 Zoom;5.744;dpreview
 Fujifilm;Fujifilm FinePix S5800;5.75;digicamdb
 Fujifilm;Fujifilm FinePix S6000fd;7.44;dpreview
-Fujifilm;Fujifilm FinePix S602 Zoom;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S602Z Pro;7.44;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S6500fd;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S602 Zoom;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S602Z Pro;7.44;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S6500fd;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S6600;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S6700;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S6800;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix S700;5.744;dpreview
-Fujifilm;Fujifilm FinePix S7000 Zoom;7.44;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S7000 Zoom;7.44;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S8000fd;6.03;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S8100fd;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S8100fd;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix S8100fd ;6.2;imaging-resource
-Fujifilm;Fujifilm FinePix S8200;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S8300;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix S8200;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix S8300;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix S8400;6.16;digicamdb
 Fujifilm;Fujifilm FinePix S8400W;6.17;dpreview,imaging-resource
-Fujifilm;Fujifilm FinePix S8500;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S8600;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix S8500;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S8600;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix S9000 Zoom;8.0;digicamdb
 Fujifilm;Fujifilm FinePix S9100;8.0;dpreview
-Fujifilm;Fujifilm FinePix S9200;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S9400W;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S9500;8.0;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S9600;8.0;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix S9800;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix S9900W;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix SL1000;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm FinePix SL240;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix S9200;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix S9400W;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix S9500;8.0;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S9600;8.0;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix S9800;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix S9900W;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix SL1000;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm FinePix SL240;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix SL260;6.16;digicamdb
 Fujifilm;Fujifilm FinePix SL280;6.16;digicamdb
-Fujifilm;Fujifilm FinePix SL300;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix SL300;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix T200;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix T205;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix T205;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix T300;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix T305;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix T305;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix T350;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix T400;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix T500;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix T550;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix T400;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix T500;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix T550;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix V10;5.8;imaging-resource
-Fujifilm;Fujifilm FinePix V10 Zoom;5.744;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix V10 Zoom;5.744;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix X S1;8.8;dxomark
 Fujifilm;Fujifilm FinePix X-Pro1;23.6;dxomark
 Fujifilm;Fujifilm FinePix X10;8.8;dxomark
-Fujifilm;Fujifilm FinePix X100;23.6;dpreview,digicamdb,imaging-resource,dxomark
+Fujifilm;Fujifilm FinePix X100;23.6;digicamdb,dpreview,dxomark,imaging-resource
 Fujifilm;Fujifilm FinePix X100S;23.6;dxomark
 Fujifilm;Fujifilm FinePix X20;8.8;dxomark
 Fujifilm;Fujifilm FinePix XP10;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix XP100;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix XP11;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix XP120;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix XP130;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix XP150;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix XP11;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix XP120;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix XP130;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix XP140;6.16;digicamdb
+Fujifilm;Fujifilm FinePix XP150;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix XP170;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix XP20;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix XP200;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix XP200;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix XP22;6.16;digicamdb
-Fujifilm;Fujifilm FinePix XP30;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix XP30;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix XP33;6.16;digicamdb
-Fujifilm;Fujifilm FinePix XP50;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix XP60;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix XP70;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix XP50;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix XP60;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix XP70;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix XP80;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix XP90;6.16;imaging-resource
 Fujifilm;Fujifilm FinePix XP90 XP91 XP95;6.16;usercontribution
-Fujifilm;Fujifilm FinePix Z1;5.744;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix Z1000EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix Z100fd;5.744;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix Z10fd;5.744;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix Z110;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix Z2;5.744;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix Z1;5.744;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix Z1000EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix Z100fd;5.744;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix Z10fd;5.744;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix Z110;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix Z2;5.744;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix Z200fd;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix Z20fd;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix Z3;5.744;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix Z30;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix Z300;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix Z20fd;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix Z3;5.744;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix Z30;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix Z300;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix Z30fd;6.2;imaging-resource
 Fujifilm;Fujifilm FinePix Z31;6.16;digicamdb
-Fujifilm;Fujifilm FinePix Z33WP;6.17;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix Z35;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix Z37;6.17;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix Z33WP;6.17;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm FinePix Z35;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix Z37;6.17;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix Z5fd;5.75;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix Z70;6.16;digicamdb,imaging-resource
 Fujifilm;Fujifilm FinePix Z700EXR;6.4;dpreview
-Fujifilm;Fujifilm FinePix Z707EXR;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm FinePix Z71;6.17;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix Z707EXR;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm FinePix Z71;6.17;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix Z80;6.16;digicamdb
 Fujifilm;Fujifilm FinePix Z800EXR;6.4;dpreview
-Fujifilm;Fujifilm FinePix Z808EXR;6.4;dpreview,digicamdb
+Fujifilm;Fujifilm FinePix Z808EXR;6.4;digicamdb,dpreview
 Fujifilm;Fujifilm FinePix Z81;6.16;digicamdb
 Fujifilm;Fujifilm FinePix Z90;6.16;digicamdb,imaging-resource
-Fujifilm;Fujifilm FinePix Z900EXR;6.4;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm FinePix Z900EXR;6.4;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm FinePix Z909EXR;6.4;digicamdb
 Fujifilm;Fujifilm FinePix Z91;6.16;digicamdb
 Fujifilm;Fujifilm FinePix Z950EXR;6.4;digicamdb
+Fujifilm;Fujifilm GFX 100;43.8;dxomark
+Fujifilm;Fujifilm GFX 100S;43.8;imaging-resource
 Fujifilm;Fujifilm GFX 50R;43.8;imaging-resource
-Fujifilm;Fujifilm GFX 50S;43.8;imaging-resource,dxomark
+Fujifilm;Fujifilm GFX 50S;43.8;dxomark,imaging-resource
+Fujifilm;Fujifilm GFX 50S II;43.8;imaging-resource
 Fujifilm;Fujifilm GFX100;43.8;usercontribution
 Fujifilm;Fujifilm GFX100S;43.8;usercontribution
 Fujifilm;Fujifilm IS Pro;23.7;imaging-resource
@@ -2011,45 +2042,55 @@ Fujifilm;Fujifilm MX-1500;6.4;digicamdb
 Fujifilm;Fujifilm MX-1700;6.4;digicamdb
 Fujifilm;Fujifilm MX-2700;6.4;digicamdb
 Fujifilm;Fujifilm MX-2900 Zoom;6.4;digicamdb
-Fujifilm;Fujifilm MX-500;6.4;dpreview,digicamdb
-Fujifilm;Fujifilm MX-600 Zoom;6.4;dpreview,digicamdb
+Fujifilm;Fujifilm MX-500;6.4;digicamdb,dpreview
+Fujifilm;Fujifilm MX-600 Zoom;6.4;digicamdb,dpreview
 Fujifilm;Fujifilm MX-700;6.4;digicamdb
-Fujifilm;Fujifilm X-A1;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-A10;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-A2;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-A3;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-A5;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-E1;23.6;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X-E2;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-E2S;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-E3;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-H1;23.5;dpreview,digicamdb,dxomark
-Fujifilm;Fujifilm X-M1;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-Pro1;23.6;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X-Pro2;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-S1;8.8;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm X-A1;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-A10;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-A2;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-A3;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-A5;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-A7;23.5;digicamdb
+Fujifilm;Fujifilm X-E1;23.6;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X-E2;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-E2S;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-E3;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-E4;23.5;digicamdb
+Fujifilm;Fujifilm X-H1;23.5;digicamdb,dpreview,dxomark
+Fujifilm;Fujifilm X-H2;23.5;imaging-resource
+Fujifilm;Fujifilm X-H2S;23.5;imaging-resource
+Fujifilm;Fujifilm X-M1;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-Pro1;23.6;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X-Pro2;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-Pro3;23.5;digicamdb
+Fujifilm;Fujifilm X-S1;8.8;digicamdb,dpreview,imaging-resource
 FUJIFILM;FUJIFILM X-S10;23.5;usercontribution
-Fujifilm;Fujifilm X-T1;23.6;dpreview,digicamdb,imaging-resource,dxomark
+Fujifilm;Fujifilm X-T1;23.6;digicamdb,dpreview,dxomark,imaging-resource
 Fujifilm;Fujifilm X-T1 IR;23.6;dpreview,imaging-resource
-Fujifilm;Fujifilm X-T10;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-T100;23.5;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X-T2;23.6;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X-T20;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X-T3;23.5;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm X-T10;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-T100;23.5;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X-T2;23.6;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X-T20;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X-T200;23.5;digicamdb
+Fujifilm;Fujifilm X-T3;23.5;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X-T30;23.5;dxomark
+Fujifilm;Fujifilm X-T30 II;23.5;digicamdb
 Fujifilm;Fujifilm X-T4;23.5;usercontribution
-Fujifilm;Fujifilm X10;8.8;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X100F;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X100S;23.6;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X100T;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm X20;8.8;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X30;8.8;dpreview,digicamdb,imaging-resource
-Fujifilm;Fujifilm X70;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm XF1;8.8;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm XF10;23.5;dpreview,digicamdb,imaging-resource
+Fujifilm;Fujifilm X-T5;23.5;imaging-resource
+Fujifilm;Fujifilm X10;8.8;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X100F;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X100S;23.6;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X100T;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm X100V;23.5;digicamdb
+Fujifilm;Fujifilm X20;8.8;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X30;8.8;digicamdb,dpreview,imaging-resource
+Fujifilm;Fujifilm X70;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm XF1;8.8;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm XF10;23.5;digicamdb,dpreview,imaging-resource
 Fujifilm;Fujifilm XP80;6.17;dpreview
-Fujifilm;Fujifilm XP90;6.17;dpreview,digicamdb
-Fujifilm;Fujifilm XQ1;8.8;dpreview,digicamdb,imaging-resource,dxomark
-Fujifilm;Fujifilm XQ2;8.8;dpreview,digicamdb,imaging-resource,dxomark
+Fujifilm;Fujifilm XP90;6.17;digicamdb,dpreview
+Fujifilm;Fujifilm XQ1;8.8;digicamdb,dpreview,dxomark,imaging-resource
+Fujifilm;Fujifilm XQ2;8.8;digicamdb,dpreview,dxomark,imaging-resource
 Fujifilm;Fujifilm XT-2;23.6;dxomark
 Fujitsu;Fujitsu Arrows M03;4.69;devicespecifications
 Fujitsu;Fujitsu Arrows M04;4.69;devicespecifications
@@ -2141,6 +2182,7 @@ Gionee;Gionee S8;4.74;devicespecifications
 Goclever;Goclever Insignia 530 LTE;4.69;devicespecifications
 Gome;Gome K1;4.74;devicespecifications
 Gome;Gome U7;4.73;devicespecifications
+Google;Google 5G;5.56;usercontribution
 Google;Google Pixel;6.25;devicespecifications
 Google;Google Pixel 2;5.5;imaging-resource
 Google;Google Pixel 3;5.76;techradar
@@ -2149,14 +2191,16 @@ Google;Pixel 2 XL;5.5;devicespecifications
 Google;Pixel 3 XL;5.76;techradar
 Google;Pixel 3a;5.76;devicespecifications
 Google;Pixel 4 XL;5.98;usercontribution
-Google;Pixel 4a (5G);5.56;usercontribution
+Google;Pixel 4a;5.56;usercontribution
 Google;Pixel 5;5.56;usercontribution
 Google;Pixel 6;9.79;usercontribution
 Google;Pixel 6 Pro;9.79;usercontribution
 GoPro;GoPro Fusion;6.17;dpreview
 GoPro;GoPro Hero 2018;6.17;dpreview
 GoPro;GoPro Hero3-Silver Edition;5.37;usercontribution
+GoPro;GoPro HERO5 Black;6.17;dxomark
 GoPro;GoPro HERO7 Black;6.17;usercontribution
+Gopro;GoPro Max;6.17;dpreview
 GoPro;HERO;6.17;usercontribution
 GoPro;HERO3+ Black Edition;6.17;vfxcamdb
 GoPro;HERO4 Black;6.17;vfxcamdb
@@ -2187,13 +2231,17 @@ Hasselblad;Hasselblad Lusso;35.9;dxomark
 Hasselblad;Hasselblad Stellar;13.2;dxomark
 Hasselblad;Hasselblad Stellar II;13.2;dxomark
 Hasselblad;Hasselblad X1D;44.0;dpreview
-Hasselblad;Hasselblad X1D-50c;43.8;imaging-resource,dxomark
+Hasselblad;Hasselblad X1D II 50C;43.8;dxomark
+Hasselblad;Hasselblad X1D-50c;43.8;dxomark,imaging-resource
+Hasselblad;Hasselblad X2D 100c;44.0;dpreview
 Helio;Helio S1;4.69;devicespecifications
 Helio;Helio S10;4.71;devicespecifications
 Helio;Helio S25;4.71;devicespecifications
+Hewlett-Packard;Hewlett-Packard V01.61;7.176;usercontribution
+Hewlett-Packard;Hewlett-Packard V1.1;5.27;usercontribution
 Hewlett-Packard;HP PhotoSmart 43x series;5.27;usercontribution
-Hewlett-Packard;HP PhotoSmart 618 (V1.1);5.27;usercontribution
-Hewlett-Packard;HP PhotoSmart C945 (V01.61);7.176;usercontribution
+Hewlett-Packard;HP PhotoSmart 618;5.27;usercontribution
+Hewlett-Packard;HP PhotoSmart C945;7.176;usercontribution
 Highscreen;Highscreen Bay;4.69;devicespecifications
 Highscreen;Highscreen Boost 3;4.69;devicespecifications
 Highscreen;Highscreen Boost 3 Pro;4.69;devicespecifications
@@ -2602,19 +2650,19 @@ Kodak;Kodak DC3400;7.53;digicamdb
 Kodak;Kodak DC3800;7.53;digicamdb
 Kodak;Kodak DC4800;7.27;digicamdb
 Kodak;Kodak DC5000;7.27;digicamdb
-Kodak;Kodak DCS Pro 14n;36.0;dpreview,digicamdb
+Kodak;Kodak DCS Pro 14n;36.0;digicamdb,dpreview
 Kodak;Kodak DCS Pro SLR;36.0;usercontribution
 Kodak;Kodak DCS315;27.65;digicamdb
 Kodak;Kodak DCS330;18.1;digicamdb
 Kodak;Kodak DCS420;14.0;digicamdb
-Kodak;Kodak DCS460;27.65;dpreview,digicamdb
+Kodak;Kodak DCS460;27.65;digicamdb,dpreview
 Kodak;Kodak DCS520;27.65;digicamdb
 Kodak;Kodak DCS560;27.65;digicamdb
 Kodak;Kodak DCS620;27.65;digicamdb
 Kodak;Kodak DCS620x;22.8;digicamdb
-Kodak;Kodak DCS660;27.65;dpreview,digicamdb
+Kodak;Kodak DCS660;27.65;digicamdb,dpreview
 Kodak;Kodak DCS720x;22.8;digicamdb
-Kodak;Kodak DCS760;27.65;dpreview,digicamdb
+Kodak;Kodak DCS760;27.65;digicamdb,dpreview
 Kodak;Kodak DX3215;5.312;dpreview
 Kodak;Kodak DX3500;6.4;dpreview
 Kodak;Kodak DX3600;6.4;dpreview
@@ -2629,9 +2677,9 @@ Kodak;Kodak DX6490;5.744;dpreview
 Kodak;Kodak DX7440;5.744;dpreview
 Kodak;Kodak DX7590;5.744;dpreview
 Kodak;Kodak DX7630;7.144;dpreview
-Kodak;Kodak EasyShare C1013;6.17;dpreview,digicamdb
-Kodak;Kodak EasyShare C135;6.17;dpreview,digicamdb
-Kodak;Kodak EasyShare C140;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare C1013;6.17;digicamdb,dpreview
+Kodak;Kodak EasyShare C135;6.17;digicamdb,dpreview
+Kodak;Kodak EasyShare C140;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare C142;5.75;digicamdb
 Kodak;Kodak EasyShare C143;6.16;digicamdb
 Kodak;Kodak EasyShare C1505;6.16;digicamdb
@@ -2648,24 +2696,24 @@ Kodak;Kodak EasyShare C310;7.11;digicamdb
 Kodak;Kodak EasyShare C330;7.11;digicamdb
 Kodak;Kodak EasyShare C340;7.11;digicamdb
 Kodak;Kodak EasyShare C360;7.11;digicamdb
-Kodak;Kodak EasyShare C433;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare C433;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare C503;5.75;digicamdb
-Kodak;Kodak EasyShare C513;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare C513;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare C530;5.75;digicamdb
 Kodak;Kodak EasyShare C533;5.75;digicamdb
 Kodak;Kodak EasyShare C610;5.75;digicamdb
-Kodak;Kodak EasyShare C613;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare C613;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare C623;5.75;digicamdb
-Kodak;Kodak EasyShare C643;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare C653;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare C643;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare C653;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare C663;5.75;digicamdb
 Kodak;Kodak EasyShare C703;5.75;digicamdb
-Kodak;Kodak EasyShare C713;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare C743;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare C763;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare C813;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare C875;7.144;dpreview,digicamdb
-Kodak;Kodak EasyShare C913;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare C713;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare C743;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare C763;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare C813;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare C875;7.144;digicamdb,dpreview
+Kodak;Kodak EasyShare C913;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare CD1013;6.16;digicamdb
 Kodak;Kodak EasyShare CD703;5.75;digicamdb
 Kodak;Kodak EasyShare CD80;6.16;digicamdb
@@ -2684,7 +2732,7 @@ Kodak;Kodak EasyShare CX7300;5.33;digicamdb
 Kodak;Kodak EasyShare CX7330;5.75;digicamdb
 Kodak;Kodak EasyShare CX7430;5.75;digicamdb
 Kodak;Kodak EasyShare CX7525;5.75;digicamdb
-Kodak;Kodak EasyShare CX7530;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare CX7530;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare DX3215;5.33;digicamdb
 Kodak;Kodak EasyShare DX3500;6.4;digicamdb
 Kodak;Kodak EasyShare DX3600;6.4;digicamdb
@@ -2706,37 +2754,37 @@ Kodak;Kodak EasyShare LS743;7.11;digicamdb
 Kodak;Kodak EasyShare LS745;7.11;digicamdb
 Kodak;Kodak EasyShare LS753;7.11;digicamdb
 Kodak;Kodak EasyShare LS755;5.75;digicamdb
-Kodak;Kodak EasyShare M1033;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare M1033;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare M1063;5.75;digicamdb
 Kodak;Kodak EasyShare M1073 IS;5.75;digicamdb
-Kodak;Kodak EasyShare M1093 IS;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare M1093 IS;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare M215;4.8;digicamdb
-Kodak;Kodak EasyShare M320;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare M340;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare M320;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare M340;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare M341;6.16;digicamdb
-Kodak;Kodak EasyShare M380;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare M380;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare M381;6.16;digicamdb
 Kodak;Kodak EasyShare M420;6.16;digicamdb
 Kodak;Kodak EasyShare M522;6.16;digicamdb
-Kodak;Kodak EasyShare M530;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare M530;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare M531;6.16;digicamdb
 Kodak;Kodak EasyShare M532;6.16;digicamdb
 Kodak;Kodak EasyShare M5370;6.16;digicamdb
-Kodak;Kodak EasyShare M550;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare M550;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare M552;6.16;digicamdb
 Kodak;Kodak EasyShare M565;6.16;digicamdb
-Kodak;Kodak EasyShare M575;6.17;dpreview,digicamdb
-Kodak;Kodak EasyShare M580;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare M575;6.17;digicamdb,dpreview
+Kodak;Kodak EasyShare M580;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare M583;6.08;digicamdb
 Kodak;Kodak EasyShare M590;4.8;digicamdb
-Kodak;Kodak EasyShare M750;6.17;dpreview,digicamdb
-Kodak;Kodak EasyShare M753;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare M763;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare M853;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare M863;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare M873;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare M883;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare M893 IS;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare M750;6.17;digicamdb,dpreview
+Kodak;Kodak EasyShare M753;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare M763;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare M853;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare M863;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare M873;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare M883;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare M893 IS;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare Max;6.08;dpreview
 Kodak;Kodak EasyShare Max Z990;6.08;digicamdb
 Kodak;Kodak EasyShare MD1063;6.08;digicamdb
@@ -2745,53 +2793,53 @@ Kodak;Kodak EasyShare MD41;6.08;digicamdb
 Kodak;Kodak EasyShare MD81;6.08;digicamdb
 Kodak;Kodak EasyShare MD853;5.75;digicamdb
 Kodak;Kodak EasyShare MD863;5.75;digicamdb
-Kodak;Kodak EasyShare Mini;4.8;dpreview,digicamdb
+Kodak;Kodak EasyShare Mini;4.8;digicamdb,dpreview
 Kodak;Kodak EasyShare MX1063;6.08;digicamdb
 Kodak;Kodak EasyShare One;5.75;usercontribution
 Kodak;Kodak EasyShare One 6MP;5.75;digicamdb
-Kodak;Kodak EasyShare P712;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare P850;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare P880;7.144;dpreview,digicamdb
-Kodak;Kodak EasyShare Sport;6.17;dpreview,digicamdb
+Kodak;Kodak EasyShare P712;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare P850;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare P880;7.144;digicamdb,dpreview
+Kodak;Kodak EasyShare Sport;6.17;digicamdb,dpreview
 Kodak;Kodak EasyShare Touch;4.8;dpreview
 Kodak;Kodak EasyShare Touch M577;6.16;digicamdb
-Kodak;Kodak EasyShare V1003;7.144;dpreview,digicamdb
+Kodak;Kodak EasyShare V1003;7.144;digicamdb,dpreview
 Kodak;Kodak EasyShare V1073;7.85;digicamdb
-Kodak;Kodak EasyShare V1233;7.44;dpreview,digicamdb
-Kodak;Kodak EasyShare V1253;7.44;dpreview,digicamdb
-Kodak;Kodak EasyShare V1273;7.44;dpreview,digicamdb
+Kodak;Kodak EasyShare V1233;7.44;digicamdb,dpreview
+Kodak;Kodak EasyShare V1253;7.44;digicamdb,dpreview
+Kodak;Kodak EasyShare V1273;7.44;digicamdb,dpreview
 Kodak;Kodak EasyShare V530;5.75;digicamdb
 Kodak;Kodak EasyShare V550;5.75;digicamdb
 Kodak;Kodak EasyShare V570;5.75;digicamdb
 Kodak;Kodak EasyShare V603;5.75;digicamdb
 Kodak;Kodak EasyShare V610;5.75;digicamdb
-Kodak;Kodak EasyShare V705;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare V803;7.144;dpreview,digicamdb
-Kodak;Kodak EasyShare Z1012 IS;6.08;dpreview,digicamdb
-Kodak;Kodak EasyShare Z1015 IS;6.08;dpreview,digicamdb
+Kodak;Kodak EasyShare V705;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare V803;7.144;digicamdb,dpreview
+Kodak;Kodak EasyShare Z1012 IS;6.08;digicamdb,dpreview
+Kodak;Kodak EasyShare Z1015 IS;6.08;digicamdb,dpreview
 Kodak;Kodak EasyShare Z1085 IS;7.85;digicamdb
-Kodak;Kodak EasyShare Z1275;7.44;dpreview,digicamdb
-Kodak;Kodak EasyShare Z1285;7.44;dpreview,digicamdb
-Kodak;Kodak EasyShare Z1485 IS;7.44;dpreview,digicamdb
+Kodak;Kodak EasyShare Z1275;7.44;digicamdb,dpreview
+Kodak;Kodak EasyShare Z1285;7.44;digicamdb,dpreview
+Kodak;Kodak EasyShare Z1485 IS;7.44;digicamdb,dpreview
 Kodak;Kodak EasyShare Z5010;6.16;digicamdb
 Kodak;Kodak EasyShare Z5120;6.08;digicamdb
-Kodak;Kodak EasyShare Z612;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z650;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z700;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z710;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z712 IS;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z730;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z740;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z7590;5.744;dpreview,digicamdb
+Kodak;Kodak EasyShare Z612;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z650;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z700;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z710;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z712 IS;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z730;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z740;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z7590;5.744;digicamdb,dpreview
 Kodak;Kodak EasyShare Z760;7.11;digicamdb
-Kodak;Kodak EasyShare Z812 IS;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z8612 IS;5.744;dpreview,digicamdb
-Kodak;Kodak EasyShare Z885;7.144;dpreview,digicamdb
-Kodak;Kodak EasyShare Z915;6.17;dpreview,digicamdb
-Kodak;Kodak EasyShare Z950;6.08;dpreview,digicamdb
-Kodak;Kodak EasyShare Z980;6.08;dpreview,digicamdb
-Kodak;Kodak EasyShare Z981;6.08;dpreview,digicamdb
-Kodak;Kodak EasyShare Z990;6.08;dpreview,digicamdb
+Kodak;Kodak EasyShare Z812 IS;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z8612 IS;5.744;digicamdb,dpreview
+Kodak;Kodak EasyShare Z885;7.144;digicamdb,dpreview
+Kodak;Kodak EasyShare Z915;6.17;digicamdb,dpreview
+Kodak;Kodak EasyShare Z950;6.08;digicamdb,dpreview
+Kodak;Kodak EasyShare Z980;6.08;digicamdb,dpreview
+Kodak;Kodak EasyShare Z981;6.08;digicamdb,dpreview
+Kodak;Kodak EasyShare Z990;6.08;digicamdb,dpreview
 Kodak;Kodak EasyShare ZD15;6.16;digicamdb
 Kodak;Kodak EasyShare ZD710;5.75;digicamdb
 Kodak;Kodak EasyShare ZD8612 IS;5.75;digicamdb
@@ -2839,11 +2887,29 @@ Konica;Konica Revio KD-410Z;7.11;digicamdb
 Konica;Konica Revio KD-420Z;5.75;digicamdb
 Konica;Konica Revio KD-500Z;7.11;digicamdb
 Konica;Konica Revio KD-510Z;7.11;digicamdb
+Konica Minolta;Konica Minolta DYNAX 5D;24.0;dxomark
+Konica Minolta;Konica Minolta DYNAX 7D;24.0;dxomark
 Konica-Minolta;Konica KD-200 Zoom;5.312;dpreview
 Konica-Minolta;Konica KD-300 Zoom;7.144;dpreview
 Konica-Minolta;Konica KD-400 Zoom;7.144;dpreview
 Konica-Minolta;Konica KD-500 Zoom;7.144;dpreview
 Konica-Minolta;Konica KD-510 Zoom;7.144;dpreview
+Konica-Minolta;Konica Minolta DiMAGE A2;8.8;dpreview
+Konica-Minolta;Konica Minolta DiMAGE A200;8.8;dpreview
+Konica-Minolta;Konica Minolta DiMAGE G600;7.144;dpreview
+Konica-Minolta;Konica Minolta DiMAGE X1;7.144;dpreview
+Konica-Minolta;Konica Minolta DiMAGE X31;4.544;dpreview
+Konica-Minolta;Konica Minolta DiMAGE X50;5.744;dpreview
+Konica-Minolta;Konica Minolta DiMAGE X60;5.744;dpreview
+Konica-Minolta;Konica Minolta DiMAGE Xg;5.312;dpreview
+Konica-Minolta;Konica Minolta DiMAGE Z10;5.744;dpreview
+Konica-Minolta;Konica Minolta DiMAGE Z2;5.744;dpreview
+Konica-Minolta;Konica Minolta DiMAGE Z20;5.744;dpreview
+Konica-Minolta;Konica Minolta DiMAGE Z3;5.744;dpreview
+Konica-Minolta;Konica Minolta DiMAGE Z5;5.744;dpreview
+Konica-Minolta;Konica Minolta DiMAGE Z6;5.744;dpreview
+Konica-Minolta;Konica Minolta Maxxum 5D;23.5;dpreview
+Konica-Minolta;Konica Minolta Maxxum 7D;23.5;dpreview
 Konica-Minolta;Konica-Minolta DG-5W;5.75;digicamdb
 Konica-Minolta;Konica-Minolta DiMAGE A2;8.8;dpreview
 Konica-Minolta;Konica-Minolta DiMAGE A200;8.8;dpreview
@@ -2918,23 +2984,23 @@ Koolnee;Koolnee K1 Trio;4.69;devicespecifications
 Koolnee;Koolnee K3;2.92;devicespecifications
 Kult;Kult 10;4.69;devicespecifications
 Kyocera;Kyocera DuraForce;4.61;devicespecifications
-Kyocera;Kyocera Finecam 3300;7.144;dpreview,digicamdb
+Kyocera;Kyocera Finecam 3300;7.144;digicamdb,dpreview
 Kyocera;Kyocera Finecam L3;5.33;digicamdb
-Kyocera;Kyocera Finecam L30;5.312;dpreview,digicamdb
+Kyocera;Kyocera Finecam L30;5.312;digicamdb,dpreview
 Kyocera;Kyocera Finecam L3V;5.312;dpreview
 Kyocera;Kyocera Finecam L4;5.75;digicamdb
 Kyocera;Kyocera Finecam L4v;7.144;digicamdb
-Kyocera;Kyocera Finecam M400R;5.312;dpreview,digicamdb
-Kyocera;Kyocera Finecam M410R;5.312;dpreview,digicamdb
-Kyocera;Kyocera Finecam S3;7.144;dpreview,digicamdb
-Kyocera;Kyocera Finecam S3L;7.144;dpreview,digicamdb
-Kyocera;Kyocera Finecam S3R;7.144;dpreview,digicamdb
+Kyocera;Kyocera Finecam M400R;5.312;digicamdb,dpreview
+Kyocera;Kyocera Finecam M410R;5.312;digicamdb,dpreview
+Kyocera;Kyocera Finecam S3;7.144;digicamdb,dpreview
+Kyocera;Kyocera Finecam S3L;7.144;digicamdb,dpreview
+Kyocera;Kyocera Finecam S3R;7.144;digicamdb,dpreview
 Kyocera;Kyocera Finecam S3X;7.144;digicamdb
-Kyocera;Kyocera Finecam S4;7.144;dpreview,digicamdb
-Kyocera;Kyocera Finecam S5;7.144;dpreview,digicamdb
-Kyocera;Kyocera Finecam S5R;7.144;dpreview,digicamdb
-Kyocera;Kyocera Finecam SL300R;5.312;dpreview,digicamdb
-Kyocera;Kyocera Finecam SL400R;5.312;dpreview,digicamdb
+Kyocera;Kyocera Finecam S4;7.144;digicamdb,dpreview
+Kyocera;Kyocera Finecam S5;7.144;digicamdb,dpreview
+Kyocera;Kyocera Finecam S5R;7.144;digicamdb,dpreview
+Kyocera;Kyocera Finecam SL300R;5.312;digicamdb,dpreview
+Kyocera;Kyocera Finecam SL400R;5.312;digicamdb,dpreview
 Kyocera;Kyocera Hydro Icon;4.61;devicespecifications
 Landvo;Landvo L550;3.67;devicespecifications
 Landvo;Landvo L600 Pro;4.69;devicespecifications
@@ -2982,14 +3048,15 @@ Leeco;Leeco Le S3 Helio X20;4.74;devicespecifications
 Leeco;Leeco Le X920;5.49;devicespecifications
 Leica;Leica C;7.4;dxomark
 Leica;Leica C (Typ 112);7.6;imaging-resource
-Leica;Leica C (Typ112);7.44;dpreview,digicamdb
+Leica;Leica C (Typ112);7.44;digicamdb,dpreview
 Leica;Leica C-Lux;13.2;dpreview
-Leica;Leica C-LUX 1;5.744;dpreview,digicamdb,imaging-resource
-Leica;Leica C-LUX 2;5.744;dpreview,digicamdb,imaging-resource
-Leica;Leica C-LUX 3;6.08;dpreview,digicamdb,imaging-resource
-Leica;Leica CL;23.6;dpreview,digicamdb,imaging-resource
+Leica;Leica C-LUX 1;5.744;digicamdb,dpreview,imaging-resource
+Leica;Leica C-LUX 2;5.744;digicamdb,dpreview,imaging-resource
+Leica;Leica C-LUX 3;6.08;digicamdb,dpreview,imaging-resource
+Leica;Leica C-Lux Typ 1546;13.2;dxomark
+Leica;Leica CL;23.6;digicamdb,dpreview,imaging-resource
 Leica;Leica D-LUX;5.75;digicamdb
-Leica;Leica D-Lux (Typ 109);17.3;dpreview,digicamdb
+Leica;Leica D-Lux (Typ 109);17.3;digicamdb,dpreview
 Leica;Leica D-LUX 2;7.76;digicamdb,imaging-resource
 Leica;Leica D-LUX 3;7.76;digicamdb,imaging-resource
 Leica;Leica D-LUX 4;7.85;digicamdb
@@ -2997,40 +3064,48 @@ Leica;Leica D-LUX 5;7.85;digicamdb
 Leica;Leica D-LUX 6;7.44;dxomark
 Leica;Leica D-Lux 7;17.3;dpreview
 Leica;Leica D-Lux Typ 109;17.3;dxomark
-Leica;Leica Digilux;6.4;dpreview,digicamdb
+Leica;Leica Digilux;6.4;digicamdb,dpreview
 Leica;Leica Digilux 1;7.53;digicamdb
-Leica;Leica Digilux 2;8.8;dpreview,digicamdb
-Leica;Leica Digilux 3;17.3;dpreview,digicamdb,imaging-resource
-Leica;Leica Digilux 4.3;7.44;dpreview,digicamdb
-Leica;Leica Digilux Zoom;6.4;dpreview,digicamdb
+Leica;Leica Digilux 2;8.8;digicamdb,dpreview
+Leica;Leica Digilux 3;17.3;digicamdb,dpreview,imaging-resource
+Leica;Leica Digilux 4.3;7.44;digicamdb,dpreview
+Leica;Leica Digilux Zoom;6.4;digicamdb,dpreview
 Leica;Leica M (Typ 240);36.0;imaging-resource
-Leica;Leica M (Typ 262);35.8;dpreview,digicamdb,imaging-resource
-Leica;Leica M Edition 60;36.0;dpreview,digicamdb
+Leica;Leica M (Typ 262);35.8;digicamdb,dpreview,imaging-resource
+Leica;Leica M Edition 60;36.0;digicamdb,dpreview
 Leica;Leica M Monochrom;35.8;imaging-resource
-Leica;Leica M Monochrom (Typ 246);35.8;dpreview,digicamdb,imaging-resource,dxomark
-Leica;Leica M Typ 240;36.0;dpreview,digicamdb,dxomark
+Leica;Leica M Monochrom (Typ 246);35.8;digicamdb,dpreview,dxomark,imaging-resource
+Leica;Leica M Typ 240;36.0;digicamdb,dpreview,dxomark
 Leica;Leica M Typ 262;35.8;dxomark
 Leica;Leica M-D (Typ 262);35.8;imaging-resource
 Leica;Leica M-D Typ 262;35.8;dxomark
 Leica;Leica M-E (Typ 220);36.0;imaging-resource
+Leica;Leica M-E (Typ 240);36.0;dpreview
 Leica;Leica M-E Typ 220;36.0;dpreview,dxomark
+Leica;Leica M-E Typ 240;35.8;dxomark
 Leica;Leica M-Monochrom;35.8;digicamdb
 Leica;Leica M-P;36.0;digicamdb
 Leica;Leica M-P (Typ 240);36.0;dpreview,imaging-resource
 Leica;Leica M-P Typ 240;35.8;dxomark
 Leica;Leica M10;36.0;dxomark
 Leica;Leica M10 (Typ 3656);36.0;digicamdb,imaging-resource
+Leica;Leica M10 Monochrom;36.0;dpreview
 Leica;Leica M10-D;35.8;dpreview
 Leica;Leica M10-P;35.8;dpreview
-Leica;Leica M8;27.0;dpreview,digicamdb,imaging-resource,dxomark
-Leica;Leica M8.2;27.0;dpreview,digicamdb,imaging-resource
+Leica;Leica M10-R;36.0;digicamdb
+Leica;Leica M11;36.0;dxomark
+Leica;Leica M11 (Typ 2416);36.0;imaging-resource
+Leica;Leica M8;27.0;digicamdb,dpreview,dxomark,imaging-resource
+Leica;Leica M8.2;27.0;digicamdb,dpreview,imaging-resource
 Leica;Leica M9;35.8;digicamdb,imaging-resource
 Leica;Leica M9 P;35.8;dxomark
 Leica;Leica M9 Titanium;35.8;digicamdb
 Leica;Leica M9-P;35.8;digicamdb
-Leica;Leica Q (Typ 116);36.0;dpreview,digicamdb,imaging-resource
+Leica;Leica Q (Typ 116);36.0;digicamdb,dpreview,imaging-resource
 Leica;Leica Q Typ 116;36.0;dxomark
 Leica;Leica Q-P;36.0;dpreview
+Leica;Leica Q2;36.0;dxomark
+Leica;Leica Q2 Monochrom;36.0;dpreview
 Leica;Leica S;45.0;dxomark
 Leica;Leica S (Typ 006);45.0;imaging-resource
 Leica;Leica S (Typ 007);45.0;imaging-resource
@@ -3039,35 +3114,38 @@ Leica;Leica S Typ 007;45.0;dxomark
 Leica;Leica S-E;45;usercontribution
 Leica;Leica S-E (Typ 006);45.0;digicamdb,imaging-resource
 Leica;Leica S-E Typ 006;45.0;dxomark
-Leica;Leica S2;45.0;dpreview,digicamdb,imaging-resource
-Leica;Leica SL (Typ 601);36.0;dpreview,digicamdb,imaging-resource,dxomark
+Leica;Leica S2;45.0;digicamdb,dpreview,imaging-resource
+Leica;Leica S3;45.0;dxomark
+Leica;Leica SL (Typ 601);36.0;digicamdb,dpreview,dxomark,imaging-resource
+Leica;Leica SL2;36.0;digicamdb
 Leica;Leica SL2-S;36.00;usercontribution
 Leica;Leica T;23.6;dxomark
-Leica;Leica T (Typ 701);23.6;dpreview,digicamdb,imaging-resource
-Leica;Leica TL;23.6;dpreview,digicamdb,imaging-resource
-Leica;Leica TL2;23.6;dpreview,digicamdb,imaging-resource,dxomark
+Leica;Leica T (Typ 701);23.6;digicamdb,dpreview,imaging-resource
+Leica;Leica TL;23.6;digicamdb,dpreview,imaging-resource
+Leica;Leica TL2;23.6;digicamdb,dpreview,dxomark,imaging-resource
 Leica;Leica V LUX 3;6.5;dxomark
 Leica;Leica V-Lux (Typ 114);13.2;dpreview
 Leica;Leica V-Lux (Typ 114) ;13.2;digicamdb
-Leica;Leica V-LUX 1;7.144;dpreview,digicamdb
+Leica;Leica V-LUX 1;7.144;digicamdb,dpreview
 Leica;Leica V-Lux 2;6.08;dpreview
 Leica;Leica V-Lux 20;6.08;dpreview
 Leica;Leica V-LUX 3;6.08;digicamdb
 Leica;Leica V-Lux 30;6.08;dpreview
 Leica;Leica V-Lux 4;6.16;digicamdb
-Leica;Leica V-Lux 40;6.08;dpreview,digicamdb
+Leica;Leica V-Lux 40;6.08;digicamdb,dpreview
+Leica;Leica V-Lux 5;13.2;dpreview
 Leica;Leica V-Lux Typ 114;13.2;dxomark
 Leica;Leica X (Typ 113);23.7;digicamdb,imaging-resource
 Leica;Leica X Typ 113;23.6;dxomark
-Leica;Leica X Vario;23.6;dpreview,digicamdb,dxomark
+Leica;Leica X Vario;23.6;digicamdb,dpreview,dxomark
 Leica;Leica X Vario (Typ 107);23.6;imaging-resource
 Leica;Leica X-E;23.6;digicamdb
 Leica;Leica X-E (Typ 102);23.7;imaging-resource
 Leica;Leica X-E Typ 102;23.6;dxomark
-Leica;Leica X-U (Typ 113);23.6;dpreview,digicamdb,imaging-resource
+Leica;Leica X-U (Typ 113);23.6;digicamdb,dpreview,imaging-resource
 Leica;Leica X-U Typ 113;23.6;dxomark
 Leica;Leica X1;23.6;dpreview,imaging-resource
-Leica;Leica X2;23.6;dpreview,digicamdb,imaging-resource,dxomark
+Leica;Leica X2;23.6;digicamdb,dpreview,dxomark,imaging-resource
 Lenovo;Lenovo A7000 Turbo;4.82;devicespecifications
 Lenovo;Lenovo A7010;3.67;devicespecifications
 Lenovo;Lenovo K3 Note;4.82;devicespecifications
@@ -3103,6 +3181,7 @@ Letv;Letv One;4.69;devicespecifications
 Letv;Letv One Max;5.99;devicespecifications
 Letv;Letv One Pro;4.69;devicespecifications
 Lg;Lg 2017;4.6;devicespecifications
+Lg;Lg 2019;4.65;devicespecifications,usercontribution
 Lg;Lg Class;3.7;devicespecifications
 Lg;Lg G2;4.69;devicespecifications
 Lg;Lg G3;4.69;devicespecifications
@@ -3143,7 +3222,7 @@ Lg;Lg V50;4.03;devicespecifications,usercontribution
 Lg;Lg V50S ThinQ;5.64;devicespecifications,usercontribution
 Lg;Lg V60 ThinQ;7.42;devicespecifications,usercontribution
 Lg;Lg Velvet;6.4;devicespecifications,usercontribution
-Lg;Lg X4 (2019);4.65;devicespecifications,usercontribution
+Lg;Lg X4;4.65;devicespecifications,usercontribution
 Lg;Lg X420BMW;4.65;devicespecifications,usercontribution
 Lg;Lg X420EM;4.65;devicespecifications,usercontribution
 Lg;Lg X420EMW;4.65;devicespecifications,usercontribution
@@ -3152,13 +3231,9 @@ Lg;Lg Zero;3.7;devicespecifications
 LG Electronics;LG-G900N;6.4;devicespecifications,usercontribution
 LG Electronics;LG-H815;5.95;devicespecifications,usercontribution
 LG Electronics;LG-H870;4.71;usercontribution
-LG Electronics;LG-H870;4.71;usercontribution
-LG Electronics;LG-H870DS;5.867;usercontribution
 LG Electronics;LG-H870DS;5.867;usercontribution
 LG Electronics;LG-H873;4.8;usercontribution
 LG Electronics;LG-H930;5.893;usercontribution
-LG Electronics;LG-H930;5.893;usercontribution
-LG Electronics;LG-H932;5.893;usercontribution
 LG Electronics;LG-H932;5.893;usercontribution
 LG Electronics;LG-V510;5.64;devicespecifications,usercontribution
 LG Electronics;LM-G810EAW;5.64;devicespecifications,usercontribution
@@ -3382,13 +3457,14 @@ Mlais;Mlais MX Base;3.67;devicespecifications
 Mobiistar;Mobiistar Prime X Grand;3.67;devicespecifications
 Mobiistar;Mobiistar Prime X Max;5.99;devicespecifications
 Mobiwire;Mobiwire Tala;4.74;devicespecifications
-Motorola;Moto G (4);6.06;usercontribution
-Motorola;Moto G (7);5.12;devicespecifications
+Motorola;Moto G;6.06;usercontribution
 Motorola;Moto x4;4.0;usercontribution
-Motorola;Moto Z (2);4.96;devicespecifications
+Motorola;Moto Z;4.96;devicespecifications
+Motorola;Motorola 2;4.96;devicespecifications
 Motorola;Motorola 2nd Gen;4.69;devicespecifications
 Motorola;Motorola 3rd Gen;4.69;devicespecifications
 Motorola;Motorola 4;6.06;usercontribution
+Motorola;Motorola 7;5.12;devicespecifications
 Motorola;Motorola Droid Maxx 2;5.99;devicespecifications
 Motorola;Motorola Droid Turbo 2;5.99;devicespecifications
 Motorola;Motorola Moto G;4.69;devicespecifications
@@ -3448,149 +3524,152 @@ NIKON;E7900;7.176;usercontribution
 NIKON;E8800;8.8;usercontribution
 NIKON;E990;7.176;usercontribution
 NIKON;E995;7.176;usercontribution
-Nikon;Nikon 1 AW1;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 J1;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 J2;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 J3;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 J4;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 J5;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 S1;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 S2;13.1;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 V1;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 V2;13.2;dpreview,digicamdb,dxomark
-Nikon;Nikon 1 V3;13.2;dpreview,digicamdb,dxomark
+Nikon;Nikon 1 AW1;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 J1;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 J2;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 J3;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 J4;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 J5;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 S1;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 S2;13.1;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 V1;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 V2;13.2;digicamdb,dpreview,dxomark
+Nikon;Nikon 1 V3;13.2;digicamdb,dpreview,dxomark
 Nikon;Nikon AW1;13.2;imaging-resource
-Nikon;Nikon Coolpix 100;4.8;dpreview,digicamdb
-Nikon;Nikon Coolpix 2000;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 2100;4.544;dpreview,digicamdb
-Nikon;Nikon Coolpix 2200;4.544;dpreview,digicamdb
-Nikon;Nikon Coolpix 2500;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 300;4.8;dpreview,digicamdb
-Nikon;Nikon Coolpix 3100;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 3200;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 3500;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 3700;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 4100;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix 4200;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 4300;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 4500;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 4600;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix 4800;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix 5000;8.8;dpreview,digicamdb
-Nikon;Nikon Coolpix 5200;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 5400;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 5600;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix 5700;8.8;dpreview,digicamdb
-Nikon;Nikon Coolpix 5900;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 600;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 700;6.4;dpreview,digicamdb
-Nikon;Nikon Coolpix 7600;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 775;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix 7900;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 800;6.4;dpreview,digicamdb
-Nikon;Nikon Coolpix 8400;8.8;dpreview,digicamdb
-Nikon;Nikon Coolpix 8700;8.8;dpreview,digicamdb
-Nikon;Nikon Coolpix 880;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 8800;8.8;dpreview,digicamdb
-Nikon;Nikon Coolpix 885;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 900;5.312;dpreview,digicamdb
+Nikon;Nikon Coolpix 100;4.8;digicamdb,dpreview
+Nikon;Nikon Coolpix 2000;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 2100;4.544;digicamdb,dpreview
+Nikon;Nikon Coolpix 2200;4.544;digicamdb,dpreview
+Nikon;Nikon Coolpix 2500;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 300;4.8;digicamdb,dpreview
+Nikon;Nikon Coolpix 3100;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 3200;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 3500;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 3700;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 4100;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix 4200;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 4300;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 4500;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 4600;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix 4800;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix 5000;8.8;digicamdb,dpreview
+Nikon;Nikon Coolpix 5200;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 5400;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 5600;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix 5700;8.8;digicamdb,dpreview
+Nikon;Nikon Coolpix 5900;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 600;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 700;6.4;digicamdb,dpreview
+Nikon;Nikon Coolpix 7600;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 775;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix 7900;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 800;6.4;digicamdb,dpreview
+Nikon;Nikon Coolpix 8400;8.8;digicamdb,dpreview
+Nikon;Nikon Coolpix 8700;8.8;digicamdb,dpreview
+Nikon;Nikon Coolpix 880;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 8800;8.8;digicamdb,dpreview
+Nikon;Nikon Coolpix 885;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 900;5.312;digicamdb,dpreview
 Nikon;Nikon Coolpix 900S;5.312;dpreview
 Nikon;Nikon Coolpix 910;6.4;digicamdb
-Nikon;Nikon Coolpix 950;6.4;dpreview,digicamdb
-Nikon;Nikon Coolpix 990;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix 995;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix A;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix A10;6.17;dpreview,digicamdb
-Nikon;Nikon Coolpix A100;6.17;dpreview,digicamdb
+Nikon;Nikon Coolpix 950;6.4;digicamdb,dpreview
+Nikon;Nikon Coolpix 990;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix 995;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix A;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix A10;6.17;digicamdb,dpreview
+Nikon;Nikon Coolpix A100;6.17;digicamdb,dpreview
+Nikon;Nikon Coolpix A1000;6.16;dxomark
 Nikon;Nikon Coolpix A300;6.17;dpreview,imaging-resource
-Nikon;Nikon Coolpix A900;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix AW100;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix A900;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix AW100;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix AW100s;6.16;digicamdb
-Nikon;Nikon Coolpix AW110;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix AW120;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix AW130;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix B500;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix B700;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix L1;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L10;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L100;6.08;dpreview,digicamdb
+Nikon;Nikon Coolpix AW110;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix AW120;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix AW130;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix B500;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix B600;6.16;digicamdb
+Nikon;Nikon Coolpix B700;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix L1;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L10;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L100;6.08;digicamdb,dpreview
 Nikon;Nikon Coolpix L101;5.75;digicamdb
-Nikon;Nikon Coolpix L11;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L110;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L12;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L120;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L14;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L15;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L16;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix L18;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L19;5.744;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L11;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L110;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L12;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L120;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L14;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L15;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L16;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix L18;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L19;5.744;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L2;5.744;dpreview,imaging-resource
-Nikon;Nikon Coolpix L20;6.08;dpreview,digicamdb
-Nikon;Nikon Coolpix L21;6.08;dpreview,digicamdb
-Nikon;Nikon Coolpix L22;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L20;6.08;digicamdb,dpreview
+Nikon;Nikon Coolpix L21;6.08;digicamdb,dpreview
+Nikon;Nikon Coolpix L22;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L23;4.96;digicamdb
-Nikon;Nikon Coolpix L24;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L24;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L25;4.8;digicamdb
-Nikon;Nikon Coolpix L26;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L26;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L27;6.16;digicamdb
 Nikon;Nikon Coolpix L28;6.16;digicamdb,imaging-resource
 Nikon;Nikon Coolpix L29;6.16;digicamdb
 Nikon;Nikon Coolpix L3;5.744;dpreview,imaging-resource
 Nikon;Nikon Coolpix L30;6.16;digicamdb,imaging-resource
-Nikon;Nikon Coolpix L31;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L31;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L310;6.16;digicamdb
-Nikon;Nikon Coolpix L32;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L32;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L320;6.16;digicamdb
 Nikon;Nikon Coolpix L330;6.16;digicamdb
 Nikon;Nikon Coolpix L4;5.744;dpreview,imaging-resource
-Nikon;Nikon Coolpix L5;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L6;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L610;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L5;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L6;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L610;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L620;6.16;digicamdb,imaging-resource
-Nikon;Nikon Coolpix L810;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L810;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix L820;6.16;digicamdb,imaging-resource
-Nikon;Nikon Coolpix L830;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix L840;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P1;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix P100;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P1000;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P2;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix P3;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix P300;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P310;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P330;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix P340;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix P4;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix P50;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P500;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P5000;7.144;dpreview,digicamdb
-Nikon;Nikon Coolpix P510;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P5100;7.44;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix L830;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix L840;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P1;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix P100;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P1000;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P2;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix P3;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix P300;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P310;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P330;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix P340;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix P4;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix P50;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P500;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P5000;7.144;digicamdb,dpreview
+Nikon;Nikon Coolpix P510;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P5100;7.44;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix P520;6.16;digicamdb,imaging-resource
-Nikon;Nikon Coolpix P530;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P60;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P600;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P6000;7.44;dpreview,digicamdb
-Nikon;Nikon Coolpix P610;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P7000;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix P7100;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix P7700;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix P7800;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Coolpix P80;6.08;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P90;6.08;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix P900;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix P530;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P60;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P600;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P6000;7.44;digicamdb,dpreview
+Nikon;Nikon Coolpix P610;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P7000;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix P7100;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix P7700;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix P7800;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Coolpix P80;6.08;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P90;6.08;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P900;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix P950;6.17;imaging-resource
 Nikon;Nikon Coolpix S01;4.96;digicamdb,imaging-resource
-Nikon;Nikon Coolpix S02;4.8;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S1;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix S10;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S100;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S1000pj;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S1100pj;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S1200pj;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S2;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix S200;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S210;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S220;6.08;dpreview,digicamdb
+Nikon;Nikon Coolpix S02;4.8;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S1;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix S10;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S100;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S1000pj;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S1100pj;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S1200pj;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S2;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix S200;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S210;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S220;6.08;digicamdb,dpreview
 Nikon;Nikon Coolpix S225;6.08;digicamdb
 Nikon;Nikon Coolpix S230;6.08;digicamdb
 Nikon;Nikon Coolpix S2500;6.16;digicamdb,imaging-resource
@@ -3598,142 +3677,144 @@ Nikon;Nikon Coolpix S2600;6.16;digicamdb
 Nikon;Nikon Coolpix S2700;6.16;digicamdb
 Nikon;Nikon Coolpix S2750;6.16;digicamdb
 Nikon;Nikon Coolpix S2800 ;6.16;digicamdb
-Nikon;Nikon Coolpix S2900;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S3;5.744;dpreview,digicamdb
-Nikon;Nikon Coolpix S30;4.8;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S3000;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S2900;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S3;5.744;digicamdb,dpreview
+Nikon;Nikon Coolpix S30;4.8;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S3000;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S31;4.96;digicamdb
-Nikon;Nikon Coolpix S3100;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S32;4.7;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S3100;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S32;4.7;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S3200;6.16;digicamdb
-Nikon;Nikon Coolpix S33;4.7;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S3300;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S33;4.7;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S3300;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S3400;6.16;digicamdb
 Nikon;Nikon Coolpix S3500;6.16;digicamdb,imaging-resource
-Nikon;Nikon Coolpix S3600;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S3700;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S4;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S4000;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S4100;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S3600;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S3700;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S4;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S4000;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S4100;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S4150;6.16;digicamdb
 Nikon;Nikon Coolpix S4200;6.16;digicamdb
-Nikon;Nikon Coolpix S4300;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S4300;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S4400;6.16;digicamdb
-Nikon;Nikon Coolpix S5;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S50;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S500;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S50c;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S51;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S510;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S5100;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S51c;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S52;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S520;5.744;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S5;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S50;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S500;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S50c;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S51;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S510;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S5100;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S51c;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S52;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S520;5.744;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S5200;6.16;digicamdb,imaging-resource
-Nikon;Nikon Coolpix S52c;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S5300;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S550;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S52c;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S5300;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S550;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S560;6.08;digicamdb,imaging-resource
-Nikon;Nikon Coolpix S570;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S6;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S60;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S600;6.08;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S6000;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S610;6.08;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S6100;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S610c;6.08;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S570;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S6;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S60;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S600;6.08;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S6000;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S610;6.08;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S6100;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S610c;6.08;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S6150;6.16;digicamdb
-Nikon;Nikon Coolpix S620;6.08;dpreview,digicamdb
-Nikon;Nikon Coolpix S6200;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S630;6.08;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S6300;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S640;6.08;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S6400;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S6500;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S620;6.08;digicamdb,dpreview
+Nikon;Nikon Coolpix S6200;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S630;6.08;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S6300;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S640;6.08;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S6400;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S6500;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S6600 ;6.16;digicamdb
 Nikon;Nikon Coolpix S6700;6.16;digicamdb
-Nikon;Nikon Coolpix S6800;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S6900;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S70;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S700;7.44;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S7000;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S710;7.44;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S7c;5.744;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S80;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S8000;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S800c;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S8100;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S810c;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S8200;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S9;5.744;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S6800;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S6900;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S70;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S700;7.44;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S7000;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S710;7.44;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S7c;5.744;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S80;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S8000;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S800c;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S8100;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S810c;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S8200;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S9;5.744;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S9050;6.16;digicamdb
-Nikon;Nikon Coolpix S9100;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S9100;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S9200;6.16;digicamdb
-Nikon;Nikon Coolpix S9300;6.17;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Coolpix S9300;6.17;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Coolpix S9400;6.16;digicamdb
 Nikon;Nikon Coolpix S9500;6.16;digicamdb,imaging-resource
 Nikon;Nikon Coolpix S9600;6.16;digicamdb
-Nikon;Nikon Coolpix S9700;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix S9900;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix SQ;5.312;dpreview,digicamdb
-Nikon;Nikon Coolpix W100;4.7;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Coolpix W300;6.17;dpreview,digicamdb,imaging-resource
-Nikon;Nikon D1;23.7;dpreview,digicamdb
-Nikon;Nikon D100;23.7;dpreview,digicamdb
-Nikon;Nikon D1H;23.7;dpreview,digicamdb
-Nikon;Nikon D1X;23.7;dpreview,digicamdb
-Nikon;Nikon D200;23.6;dpreview,digicamdb,imaging-resource
-Nikon;Nikon D2H;23.7;dpreview,digicamdb
+Nikon;Nikon Coolpix S9700;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix S9900;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix SQ;5.312;digicamdb,dpreview
+Nikon;Nikon Coolpix W100;4.7;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Coolpix W150;4.8;digicamdb
+Nikon;Nikon Coolpix W300;6.17;digicamdb,dpreview,imaging-resource
+Nikon;Nikon D1;23.7;digicamdb,dpreview
+Nikon;Nikon D100;23.7;digicamdb,dpreview
+Nikon;Nikon D1H;23.7;digicamdb,dpreview
+Nikon;Nikon D1X;23.7;digicamdb,dpreview
+Nikon;Nikon D200;23.6;digicamdb,dpreview,imaging-resource
+Nikon;Nikon D2H;23.7;digicamdb,dpreview
 Nikon;Nikon D2Hs;23.2;digicamdb
-Nikon;Nikon D2X;23.7;dpreview,digicamdb
-Nikon;Nikon D2Xs;23.7;dpreview,digicamdb,imaging-resource
-Nikon;Nikon D3;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D300;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D3000;23.6;dpreview,digicamdb,imaging-resource,dxomark
+Nikon;Nikon D2X;23.7;digicamdb,dpreview
+Nikon;Nikon D2Xs;23.7;digicamdb,dpreview,imaging-resource
+Nikon;Nikon D3;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D300;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D3000;23.6;digicamdb,dpreview,dxomark,imaging-resource
 Nikon;Nikon D300s;23.6;digicamdb,dxomark
-Nikon;Nikon D3100;23.1;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D3200;23.2;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D3300;23.5;dpreview,digicamdb,imaging-resource
-Nikon;Nikon D3400;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D3500;23.5;dpreview,digicamdb,imaging-resource
+Nikon;Nikon D3100;23.1;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D3200;23.2;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D3300;23.5;digicamdb,dpreview,imaging-resource
+Nikon;Nikon D3400;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D3500;23.5;digicamdb,dpreview,imaging-resource
 Nikon;Nikon D3s;36.0;digicamdb,dxomark
-Nikon;Nikon D3X;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D4;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D40;23.7;dpreview,digicamdb,imaging-resource
+Nikon;Nikon D3X;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D4;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D40;23.7;digicamdb,dpreview,imaging-resource
 Nikon;Nikon D40x;23.6;digicamdb
-Nikon;Nikon D4s;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D5;35.9;dpreview,imaging-resource,dxomark
-Nikon;Nikon D50;23.7;dpreview,digicamdb
-Nikon;Nikon D500;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D5000;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D5100;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D5200;23.5;dpreview,digicamdb,imaging-resource
-Nikon;Nikon D5300;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D5500;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D5600;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D60;23.6;dpreview,digicamdb,imaging-resource
-Nikon;Nikon D600;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D610;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D70;23.7;dpreview,digicamdb
-Nikon;Nikon D700;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D7000;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D70s;23.7;dpreview,digicamdb
-Nikon;Nikon D7100;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D7200;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D750;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D7500;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Nikon;Nikon D4s;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D5;35.9;dpreview,dxomark,imaging-resource
+Nikon;Nikon D50;23.7;digicamdb,dpreview
+Nikon;Nikon D500;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D5000;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D5100;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D5200;23.5;digicamdb,dpreview,imaging-resource
+Nikon;Nikon D5300;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D5500;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D5600;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D6;35.9;digicamdb
+Nikon;Nikon D60;23.6;digicamdb,dpreview,imaging-resource
+Nikon;Nikon D600;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D610;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D70;23.7;digicamdb,dpreview
+Nikon;Nikon D700;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D7000;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D70s;23.7;digicamdb,dpreview
+Nikon;Nikon D7100;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D7200;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D750;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D7500;23.5;digicamdb,dpreview,dxomark,imaging-resource
 Nikon;Nikon D780;35.9;digicamdb,imaging-resource
-Nikon;Nikon D80;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D800;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D800E;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D810;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D810A;35.9;dpreview,imaging-resource,dxomark
-Nikon;Nikon D850;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon D90;23.6;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon Df;36.0;dpreview,digicamdb,imaging-resource,dxomark
-Nikon;Nikon DL18-50;13.2;digicamdb,imaging-resource,dxomark
-Nikon;Nikon DL24-500;13.2;digicamdb,imaging-resource,dxomark
-Nikon;Nikon DL24-85;13.2;digicamdb,imaging-resource,dxomark
+Nikon;Nikon D80;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D800;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D800E;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D810;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D810A;35.9;dpreview,dxomark,imaging-resource
+Nikon;Nikon D850;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon D90;23.6;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon Df;36.0;digicamdb,dpreview,dxomark,imaging-resource
+Nikon;Nikon DL18-50;13.2;digicamdb,dxomark,imaging-resource
+Nikon;Nikon DL24-500;13.2;digicamdb,dxomark,imaging-resource
+Nikon;Nikon DL24-85;13.2;digicamdb,dxomark,imaging-resource
 Nikon;Nikon E2n;8.8;digicamdb
 Nikon;Nikon E2Ns;8.8;digicamdb
 Nikon;Nikon E2s;8.8;digicamdb
@@ -3752,10 +3833,20 @@ Nikon;Nikon S2;13.1;imaging-resource
 Nikon;Nikon V1;13.2;imaging-resource
 Nikon;Nikon V2;13.2;imaging-resource
 Nikon;Nikon V3;13.2;imaging-resource
+Nikon;Nikon Z 30;23.5;imaging-resource
 Nikon;Nikon Z 6;35.9;usercontribution
 Nikon;Nikon Z 7;35.9;usercontribution
-Nikon;Nikon Z6;35.9;dpreview,digicamdb,imaging-resource
-Nikon;Nikon Z7;35.9;dpreview,digicamdb,imaging-resource
+Nikon;Nikon Z fc;23.5;digicamdb
+Nikon;Nikon Z30;23.5;dpreview
+Nikon;Nikon Z5;35.9;digicamdb
+Nikon;Nikon Z50;23.5;digicamdb
+Nikon;Nikon Z6;35.9;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Z6 II;35.9;digicamdb
+Nikon;Nikon Z6II;35.9;dxomark
+Nikon;Nikon Z7;35.9;digicamdb,dpreview,imaging-resource
+Nikon;Nikon Z7 II;35.9;digicamdb
+Nikon;Nikon Z7II;35.9;dxomark
+Nikon;Nikon Z9;35.9;dxomark
 Noa;Noa H10;4.69;devicespecifications
 Noa;Noa H10le;4.69;devicespecifications
 Noa;Noa H8;4.69;devicespecifications
@@ -3776,7 +3867,7 @@ Nokia;Nokia Asha 502;3.67;devicespecifications
 Nokia;Nokia Lumia 1020;8.8;devicespecifications
 Nokia;Nokia Lumia 1320;3.67;devicespecifications
 Nokia;Nokia Lumia 1320 LTE;3.67;devicespecifications
-Nokia;Nokia Lumia 1520;5.76;dxomark,devicespecifications
+Nokia;Nokia Lumia 1520;5.76;devicespecifications,dxomark
 Nokia;Nokia Lumia 2520;4.23;devicespecifications
 Nokia;Nokia Lumia 520;3.6;devicespecifications
 Nokia;Nokia Lumia 521;3.6;devicespecifications
@@ -3860,72 +3951,72 @@ Obi worldphone;Obi worldphone SF1;4.69;devicespecifications
 Obi worldphone;Obi worldphone SJ1.5;4.61;devicespecifications
 OLYMPUS;C310Z;5.27;usercontribution
 OLYMPUS;D540Z;5.27;usercontribution
-Olympus;Olympus Air A01;17.3;dpreview,digicamdb,dxomark
+Olympus;Olympus Air A01;17.3;digicamdb,dpreview,dxomark
 Olympus;Olympus AZ-1;5.33;digicamdb
 Olympus;Olympus AZ-1 Ferrari 2004;5.33;digicamdb
 Olympus;Olympus AZ-2 Zoom;5.33;digicamdb
-Olympus;Olympus C-1;4.544;dpreview,digicamdb
+Olympus;Olympus C-1;4.544;digicamdb,dpreview
 Olympus;Olympus C-1 Zoom;4.5;digicamdb
-Olympus;Olympus C-100;4.544;dpreview,digicamdb
+Olympus;Olympus C-100;4.544;digicamdb,dpreview
 Olympus;Olympus C-1000L;6.4;digicamdb
-Olympus;Olympus C-120;4.544;dpreview,digicamdb
+Olympus;Olympus C-120;4.544;digicamdb,dpreview
 Olympus;Olympus C-1400L;8.8;digicamdb
 Olympus;Olympus C-1400XL;8.8;digicamdb
-Olympus;Olympus C-150;4.544;dpreview,digicamdb
-Olympus;Olympus C-160;5.312;dpreview,digicamdb
-Olympus;Olympus C-170;5.744;dpreview,digicamdb
-Olympus;Olympus C-180;5.744;dpreview,digicamdb
+Olympus;Olympus C-150;4.544;digicamdb,dpreview
+Olympus;Olympus C-160;5.312;digicamdb,dpreview
+Olympus;Olympus C-170;5.744;digicamdb,dpreview
+Olympus;Olympus C-180;5.744;digicamdb,dpreview
 Olympus;Olympus C-1Z;4.544;dpreview
-Olympus;Olympus C-2;5.312;dpreview,digicamdb
-Olympus;Olympus C-200 Zoom;5.312;dpreview,digicamdb
-Olympus;Olympus C-2000 Zoom;6.4;dpreview,digicamdb
-Olympus;Olympus C-2020 Zoom;6.4;dpreview,digicamdb
-Olympus;Olympus C-2040 Zoom;6.4;dpreview,digicamdb
-Olympus;Olympus C-21;6.4;dpreview,digicamdb
-Olympus;Olympus C-2100 UZ;6.4;dpreview,digicamdb
-Olympus;Olympus C-220 Zoom;4.544;dpreview,digicamdb
+Olympus;Olympus C-2;5.312;digicamdb,dpreview
+Olympus;Olympus C-200 Zoom;5.312;digicamdb,dpreview
+Olympus;Olympus C-2000 Zoom;6.4;digicamdb,dpreview
+Olympus;Olympus C-2020 Zoom;6.4;digicamdb,dpreview
+Olympus;Olympus C-2040 Zoom;6.4;digicamdb,dpreview
+Olympus;Olympus C-21;6.4;digicamdb,dpreview
+Olympus;Olympus C-2100 UZ;6.4;digicamdb,dpreview
+Olympus;Olympus C-220 Zoom;4.544;digicamdb,dpreview
 Olympus;Olympus C-25;5.76;dpreview
-Olympus;Olympus C-2500 L;8.8;dpreview,digicamdb
-Olympus;Olympus C-300 Zoom;5.744;dpreview,digicamdb
-Olympus;Olympus C-3000 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-3020 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-3030 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-3040 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-310 Zoom;5.312;dpreview,digicamdb
+Olympus;Olympus C-2500 L;8.8;digicamdb,dpreview
+Olympus;Olympus C-300 Zoom;5.744;digicamdb,dpreview
+Olympus;Olympus C-3000 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-3020 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-3030 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-3040 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-310 Zoom;5.312;digicamdb,dpreview
 Olympus;Olympus C-315 Zoom;5.75;digicamdb
-Olympus;Olympus C-350 Zoom;5.744;dpreview,digicamdb
+Olympus;Olympus C-350 Zoom;5.744;digicamdb,dpreview
 Olympus;Olympus C-360 Zoom;5.75;digicamdb
-Olympus;Olympus C-370 Zoom;5.312;dpreview,digicamdb
-Olympus;Olympus C-40 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-4000 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-4040 Zoom;7.144;dpreview,digicamdb
+Olympus;Olympus C-370 Zoom;5.312;digicamdb,dpreview
+Olympus;Olympus C-40 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-4000 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-4040 Zoom;7.144;digicamdb,dpreview
 Olympus;Olympus C-450 Zoom;5.75;digicamdb
 Olympus;Olympus C-460 Zoom;5.312;dpreview
 Olympus;Olympus C-460 Zoom del Sol;5.75;digicamdb
 Olympus;Olympus C-470 Zoom;5.75;digicamdb
-Olympus;Olympus C-480 Zoom;5.744;dpreview,digicamdb
-Olympus;Olympus C-50 Zoom;7.144;dpreview,digicamdb
+Olympus;Olympus C-480 Zoom;5.744;digicamdb,dpreview
+Olympus;Olympus C-50 Zoom;7.144;digicamdb,dpreview
 Olympus;Olympus C-500 Zoom;5.744;dpreview
 Olympus;Olympus C-5000 Zoom;7.27;digicamdb
-Olympus;Olympus C-5050 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-5060 Wide Zoom;7.144;dpreview,digicamdb
+Olympus;Olympus C-5050 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-5060 Wide Zoom;7.144;digicamdb,dpreview
 Olympus;Olympus C-55 Zoom;7.11;digicamdb
-Olympus;Olympus C-5500 Sport Zoom;7.144;dpreview,digicamdb
+Olympus;Olympus C-5500 Sport Zoom;7.144;digicamdb,dpreview
 Olympus;Olympus C-560;5.76;dpreview
 Olympus;Olympus C-570;5.76;dpreview
 Olympus;Olympus C-60 Zoom;7.27;digicamdb
 Olympus;Olympus C-70 Zoom;7.11;digicamdb
-Olympus;Olympus C-700 UZ;5.312;dpreview,digicamdb
-Olympus;Olympus C-7000 Zoom;7.144;dpreview,digicamdb
-Olympus;Olympus C-7070 Wide Zoom;7.144;dpreview,digicamdb
+Olympus;Olympus C-700 UZ;5.312;digicamdb,dpreview
+Olympus;Olympus C-7000 Zoom;7.144;digicamdb,dpreview
+Olympus;Olympus C-7070 Wide Zoom;7.144;digicamdb,dpreview
 Olympus;Olympus C-720 UZ;5.75;digicamdb
-Olympus;Olympus C-730 UZ;5.312;dpreview,digicamdb
-Olympus;Olympus C-740 UZ;5.744;dpreview,digicamdb
-Olympus;Olympus C-750 UZ;5.312;dpreview,digicamdb
+Olympus;Olympus C-730 UZ;5.312;digicamdb,dpreview
+Olympus;Olympus C-740 UZ;5.744;digicamdb,dpreview
+Olympus;Olympus C-750 UZ;5.312;digicamdb,dpreview
 Olympus;Olympus C-760 UZ;5.33;digicamdb
-Olympus;Olympus C-765 UZ;5.744;dpreview,digicamdb
-Olympus;Olympus C-770 UZ;5.744;dpreview,digicamdb
-Olympus;Olympus C-8080 Wide Zoom;8.8;dpreview,digicamdb
+Olympus;Olympus C-765 UZ;5.744;digicamdb,dpreview
+Olympus;Olympus C-770 UZ;5.744;digicamdb,dpreview
+Olympus;Olympus C-8080 Wide Zoom;8.8;digicamdb,dpreview
 Olympus;Olympus C-820L;4.8;digicamdb
 Olympus;Olympus C-840L;5.33;digicamdb
 Olympus;Olympus C-860L;5.33;digicamdb
@@ -3938,54 +4029,54 @@ Olympus;Olympus C920Z;5.312;dpreview
 Olympus;Olympus C990Z;5.312;dpreview
 Olympus;Olympus Camedia SP-700;5.8;imaging-resource
 Olympus;Olympus D-100;4.544;dpreview
-Olympus;Olympus D-150Z;4.544;dpreview,digicamdb
+Olympus;Olympus D-150Z;4.544;digicamdb,dpreview
 Olympus;Olympus D-200L;8.8;digicamdb
 Olympus;Olympus D-300L;8.8;digicamdb
 Olympus;Olympus D-340L;8.8;digicamdb
 Olympus;Olympus D-340R;6.4;digicamdb
 Olympus;Olympus D-360L;7.11;digicamdb
-Olympus;Olympus D-370;4.544;dpreview,digicamdb
-Olympus;Olympus D-380;4.544;dpreview,digicamdb
-Olympus;Olympus D-390;4.544;dpreview,digicamdb
-Olympus;Olympus D-395;5.312;dpreview,digicamdb
-Olympus;Olympus D-40 Zoom;7.144;dpreview,digicamdb
+Olympus;Olympus D-370;4.544;digicamdb,dpreview
+Olympus;Olympus D-380;4.544;digicamdb,dpreview
+Olympus;Olympus D-390;4.544;digicamdb,dpreview
+Olympus;Olympus D-395;5.312;digicamdb,dpreview
+Olympus;Olympus D-40 Zoom;7.144;digicamdb,dpreview
 Olympus;Olympus D-400 Zoom;6.4;digicamdb
-Olympus;Olympus D-425;5.744;dpreview,digicamdb
-Olympus;Olympus D-435;5.744;dpreview,digicamdb
-Olympus;Olympus D-450 Zoom;5.312;dpreview,digicamdb
+Olympus;Olympus D-425;5.744;digicamdb,dpreview
+Olympus;Olympus D-435;5.744;digicamdb,dpreview
+Olympus;Olympus D-450 Zoom;5.312;digicamdb,dpreview
 Olympus;Olympus D-460 Zoom;7.11;digicamdb
-Olympus;Olympus D-490 Zoom;5.312;dpreview,digicamdb
+Olympus;Olympus D-490 Zoom;5.312;digicamdb,dpreview
 Olympus;Olympus D-500L;8.8;digicamdb
-Olympus;Olympus D-510 Zoom;5.312;dpreview,digicamdb
-Olympus;Olympus D-520 Zoom;4.544;dpreview,digicamdb
-Olympus;Olympus D-535 Zoom;5.312;dpreview,digicamdb
-Olympus;Olympus D-540 Zoom;5.312;dpreview,digicamdb
-Olympus;Olympus D-545 Zoom;5.744;dpreview,digicamdb
-Olympus;Olympus D-560 Zoom;5.744;dpreview,digicamdb
+Olympus;Olympus D-510 Zoom;5.312;digicamdb,dpreview
+Olympus;Olympus D-520 Zoom;4.544;digicamdb,dpreview
+Olympus;Olympus D-535 Zoom;5.312;digicamdb,dpreview
+Olympus;Olympus D-540 Zoom;5.312;digicamdb,dpreview
+Olympus;Olympus D-545 Zoom;5.744;digicamdb,dpreview
+Olympus;Olympus D-560 Zoom;5.744;digicamdb,dpreview
 Olympus;Olympus D-575 Zoom;5.75;usercontribution
-Olympus;Olympus D-580 Zoom;5.312;dpreview,digicamdb
-Olympus;Olympus D-595 Zoom;5.744;dpreview,digicamdb
-Olympus;Olympus D-600L;8.8;dpreview,digicamdb
-Olympus;Olympus D-620L;8.8;dpreview,digicamdb
-Olympus;Olympus D-630 Zoom;5.744;dpreview,digicamdb
-Olympus;Olympus E-1;17.3;dpreview,digicamdb
-Olympus;Olympus E-10;8.8;dpreview,digicamdb
-Olympus;Olympus E-100 RS;6.4;dpreview,digicamdb
-Olympus;Olympus E-20;8.8;dpreview,digicamdb
-Olympus;Olympus E-3;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus E-30;17.3;dpreview,digicamdb,imaging-resource
+Olympus;Olympus D-580 Zoom;5.312;digicamdb,dpreview
+Olympus;Olympus D-595 Zoom;5.744;digicamdb,dpreview
+Olympus;Olympus D-600L;8.8;digicamdb,dpreview
+Olympus;Olympus D-620L;8.8;digicamdb,dpreview
+Olympus;Olympus D-630 Zoom;5.744;digicamdb,dpreview
+Olympus;Olympus E-1;17.3;digicamdb,dpreview
+Olympus;Olympus E-10;8.8;digicamdb,dpreview
+Olympus;Olympus E-100 RS;6.4;digicamdb,dpreview
+Olympus;Olympus E-20;8.8;digicamdb,dpreview
+Olympus;Olympus E-3;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus E-30;17.3;digicamdb,dpreview,imaging-resource
 Olympus;Olympus E-300;17.3;dpreview
 Olympus;Olympus E-330;17.3;dpreview
 Olympus;Olympus E-400;17.3;digicamdb
-Olympus;Olympus E-410;17.3;dpreview,digicamdb
-Olympus;Olympus E-420;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus E-450;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus E-5;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus E-500;17.3;dpreview,digicamdb
-Olympus;Olympus E-510;17.3;dpreview,digicamdb
-Olympus;Olympus E-520;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus E-600;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus E-620;17.3;dpreview,digicamdb,imaging-resource
+Olympus;Olympus E-410;17.3;digicamdb,dpreview
+Olympus;Olympus E-420;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus E-450;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus E-5;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus E-500;17.3;digicamdb,dpreview
+Olympus;Olympus E-510;17.3;digicamdb,dpreview
+Olympus;Olympus E-520;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus E-600;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus E-620;17.3;digicamdb,dpreview,imaging-resource
 Olympus;Olympus E-M1;17.3;usercontribution
 Olympus;Olympus E-M10;17.3;usercontribution
 Olympus;Olympus E-M10 Mark III;17.3;usercontribution
@@ -4014,59 +4105,59 @@ Olympus;Olympus EVOLT E-510;17.3;dpreview,imaging-resource
 Olympus;Olympus EVOLT E-520;17.3;dpreview
 Olympus;Olympus EVOLT E-600;17.3;dpreview
 Olympus;Olympus EVOLT E-620;17.3;dpreview
-Olympus;Olympus FE-100;5.744;dpreview,digicamdb
-Olympus;Olympus FE-110;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-115;5.744;dpreview,digicamdb
-Olympus;Olympus FE-120;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-130;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-140;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-150;5.744;dpreview,digicamdb
+Olympus;Olympus FE-100;5.744;digicamdb,dpreview
+Olympus;Olympus FE-110;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-115;5.744;digicamdb,dpreview
+Olympus;Olympus FE-120;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-130;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-140;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-150;5.744;digicamdb,dpreview
 Olympus;Olympus FE-160;5.75;digicamdb
-Olympus;Olympus FE-170;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-180;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-190;5.744;dpreview,digicamdb,imaging-resource
+Olympus;Olympus FE-170;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-180;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-190;5.744;digicamdb,dpreview,imaging-resource
 Olympus;Olympus FE-20;6.03;digicamdb
-Olympus;Olympus FE-200;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-210;5.744;dpreview,digicamdb,imaging-resource
+Olympus;Olympus FE-200;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-210;5.744;digicamdb,dpreview,imaging-resource
 Olympus;Olympus FE-220;5.75;digicamdb
-Olympus;Olympus FE-230;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-240;5.744;dpreview,digicamdb,imaging-resource
+Olympus;Olympus FE-230;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-240;5.744;digicamdb,dpreview,imaging-resource
 Olympus;Olympus FE-25;6.08;digicamdb
-Olympus;Olympus FE-250;7.144;dpreview,digicamdb
+Olympus;Olympus FE-250;7.144;digicamdb,dpreview
 Olympus;Olympus FE-26;6.08;digicamdb
-Olympus;Olympus FE-270;5.744;dpreview,digicamdb
-Olympus;Olympus FE-280;6.17;dpreview,digicamdb
-Olympus;Olympus FE-290;5.744;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-300;7.44;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-3000;6.08;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-3010;6.08;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-310;5.744;dpreview,digicamdb,imaging-resource
+Olympus;Olympus FE-270;5.744;digicamdb,dpreview
+Olympus;Olympus FE-280;6.17;digicamdb,dpreview
+Olympus;Olympus FE-290;5.744;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-300;7.44;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-3000;6.08;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-3010;6.08;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-310;5.744;digicamdb,dpreview,imaging-resource
 Olympus;Olympus FE-320;6.0;imaging-resource
 Olympus;Olympus FE-340;5.76;dpreview,imaging-resource
-Olympus;Olympus FE-350;5.744;dpreview,digicamdb
+Olympus;Olympus FE-350;5.744;digicamdb,dpreview
 Olympus;Olympus FE-350 Wide;5.8;imaging-resource
 Olympus;Olympus FE-360;6.03;digicamdb,imaging-resource
 Olympus;Olympus FE-370;6.03;digicamdb,imaging-resource
-Olympus;Olympus FE-4000;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus FE-4000;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus FE-4010;6.16;digicamdb
 Olympus;Olympus FE-4020;6.16;digicamdb,imaging-resource
-Olympus;Olympus FE-4030;6.08;dpreview,digicamdb
-Olympus;Olympus FE-4040;6.08;dpreview,digicamdb
+Olympus;Olympus FE-4030;6.08;digicamdb,dpreview
+Olympus;Olympus FE-4040;6.08;digicamdb,dpreview
 Olympus;Olympus FE-4050;6.16;digicamdb,imaging-resource
-Olympus;Olympus FE-45;6.08;dpreview,digicamdb
+Olympus;Olympus FE-45;6.08;digicamdb,dpreview
 Olympus;Olympus FE-46;6.2;imaging-resource
-Olympus;Olympus FE-47;6.08;dpreview,digicamdb
+Olympus;Olympus FE-47;6.08;digicamdb,dpreview
 Olympus;Olympus FE-48;6.16;digicamdb
-Olympus;Olympus FE-5000;6.08;dpreview,digicamdb
-Olympus;Olympus FE-5010;6.08;dpreview,digicamdb,imaging-resource
-Olympus;Olympus FE-5020;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus FE-5000;6.08;digicamdb,dpreview
+Olympus;Olympus FE-5010;6.08;digicamdb,dpreview,imaging-resource
+Olympus;Olympus FE-5020;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus FE-5030;6.08;digicamdb
 Olympus;Olympus FE-5035;6.08;digicamdb
-Olympus;Olympus FE-5040;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus FE-5040;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus FE-5050;6.16;digicamdb,imaging-resource
 Olympus;Olympus FE-5500;5.744;dpreview
 Olympus;Olympus IR 500;5.33;digicamdb
-Olympus;Olympus IR-300;5.744;dpreview,digicamdb
+Olympus;Olympus IR-300;5.744;digicamdb,dpreview
 Olympus;Olympus m:robe MR 500i;3.2;digicamdb
 Olympus;Olympus mju  550WP;6.08;dpreview
 Olympus;Olympus mju 1000 Digital;7.144;dpreview
@@ -4099,40 +4190,48 @@ Olympus;Olympus mju 830 Digital;6.17;dpreview
 Olympus;Olympus mju 9000;6.08;dpreview
 Olympus;Olympus mju 9010;6.08;dpreview
 Olympus;Olympus mju mini Digital;5.75;digicamdb
-Olympus;Olympus mju mini Digital S;5.744;dpreview,digicamdb
+Olympus;Olympus mju mini Digital S;5.744;digicamdb,dpreview
 Olympus;Olympus mju Tough 3000;6.08;dpreview
 Olympus;Olympus mju Tough 6000;6.17;dpreview
 Olympus;Olympus mju Tough 6010;6.17;dpreview
 Olympus;Olympus mju Tough 6020;6.08;dpreview
 Olympus;Olympus mju Tough 8000;6.08;dpreview
 Olympus;Olympus mju Tough 8010;6.08;dpreview
-Olympus;Olympus OM-D E-M1;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Olympus;Olympus OM-1;17.3;digicamdb
+Olympus;Olympus OM-D E-M1;17.3;digicamdb,dpreview,dxomark,imaging-resource
 Olympus;Olympus OM-D E-M1 II;17.4;imaging-resource
-Olympus;Olympus OM-D E-M1 Mark II;17.4;dpreview,digicamdb,dxomark
-Olympus;Olympus OM-D E-M10;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus OM-D E-M10 II;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus OM-D E-M10 III;17.4;dpreview,digicamdb,imaging-resource
+Olympus;Olympus OM-D E-M1 Mark II;17.4;digicamdb,dpreview,dxomark
+Olympus;Olympus OM-D E-M1 Mark III;17.4;imaging-resource
+Olympus;Olympus OM-D E-M10;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus OM-D E-M10 II;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus OM-D E-M10 III;17.4;digicamdb,dpreview,imaging-resource
+Olympus;Olympus OM-D E-M10 IIIs;17.4;dpreview
+Olympus;Olympus OM-D E-M10 IV;17.4;imaging-resource
 Olympus;Olympus OM-D E-M10 Mark II;17.3;dxomark
 Olympus;Olympus OM-D E-M10 Mark III;17.3;dxomark
-Olympus;Olympus OM-D E-M5;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Olympus;Olympus OM-D E-M1X;17.3;dxomark
+Olympus;Olympus OM-D E-M5;17.3;digicamdb,dpreview,dxomark,imaging-resource
 Olympus;Olympus OM-D E-M5 II;17.3;dpreview,imaging-resource
+Olympus;Olympus OM-D E-M5 III;17.4;imaging-resource
 Olympus;Olympus OM-D E-M5 Mark II;17.3;digicamdb,dxomark
 Olympus;Olympus OM-D E-M5 Mark III;17.3;digicamdb,dxomark
-Olympus;Olympus PEN E-P1;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus PEN E-P2;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus PEN E-P3;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus PEN E-P5;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus PEN E-PL1;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus PEN E-PL1s;17.3;dpreview,digicamdb
-Olympus;Olympus PEN E-PL2;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus PEN E-PL3;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus PEN E-PL5;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus PEN E-PL6;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus PEN E-PL7;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus PEN E-PL8;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus PEN E-PL9;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus PEN E-PM1;17.3;dpreview,digicamdb,imaging-resource
-Olympus;Olympus PEN E-PM2;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Olympus;Olympus PEN E-P1;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus PEN E-P2;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus PEN E-P3;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus PEN E-P5;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus PEN E-P7;17.4;imaging-resource
+Olympus;Olympus PEN E-PL1;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus PEN E-PL10;17.3;digicamdb
+Olympus;Olympus PEN E-PL1s;17.3;digicamdb,dpreview
+Olympus;Olympus PEN E-PL2;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus PEN E-PL3;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus PEN E-PL5;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus PEN E-PL6;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus PEN E-PL7;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus PEN E-PL8;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus PEN E-PL9;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus PEN E-PM1;17.3;digicamdb,dpreview,imaging-resource
+Olympus;Olympus PEN E-PM2;17.3;digicamdb,dpreview,dxomark,imaging-resource
 Olympus;Olympus PEN EP1;17.3;dxomark
 Olympus;Olympus PEN EP2;17.3;dxomark
 Olympus;Olympus PEN EP3;17.3;dxomark
@@ -4141,7 +4240,7 @@ Olympus;Olympus PEN EPL2;17.3;dxomark
 Olympus;Olympus PEN EPL3;17.3;dxomark
 Olympus;Olympus PEN EPM1;17.3;dxomark
 Olympus;Olympus PEN Lite E-PL1s;17.3;imaging-resource
-Olympus;Olympus PEN-F;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Olympus;Olympus PEN-F;17.3;digicamdb,dpreview,dxomark,imaging-resource
 Olympus;Olympus SH-21;6.16;digicamdb,imaging-resource
 Olympus;Olympus SH-25MR;6.16;digicamdb
 Olympus;Olympus SH-50;6.17;dpreview
@@ -4172,15 +4271,15 @@ Olympus;Olympus SP-550 UZ;5.744;dpreview
 Olympus;Olympus SP-560 UltraZoom;6.0;imaging-resource
 Olympus;Olympus SP-560 UZ;6.17;dpreview
 Olympus;Olympus SP-565 UltraZoom;6.1;imaging-resource
-Olympus;Olympus SP-565UZ;6.08;dpreview,digicamdb
+Olympus;Olympus SP-565UZ;6.08;digicamdb,dpreview
 Olympus;Olympus SP-570 UltraZoom;6.1;imaging-resource
 Olympus;Olympus SP-570 UZ;6.08;dpreview
 Olympus;Olympus SP-590 UltraZoom;6.1;imaging-resource
 Olympus;Olympus SP-590 UZ;6.08;dpreview
 Olympus;Olympus SP-600 UZ;6.08;dpreview
 Olympus;Olympus SP-600UZ;6.2;imaging-resource
-Olympus;Olympus SP-610UZ;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus SP-620 UZ;6.17;dpreview,digicamdb
+Olympus;Olympus SP-610UZ;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus SP-620 UZ;6.17;digicamdb,dpreview
 Olympus;Olympus SP-620UZ;6.2;imaging-resource
 Olympus;Olympus SP-700;5.744;dpreview
 Olympus;Olympus SP-720UZ;6.16;digicamdb,imaging-resource
@@ -4189,71 +4288,71 @@ Olympus;Olympus SP-800UZ;6.2;imaging-resource
 Olympus;Olympus SP-810 UZ;6.17;dpreview
 Olympus;Olympus SP-810UZ;6.2;imaging-resource
 Olympus;Olympus SP-820UZ;6.2;imaging-resource
-Olympus;Olympus Stylus 1;7.44;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 1000;7.144;dpreview,digicamdb
-Olympus;Olympus Stylus 1010;6.08;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 1020;6.08;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 1030 SW;6.08;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 1040;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus 1050 SW;6.08;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 1200;7.44;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 1s;7.44;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 300;5.744;dpreview,digicamdb
-Olympus;Olympus Stylus 400;5.744;dpreview,digicamdb
-Olympus;Olympus Stylus 410;5.744;dpreview,digicamdb
-Olympus;Olympus Stylus 500;5.744;dpreview,digicamdb
-Olympus;Olympus Stylus 5010;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus 550WP;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus 600;5.744;dpreview,digicamdb
-Olympus;Olympus Stylus 700;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus 7000;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus 7010;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus 7030;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus 7040;6.08;dpreview,digicamdb
+Olympus;Olympus Stylus 1;7.44;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 1000;7.144;digicamdb,dpreview
+Olympus;Olympus Stylus 1010;6.08;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 1020;6.08;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 1030 SW;6.08;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 1040;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus 1050 SW;6.08;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 1200;7.44;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 1s;7.44;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 300;5.744;digicamdb,dpreview
+Olympus;Olympus Stylus 400;5.744;digicamdb,dpreview
+Olympus;Olympus Stylus 410;5.744;digicamdb,dpreview
+Olympus;Olympus Stylus 500;5.744;digicamdb,dpreview
+Olympus;Olympus Stylus 5010;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus 550WP;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus 600;5.744;digicamdb,dpreview
+Olympus;Olympus Stylus 700;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus 7000;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus 7010;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus 7030;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus 7040;6.08;digicamdb,dpreview
 Olympus;Olympus Stylus 710;6.2;imaging-resource
-Olympus;Olympus Stylus 720 SW;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus 725 SW;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus 730;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 740;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 750;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 760;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 770 SW;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus 780;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus 790 SW;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus 800;7.144;dpreview,digicamdb
-Olympus;Olympus Stylus 810;7.144;dpreview,digicamdb
-Olympus;Olympus Stylus 820;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus 830;6.17;dpreview,digicamdb
+Olympus;Olympus Stylus 720 SW;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus 725 SW;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus 730;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 740;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 750;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 760;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 770 SW;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus 780;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus 790 SW;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus 800;7.144;digicamdb,dpreview
+Olympus;Olympus Stylus 810;7.144;digicamdb,dpreview
+Olympus;Olympus Stylus 820;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus 830;6.17;digicamdb,dpreview
 Olympus;Olympus Stylus 840;6.03;digicamdb,imaging-resource
 Olympus;Olympus Stylus 850 SW;6.03;digicamdb,imaging-resource
-Olympus;Olympus Stylus 9000;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus 9010;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus SH-1;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Stylus SH-2;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Olympus;Olympus Stylus SH-3;6.17;dpreview,digicamdb,dxomark
+Olympus;Olympus Stylus 9000;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus 9010;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus SH-1;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Stylus SH-2;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus Stylus SH-3;6.17;digicamdb,dpreview,dxomark
 Olympus;Olympus Stylus SH-50;6.2;imaging-resource
 Olympus;Olympus Stylus SP-100;6.17;dpreview,imaging-resource
-Olympus;Olympus Stylus SP-820UZ;6.17;dpreview,digicamdb
+Olympus;Olympus Stylus SP-820UZ;6.17;digicamdb,dpreview
 Olympus;Olympus Stylus SZ-15;6.2;imaging-resource
 Olympus;Olympus Stylus SZ-16;6.2;imaging-resource
 Olympus;Olympus Stylus Tough 3000;6.08;dpreview
-Olympus;Olympus Stylus Tough 6000;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus Tough 6010;6.17;dpreview,digicamdb
-Olympus;Olympus Stylus Tough 6020;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus Tough 8000;6.08;dpreview,digicamdb
-Olympus;Olympus Stylus Tough 8010;6.08;dpreview,digicamdb
+Olympus;Olympus Stylus Tough 6000;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus Tough 6010;6.17;digicamdb,dpreview
+Olympus;Olympus Stylus Tough 6020;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus Tough 8000;6.08;digicamdb,dpreview
+Olympus;Olympus Stylus Tough 8010;6.08;digicamdb,dpreview
 Olympus;Olympus Stylus Tough TG-850 iHS;6.17;dpreview
 Olympus;Olympus Stylus Tough TG-860;6.17;dpreview
-Olympus;Olympus Stylus Tough TG-870;6.17;dpreview,digicamdb
+Olympus;Olympus Stylus Tough TG-870;6.17;digicamdb,dpreview
 Olympus;Olympus Stylus Tough-3000;6.08;digicamdb
 Olympus;Olympus Stylus Tough-6000;6.2;imaging-resource
 Olympus;Olympus Stylus Tough-6020;6.2;imaging-resource
 Olympus;Olympus Stylus Tough-8000;6.1;imaging-resource
 Olympus;Olympus Stylus Tough-8010;6.2;imaging-resource
-Olympus;Olympus Stylus Verve;5.744;dpreview,digicamdb
-Olympus;Olympus Stylus Verve  S;5.744;dpreview,digicamdb
+Olympus;Olympus Stylus Verve;5.744;digicamdb,dpreview
+Olympus;Olympus Stylus Verve  S;5.744;digicamdb,dpreview
 Olympus;Olympus Stylus Verve S;5.75;usercontribution
-Olympus;Olympus Stylus XZ-10;6.17;dpreview,digicamdb,imaging-resource,dxomark
+Olympus;Olympus Stylus XZ-10;6.17;digicamdb,dpreview,dxomark,imaging-resource
 Olympus;Olympus Stylus XZ-2;7.6;imaging-resource
 Olympus;Olympus Stylus-5010;6.2;imaging-resource
 Olympus;Olympus Stylus-550WP;6.1;imaging-resource
@@ -4264,40 +4363,41 @@ Olympus;Olympus Stylus-7040;6.2;imaging-resource
 Olympus;Olympus Stylus-7050;6.2;imaging-resource
 Olympus;Olympus Stylus-9000;6.1;imaging-resource
 Olympus;Olympus Stylus1;7.4;dxomark
-Olympus;Olympus SZ-10;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus SZ-11;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus SZ-12;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus SZ-10;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus SZ-11;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus SZ-12;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus SZ-14;6.16;digicamdb
-Olympus;Olympus SZ-15;6.17;dpreview,digicamdb
+Olympus;Olympus SZ-15;6.17;digicamdb,dpreview
 Olympus;Olympus SZ-16;6.16;digicamdb
 Olympus;Olympus SZ-16 iHS;6.17;dpreview
 Olympus;Olympus SZ-20;6.16;digicamdb
-Olympus;Olympus SZ-30MR;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus SZ-30MR;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus SZ-31MR;6.2;imaging-resource
-Olympus;Olympus SZ-31MR iHS;6.17;dpreview,digicamdb
+Olympus;Olympus SZ-31MR iHS;6.17;digicamdb,dpreview
 Olympus;Olympus T-10;6.16;digicamdb,imaging-resource
 Olympus;Olympus T-100;6.16;digicamdb
 Olympus;Olympus T-110;6.16;digicamdb,imaging-resource
 Olympus;Olympus TG-1;6.16;usercontribution
 Olympus;Olympus TG-3;6.16;usercontribution
-Olympus;Olympus TG-310;6.17;dpreview,digicamdb
-Olympus;Olympus TG-320;6.17;dpreview,digicamdb
+Olympus;Olympus TG-310;6.17;digicamdb,dpreview
+Olympus;Olympus TG-320;6.17;digicamdb,dpreview
 Olympus;Olympus TG-5;6.16;usercontribution
-Olympus;Olympus TG-610;6.17;dpreview,digicamdb
-Olympus;Olympus TG-630 iHS;6.17;dpreview,digicamdb
-Olympus;Olympus TG-810;6.17;dpreview,digicamdb
-Olympus;Olympus TG-820 iHS;6.17;dpreview,digicamdb
-Olympus;Olympus TG-830 iHS;6.17;dpreview,digicamdb
+Olympus;Olympus TG-610;6.17;digicamdb,dpreview
+Olympus;Olympus TG-630 iHS;6.17;digicamdb,dpreview
+Olympus;Olympus TG-810;6.17;digicamdb,dpreview
+Olympus;Olympus TG-820 iHS;6.17;digicamdb,dpreview
+Olympus;Olympus TG-830 iHS;6.17;digicamdb,dpreview
 Olympus;Olympus TG-850 iHS;6.16;digicamdb
 Olympus;Olympus Tough TG-1;6.2;imaging-resource
-Olympus;Olympus Tough TG-1 iHS;6.17;dpreview,digicamdb
+Olympus;Olympus Tough TG-1 iHS;6.17;digicamdb,dpreview
 Olympus;Olympus Tough TG-2;6.2;imaging-resource
-Olympus;Olympus Tough TG-2 iHS;6.17;dpreview,digicamdb
-Olympus;Olympus Tough TG-3;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus Tough TG-2 iHS;6.17;digicamdb,dpreview
+Olympus;Olympus Tough TG-3;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus Tough TG-310;6.2;imaging-resource
 Olympus;Olympus Tough TG-320;6.2;imaging-resource
-Olympus;Olympus Tough TG-4;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus Tough TG-5;6.17;dpreview,digicamdb,imaging-resource,dxomark
+Olympus;Olympus Tough TG-4;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus Tough TG-5;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Olympus;Olympus Tough TG-6;6.16;digicamdb
 Olympus;Olympus Tough TG-610;6.2;imaging-resource
 Olympus;Olympus Tough TG-620;6.16;digicamdb
 Olympus;Olympus Tough TG-630;6.2;imaging-resource
@@ -4308,25 +4408,25 @@ Olympus;Olympus Tough TG-850;6.2;imaging-resource
 Olympus;Olympus Tough TG-860;6.16;digicamdb,imaging-resource
 Olympus;Olympus Tough TG-870;6.2;imaging-resource
 Olympus;Olympus Tough TG-Tracker;6.2;imaging-resource
-Olympus;Olympus VG-110;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus VG-120;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus VG-110;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus VG-120;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus VG-130;6.16;digicamdb
-Olympus;Olympus VG-145;6.17;dpreview,digicamdb
+Olympus;Olympus VG-145;6.17;digicamdb,dpreview
 Olympus;Olympus VG-150;6.16;digicamdb,imaging-resource
-Olympus;Olympus VG-160;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus VG-160;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus VG-165;6.16;digicamdb
 Olympus;Olympus VG-170;6.16;digicamdb,imaging-resource
 Olympus;Olympus VG-180;6.16;digicamdb
 Olympus;Olympus VG-190;6.16;digicamdb
 Olympus;Olympus VH-210;6.16;digicamdb,imaging-resource
-Olympus;Olympus VH-410;6.17;dpreview,digicamdb
+Olympus;Olympus VH-410;6.17;digicamdb,dpreview
 Olympus;Olympus VH-510;6.16;digicamdb
-Olympus;Olympus VH-515;6.17;dpreview,digicamdb
+Olympus;Olympus VH-515;6.17;digicamdb,dpreview
 Olympus;Olympus VH-520;6.16;digicamdb
 Olympus;Olympus VR-310;6.16;digicamdb
-Olympus;Olympus VR-320;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus VR-330;6.17;dpreview,digicamdb,imaging-resource
-Olympus;Olympus VR-340;6.17;dpreview,digicamdb,imaging-resource
+Olympus;Olympus VR-320;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus VR-330;6.17;digicamdb,dpreview,imaging-resource
+Olympus;Olympus VR-340;6.17;digicamdb,dpreview,imaging-resource
 Olympus;Olympus VR-350;6.16;digicamdb
 Olympus;Olympus VR-360;6.16;digicamdb,imaging-resource
 Olympus;Olympus VR-370;6.16;digicamdb
@@ -4342,8 +4442,10 @@ Olympus;Olympus X-920;6.16;digicamdb
 Olympus;Olympus X-925;6.17;dpreview
 Olympus;Olympus X-935;6.17;dpreview
 Olympus;Olympus XZ-1;7.85;digicamdb
-Olympus;Olympus XZ-2 iHS;7.44;dpreview,digicamdb,dxomark
+Olympus;Olympus XZ-2 iHS;7.44;digicamdb,dpreview,dxomark
 Olympus;Olympus XZ1;7.9;dxomark
+Olympus;OM System OM-1;17.4;dpreview
+Olympus;OM System OM-5;17.4;dpreview
 OLYMPUS;SP550UZ;5.76;usercontribution
 OLYMPUS;X100;5.27;usercontribution
 OLYMPUS CORPORATION;C-5000Z;7.176;usercontribution
@@ -4357,7 +4459,6 @@ OLYMPUS CORPORATION;D560Z;5.76;usercontribution
 OLYMPUS CORPORATION;D580Z;5.27;usercontribution
 OLYMPUS CORPORATION;E-M10MarkII;17.3;usercontribution
 OLYMPUS CORPORATION;E-M1MarkII;17.3;usercontribution
-OLYMPUS CORPORATION;E-M1MarkII;17.4;dpreview,imaging-resource,dxomark,olympus
 OLYMPUS CORPORATION;X-3,C-60Z;7.176;usercontribution
 OLYMPUS CORPORATION;X250;5.76;usercontribution
 OLYMPUS CORPORATION;X400;5.27;usercontribution
@@ -4448,7 +4549,6 @@ Oppo;Oppo Find 5;4.69;devicespecifications
 Oppo;Oppo Find 7;4.69;devicespecifications
 Oppo;Oppo Find 7a;4.69;devicespecifications
 Oppo;Oppo Find X2;6.4;kimovil
-Oppo;Oppo Find X2 Lite;6.4;kimovil
 Oppo;Oppo Find X2 Lite;6.4;kimovil
 Oppo;Oppo Find X2 Neo;6.4;kimovil
 Oppo;Oppo Mirror 3;4.54;devicespecifications
@@ -4549,30 +4649,45 @@ Panasonic;Panasonic Eluga Switch;4.69;devicespecifications
 Panasonic;Panasonic GF90;17.3;dpreview
 Panasonic;Panasonic Lumix BGH1;19.0;usercontribution
 Panasonic;Panasonic Lumix BS1H;35.6;usercontribution
-Panasonic;Panasonic Lumix DC-FT7;6.17;dpreview,digicamdb
-Panasonic;Panasonic Lumix DC-FZ80;6.17;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DC-FZ82;6.17;dpreview,digicamdb,dxomark
-Panasonic;Panasonic Lumix DC-G9;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Panasonic;Panasonic Lumix DC-BGH1;17.3;digicamdb
+Panasonic;Panasonic Lumix DC-BS1H;35.6;digicamdb
+Panasonic;Panasonic Lumix DC-FT7;6.17;digicamdb,dpreview
+Panasonic;Panasonic Lumix DC-FZ1000 II;13.2;dxomark
+Panasonic;Panasonic Lumix DC-FZ80;6.17;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DC-FZ82;6.17;digicamdb,dpreview,dxomark
+Panasonic;Panasonic Lumix DC-G100;17.3;imaging-resource
+Panasonic;Panasonic Lumix DC-G110;17.3;dpreview
+Panasonic;Panasonic Lumix DC-G9;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DC-G90;17.3;dxomark
+Panasonic;Panasonic Lumix DC-G91;17.3;digicamdb
+Panasonic;Panasonic Lumix DC-G95;17.3;digicamdb
 Panasonic;Panasonic Lumix DC-GF10;17.3;dpreview
 Panasonic;Panasonic Lumix DC-GF9;17.3;digicamdb
 Panasonic;Panasonic Lumix DC-GF90;17.3;dxomark
-Panasonic;Panasonic Lumix DC-GH5;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DC-GH5S;17.3;digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DC-GX800;17.3;dpreview,digicamdb,dxomark
-Panasonic;Panasonic Lumix DC-GX850;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DC-GX9;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DC-LX100 II;17.3;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DC-GH5;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DC-GH5 II;17.3;dxomark
+Panasonic;Panasonic Lumix DC-GH5M2;17.3;dpreview
+Panasonic;Panasonic Lumix DC-GH5S;17.3;digicamdb,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DC-GH6;17.3;imaging-resource
+Panasonic;Panasonic Lumix DC-GX800;17.3;digicamdb,dpreview,dxomark
+Panasonic;Panasonic Lumix DC-GX850;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DC-GX9;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DC-LX100 II;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DC-S1;35.6;dxomark
 Panasonic;Panasonic Lumix DC-S1H;35.6;usercontribution
-Panasonic;Panasonic Lumix DC-TS7;6.17;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DC-TZ200;13.2;dpreview,digicamdb
+Panasonic;Panasonic Lumix DC-S1R;36.0;dxomark
+Panasonic;Panasonic Lumix DC-S5;35.6;digicamdb
+Panasonic;Panasonic Lumix DC-TS7;6.17;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DC-TZ200;13.2;digicamdb,dpreview
 Panasonic;Panasonic Lumix DC-TZ90;6.16;usercontribution
-Panasonic;Panasonic Lumix DC-TZ90;6.17;dpreview,digicamdb
 Panasonic;Panasonic Lumix DC-TZ91;6.16;usercontribution
 Panasonic;Panasonic Lumix DC-TZ92;6.16;usercontribution
 Panasonic;Panasonic Lumix DC-TZ93;6.16;usercontribution
-Panasonic;Panasonic Lumix DC-ZS200;13.2;dpreview,digicamdb,imaging-resource,dxomark
+Panasonic;Panasonic Lumix DC-TZ95;6.16;dxomark
+Panasonic;Panasonic Lumix DC-ZS200;13.2;digicamdb,dpreview,dxomark,imaging-resource
 Panasonic;Panasonic Lumix DC-ZS70;6.16;usercontribution
-Panasonic;Panasonic Lumix DC-ZS70;6.17;dpreview,digicamdb,imaging-resource,dxomark
+Panasonic;Panasonic Lumix DC-ZS80;6.16;digicamdb
+Panasonic;Panasonic Lumix DCS5;35.6;dxomark
 Panasonic;Panasonic Lumix DMC FX150;7.0;dxomark
 Panasonic;Panasonic Lumix DMC G1;17.3;dxomark
 Panasonic;Panasonic Lumix DMC G10;17.3;dxomark
@@ -4594,275 +4709,275 @@ Panasonic;Panasonic Lumix DMC LX10;13.2;dxomark
 Panasonic;Panasonic Lumix DMC LX3;7.9;dxomark
 Panasonic;Panasonic Lumix DMC LX5;7.9;dxomark
 Panasonic;Panasonic Lumix DMC LX7;7.4;dxomark
-Panasonic;Panasonic Lumix DMC-3D1;6.17;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-3D1;6.17;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-CM1;12.8;dxomark
 Panasonic;Panasonic Lumix DMC-F1;5.75;digicamdb
 Panasonic;Panasonic Lumix DMC-F3;6.08;digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-F5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-F7;5.312;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FH1;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH10;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH2;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH20;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH22;6.08;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-F5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-F7;5.312;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FH1;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH10;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH2;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH20;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH22;6.08;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-FH25;6.08;dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-FH27;6.08;dpreview,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH3;6.08;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH3;6.08;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-FH4;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-FH5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH6;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH7;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FH8;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FP1;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FP2;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FP3;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FP5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FP7;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FP8;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FS10;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS11;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS12;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS15;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FS16;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS18;6.08;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-FH5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH6;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH7;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FH8;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FP1;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FP2;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FP3;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FP5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FP7;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FP8;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FS10;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS11;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS12;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS15;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FS16;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS18;6.08;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-FS2;5.75;digicamdb
-Panasonic;Panasonic Lumix DMC-FS20;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FS22;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS25;6.08;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-FS20;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FS22;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS25;6.08;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-FS28;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-FS3;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FS30;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS33;6.08;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-FS3;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FS30;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS33;6.08;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-FS35;6.16;digicamdb
 Panasonic;Panasonic Lumix DMC-FS37;6.16;digicamdb
 Panasonic;Panasonic Lumix DMC-FS40;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-FS42;5.744;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-FS42;5.744;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-FS45;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-FS5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FS6;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS62;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FS7;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FT1;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT10;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT2;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT20;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT25;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT3;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT30;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT4;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT5;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FT6;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX01;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX07;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX1;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX10;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX100;7.44;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX12;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX150;7.44;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX2;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX3;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX30;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX33;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX35;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX37;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX40;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX48;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX5;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX50;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX500;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX55;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX550;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX580;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX60;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX65;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX66;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX68;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX7;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX70;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX700;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX75;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX77;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX78;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FX8;5.744;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-FS5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FS6;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS62;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FS7;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FT1;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT10;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT2;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT20;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT25;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT3;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT30;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT4;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT5;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FT6;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX01;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX07;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX1;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX10;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX100;7.44;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX12;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX150;7.44;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX2;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX3;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX30;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX33;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX35;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX37;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX40;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX48;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX5;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX50;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX500;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX55;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX550;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX580;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX60;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX65;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX66;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX68;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX7;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX70;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX700;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX75;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX77;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX78;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FX8;5.744;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-FX80;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-FX9;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FX90;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ1;4.544;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ10;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ100;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ1000;13.2;dpreview,digicamdb,imaging-resource,dxomark
+Panasonic;Panasonic Lumix DMC-FX9;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FX90;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ1;4.544;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ10;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ100;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ1000;13.2;digicamdb,dpreview,dxomark,imaging-resource
 Panasonic;Panasonic Lumix DMC-FZ15;5.75;digicamdb
 Panasonic;Panasonic Lumix DMC-FZ150;6.17;dpreview,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ18;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ2;4.544;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ20;5.744;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-FZ18;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ2;4.544;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ20;5.744;digicamdb,dpreview
 Panasonic;Panasonic LUMIX DMC-FZ200;6.1;dxomark
-Panasonic;Panasonic Lumix DMC-FZ2000;13.2;dpreview,digicamdb,dxomark
-Panasonic;Panasonic Lumix DMC-FZ2500;13.2;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ28;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ3;4.544;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ30;7.144;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ300;6.17;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ2000;13.2;digicamdb,dpreview,dxomark
+Panasonic;Panasonic Lumix DMC-FZ2500;13.2;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ28;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ3;4.544;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ30;7.144;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ300;6.17;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-FZ330;6.2;dxomark
-Panasonic;Panasonic Lumix DMC-FZ35;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ38;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ4;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ40;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ45;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ47;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ48;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ5;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ50;7.144;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ60;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ62;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-FZ7;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-FZ70;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-FZ8;5.744;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ35;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ38;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ4;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ40;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ45;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ47;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ48;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ5;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ50;7.144;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ60;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ62;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-FZ7;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ70;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-FZ8;5.744;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-FZH1;13.2;digicamdb
-Panasonic;Panasonic Lumix DMC-G1;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-G10;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-G2;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-G3;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-G5;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-G6;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-G7;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Panasonic;Panasonic Lumix DMC-G1;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-G10;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-G2;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-G3;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-G5;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-G6;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-G7;17.3;digicamdb,dpreview,dxomark,imaging-resource
 Panasonic;Panasonic Lumix DMC-G8;17.3;digicamdb
-Panasonic;Panasonic Lumix DMC-G80;17.3;dpreview,digicamdb,dxomark
+Panasonic;Panasonic Lumix DMC-G80;17.3;digicamdb,dpreview,dxomark
 Panasonic;Panasonic Lumix DMC-G81;17.3;digicamdb
-Panasonic;Panasonic Lumix DMC-G85;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GF1;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GF2;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GF3;17.3;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-G85;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GF1;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GF2;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GF3;17.3;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-GF3X;17.3;imaging-resource
-Panasonic;Panasonic Lumix DMC-GF5;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GF6;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GF7;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GF8;17.3;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-GF5;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GF6;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GF7;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GF8;17.3;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-GH1;17.3;digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GH2;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GH3;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-GH4;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-GM1;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Panasonic;Panasonic Lumix DMC-GH2;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GH3;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-GH4;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-GM1;17.3;digicamdb,dpreview,dxomark,imaging-resource
 Panasonic;Panasonic Lumix DMC-GM1S;17.3;usercontribution
-Panasonic;Panasonic Lumix DMC-GM5;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-GX1;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-GX7;17.3;dpreview,digicamdb,imaging-resource,dxomark
+Panasonic;Panasonic Lumix DMC-GM5;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-GX1;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-GX7;17.3;digicamdb,dpreview,dxomark,imaging-resource
 Panasonic;Panasonic Lumix DMC-GX7 Mark II;17.3;digicamdb
 Panasonic;Panasonic Lumix DMC-GX7MK2;17.3;usercontribution
-Panasonic;Panasonic Lumix DMC-GX8;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-GX80;17.3;dpreview,digicamdb,dxomark
-Panasonic;Panasonic Lumix DMC-GX85;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-L1;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-L10;17.3;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LC1;8.8;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LC20;5.312;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LC33;5.744;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-GX8;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-GX80;17.3;digicamdb,dpreview,dxomark
+Panasonic;Panasonic Lumix DMC-GX85;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-L1;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-L10;17.3;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LC1;8.8;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LC20;5.312;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LC33;5.744;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-LC40;7.53;digicamdb
-Panasonic;Panasonic Lumix DMC-LC43;5.744;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-LC43;5.744;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-LC5;7.53;digicamdb
-Panasonic;Panasonic Lumix DMC-LC50;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LC70;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LC80;5.744;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-LC50;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LC70;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LC80;5.744;digicamdb,dpreview
 Panasonic;Panasonic LUMIX DMC-LF1;7.44;dxomark
-Panasonic;Panasonic Lumix DMC-LS1;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LS2;5.744;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-LS1;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LS2;5.744;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-LS3;5.75;digicamdb
-Panasonic;Panasonic Lumix DMC-LS5;6.08;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-LS5;6.08;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-LS6;6.08;digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LS60;5.744;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-LS60;5.744;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-LS70;5.8;imaging-resource
-Panasonic;Panasonic Lumix DMC-LS75;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LS80;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LS85;5.744;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-LS75;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LS80;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LS85;5.744;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-LX1;7.76;digicamdb
-Panasonic;Panasonic Lumix DMC-LX10;13.2;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LX100;17.3;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-LX15;13.2;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-LX10;13.2;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LX100;17.3;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-LX15;13.2;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-LX2;7.76;digicamdb,imaging-resource
 Panasonic;Panasonic Lumix DMC-LX3;7.85;digicamdb
 Panasonic;Panasonic Lumix DMC-LX5;7.85;digicamdb
-Panasonic;Panasonic Lumix DMC-LX7;7.44;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-LX7;7.44;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-LX9;13.2;digicamdb
-Panasonic;Panasonic Lumix DMC-LZ1;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LZ10;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LZ2;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LZ20;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LZ3;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LZ30;6.17;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-LZ40;6.17;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LZ5;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LZ6;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-LZ7;5.744;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-LZ1;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LZ10;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LZ2;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LZ20;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LZ3;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LZ30;6.17;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-LZ40;6.17;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LZ5;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LZ6;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-LZ7;5.744;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-LZ7 ;5.8;imaging-resource
-Panasonic;Panasonic Lumix DMC-LZ8;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-S1;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-S2;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-S3;6.08;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-LZ8;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-S1;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-S2;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-S3;6.08;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-S5;6.08;digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-SZ1;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-SZ10;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-SZ3;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-SZ5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-SZ7;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-SZ8;6.08;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-SZ1;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-SZ10;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-SZ3;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-SZ5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-SZ7;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-SZ8;6.08;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-SZ9;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-TS1;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS10;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS2;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS20;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS25;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS3;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS30;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS4;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TS6;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TZ1;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TZ10;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ100;13.2;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ18;6.08;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-TS1;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS10;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS2;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS20;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS25;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS3;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS30;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS4;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TS6;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TZ1;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TZ10;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ100;13.2;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ18;6.08;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-TZ2;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-TZ20;6.08;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-TZ20;6.08;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-TZ22;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-TZ25;6.17;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-TZ25;6.17;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-TZ3;6.08;digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TZ30;6.08;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-TZ30;6.08;digicamdb,dpreview
 Panasonic;Panasonic Lumix DMC-TZ31;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-TZ35;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ4;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TZ40;6.17;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TZ50;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-TZ55;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ57;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ6;5.744;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ60;6.17;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ7;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ70;6.17;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ8;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-TZ80;6.17;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-XS1;6.08;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-TZ35;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ4;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TZ40;6.17;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TZ50;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-TZ55;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ57;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ6;5.744;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ60;6.17;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ7;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ70;6.17;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ8;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-TZ80;6.17;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-XS1;6.08;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-XS3;6.08;digicamdb
-Panasonic;Panasonic Lumix DMC-ZR1;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZR3;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS1;5.744;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS10;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS100;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-ZS15;6.17;dpreview,digicamdb,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZR1;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZR3;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS1;5.744;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS10;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS100;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS15;6.17;digicamdb,dpreview,imaging-resource
 Panasonic;Panasonic Lumix DMC-ZS19;6.1;imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS20;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS25;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS3;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS30;6.17;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS35;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS40;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-ZS45;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS5;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS50;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-ZS60;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Panasonic;Panasonic Lumix DMC-ZS7;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZS8;6.08;dpreview,digicamdb,imaging-resource
-Panasonic;Panasonic Lumix DMC-ZX1;6.08;dpreview,digicamdb
-Panasonic;Panasonic Lumix DMC-ZX3;6.08;dpreview,digicamdb
+Panasonic;Panasonic Lumix DMC-ZS20;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS25;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS3;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS30;6.17;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS35;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS40;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS45;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS5;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS50;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS60;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS7;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZS8;6.08;digicamdb,dpreview,imaging-resource
+Panasonic;Panasonic Lumix DMC-ZX1;6.08;digicamdb,dpreview
+Panasonic;Panasonic Lumix DMC-ZX3;6.08;digicamdb,dpreview
 Panasonic;Panasonic Lumix GH4R;17.3;dxomark
 Panasonic;Panasonic Lumix GH5;17.3;usercontribution
 Panasonic;Panasonic Lumix GH5 II;17.3;usercontribution
@@ -4876,173 +4991,172 @@ Panasonic;Panasonic T44;2.95;devicespecifications
 Parrot;Anafi;5.9;devicespecifications
 Parrot;Bebop;8.4;usercontribution
 PENTAX;Optio330RS;7.176;usercontribution
-Pentax;Pentax *ist D;23.5;dpreview,digicamdb
-Pentax;Pentax *ist DL;23.5;dpreview,digicamdb
-Pentax;Pentax *ist DL2;23.5;dpreview,digicamdb,imaging-resource
-Pentax;Pentax *ist DS;23.5;dpreview,digicamdb
-Pentax;Pentax *ist DS2;23.5;dpreview,digicamdb
-Pentax;Pentax 645D;44.0;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax 645Z;43.8;imaging-resource,dxomark
+Pentax;Pentax *ist D;23.5;digicamdb,dpreview
+Pentax;Pentax *ist DL;23.5;digicamdb,dpreview
+Pentax;Pentax *ist DL2;23.5;digicamdb,dpreview,imaging-resource
+Pentax;Pentax *ist DS;23.5;digicamdb,dpreview
+Pentax;Pentax *ist DS2;23.5;digicamdb,dpreview
+Pentax;Pentax 645D;44.0;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax 645Z;43.8;dxomark,imaging-resource
 Pentax;Pentax 645Z IR;43.8;dxomark
-Pentax;Pentax Efina;6.17;dpreview,digicamdb
-Pentax;Pentax EI-100;4.544;dpreview,digicamdb
-Pentax;Pentax EI-200;5.312;dpreview,digicamdb
-Pentax;Pentax EI-2000;8.8;dpreview,digicamdb
+Pentax;Pentax Efina;6.17;digicamdb,dpreview
+Pentax;Pentax EI-100;4.544;digicamdb,dpreview
+Pentax;Pentax EI-200;5.312;digicamdb,dpreview
+Pentax;Pentax EI-2000;8.8;digicamdb,dpreview
 Pentax;Pentax K 01;23.7;dxomark
-Pentax;Pentax K-01;23.7;dpreview,digicamdb,imaging-resource
-Pentax;Pentax K-1;35.9;dpreview,digicamdb,imaging-resource,dxomark
+Pentax;Pentax K-01;23.7;digicamdb,dpreview,imaging-resource
+Pentax;Pentax K-1;35.9;digicamdb,dpreview,dxomark,imaging-resource
 Pentax;Pentax K-1 II;35.9;imaging-resource
-Pentax;Pentax K-1 Mark II;35.9;dpreview,digicamdb,dxomark
-Pentax;Pentax K-3;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-3 II;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-30;23.7;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-5;23.7;dpreview,digicamdb,imaging-resource
-Pentax;Pentax K-5 II;23.7;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-5 IIs;23.7;dpreview,imaging-resource,dxomark
-Pentax;Pentax K-50;23.7;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-500;23.7;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-7;23.4;dpreview,digicamdb
-Pentax;Pentax K-70;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-m;23.5;dpreview,digicamdb
-Pentax;Pentax K-r;23.6;dpreview,digicamdb,imaging-resource
-Pentax;Pentax K-S1;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-x;23.6;dpreview,digicamdb,imaging-resource
-Pentax;Pentax K100D;23.5;dpreview,digicamdb
-Pentax;Pentax K100D Super;23.5;dpreview,digicamdb
-Pentax;Pentax K10D;23.5;dpreview,digicamdb
+Pentax;Pentax K-1 Mark II;35.9;digicamdb,dpreview,dxomark
+Pentax;Pentax K-3;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-3 II;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-3 III;23.3;imaging-resource
+Pentax;Pentax K-3 Mark III;23.0;dpreview
+Pentax;Pentax K-30;23.7;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-5;23.7;digicamdb,dpreview,imaging-resource
+Pentax;Pentax K-5 II;23.7;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-5 IIs;23.7;dpreview,dxomark,imaging-resource
+Pentax;Pentax K-50;23.7;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-500;23.7;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-7;23.4;digicamdb,dpreview
+Pentax;Pentax K-70;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-m;23.5;digicamdb,dpreview
+Pentax;Pentax K-r;23.6;digicamdb,dpreview,imaging-resource
+Pentax;Pentax K-S1;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax K-S2;23.5;dxomark
+Pentax;Pentax K-x;23.6;digicamdb,dpreview,imaging-resource
+Pentax;Pentax K100D;23.5;digicamdb,dpreview
+Pentax;Pentax K100D Super;23.5;digicamdb,dpreview
+Pentax;Pentax K10D;23.5;digicamdb,dpreview
 Pentax;Pentax K110D;23.7;digicamdb
 Pentax;Pentax K2000;23.7;imaging-resource
-Pentax;Pentax K200D;23.5;dpreview,digicamdb
-Pentax;Pentax K20D;23.4;dpreview,digicamdb
+Pentax;Pentax K200D;23.5;digicamdb,dpreview
+Pentax;Pentax K20D;23.4;digicamdb,dpreview
 Pentax;Pentax K5;23.7;dxomark
 Pentax;Pentax K7;23.4;dxomark
 Pentax;Pentax KM;24.0;dxomark
-Pentax;Pentax KP;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Pentax;Pentax KP;23.5;digicamdb,dpreview,dxomark,imaging-resource
 Pentax;Pentax Kr;23.6;dxomark
 Pentax;Pentax Kx;23.6;dxomark
-Pentax;Pentax MX-1;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax Optio 230;5.312;dpreview,digicamdb
+Pentax;Pentax MX-1;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax Optio 230;5.312;digicamdb,dpreview
 Pentax;Pentax Optio 30;5.33;digicamdb
-Pentax;Pentax Optio 330;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 330GS;5.312;dpreview,digicamdb
-Pentax;Pentax Optio 330RS;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 33L;5.312;dpreview,digicamdb
-Pentax;Pentax Optio 33LF;5.312;dpreview,digicamdb
-Pentax;Pentax Optio 33WR;5.312;dpreview,digicamdb
-Pentax;Pentax Optio 430;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 430RS;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 43WR;5.312;dpreview,digicamdb
-Pentax;Pentax Optio 450;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 50;5.744;dpreview,digicamdb
+Pentax;Pentax Optio 330;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 330GS;5.312;digicamdb,dpreview
+Pentax;Pentax Optio 330RS;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 33L;5.312;digicamdb,dpreview
+Pentax;Pentax Optio 33LF;5.312;digicamdb,dpreview
+Pentax;Pentax Optio 33WR;5.312;digicamdb,dpreview
+Pentax;Pentax Optio 430;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 430RS;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 43WR;5.312;digicamdb,dpreview
+Pentax;Pentax Optio 450;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 50;5.744;digicamdb,dpreview
 Pentax;Pentax Optio 50L;5.75;digicamdb,imaging-resource
-Pentax;Pentax Optio 550;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 555;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 60;7.144;dpreview,digicamdb
-Pentax;Pentax Optio 750Z;7.144;dpreview,digicamdb
-Pentax;Pentax Optio A10;7.144;dpreview,digicamdb
-Pentax;Pentax Optio A20;5.744;dpreview,digicamdb
-Pentax;Pentax Optio A30;7.144;dpreview,digicamdb
-Pentax;Pentax Optio A40;7.44;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio E10;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio E20;5.744;dpreview,digicamdb
+Pentax;Pentax Optio 550;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 555;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 60;7.144;digicamdb,dpreview
+Pentax;Pentax Optio 750Z;7.144;digicamdb,dpreview
+Pentax;Pentax Optio A10;7.144;digicamdb,dpreview
+Pentax;Pentax Optio A20;5.744;digicamdb,dpreview
+Pentax;Pentax Optio A30;7.144;digicamdb,dpreview
+Pentax;Pentax Optio A40;7.44;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio E10;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio E20;5.744;digicamdb,dpreview
 Pentax;Pentax Optio E25;5.75;digicamdb
-Pentax;Pentax Optio E30;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio E40;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio E50;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio E60;6.08;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio E30;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio E40;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio E50;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio E60;6.08;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio E70;6.08;dpreview,imaging-resource
 Pentax;Pentax Optio E70L;6.16;digicamdb
 Pentax;Pentax Optio E75;6.08;digicamdb
-Pentax;Pentax Optio E80;6.08;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio E85;6.17;dpreview,digicamdb
+Pentax;Pentax Optio E80;6.08;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio E85;6.17;digicamdb,dpreview
 Pentax;Pentax Optio E90;6.16;digicamdb,imaging-resource
-Pentax;Pentax Optio H90;6.17;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio I-10;6.17;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio H90;6.17;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio I-10;6.17;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio L20;5.75;digicamdb
 Pentax;Pentax Optio L50;6.03;digicamdb
 Pentax;Pentax Optio LS1000;6.16;digicamdb
 Pentax;Pentax Optio LS1100;6.08;digicamdb
 Pentax;Pentax Optio LS465;23.7;digicamdb
-Pentax;Pentax Optio M10;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio M20;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio M30;5.744;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio M10;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio M20;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio M30;5.744;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio M40;6.03;digicamdb,imaging-resource
 Pentax;Pentax Optio M50;6.03;digicamdb,imaging-resource
-Pentax;Pentax Optio M60;6.17;dpreview,digicamdb
-Pentax;Pentax Optio M85;6.17;dpreview,digicamdb
+Pentax;Pentax Optio M60;6.17;digicamdb,dpreview
+Pentax;Pentax Optio M85;6.17;digicamdb,dpreview
 Pentax;Pentax Optio M90;6.17;dpreview,imaging-resource
 Pentax;Pentax Optio MX;5.33;digicamdb
-Pentax;Pentax Optio MX4;5.312;dpreview,digicamdb
+Pentax;Pentax Optio MX4;5.312;digicamdb,dpreview
 Pentax;Pentax Optio NB1000;6.2;imaging-resource
-Pentax;Pentax Optio P70;6.17;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio P80;6.17;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio P70;6.17;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio P80;6.17;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio RS1000;6.16;digicamdb,imaging-resource
 Pentax;Pentax Optio RS1500;6.17;dpreview,imaging-resource
-Pentax;Pentax Optio RZ10;6.08;dpreview,digicamdb
-Pentax;Pentax Optio RZ18;6.08;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio S;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S1;6.17;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio S10;7.144;dpreview,digicamdb
-Pentax;Pentax Optio S12;7.44;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio S30;5.312;dpreview,digicamdb
-Pentax;Pentax Optio S4;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S40;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S45;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S4i;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S50;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S55;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S5i;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S5n;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S5z;5.744;dpreview,digicamdb
-Pentax;Pentax Optio S6;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio S60;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio S7;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio SV;5.744;dpreview,digicamdb
-Pentax;Pentax Optio SVi;5.744;dpreview,digicamdb
-Pentax;Pentax Optio T10;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio T20;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio T30;5.744;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio RZ10;6.08;digicamdb,dpreview
+Pentax;Pentax Optio RZ18;6.08;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio S;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S1;6.17;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio S10;7.144;digicamdb,dpreview
+Pentax;Pentax Optio S12;7.44;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio S30;5.312;digicamdb,dpreview
+Pentax;Pentax Optio S4;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S40;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S45;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S4i;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S50;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S55;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S5i;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S5n;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S5z;5.744;digicamdb,dpreview
+Pentax;Pentax Optio S6;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio S60;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio S7;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio SV;5.744;digicamdb,dpreview
+Pentax;Pentax Optio SVi;5.744;digicamdb,dpreview
+Pentax;Pentax Optio T10;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio T20;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio T30;5.744;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio V10;6.03;digicamdb,imaging-resource
 Pentax;Pentax Optio V20;6.03;digicamdb,imaging-resource
-Pentax;Pentax Optio VS20;6.08;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio W10;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio W20;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio W30;5.744;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio VS20;6.08;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio W10;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio W20;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio W30;5.744;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio W60;6.16;digicamdb,imaging-resource
 Pentax;Pentax Optio W80;6.16;digicamdb,imaging-resource
-Pentax;Pentax Optio W90;6.17;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio WG-1;6.17;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio WG-1 GPS;6.17;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio W90;6.17;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio WG-1;6.17;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio WG-1 GPS;6.17;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio WG-10;6.16;digicamdb
-Pentax;Pentax Optio WG-2;6.17;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Optio WG-2 GPS;6.17;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio WG-2;6.17;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Optio WG-2 GPS;6.17;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio WG-3;6.16;digicamdb
-Pentax;Pentax Optio WP;5.744;dpreview,digicamdb
-Pentax;Pentax Optio WPi;5.744;dpreview,digicamdb,imaging-resource
+Pentax;Pentax Optio WP;5.744;digicamdb,dpreview
+Pentax;Pentax Optio WPi;5.744;digicamdb,dpreview,imaging-resource
 Pentax;Pentax Optio WS80;6.17;dpreview,imaging-resource
-Pentax;Pentax Optio X;5.744;dpreview,digicamdb
-Pentax;Pentax Optio Z10;5.744;dpreview,digicamdb,imaging-resource
-Pentax;Pentax Q;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax Q-S1;7.44;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax Q10;6.17;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax Q7;7.44;dpreview,digicamdb,imaging-resource,dxomark
+Pentax;Pentax Optio X;5.744;digicamdb,dpreview
+Pentax;Pentax Optio Z10;5.744;digicamdb,dpreview,imaging-resource
+Pentax;Pentax Q;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax Q-S1;7.44;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax Q10;6.17;digicamdb,dpreview,dxomark,imaging-resource
+Pentax;Pentax Q7;7.44;digicamdb,dpreview,dxomark,imaging-resource
 Pentax;Pentax WG-10;6.17;dpreview,imaging-resource
 Pentax;Pentax WG-3;6.17;dpreview,imaging-resource
 Pentax;Pentax WG-3 GPS;6.17;dpreview,imaging-resource
-Pentax;Pentax X-5;6.08;dpreview,digicamdb,imaging-resource
+Pentax;Pentax X-5;6.08;digicamdb,dpreview,imaging-resource
 Pentax;Pentax X70;6.08;digicamdb,imaging-resource
-Pentax;Pentax X90;6.08;dpreview,digicamdb,imaging-resource
+Pentax;Pentax X90;6.08;digicamdb,dpreview,imaging-resource
 Pentax;Pentax XG-1;6.08;digicamdb
 Pepsi;Pepsi P1;4.69;devicespecifications
 Pepsi;Pepsi P1S;4.69;devicespecifications
 Phase One;IQ140;43.9;usercontribution
-Phase One;IQ140;43.9;usercontribution
-Phase One;IQ160;53.9;usercontribution
 Phase One;IQ160;53.9;usercontribution
 Phase One;IQ250;44.0;usercontribution
 Phase One;IQ260;53.9;usercontribution
-Phase One;IQ260;53.9;usercontribution
-Phase One;IQ280;53.7;usercontribution
 Phase One;IQ280;53.7;usercontribution
 Phase One;Phase One IQ180 Digital Back;53.7;dxomark
 Phase One;Phase One IQ3 100MP;53.7;usercontribution
@@ -5050,8 +5164,10 @@ Phase One;Phase One P40 Plus;43.9;dxomark
 Phase One;Phase One P45 Plus;49.0;dxomark
 Phase One;Phase One P65 Plus;53.9;dxomark
 Phase One;Phase One XF 100MP;53.7;imaging-resource
+Phase One;Phase One XT;53.7;imaging-resource
 Phicomm;Phicomm P660 Passion;4.69;devicespecifications
 Philips;Philips i966 Aurora;6.17;devicespecifications
+Pixii;Pixii A1571;23.5;dxomark
 Poptel;Poptel P10;4.69;devicespecifications
 Poptel;Poptel P60;4.74;devicespecifications
 Posh mobile;Posh mobile Titan HD;4.69;devicespecifications
@@ -5227,102 +5343,109 @@ RED;RANGER MONSTRO 8K VV;40.96;usercontribution
 Red;Red Dragon 4K HD;19.19;usercontribution
 Red;Red Helium 8K S35;29.90;usercontribution
 Red;Red Mysterium-X 4K HD;20.74;usercontribution
-Ricoh;Pentax K-1;35.9;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax K-1;35.9;digicamdb,dpreview,dxomark,imaging-resource
 Ricoh;Pentax K-1 II;35.9;imaging-resource
-Ricoh;Pentax K-1 Mark II;35.9;dpreview,digicamdb,dxomark
-Ricoh;Pentax K-3;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Ricoh;Pentax K-3 II;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Ricoh;Pentax K-70;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Ricoh;Pentax K-S1;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Ricoh;Pentax K-S2;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Ricoh;Pentax KP;23.5;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Pentax K-1 Mark II;35.9;digicamdb,dpreview,dxomark
+Ricoh;Pentax K-3;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Ricoh;Pentax K-3 II;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Ricoh;Pentax K-70;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Ricoh;Pentax K-S1;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Ricoh;Pentax K-S2;23.5;digicamdb,dpreview,dxomark,imaging-resource
+Ricoh;Pentax KP;23.5;digicamdb,dpreview,dxomark,imaging-resource
 Ricoh;Ricoh Caplio 400G Wide;5.33;digicamdb
-Ricoh;Ricoh Caplio 500G;7.144;dpreview,digicamdb
+Ricoh;Ricoh Caplio 500G;7.144;digicamdb,dpreview
 Ricoh;Ricoh Caplio 500G Wide;7.11;digicamdb
-Ricoh;Ricoh Caplio 500SE;7.144;dpreview,digicamdb
+Ricoh;Ricoh Caplio 500SE;7.144;digicamdb,dpreview
 Ricoh;Ricoh Caplio G3;5.33;digicamdb
 Ricoh;Ricoh Caplio G3s;5.33;digicamdb
 Ricoh;Ricoh Caplio GR Digital II;7.4;imaging-resource
 Ricoh;Ricoh Caplio GX;7.11;digicamdb
 Ricoh;Ricoh Caplio GX100;7.36;dpreview,imaging-resource
-Ricoh;Ricoh Caplio GX200;7.44;dpreview,digicamdb
-Ricoh;Ricoh Caplio GX8;7.144;dpreview,digicamdb
+Ricoh;Ricoh Caplio GX200;7.44;digicamdb,dpreview
+Ricoh;Ricoh Caplio GX8;7.144;digicamdb,dpreview
 Ricoh;Ricoh Caplio R1;7.11;digicamdb
-Ricoh;Ricoh Caplio R1V;5.744;dpreview,digicamdb
-Ricoh;Ricoh Caplio R2;5.744;dpreview,digicamdb
+Ricoh;Ricoh Caplio R1V;5.744;digicamdb,dpreview
+Ricoh;Ricoh Caplio R2;5.744;digicamdb,dpreview
 Ricoh;Ricoh Caplio R2S;5.75;digicamdb
-Ricoh;Ricoh Caplio R3;5.744;dpreview,digicamdb
-Ricoh;Ricoh Caplio R30;5.744;dpreview,digicamdb,imaging-resource
-Ricoh;Ricoh Caplio R4;5.744;dpreview,digicamdb,imaging-resource
-Ricoh;Ricoh Caplio R40;5.744;dpreview,digicamdb
-Ricoh;Ricoh Caplio R5;5.744;dpreview,digicamdb
-Ricoh;Ricoh Caplio R6;5.744;dpreview,digicamdb
-Ricoh;Ricoh Caplio R7;5.744;dpreview,digicamdb
-Ricoh;Ricoh Caplio R8;6.17;dpreview,digicamdb
-Ricoh;Ricoh Caplio RR1;7.144;dpreview,digicamdb
+Ricoh;Ricoh Caplio R3;5.744;digicamdb,dpreview
+Ricoh;Ricoh Caplio R30;5.744;digicamdb,dpreview,imaging-resource
+Ricoh;Ricoh Caplio R4;5.744;digicamdb,dpreview,imaging-resource
+Ricoh;Ricoh Caplio R40;5.744;digicamdb,dpreview
+Ricoh;Ricoh Caplio R5;5.744;digicamdb,dpreview
+Ricoh;Ricoh Caplio R6;5.744;digicamdb,dpreview
+Ricoh;Ricoh Caplio R7;5.744;digicamdb,dpreview
+Ricoh;Ricoh Caplio R8;6.17;digicamdb,dpreview
+Ricoh;Ricoh Caplio RR1;7.144;digicamdb,dpreview
 Ricoh;Ricoh Caplio RR10;5.33;digicamdb
 Ricoh;Ricoh Caplio RR120;4.5;digicamdb
 Ricoh;Ricoh Caplio RR230;4.5;digicamdb
 Ricoh;Ricoh Caplio RR30;5.33;digicamdb
 Ricoh;Ricoh Caplio RR330;5.75;digicamdb
-Ricoh;Ricoh Caplio RR530;5.744;dpreview,digicamdb
+Ricoh;Ricoh Caplio RR530;5.744;digicamdb,dpreview
 Ricoh;Ricoh Caplio RR630;7.11;digicamdb
 Ricoh;Ricoh Caplio RR660;5.75;digicamdb
 Ricoh;Ricoh Caplio RR750;5.75;digicamdb
 Ricoh;Ricoh Caplio RR770;5.75;digicamdb
-Ricoh;Ricoh Caplio RX;5.312;dpreview,digicamdb
+Ricoh;Ricoh Caplio RX;5.312;digicamdb,dpreview
 Ricoh;Ricoh Caplio RZ1;5.75;digicamdb
-Ricoh;Ricoh CX1;6.17;dpreview,digicamdb
-Ricoh;Ricoh CX2;6.17;dpreview,digicamdb
-Ricoh;Ricoh CX3;6.17;dpreview,digicamdb
-Ricoh;Ricoh CX4;6.17;dpreview,digicamdb,imaging-resource
-Ricoh;Ricoh CX5;6.17;dpreview,digicamdb,imaging-resource
-Ricoh;Ricoh CX6;6.17;dpreview,digicamdb
-Ricoh;Ricoh G600;6.17;dpreview,digicamdb
+Ricoh;Ricoh CX1;6.17;digicamdb,dpreview
+Ricoh;Ricoh CX2;6.17;digicamdb,dpreview
+Ricoh;Ricoh CX3;6.17;digicamdb,dpreview
+Ricoh;Ricoh CX4;6.17;digicamdb,dpreview,imaging-resource
+Ricoh;Ricoh CX5;6.17;digicamdb,dpreview,imaging-resource
+Ricoh;Ricoh CX6;6.17;digicamdb,dpreview
+Ricoh;Ricoh G600;6.17;digicamdb,dpreview
 Ricoh;Ricoh G700;6.16;digicamdb,imaging-resource
-Ricoh;Ricoh G700SE;6.17;dpreview,digicamdb,imaging-resource
+Ricoh;Ricoh G700SE;6.17;digicamdb,dpreview,imaging-resource
 Ricoh;Ricoh G800;6.16;digicamdb
-Ricoh;Ricoh GR;23.7;dpreview,digicamdb,imaging-resource,dxomark
-Ricoh;Ricoh GR Digital;7.144;dpreview,digicamdb
+Ricoh;Ricoh G900;6.16;digicamdb
+Ricoh;Ricoh GR;23.7;digicamdb,dpreview,dxomark,imaging-resource
+Ricoh;Ricoh GR Digital;7.144;digicamdb,dpreview
 Ricoh;Ricoh GR Digital 3;7.53;digicamdb
 Ricoh;Ricoh GR Digital 4;7.53;digicamdb
 Ricoh;Ricoh GR Digital II;7.31;digicamdb
 Ricoh;Ricoh GR Digital III;7.44;dpreview
-Ricoh;Ricoh GR Digital IV;7.6;imaging-resource,dxomark
-Ricoh;Ricoh GR II;23.7;dpreview,digicamdb,imaging-resource,dxomark
+Ricoh;Ricoh GR Digital IV;7.6;dxomark,imaging-resource
+Ricoh;Ricoh GR II;23.7;digicamdb,dpreview,dxomark,imaging-resource
 Ricoh;Ricoh GR III;23.5;dpreview,imaging-resource
+Ricoh;Ricoh GR IIIx;23.5;digicamdb
 Ricoh;Ricoh GX200;7.53;usercontribution
 Ricoh;Ricoh GXR;23.7;imaging-resource
-Ricoh;Ricoh GXR A12 50mm F2.5 Macro;23.6;dpreview,digicamdb
-Ricoh;Ricoh GXR A16 24-85mm F3.5-5.5;23.6;dpreview,digicamdb
-Ricoh;Ricoh GXR GR Lens A12 28mm F2.5;23.6;dpreview,digicamdb
-Ricoh;Ricoh GXR Mount A12;23.6;dpreview,digicamdb
-Ricoh;Ricoh GXR P10 28-300mm F3.5-5.6 VC;6.17;dpreview,digicamdb
-Ricoh;Ricoh GXR S10 24-72mm F2.5-4.4 VC;7.44;dpreview,digicamdb
+Ricoh;Ricoh GXR A12 50mm F2.5 Macro;23.6;digicamdb,dpreview
+Ricoh;Ricoh GXR A16 24-85mm F3.5-5.5;23.6;digicamdb,dpreview
+Ricoh;Ricoh GXR GR Lens A12 28mm F2.5;23.6;digicamdb,dpreview
+Ricoh;Ricoh GXR Mount A12;23.6;digicamdb,dpreview
+Ricoh;Ricoh GXR P10 28-300mm F3.5-5.6 VC;6.17;digicamdb,dpreview
+Ricoh;Ricoh GXR S10 24-72mm F2.5-4.4 VC;7.44;digicamdb,dpreview
 Ricoh;Ricoh HZ15;6.16;digicamdb
-Ricoh;Ricoh PX;6.17;dpreview,digicamdb
-Ricoh;Ricoh R10;6.17;dpreview,digicamdb,imaging-resource
+Ricoh;Ricoh PX;6.17;digicamdb,dpreview
+Ricoh;Ricoh R10;6.17;digicamdb,dpreview,imaging-resource
 Ricoh;Ricoh R50;6.08;digicamdb
 Ricoh;Ricoh R8;6.16;digicamdb,imaging-resource
-Ricoh;Ricoh RDC-200G;6.4;dpreview,digicamdb
-Ricoh;Ricoh RDC-4300;4.8;dpreview,digicamdb
+Ricoh;Ricoh RDC-200G;6.4;digicamdb,dpreview
+Ricoh;Ricoh RDC-4300;4.8;digicamdb,dpreview
 Ricoh;Ricoh RDC-5000;5.33;digicamdb
 Ricoh;Ricoh RDC-5300;5.33;digicamdb
-Ricoh;Ricoh RDC-6000;6.4;dpreview,digicamdb
-Ricoh;Ricoh RDC-7;7.144;dpreview,digicamdb
-Ricoh;Ricoh RDC-i500;7.144;dpreview,digicamdb
-Ricoh;Ricoh RDC-i700;7.144;dpreview,digicamdb
+Ricoh;Ricoh RDC-6000;6.4;digicamdb,dpreview
+Ricoh;Ricoh RDC-7;7.144;digicamdb,dpreview
+Ricoh;Ricoh RDC-i500;7.144;digicamdb,dpreview
+Ricoh;Ricoh RDC-i700;7.144;digicamdb,dpreview
 RICOH;RICOH THETA S;6.17;usercontribution
 Ricoh;Ricoh Theta SC;6.2;imaging-resource
 Ricoh;Ricoh Theta V;6.17;dpreview,imaging-resource
-Ricoh;Ricoh WG-20;6.17;dpreview,digicamdb,imaging-resource
-Ricoh;Ricoh WG-30;6.17;dpreview,digicamdb,imaging-resource
+Ricoh;Ricoh Theta Z1;13.2;imaging-resource
+Ricoh;Ricoh WG-20;6.17;digicamdb,dpreview,imaging-resource
+Ricoh;Ricoh WG-30;6.17;digicamdb,dpreview,imaging-resource
 Ricoh;Ricoh WG-30W;6.17;dpreview
-Ricoh;Ricoh WG-4;6.17;dpreview,digicamdb,imaging-resource
+Ricoh;Ricoh WG-4;6.17;digicamdb,dpreview,imaging-resource
 Ricoh;Ricoh WG-4 GPS;6.17;dpreview,imaging-resource
-Ricoh;Ricoh WG-5 GPS;6.17;dpreview,digicamdb,imaging-resource
-Ricoh;Ricoh WG-50;6.17;dpreview,digicamdb,imaging-resource
-Ricoh;Ricoh WG-M1;6.17;dpreview,digicamdb
+Ricoh;Ricoh WG-5 GPS;6.17;digicamdb,dpreview,imaging-resource
+Ricoh;Ricoh WG-50;6.17;digicamdb,dpreview,imaging-resource
+Ricoh;Ricoh WG-6;6.16;digicamdb
+Ricoh;Ricoh WG-60;6.17;dpreview
+Ricoh;Ricoh WG-70;6.16;digicamdb
+Ricoh;Ricoh WG-80;6.17;imaging-resource
+Ricoh;Ricoh WG-M1;6.17;digicamdb,dpreview
 Rollei;Rollei Compactline 100;6.16;digicamdb
 Rollei;Rollei Compactline 101;5.75;digicamdb
 Rollei;Rollei Compactline 102;5.75;digicamdb
@@ -5446,51 +5569,51 @@ Rollei;Rollei XS-8;5.75;digicamdb
 Rollei;Rollei XS-8 Crystal;5.75;digicamdb
 Samsung;Samsung 2016;4.69;devicespecifications
 Samsung;Samsung 2017;4.73;devicespecifications
-Samsung;Samsung AQ100;6.08;dpreview,digicamdb
-Samsung;Samsung CL5;5.744;dpreview,digicamdb
+Samsung;Samsung AQ100;6.08;digicamdb,dpreview
+Samsung;Samsung CL5;5.744;digicamdb,dpreview
 Samsung;Samsung CL50;5.744;dpreview
-Samsung;Samsung CL65;6.08;dpreview,digicamdb
-Samsung;Samsung CL80;6.17;dpreview,digicamdb
+Samsung;Samsung CL65;6.08;digicamdb,dpreview
+Samsung;Samsung CL80;6.17;digicamdb,dpreview
 Samsung;Samsung D75;5.75;digicamdb
 Samsung;Samsung D830;7.11;digicamdb
 Samsung;Samsung D85;5.75;digicamdb
 Samsung;Samsung D860;5.75;digicamdb
 Samsung;Samsung Digimax 101;6.4;digicamdb
-Samsung;Samsung Digimax 130;4.544;dpreview,digicamdb
+Samsung;Samsung Digimax 130;4.544;digicamdb,dpreview
 Samsung;Samsung Digimax 200;5.33;digicamdb
 Samsung;Samsung Digimax 201;4.5;digicamdb
-Samsung;Samsung Digimax 202;6.4;dpreview,digicamdb
+Samsung;Samsung Digimax 202;6.4;digicamdb,dpreview
 Samsung;Samsung Digimax 210 SE;5.33;digicamdb
 Samsung;Samsung Digimax 220 SE;5.33;digicamdb
-Samsung;Samsung Digimax 230;5.312;dpreview,digicamdb
+Samsung;Samsung Digimax 230;5.312;digicamdb,dpreview
 Samsung;Samsung Digimax 240;4.5;digicamdb
-Samsung;Samsung Digimax 250;4.544;dpreview,digicamdb
-Samsung;Samsung Digimax 301;5.312;dpreview,digicamdb
+Samsung;Samsung Digimax 250;4.544;digicamdb,dpreview
+Samsung;Samsung Digimax 301;5.312;digicamdb,dpreview
 Samsung;Samsung Digimax 330;7.53;digicamdb
 Samsung;Samsung Digimax 340;7.11;digicamdb
 Samsung;Samsung Digimax 35 MP3;4.8;digicamdb
-Samsung;Samsung Digimax 350SE;7.144;dpreview,digicamdb
+Samsung;Samsung Digimax 350SE;7.144;digicamdb,dpreview
 Samsung;Samsung Digimax 360;7.11;digicamdb
 Samsung;Samsung Digimax 370;5.75;digicamdb
-Samsung;Samsung Digimax 401;5.744;dpreview,digicamdb
-Samsung;Samsung Digimax 410;7.144;dpreview,digicamdb
+Samsung;Samsung Digimax 401;5.744;digicamdb,dpreview
+Samsung;Samsung Digimax 410;7.144;digicamdb,dpreview
 Samsung;Samsung Digimax 420;7.11;digicamdb
-Samsung;Samsung Digimax 430;5.744;dpreview,digicamdb
+Samsung;Samsung Digimax 430;5.744;digicamdb,dpreview
 Samsung;Samsung Digimax 50 duo;4.8;digicamdb
-Samsung;Samsung Digimax 530;7.144;dpreview,digicamdb
+Samsung;Samsung Digimax 530;7.144;digicamdb,dpreview
 Samsung;Samsung Digimax A400;5.75;digicamdb
 Samsung;Samsung Digimax A402;5.75;digicamdb
 Samsung;Samsung Digimax A5;7.11;digicamdb
-Samsung;Samsung Digimax A50;5.744;dpreview,digicamdb
-Samsung;Samsung Digimax A502;5.744;dpreview,digicamdb
+Samsung;Samsung Digimax A50;5.744;digicamdb,dpreview
+Samsung;Samsung Digimax A502;5.744;digicamdb,dpreview
 Samsung;Samsung Digimax A503;5.75;digicamdb
-Samsung;Samsung Digimax A55W;5.744;dpreview,digicamdb
+Samsung;Samsung Digimax A55W;5.744;digicamdb,dpreview
 Samsung;Samsung Digimax A6;7.11;digicamdb
 Samsung;Samsung Digimax A7;7.11;digicamdb
 Samsung;Samsung Digimax D103;7.11;digicamdb
-Samsung;Samsung Digimax i5;5.744;dpreview,digicamdb
+Samsung;Samsung Digimax i5;5.744;digicamdb,dpreview
 Samsung;Samsung Digimax i50 MP3;5.75;digicamdb
-Samsung;Samsung Digimax i6;5.744;dpreview,digicamdb
+Samsung;Samsung Digimax i6;5.744;digicamdb,dpreview
 Samsung;Samsung Digimax L50;5.75;digicamdb
 Samsung;Samsung Digimax L55W;5.75;digicamdb
 Samsung;Samsung Digimax L60;5.75;digicamdb
@@ -5501,35 +5624,35 @@ Samsung;Samsung Digimax S500;5.75;digicamdb
 Samsung;Samsung Digimax S600;5.75;digicamdb
 Samsung;Samsung Digimax S700;5.75;digicamdb
 Samsung;Samsung Digimax S800;7.11;digicamdb
-Samsung;Samsung Digimax U-CA 3;5.312;dpreview,digicamdb
-Samsung;Samsung Digimax U-CA 4;5.744;dpreview,digicamdb
-Samsung;Samsung Digimax U-CA 401;5.744;dpreview,digicamdb
+Samsung;Samsung Digimax U-CA 3;5.312;digicamdb,dpreview
+Samsung;Samsung Digimax U-CA 4;5.744;digicamdb,dpreview
+Samsung;Samsung Digimax U-CA 401;5.744;digicamdb,dpreview
 Samsung;Samsung Digimax U-CA5;5.75;digicamdb
 Samsung;Samsung Digimax U-CA501;5.75;digicamdb
 Samsung;Samsung Digimax U-CA505;5.75;digicamdb
 Samsung;Samsung Digimax V3;7.11;digicamdb
-Samsung;Samsung Digimax V4;7.144;dpreview,digicamdb
-Samsung;Samsung Digimax V40;7.144;dpreview,digicamdb
+Samsung;Samsung Digimax V4;7.144;digicamdb,dpreview
+Samsung;Samsung Digimax V40;7.144;digicamdb,dpreview
 Samsung;Samsung Digimax V4000;7.11;digicamdb
-Samsung;Samsung Digimax V5;7.144;dpreview,digicamdb
-Samsung;Samsung Digimax V50;7.144;dpreview,digicamdb
+Samsung;Samsung Digimax V5;7.144;digicamdb,dpreview
+Samsung;Samsung Digimax V50;7.144;digicamdb,dpreview
 Samsung;Samsung Digimax V6;6.74;digicamdb
 Samsung;Samsung Digimax V600;7.11;digicamdb
 Samsung;Samsung Digimax V70;7.11;digicamdb
-Samsung;Samsung Digimax V700;7.144;dpreview,digicamdb
-Samsung;Samsung Digimax V800;7.144;dpreview,digicamdb
+Samsung;Samsung Digimax V700;7.144;digicamdb,dpreview
+Samsung;Samsung Digimax V800;7.144;digicamdb,dpreview
 Samsung;Samsung DV100;6.16;digicamdb
-Samsung;Samsung DV150F;6.17;dpreview,digicamdb
-Samsung;Samsung DV300F;6.17;dpreview,digicamdb
+Samsung;Samsung DV150F;6.17;digicamdb,dpreview
+Samsung;Samsung DV300F;6.17;digicamdb,dpreview
 Samsung;Samsung ES10;5.75;digicamdb
-Samsung;Samsung ES15;6.08;dpreview,digicamdb
+Samsung;Samsung ES15;6.08;digicamdb,dpreview
 Samsung;Samsung ES17;6.08;digicamdb
 Samsung;Samsung ES20;6.08;digicamdb
 Samsung;Samsung ES25;6.08;digicamdb
 Samsung;Samsung ES28;6.08;digicamdb
 Samsung;Samsung ES30;6.16;digicamdb
 Samsung;Samsung ES50;6.08;digicamdb
-Samsung;Samsung ES55;6.08;dpreview,digicamdb
+Samsung;Samsung ES55;6.08;digicamdb,dpreview
 Samsung;Samsung ES60;6.08;digicamdb
 Samsung;Samsung ES65;6.08;digicamdb
 Samsung;Samsung ES70;6.08;digicamdb
@@ -5538,8 +5661,8 @@ Samsung;Samsung ES75;6.08;digicamdb
 Samsung;Samsung ES80;6.16;digicamdb
 Samsung;Samsung ES90;6.16;digicamdb
 Samsung;Samsung ES95;6.16;digicamdb
-Samsung;Samsung EX1;7.44;dpreview,digicamdb,dxomark
-Samsung;Samsung EX2F;7.44;dpreview,digicamdb,dxomark
+Samsung;Samsung EX1;7.44;digicamdb,dpreview,dxomark
+Samsung;Samsung EX2F;7.44;digicamdb,dpreview,dxomark
 Samsung;Samsung Galaxy A5;4.69;devicespecifications
 Samsung;Samsung Galaxy A5 Duos;4.69;devicespecifications
 Samsung;Samsung Galaxy A70;5.14;devicespecifications
@@ -5550,8 +5673,8 @@ Samsung;Samsung Galaxy A80;6.4;kimovil
 Samsung;Samsung Galaxy A9;4.69;devicespecifications
 Samsung;Samsung Galaxy C5;4.74;devicespecifications
 Samsung;Samsung Galaxy C7;4.74;devicespecifications
-Samsung;Samsung Galaxy Camera;6.17;dpreview,digicamdb
-Samsung;Samsung Galaxy Camera 2;6.16;dpreview,digicamdb,devicespecifications
+Samsung;Samsung Galaxy Camera;6.17;digicamdb,dpreview
+Samsung;Samsung Galaxy Camera 2;6.16;devicespecifications,digicamdb,dpreview
 Samsung;Samsung Galaxy Camera 3G;6.17;dpreview
 Samsung;Samsung Galaxy Camera 4G;6.17;dpreview
 Samsung;Samsung Galaxy J5;4.73;devicespecifications
@@ -5587,7 +5710,7 @@ Samsung;Samsung Galaxy Note8 SM-N950P;5.75;usercontribution
 Samsung;Samsung Galaxy Note8 SM-N950T;5.75;usercontribution
 Samsung;Samsung Galaxy Note8 SM-N950V;5.75;usercontribution
 Samsung;Samsung Galaxy Note9 SM-N960U;5.644;devicespecifications
-Samsung;Samsung Galaxy NX;23.5;dpreview,digicamdb
+Samsung;Samsung Galaxy NX;23.5;digicamdb,dpreview
 Samsung;Samsung Galaxy Round;4.54;devicespecifications
 Samsung;Samsung Galaxy S10 Lite;6.4;kimovil
 Samsung;Samsung Galaxy S10 Plus;5.75;digicamdb
@@ -5637,57 +5760,57 @@ Samsung;Samsung Galaxy Tab S2 8.0 Wi-Fi;3.6;devicespecifications
 Samsung;Samsung Galaxy Tab S2 9.7;3.6;devicespecifications
 Samsung;Samsung Galaxy Tab S2 9.7 Wi-Fi;3.6;devicespecifications
 Samsung;Samsung GX 20;23.0;dxomark
-Samsung;Samsung GX-10;23.5;dpreview,digicamdb
-Samsung;Samsung GX-1L;23.5;dpreview,digicamdb
-Samsung;Samsung GX-1S;23.5;dpreview,digicamdb
-Samsung;Samsung GX-20;23.4;dpreview,digicamdb
-Samsung;Samsung HZ10W;6.08;dpreview,digicamdb
-Samsung;Samsung HZ15W;6.08;dpreview,digicamdb
-Samsung;Samsung HZ25W;6.08;dpreview,digicamdb
-Samsung;Samsung HZ30W;6.17;dpreview,digicamdb
-Samsung;Samsung HZ35W;6.17;dpreview,digicamdb
+Samsung;Samsung GX-10;23.5;digicamdb,dpreview
+Samsung;Samsung GX-1L;23.5;digicamdb,dpreview
+Samsung;Samsung GX-1S;23.5;digicamdb,dpreview
+Samsung;Samsung GX-20;23.4;digicamdb,dpreview
+Samsung;Samsung HZ10W;6.08;digicamdb,dpreview
+Samsung;Samsung HZ15W;6.08;digicamdb,dpreview
+Samsung;Samsung HZ25W;6.08;digicamdb,dpreview
+Samsung;Samsung HZ30W;6.17;digicamdb,dpreview
+Samsung;Samsung HZ35W;6.17;digicamdb,dpreview
 Samsung;Samsung HZ50W;6.16;digicamdb
-Samsung;Samsung i100;6.08;dpreview,digicamdb
-Samsung;Samsung i7;5.744;dpreview,digicamdb
-Samsung;Samsung i70;5.744;dpreview,digicamdb
-Samsung;Samsung i8;5.744;dpreview,digicamdb
-Samsung;Samsung i80;5.744;dpreview,digicamdb
-Samsung;Samsung i85;5.744;dpreview,digicamdb
-Samsung;Samsung IT100;6.08;dpreview,digicamdb
-Samsung;Samsung L100;5.744;dpreview,digicamdb
-Samsung;Samsung L110;5.744;dpreview,digicamdb
+Samsung;Samsung i100;6.08;digicamdb,dpreview
+Samsung;Samsung i7;5.744;digicamdb,dpreview
+Samsung;Samsung i70;5.744;digicamdb,dpreview
+Samsung;Samsung i8;5.744;digicamdb,dpreview
+Samsung;Samsung i80;5.744;digicamdb,dpreview
+Samsung;Samsung i85;5.744;digicamdb,dpreview
+Samsung;Samsung IT100;6.08;digicamdb,dpreview
+Samsung;Samsung L100;5.744;digicamdb,dpreview
+Samsung;Samsung L110;5.744;digicamdb,dpreview
 Samsung;Samsung L200;5.75;digicamdb
-Samsung;Samsung L201;6.08;dpreview,digicamdb
-Samsung;Samsung L210;6.08;dpreview,digicamdb
+Samsung;Samsung L201;6.08;digicamdb,dpreview
+Samsung;Samsung L210;6.08;digicamdb,dpreview
 Samsung;Samsung L301;6.08;digicamdb
-Samsung;Samsung L310W;7.44;dpreview,digicamdb
-Samsung;Samsung L700;5.744;dpreview,digicamdb
-Samsung;Samsung L73;5.744;dpreview,digicamdb
-Samsung;Samsung L730;5.744;dpreview,digicamdb
+Samsung;Samsung L310W;7.44;digicamdb,dpreview
+Samsung;Samsung L700;5.744;digicamdb,dpreview
+Samsung;Samsung L73;5.744;digicamdb,dpreview
+Samsung;Samsung L730;5.744;digicamdb,dpreview
 Samsung;Samsung L74;5.75;digicamdb
-Samsung;Samsung L74 Wide;5.744;dpreview,digicamdb
-Samsung;Samsung L77;5.744;dpreview,digicamdb
+Samsung;Samsung L74 Wide;5.744;digicamdb,dpreview
+Samsung;Samsung L77;5.744;digicamdb,dpreview
 Samsung;Samsung L80;7.11;digicamdb
-Samsung;Samsung L830;5.744;dpreview,digicamdb
-Samsung;Samsung L83T;5.744;dpreview,digicamdb
+Samsung;Samsung L830;5.744;digicamdb,dpreview
+Samsung;Samsung L83T;5.744;digicamdb,dpreview
 Samsung;Samsung M100;5.75;digicamdb
 Samsung;Samsung Miniket VP-MS10;5.75;digicamdb
 Samsung;Samsung Miniket VP-MS11;5.75;digicamdb
 Samsung;Samsung Miniket VP-MS15;5.75;digicamdb
-Samsung;Samsung MV800;6.17;dpreview,digicamdb
-Samsung;Samsung NV10;7.144;dpreview,digicamdb
+Samsung;Samsung MV800;6.17;digicamdb,dpreview
+Samsung;Samsung NV10;7.144;digicamdb,dpreview
 Samsung;Samsung NV100 HD;7.44;digicamdb
 Samsung;Samsung NV100HD;7.4;dpreview
-Samsung;Samsung NV11;7.144;dpreview,digicamdb
-Samsung;Samsung NV15;7.32;dpreview,digicamdb
-Samsung;Samsung NV20;7.44;dpreview,digicamdb
-Samsung;Samsung NV24HD;6.17;dpreview,digicamdb
-Samsung;Samsung NV3;5.744;dpreview,digicamdb
-Samsung;Samsung NV30;5.744;dpreview,digicamdb
-Samsung;Samsung NV4;5.744;dpreview,digicamdb
-Samsung;Samsung NV40;6.08;dpreview,digicamdb
-Samsung;Samsung NV7 OPS;5.744;dpreview,digicamdb
-Samsung;Samsung NV8;7.32;dpreview,digicamdb
+Samsung;Samsung NV11;7.144;digicamdb,dpreview
+Samsung;Samsung NV15;7.32;digicamdb,dpreview
+Samsung;Samsung NV20;7.44;digicamdb,dpreview
+Samsung;Samsung NV24HD;6.17;digicamdb,dpreview
+Samsung;Samsung NV3;5.744;digicamdb,dpreview
+Samsung;Samsung NV30;5.744;digicamdb,dpreview
+Samsung;Samsung NV4;5.744;digicamdb,dpreview
+Samsung;Samsung NV40;6.08;digicamdb,dpreview
+Samsung;Samsung NV7 OPS;5.744;digicamdb,dpreview
+Samsung;Samsung NV8;7.32;digicamdb,dpreview
 Samsung;Samsung NV9;6.16;digicamdb
 Samsung;Samsung NX 10;23.4;dxomark
 Samsung;Samsung NX 100;23.4;dxomark
@@ -5698,72 +5821,72 @@ Samsung;Samsung NX 200;23.5;dxomark
 Samsung;Samsung NX 210;23.5;dxomark
 Samsung;Samsung NX 30;23.5;dxomark
 Samsung;Samsung NX 300;23.5;dxomark
-Samsung;Samsung NX mini;13.2;dpreview,digicamdb
-Samsung;Samsung NX1;23.5;dpreview,digicamdb,dxomark
-Samsung;Samsung NX10;23.4;dpreview,digicamdb
-Samsung;Samsung NX100;23.4;dpreview,digicamdb
-Samsung;Samsung NX1000;23.5;dpreview,digicamdb
-Samsung;Samsung NX11;23.4;dpreview,digicamdb
-Samsung;Samsung NX1100;23.5;dpreview,digicamdb,dxomark
-Samsung;Samsung NX20;23.5;dpreview,digicamdb
-Samsung;Samsung NX200;23.5;dpreview,digicamdb
-Samsung;Samsung NX2000;23.5;dpreview,digicamdb,dxomark
-Samsung;Samsung NX210;23.5;dpreview,digicamdb
-Samsung;Samsung NX30;23.5;dpreview,digicamdb
-Samsung;Samsung NX300;23.5;dpreview,digicamdb
-Samsung;Samsung NX3000;23.5;dpreview,digicamdb,dxomark
+Samsung;Samsung NX mini;13.2;digicamdb,dpreview
+Samsung;Samsung NX1;23.5;digicamdb,dpreview,dxomark
+Samsung;Samsung NX10;23.4;digicamdb,dpreview
+Samsung;Samsung NX100;23.4;digicamdb,dpreview
+Samsung;Samsung NX1000;23.5;digicamdb,dpreview
+Samsung;Samsung NX11;23.4;digicamdb,dpreview
+Samsung;Samsung NX1100;23.5;digicamdb,dpreview,dxomark
+Samsung;Samsung NX20;23.5;digicamdb,dpreview
+Samsung;Samsung NX200;23.5;digicamdb,dpreview
+Samsung;Samsung NX2000;23.5;digicamdb,dpreview,dxomark
+Samsung;Samsung NX210;23.5;digicamdb,dpreview
+Samsung;Samsung NX30;23.5;digicamdb,dpreview
+Samsung;Samsung NX300;23.5;digicamdb,dpreview
+Samsung;Samsung NX3000;23.5;digicamdb,dpreview,dxomark
 Samsung;Samsung NX300M;23.5;dpreview
-Samsung;Samsung NX5;23.4;dpreview,digicamdb
-Samsung;Samsung NX500;23.5;dpreview,digicamdb,dxomark
+Samsung;Samsung NX5;23.4;digicamdb,dpreview
+Samsung;Samsung NX500;23.5;digicamdb,dpreview,dxomark
 Samsung;Samsung octa core;5.95;devicespecifications
-Samsung;Samsung PL10;5.744;dpreview,digicamdb
-Samsung;Samsung PL100;6.08;dpreview,digicamdb
+Samsung;Samsung PL10;5.744;digicamdb,dpreview
+Samsung;Samsung PL100;6.08;digicamdb,dpreview
 Samsung;Samsung PL120;6.16;digicamdb
-Samsung;Samsung PL150;6.08;dpreview,digicamdb
+Samsung;Samsung PL150;6.08;digicamdb,dpreview
 Samsung;Samsung PL160;6.08;digicamdb
 Samsung;Samsung PL170;6.08;digicamdb
 Samsung;Samsung PL20;6.16;digicamdb
-Samsung;Samsung PL200;6.17;dpreview,digicamdb
+Samsung;Samsung PL200;6.17;digicamdb,dpreview
 Samsung;Samsung PL210;6.16;digicamdb
-Samsung;Samsung PL50;6.08;dpreview,digicamdb
+Samsung;Samsung PL50;6.08;digicamdb,dpreview
 Samsung;Samsung PL51;6.16;digicamdb
 Samsung;Samsung PL55;6.08;digicamdb
 Samsung;Samsung PL60;6.08;digicamdb
-Samsung;Samsung PL65;6.08;dpreview,digicamdb
-Samsung;Samsung PL70;6.08;dpreview,digicamdb
+Samsung;Samsung PL65;6.08;digicamdb,dpreview
+Samsung;Samsung PL70;6.08;digicamdb,dpreview
 Samsung;Samsung PL80;6.08;digicamdb
 Samsung;Samsung PL90;6.08;digicamdb
-Samsung;Samsung Pro815;8.8;dpreview,digicamdb
-Samsung;Samsung S1030;7.144;dpreview,digicamdb
-Samsung;Samsung S1050;7.144;dpreview,digicamdb
+Samsung;Samsung Pro815;8.8;digicamdb,dpreview
+Samsung;Samsung S1030;7.144;digicamdb,dpreview
+Samsung;Samsung S1050;7.144;digicamdb,dpreview
 Samsung;Samsung S1060;6.08;digicamdb
-Samsung;Samsung S1070;6.08;dpreview,digicamdb
-Samsung;Samsung S630;5.744;dpreview,digicamdb
-Samsung;Samsung S730;5.744;dpreview,digicamdb
+Samsung;Samsung S1070;6.08;digicamdb,dpreview
+Samsung;Samsung S630;5.744;digicamdb,dpreview
+Samsung;Samsung S730;5.744;digicamdb,dpreview
 Samsung;Samsung S750;5.75;digicamdb
-Samsung;Samsung S760;5.744;dpreview,digicamdb
-Samsung;Samsung S830;7.144;dpreview,digicamdb
-Samsung;Samsung S85;5.744;dpreview,digicamdb
-Samsung;Samsung S850;7.144;dpreview,digicamdb
-Samsung;Samsung S860;5.744;dpreview,digicamdb
+Samsung;Samsung S760;5.744;digicamdb,dpreview
+Samsung;Samsung S830;7.144;digicamdb,dpreview
+Samsung;Samsung S85;5.744;digicamdb,dpreview
+Samsung;Samsung S850;7.144;digicamdb,dpreview
+Samsung;Samsung S860;5.744;digicamdb,dpreview
 Samsung;Samsung SCV32;5.3;devicespecifications
 Samsung;Samsung SDC-MS61;5.75;digicamdb
 Samsung;Samsung SGH-I717;5.95;devicespecifications
 Samsung;Samsung SH100;6.08;digicamdb
-Samsung;Samsung SL102;6.08;dpreview,digicamdb
-Samsung;Samsung SL201;6.08;dpreview,digicamdb
-Samsung;Samsung SL202;6.08;dpreview,digicamdb
-Samsung;Samsung SL30;6.08;dpreview,digicamdb
+Samsung;Samsung SL102;6.08;digicamdb,dpreview
+Samsung;Samsung SL201;6.08;digicamdb,dpreview
+Samsung;Samsung SL202;6.08;digicamdb,dpreview
+Samsung;Samsung SL30;6.08;digicamdb,dpreview
 Samsung;Samsung SL310;7.4;dpreview
 Samsung;Samsung SL310W;7.44;digicamdb
 Samsung;Samsung SL50;6.08;digicamdb
 Samsung;Samsung SL502;6.08;digicamdb
 Samsung;Samsung SL600;6.08;digicamdb
 Samsung;Samsung SL605;6.08;digicamdb
-Samsung;Samsung SL620;6.08;dpreview,digicamdb
+Samsung;Samsung SL620;6.08;digicamdb,dpreview
 Samsung;Samsung SL630;6.08;digicamdb
-Samsung;Samsung SL720;6.08;dpreview,digicamdb
-Samsung;Samsung SL820;6.08;dpreview,digicamdb
+Samsung;Samsung SL720;6.08;digicamdb,dpreview
+Samsung;Samsung SL820;6.08;digicamdb,dpreview
 Samsung;Samsung SM-A320FL;4.8;usercontribution
 Samsung;Samsung SM-A426B;12.7;usercontribution
 Samsung;Samsung SM-A715F;7.4;camerafv5
@@ -5780,86 +5903,86 @@ Samsung;Samsung SM-G965F;5.64;usercontribution
 Samsung;Samsung SM-G975U;5.66;devicespecifications
 Samsung;Samsung SM-G988;10.82;devicespecifications
 Samsung;Samsung SM-G9880;10.82;devicespecifications
-Samsung;Samsung SM-G988B/DS;10.82;devicespecifications
+Samsung;Samsung SM-G988B;10.82;devicespecifications
 Samsung;Samsung SM-G988N;10.82;devicespecifications
 Samsung;Samsung SM-G991B;7.26;usercontribution
 Samsung;Samsung SM-M315F;7.42;devicespecifications
 Samsung;Samsung SM-N985F;9.6;devicespecifications
 Samsung;Samsung SM-N986B;9.6;devicespecifications
 Samsung;Samsung SM-N986x;9.6;devicespecifications
-Samsung;Samsung ST10;5.744;dpreview,digicamdb
-Samsung;Samsung ST100;6.17;dpreview,digicamdb
+Samsung;Samsung ST10;5.744;digicamdb,dpreview
+Samsung;Samsung ST100;6.17;digicamdb,dpreview
 Samsung;Samsung ST1000;6.16;digicamdb
-Samsung;Samsung ST150F;6.17;dpreview,digicamdb
+Samsung;Samsung ST150F;6.17;digicamdb,dpreview
 Samsung;Samsung ST200F;6.16;digicamdb
-Samsung;Samsung ST30;4.8;dpreview,digicamdb
-Samsung;Samsung ST45;6.08;dpreview,digicamdb
-Samsung;Samsung ST50;6.08;dpreview,digicamdb
+Samsung;Samsung ST30;4.8;digicamdb,dpreview
+Samsung;Samsung ST45;6.08;digicamdb,dpreview
+Samsung;Samsung ST50;6.08;digicamdb,dpreview
 Samsung;Samsung ST500;6.16;digicamdb
-Samsung;Samsung ST5000;6.17;dpreview,digicamdb
-Samsung;Samsung ST550;6.08;dpreview,digicamdb
-Samsung;Samsung ST5500;6.17;dpreview,digicamdb
+Samsung;Samsung ST5000;6.17;digicamdb,dpreview
+Samsung;Samsung ST550;6.08;digicamdb,dpreview
+Samsung;Samsung ST5500;6.17;digicamdb,dpreview
 Samsung;Samsung ST60;6.16;digicamdb
-Samsung;Samsung ST600;6.08;dpreview,digicamdb
+Samsung;Samsung ST600;6.08;digicamdb,dpreview
 Samsung;Samsung ST65;6.16;digicamdb
-Samsung;Samsung ST6500;6.08;dpreview,digicamdb
+Samsung;Samsung ST6500;6.08;digicamdb,dpreview
 Samsung;Samsung ST66;6.16;digicamdb
 Samsung;Samsung ST70;6.16;digicamdb
 Samsung;Samsung ST700;6.16;digicamdb
 Samsung;Samsung ST72;6.16;digicamdb
 Samsung;Samsung ST76;6.16;digicamdb
 Samsung;Samsung ST77;6.16;digicamdb
-Samsung;Samsung ST80;6.08;dpreview,digicamdb
+Samsung;Samsung ST80;6.08;digicamdb,dpreview
 Samsung;Samsung ST88;6.16;digicamdb
 Samsung;Samsung ST90;6.16;digicamdb
 Samsung;Samsung ST93;6.16;digicamdb
 Samsung;Samsung ST95;6.16;digicamdb
 Samsung;Samsung ST96;6.16;digicamdb
-Samsung;Samsung TL100;6.08;dpreview,digicamdb
+Samsung;Samsung TL100;6.08;digicamdb,dpreview
 Samsung;Samsung TL105;6.16;digicamdb
 Samsung;Samsung TL110;6.16;digicamdb
-Samsung;Samsung TL205;6.08;dpreview,digicamdb
-Samsung;Samsung TL210;6.08;dpreview,digicamdb
-Samsung;Samsung TL220;6.08;dpreview,digicamdb
-Samsung;Samsung TL225;6.08;dpreview,digicamdb
-Samsung;Samsung TL240;6.17;dpreview,digicamdb
-Samsung;Samsung TL320;6.08;dpreview,digicamdb
-Samsung;Samsung TL34HD;7.44;dpreview,digicamdb
-Samsung;Samsung TL350;6.08;dpreview,digicamdb
-Samsung;Samsung TL500;7.44;dpreview,digicamdb
+Samsung;Samsung TL205;6.08;digicamdb,dpreview
+Samsung;Samsung TL210;6.08;digicamdb,dpreview
+Samsung;Samsung TL220;6.08;digicamdb,dpreview
+Samsung;Samsung TL225;6.08;digicamdb,dpreview
+Samsung;Samsung TL240;6.17;digicamdb,dpreview
+Samsung;Samsung TL320;6.08;digicamdb,dpreview
+Samsung;Samsung TL34HD;7.44;digicamdb,dpreview
+Samsung;Samsung TL350;6.08;digicamdb,dpreview
+Samsung;Samsung TL500;7.44;digicamdb,dpreview
 Samsung;Samsung TL9;6.16;digicamdb
 Samsung;Samsung W2016;5.95;devicespecifications
 Samsung;Samsung WB100;6.16;digicamdb
-Samsung;Samsung WB1000;6.08;dpreview,digicamdb
+Samsung;Samsung WB1000;6.08;digicamdb,dpreview
 Samsung;Samsung WB110;6.16;digicamdb
-Samsung;Samsung WB1100F;6.17;dpreview,digicamdb
-Samsung;Samsung WB150F;6.17;dpreview,digicamdb
-Samsung;Samsung WB2000;6.08;dpreview,digicamdb
+Samsung;Samsung WB1100F;6.17;digicamdb,dpreview
+Samsung;Samsung WB150F;6.17;digicamdb,dpreview
+Samsung;Samsung WB2000;6.08;digicamdb,dpreview
 Samsung;Samsung WB200F;6.16;digicamdb
-Samsung;Samsung WB210;6.17;dpreview,digicamdb
+Samsung;Samsung WB210;6.17;digicamdb,dpreview
 Samsung;Samsung WB2100;6.16;digicamdb
-Samsung;Samsung WB2200F;6.17;dpreview,digicamdb
-Samsung;Samsung WB250F;6.17;dpreview,digicamdb
-Samsung;Samsung WB30F;6.17;dpreview,digicamdb
-Samsung;Samsung WB350F;6.17;dpreview,digicamdb
-Samsung;Samsung WB35F;6.17;dpreview,digicamdb
-Samsung;Samsung WB500;6.08;dpreview,digicamdb
-Samsung;Samsung WB5000;6.08;dpreview,digicamdb
-Samsung;Samsung WB50F;6.17;dpreview,digicamdb
+Samsung;Samsung WB2200F;6.17;digicamdb,dpreview
+Samsung;Samsung WB250F;6.17;digicamdb,dpreview
+Samsung;Samsung WB30F;6.17;digicamdb,dpreview
+Samsung;Samsung WB350F;6.17;digicamdb,dpreview
+Samsung;Samsung WB35F;6.17;digicamdb,dpreview
+Samsung;Samsung WB500;6.08;digicamdb,dpreview
+Samsung;Samsung WB5000;6.08;digicamdb,dpreview
+Samsung;Samsung WB50F;6.17;digicamdb,dpreview
 Samsung;Samsung WB510;6.08;digicamdb
-Samsung;Samsung WB550;6.08;dpreview,digicamdb
+Samsung;Samsung WB550;6.08;digicamdb,dpreview
 Samsung;Samsung WB5500;6.16;digicamdb
 Samsung;Samsung WB560;6.08;digicamdb
-Samsung;Samsung WB600;6.17;dpreview,digicamdb
-Samsung;Samsung WB650;6.17;dpreview,digicamdb
+Samsung;Samsung WB600;6.17;digicamdb,dpreview
+Samsung;Samsung WB650;6.17;digicamdb,dpreview
 Samsung;Samsung WB660;6.16;digicamdb
 Samsung;Samsung WB690;6.08;digicamdb
 Samsung;Samsung WB700;6.08;digicamdb
 Samsung;Samsung WB750;6.08;digicamdb
-Samsung;Samsung WB800F;6.17;dpreview,digicamdb
-Samsung;Samsung WB850F;6.17;dpreview,digicamdb
+Samsung;Samsung WB800F;6.17;digicamdb,dpreview
+Samsung;Samsung WB850F;6.17;digicamdb,dpreview
 Samsung;Samsung Wi-Fi;6.17;dpreview
-Samsung;Samsung WP10;6.08;dpreview,digicamdb
+Samsung;Samsung WP10;6.08;digicamdb,dpreview
 Samsung;Samsung-SGH-I537;3.0;usercontribution
 Samsung;SM-G920F;5.95;usercontribution
 Samsung;SM-G930F;5.76;usercontribution
@@ -5961,29 +6084,29 @@ Sanyo;Sanyo Xacti VPC-X1200;6.16;digicamdb
 Sealife;SeaLife DC2000;13.2;dpreview
 Sensefly;SenseFly S.O.D.A.;12.75;usercontribution
 Sharp;Sharp Z3;5.22;devicespecifications
-Sigma;Sigma dp0 Quattro;23.5;dpreview,imaging-resource,dxomark
-Sigma;Sigma DP1;20.7;dpreview,digicamdb,imaging-resource
-Sigma;Sigma DP1 Merrill;24.0;dpreview,digicamdb
-Sigma;Sigma dp1 Quattro;23.5;dpreview,imaging-resource,dxomark
-Sigma;Sigma DP1s;20.7;dpreview,digicamdb,imaging-resource
-Sigma;Sigma DP1x;20.7;dpreview,digicamdb,imaging-resource,dxomark
-Sigma;Sigma DP2;20.7;dpreview,digicamdb,imaging-resource
-Sigma;Sigma DP2 Merrill;24.0;dpreview,digicamdb
-Sigma;Sigma dp2 Quattro;23.5;dpreview,imaging-resource,dxomark
-Sigma;Sigma DP2s;20.7;dpreview,digicamdb,imaging-resource,dxomark
-Sigma;Sigma DP2x;20.7;dpreview,digicamdb,imaging-resource
-Sigma;Sigma DP3 Merrill;24.0;dpreview,digicamdb
-Sigma;Sigma dp3 Quattro;23.5;dpreview,imaging-resource,dxomark
+Sigma;Sigma dp0 Quattro;23.5;dpreview,dxomark,imaging-resource
+Sigma;Sigma DP1;20.7;digicamdb,dpreview,imaging-resource
+Sigma;Sigma DP1 Merrill;24.0;digicamdb,dpreview
+Sigma;Sigma dp1 Quattro;23.5;dpreview,dxomark,imaging-resource
+Sigma;Sigma DP1s;20.7;digicamdb,dpreview,imaging-resource
+Sigma;Sigma DP1x;20.7;digicamdb,dpreview,dxomark,imaging-resource
+Sigma;Sigma DP2;20.7;digicamdb,dpreview,imaging-resource
+Sigma;Sigma DP2 Merrill;24.0;digicamdb,dpreview
+Sigma;Sigma dp2 Quattro;23.5;dpreview,dxomark,imaging-resource
+Sigma;Sigma DP2s;20.7;digicamdb,dpreview,dxomark,imaging-resource
+Sigma;Sigma DP2x;20.7;digicamdb,dpreview,imaging-resource
+Sigma;Sigma DP3 Merrill;24.0;digicamdb,dpreview
+Sigma;Sigma dp3 Quattro;23.5;dpreview,dxomark,imaging-resource
 Sigma;Sigma FP;35.9;usercontribution
 Sigma;Sigma FP L;36.0;usercontribution
-Sigma;Sigma sd Quattro;23.5;dpreview,imaging-resource,dxomark
-Sigma;Sigma sd Quattro H;26.6;dpreview,imaging-resource,dxomark
-Sigma;Sigma SD1;24.0;dpreview,digicamdb
-Sigma;Sigma SD1 Merrill;24.0;dpreview,digicamdb
-Sigma;Sigma SD10;20.7;dpreview,digicamdb
-Sigma;Sigma SD14;20.7;dpreview,digicamdb,imaging-resource
-Sigma;Sigma SD15;20.7;dpreview,digicamdb,imaging-resource,dxomark
-Sigma;Sigma SD9;20.7;dpreview,digicamdb
+Sigma;Sigma sd Quattro;23.5;dpreview,dxomark,imaging-resource
+Sigma;Sigma sd Quattro H;26.6;dpreview,dxomark,imaging-resource
+Sigma;Sigma SD1;24.0;digicamdb,dpreview
+Sigma;Sigma SD1 Merrill;24.0;digicamdb,dpreview
+Sigma;Sigma SD10;20.7;digicamdb,dpreview
+Sigma;Sigma SD14;20.7;digicamdb,dpreview,imaging-resource
+Sigma;Sigma SD15;20.7;digicamdb,dpreview,dxomark,imaging-resource
+Sigma;Sigma SD9;20.7;digicamdb,dpreview
 Sigma mobile;Sigma mobile X-treme PQ37;4.69;devicespecifications
 Sigma mobile;Sigma mobile X-treme PQ52;4.69;devicespecifications
 Sigma mobile;Sigma mobile X-treme PQ53;3.67;devicespecifications
@@ -6043,7 +6166,7 @@ Sony;ILCA-77M2;23.5;usercontribution
 Sony;ILCE-5000;23.2;usercontribution
 Sony;ILCE-5100;23.5;usercontribution
 Sony;ILCE-6000;23.5;usercontribution
-Sony;ILCE-6100;23.5;usercontribution,dpreview
+Sony;ILCE-6100;23.5;dpreview,usercontribution
 Sony;ILCE-6300;23.5;usercontribution
 Sony;ILCE-6400;23.5;usercontribution
 Sony;ILCE-6500;23.5;usercontribution
@@ -6065,25 +6188,38 @@ Sony;PXW-FS7 II;25.5;usercontribution
 Sony;PXW-FX9;35.7;usercontribution
 Sony;SLT-A77V;23.5;usercontribution
 Sony;SLT-A99V;35.8;usercontribution
+Sony;Sony A1;35.9;dxomark
 Sony;Sony A3000;23.5;dxomark
 Sony;Sony A3500;23.2;dxomark
 Sony;Sony A5000;23.2;dxomark
 Sony;Sony A5100;23.5;dxomark
 Sony;Sony a6000;23.5;dpreview
+Sony;Sony A6100;23.5;dxomark
 Sony;Sony a6300;23.5;dpreview
 Sony;Sony a6400;23.5;sony
 Sony;Sony a6500;23.5;dpreview
+Sony;Sony A6600;23.5;dxomark
 Sony;Sony a7;35.8;dpreview
 Sony;Sony a7 II;35.8;dpreview
 Sony;Sony a7 III;35.6;dxomark
+Sony;Sony A7 IV;35.9;digicamdb
 Sony;Sony a77 II;23.5;usercontribution
+Sony;Sony A7C;35.6;dxomark
+Sony;Sony A7IV;35.9;dxomark
 Sony;Sony a7R;35.9;dpreview
 Sony;Sony a7R II;35.8;dpreview
 Sony;Sony a7R III;35.9;dpreview
+Sony;Sony a7R IIIA;35.9;dpreview
 Sony;Sony a7R IV;35.7;sony
+Sony;Sony a7R IVA;35.7;dpreview
+Sony;Sony a7R V;35.7;dpreview
 Sony;Sony a7S;35.6;dxomark
 Sony;Sony a7S II;35.6;dpreview
+Sony;Sony a7S III;35.6;digicamdb
+Sony;Sony A7SIII;35.6;dxomark
 Sony;Sony a9;35.6;dxomark
+Sony;Sony a9 II;35.6;dxomark
+Sony;Sony a99 II;35.9;dpreview
 Sony;Sony Alpha 100;24.0;dxomark
 Sony;Sony Alpha 200;24.0;dxomark
 Sony;Sony Alpha 230;23.6;dxomark
@@ -6107,66 +6243,77 @@ Sony;Sony Alpha 7S;35.6;digicamdb
 Sony;Sony Alpha 7S II;35.6;digicamdb
 Sony;Sony Alpha 850;35.9;dxomark
 Sony;Sony Alpha 900;36.0;dxomark
-Sony;Sony Alpha a3000;23.5;dpreview,digicamdb
+Sony;Sony Alpha a3000;23.5;digicamdb,dpreview
 Sony;Sony Alpha a3500;23.5;dpreview
 Sony;Sony Alpha a5000;23.5;digicamdb
-Sony;Sony Alpha a5100;23.5;dpreview,digicamdb
+Sony;Sony Alpha a5100;23.5;digicamdb,dpreview
 Sony;Sony Alpha a6000;23.5;digicamdb
 Sony;Sony Alpha a6300;23.5;digicamdb
 Sony;Sony Alpha a6400;23.5;sony
 Sony;Sony Alpha a6500;23.5;digicamdb
 Sony;Sony Alpha A7 III;35.6;digicamdb
 Sony;Sony Alpha a7R III;35.9;digicamdb
-Sony;Sony Alpha a9;35.6;dpreview,digicamdb
+Sony;Sony Alpha a9;35.6;digicamdb,dpreview
+Sony;Sony Alpha a9 II;35.6;digicamdb
 Sony;Sony Alpha a99;35.8;dpreview
 Sony;Sony Alpha A99 II;35.9;digicamdb
-Sony;Sony Alpha DSLR-A100;23.6;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha DSLR-A200;23.6;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha DSLR-A230;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A290;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A300;23.6;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha DSLR-A330;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A350;23.6;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha DSLR-A380;23.6;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha DSLR-A390;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A450;23.4;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A500;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A550;23.4;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A560;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A580;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A700;23.5;dpreview,digicamdb
-Sony;Sony Alpha DSLR-A850;35.9;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha DSLR-A900;35.9;dpreview,digicamdb,imaging-resource
+Sony;Sony Alpha DSLR-A100;23.6;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha DSLR-A200;23.6;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha DSLR-A230;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A290;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A300;23.6;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha DSLR-A330;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A350;23.6;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha DSLR-A380;23.6;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha DSLR-A390;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A450;23.4;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A500;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A550;23.4;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A560;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A580;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A700;23.5;digicamdb,dpreview
+Sony;Sony Alpha DSLR-A850;35.9;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha DSLR-A900;35.9;digicamdb,dpreview,imaging-resource
 Sony;Sony Alpha ILCA-A68;23.5;imaging-resource
 Sony;Sony Alpha ILCA-A77 II;23.5;imaging-resource
 Sony;Sony Alpha ILCA-A99 II;35.9;imaging-resource
+Sony;Sony Alpha ILCE-A1;35.9;imaging-resource
 Sony;Sony Alpha ILCE-A3000;23.2;imaging-resource
 Sony;Sony Alpha ILCE-A5000;23.2;imaging-resource
 Sony;Sony Alpha ILCE-A5100;23.5;imaging-resource
 Sony;Sony Alpha ILCE-A6000;23.5;imaging-resource
+Sony;Sony Alpha ILCE-A6100;23.5;imaging-resource
 Sony;Sony Alpha ILCE-A6300;23.5;imaging-resource
 Sony;Sony Alpha ILCE-A6400;23.5;sony
 Sony;Sony Alpha ILCE-A6500;23.5;imaging-resource
+Sony;Sony Alpha ILCE-A6600;23.5;imaging-resource
 Sony;Sony Alpha ILCE-A7;35.8;imaging-resource
 Sony;Sony Alpha ILCE-A7 II;35.8;imaging-resource
 Sony;Sony Alpha ILCE-A7 III;35.6;imaging-resource
+Sony;Sony Alpha ILCE-A7 IV;35.9;imaging-resource
+Sony;Sony Alpha ILCE-A7C;35.6;imaging-resource
 Sony;Sony Alpha ILCE-A7R;35.9;imaging-resource
 Sony;Sony Alpha ILCE-A7R II;35.9;imaging-resource
 Sony;Sony Alpha ILCE-A7R III;35.9;imaging-resource
+Sony;Sony Alpha ILCE-A7R IV;35.7;imaging-resource
+Sony;Sony Alpha ILCE-A7R V;35.7;imaging-resource
 Sony;Sony Alpha ILCE-A7S;35.6;imaging-resource
 Sony;Sony Alpha ILCE-A7S II;35.6;imaging-resource
+Sony;Sony Alpha ILCE-A7S III;35.6;imaging-resource
 Sony;Sony Alpha ILCE-A9;35.6;imaging-resource
+Sony;Sony Alpha ILCE-A9 II;35.6;imaging-resource
 Sony;Sony Alpha ILCE-QX1;23.2;imaging-resource
-Sony;Sony Alpha NEX-3;23.4;dpreview,digicamdb
-Sony;Sony Alpha NEX-3N;23.5;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha NEX-5;23.4;dpreview,digicamdb
-Sony;Sony Alpha NEX-5N;23.4;dpreview,digicamdb
-Sony;Sony Alpha NEX-5R;23.4;dpreview,digicamdb
-Sony;Sony Alpha NEX-5T;23.4;dpreview,digicamdb
-Sony;Sony Alpha NEX-6;23.5;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha NEX-7;23.5;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha NEX-C3;23.4;dpreview,digicamdb,imaging-resource
-Sony;Sony Alpha NEX-F3;23.4;dpreview,digicamdb
+Sony;Sony Alpha ILCZV-E10;23.5;imaging-resource
+Sony;Sony Alpha NEX-3;23.4;digicamdb,dpreview
+Sony;Sony Alpha NEX-3N;23.5;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha NEX-5;23.4;digicamdb,dpreview
+Sony;Sony Alpha NEX-5N;23.4;digicamdb,dpreview
+Sony;Sony Alpha NEX-5R;23.4;digicamdb,dpreview
+Sony;Sony Alpha NEX-5T;23.4;digicamdb,dpreview
+Sony;Sony Alpha NEX-6;23.5;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha NEX-7;23.5;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha NEX-C3;23.4;digicamdb,dpreview,imaging-resource
+Sony;Sony Alpha NEX-F3;23.4;digicamdb,dpreview
 Sony;Sony Alpha QX1;23.2;dpreview
 Sony;Sony Alpha SLT-A33;23.5;digicamdb
 Sony;Sony Alpha SLT-A35;23.5;digicamdb
@@ -6181,44 +6328,44 @@ Sony;Sony Alpha SLT-A77;23.5;digicamdb
 Sony;Sony Alpha SLT-A77 II;23.5;digicamdb
 Sony;Sony Alpha SLT-A99;35.8;digicamdb
 Sony;Sony Cyber-shot DSC RX100 III;13.2;dxomark
-Sony;Sony Cyber-shot DSC-D700;6.4;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-D770;6.4;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-F505;6.4;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-D700;6.4;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-D770;6.4;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-F505;6.4;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-F505v;7.144;digicamdb
-Sony;Sony Cyber-shot DSC-F55;6.4;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-F55;6.4;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-F55v;7.144;digicamdb
-Sony;Sony Cyber-shot DSC-F707;8.8;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-F717;8.8;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-F707;8.8;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-F717;8.8;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-F77;7.11;digicamdb
-Sony;Sony Cyber-shot DSC-F828;8.8;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-F828;8.8;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-F88;5.9;digicamdb
 Sony;Sony Cyber-shot DSC-FX77;7.11;digicamdb
-Sony;Sony Cyber-shot DSC-G1;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-G3;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-G1;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-G3;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-H1;5.75;digicamdb
-Sony;Sony Cyber-shot DSC-H10;5.744;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-H10;5.744;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-H100;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-H2;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H20;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-H200;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H3;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H300;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H400;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H5;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H50;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H55;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H7;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H70;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H9;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-H90;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-H2;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H20;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-H200;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H3;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H300;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H400;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H5;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H50;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H55;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H7;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H70;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H9;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-H90;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-HX1;5.9;digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX100V;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX10V;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX200V;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX20V;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-HX100V;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX10V;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX200V;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX20V;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-HX300;6.16;digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX30V;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX350;6.17;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-HX30V;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX350;6.17;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-HX400;6.16;digicamdb
 Sony;Sony Cyber-shot DSC-HX400V;6.17;dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-HX5;5.9;digicamdb
@@ -6226,207 +6373,208 @@ Sony;Sony Cyber-shot DSC-HX50;6.16;digicamdb
 Sony;Sony Cyber-shot DSC-HX50V;6.17;dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-HX5V;5.9;imaging-resource
 Sony;Sony Cyber-shot DSC-HX60;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-HX7V;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX80;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX90V;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX95;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-HX99;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-HX9V;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-HX7V;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX80;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX90V;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX95;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-HX99;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-HX9V;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-J10;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-L1;5.312;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-L1;5.312;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-M1;5.9;digicamdb
-Sony;Sony Cyber-shot DSC-M2;5.744;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-N1;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-N2;7.44;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-P1;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P10;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P100;7.144;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-M2;5.744;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-N1;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-N2;7.44;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-P1;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P10;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P100;7.144;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-P12;7.11;digicamdb
 Sony;Sony Cyber-shot DSC-P120;7.11;digicamdb
-Sony;Sony Cyber-shot DSC-P150;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P2;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P20;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P200;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P3;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P30;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P31;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P32;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P41;5.312;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-P150;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P2;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P20;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P200;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P3;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P30;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P31;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P32;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P41;5.312;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-P43;5.33;digicamdb
-Sony;Sony Cyber-shot DSC-P5;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P50;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P51;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P52;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P7;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P71;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P72;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P73;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P8;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P9;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P92;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-P93;7.144;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-P5;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P50;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P51;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P52;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P7;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P71;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P72;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P73;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P8;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P9;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P92;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-P93;7.144;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-QX1;23.2;digicamdb
-Sony;Sony Cyber-shot DSC-QX10;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-QX100;13.2;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-QX30;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-R1;21.5;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-RX1;35.8;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-RX10;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-RX10 II;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-RX10 III;13.2;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-RX10 IV;13.2;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-RX100;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-RX100 II;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-RX100 III;13.2;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-RX100 IV;13.2;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-RX100 V;13.2;dpreview,digicamdb,imaging-resource,dxomark
+Sony;Sony Cyber-shot DSC-QX10;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-QX100;13.2;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-QX30;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-R1;21.5;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-RX1;35.8;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-RX10;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-RX10 II;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-RX10 III;13.2;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-RX10 IV;13.2;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-RX100;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-RX100 II;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-RX100 III;13.2;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-RX100 IV;13.2;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-RX100 V;13.2;digicamdb,dpreview,dxomark,imaging-resource
 Sony;Sony Cyber-shot DSC-RX100 VA;13.2;dpreview,imaging-resource
-Sony;Sony Cyber-shot DSC-RX100 VI;13.2;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-RX1R;35.8;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-RX1R II;35.9;dpreview,digicamdb,imaging-resource,dxomark
-Sony;Sony Cyber-shot DSC-S2000;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-S2100;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-S30;5.312;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-RX100 VI;13.2;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-RX100 VII;13.2;dxomark
+Sony;Sony Cyber-shot DSC-RX1R;35.8;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-RX1R II;35.9;digicamdb,dpreview,dxomark,imaging-resource
+Sony;Sony Cyber-shot DSC-S2000;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-S2100;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-S30;5.312;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-S3000;4.96;digicamdb
-Sony;Sony Cyber-shot DSC-S40;5.312;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-S40;5.312;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-S45;5.75;digicamdb
-Sony;Sony Cyber-shot DSC-S50;5.312;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-S50;5.312;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-S500;5.8;imaging-resource
 Sony;Sony Cyber-shot DSC-S5000;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-S60;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-S600;5.744;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-S650;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-S70;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-S700;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-S730;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-S75;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-S750;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-S780;5.744;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-S60;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-S600;5.744;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-S650;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-S70;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-S700;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-S730;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-S75;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-S750;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-S780;5.744;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-S80;5.33;digicamdb
-Sony;Sony Cyber-shot DSC-S800;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-S85;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-S90;5.312;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-S800;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-S85;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-S90;5.312;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-S930;6.08;digicamdb
-Sony;Sony Cyber-shot DSC-S950;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-S950;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-S980;6.08;digicamdb,imaging-resource
 Sony;Sony Cyber-shot DSC-T1;5.9;digicamdb
-Sony;Sony Cyber-shot DSC-T10;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T100;5.744;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-T10;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T100;5.744;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-T11;5.9;digicamdb
-Sony;Sony Cyber-shot DSC-T110;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T2;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T20;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T200;5.744;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-T110;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T2;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T20;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T200;5.744;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-T3;5.9;digicamdb
-Sony;Sony Cyber-shot DSC-T30;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T300;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-T30;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T300;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-T33;5.9;digicamdb
-Sony;Sony Cyber-shot DSC-T5;5.744;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-T50;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T500;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-T5;5.744;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-T50;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T500;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-T7;5.9;digicamdb
 Sony;Sony Cyber-shot DSC-T70;5.75;digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T700;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T77;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-T700;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T77;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-T9;5.75;digicamdb
-Sony;Sony Cyber-shot DSC-T90;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T900;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-T99;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TF1;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-T90;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T900;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-T99;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-TF1;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-TX1;5.9;digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TX10;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TX100V;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TX20;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TX200V;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-TX10;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-TX100V;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-TX20;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-TX200V;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-TX30;6.16;digicamdb,imaging-resource
 Sony;Sony Cyber-shot DSC-TX5;5.9;digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TX55;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TX66;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-TX55;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-TX66;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-TX7;5.9;digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-TX9;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-U10;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-U20;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-U30;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-U40;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-U50;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-U60;5.312;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-V1;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-V3;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W1;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W100;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W110;5.744;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-TX9;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-U10;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-U20;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-U30;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-U40;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-U50;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-U60;5.312;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-V1;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-V3;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W1;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W100;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W110;5.744;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-W115;5.75;digicamdb
 Sony;Sony Cyber-shot DSC-W12;7.11;digicamdb
-Sony;Sony Cyber-shot DSC-W120;5.744;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W120;5.744;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W125;5.75;digicamdb
-Sony;Sony Cyber-shot DSC-W130;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W150;5.744;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W130;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W150;5.744;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W17;7.11;digicamdb
-Sony;Sony Cyber-shot DSC-W170;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W170;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W180;6.08;digicamdb
 Sony;Sony Cyber-shot DSC-W190;6.08;digicamdb
-Sony;Sony Cyber-shot DSC-W200;7.44;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W200;7.44;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W210;6.16;digicamdb
 Sony;Sony Cyber-shot DSC-W215;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-W220;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W230;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W220;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W230;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W270;7.53;digicamdb
 Sony;Sony Cyber-shot DSC-W275;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-W290;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W30;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W300;7.44;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W310;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W320;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W330;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W35;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W350;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W290;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W30;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W300;7.44;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W310;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W320;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W330;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W35;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W350;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W360;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-W370;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W380;6.17;dpreview,digicamdb
+Sony;Sony Cyber-shot DSC-W370;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W380;6.17;digicamdb,dpreview
 Sony;Sony Cyber-shot DSC-W40;5.75;digicamdb
-Sony;Sony Cyber-shot DSC-W5;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W50;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W510;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W5;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W50;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W510;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W520;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-W530;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W55;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W550;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W560;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W570;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W530;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W55;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W550;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W560;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W570;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W580;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-W610;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W620;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W610;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W620;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W630;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-W650;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W650;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W670;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-W690;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W7;7.144;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W70;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W710;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W730;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W80;5.744;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W800;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-W810;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-W830;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W690;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W7;7.144;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W70;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W710;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W730;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W80;5.744;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W800;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-W810;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-W830;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-W85;5.75;digicamdb
-Sony;Sony Cyber-shot DSC-W90;5.744;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-W90;5.744;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-WX1;5.9;digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-WX10;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-WX10;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-WX100;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-WX150;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-WX150;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-WX200;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-WX220;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-WX30;6.17;dpreview,digicamdb
-Sony;Sony Cyber-shot DSC-WX300;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-WX350;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-WX5;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-WX50;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-WX500;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-WX220;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-WX30;6.17;digicamdb,dpreview
+Sony;Sony Cyber-shot DSC-WX300;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-WX350;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-WX5;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-WX50;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-WX500;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cyber-shot DSC-WX60;6.16;digicamdb
 Sony;Sony Cyber-shot DSC-WX7;6.16;digicamdb
-Sony;Sony Cyber-shot DSC-WX70;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-WX80;6.17;dpreview,digicamdb,imaging-resource
-Sony;Sony Cyber-shot DSC-WX9;6.17;dpreview,digicamdb,imaging-resource
+Sony;Sony Cyber-shot DSC-WX70;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-WX80;6.17;digicamdb,dpreview,imaging-resource
+Sony;Sony Cyber-shot DSC-WX9;6.17;digicamdb,dpreview,imaging-resource
 Sony;Sony Cybershot DSC D700;6.4;usercontribution
 Sony;Sony Cybershot DSC D770;6.4;usercontribution
 Sony;Sony Cybershot DSC F505;6.4;usercontribution
@@ -6646,7 +6794,6 @@ Sony;Sony Cybershot DSC-HX400;6.16;usercontribution
 Sony;Sony CyberShot DSC-HX7V;6.16;usercontribution
 Sony;Sony Cybershot DSC-HX90;6.16;usercontribution
 Sony;Sony Cybershot DSC-HX90V;6.16;usercontribution
-Sony;Sony Cybershot DSC-HX90V;6.16;usercontribution
 Sony;Sony Cybershot DSC-QX10;6.16;usercontribution
 Sony;Sony Cybershot DSC-QX100;13.2;usercontribution
 Sony;Sony Cybershot DSC-RX10;13.2;usercontribution
@@ -6668,6 +6815,7 @@ Sony;Sony DSC-HX60V;6.16;usercontribution
 Sony;Sony DSC-HX7V;6.16;usercontribution
 Sony;Sony DSC-QX30U;6.16;usercontribution
 Sony;Sony DSC-RX0;13.2;dpreview,dxomark
+Sony;Sony DSC-RX0 II;13.2;dpreview
 Sony;Sony DSC-RX10;13.2;usercontribution
 Sony;Sony DSC-RX100M5;13.2;usercontribution
 Sony;Sony DSC-T110;6.16;usercontribution
@@ -6677,6 +6825,7 @@ Sony;Sony DSLR-A700;23.5;usercontribution
 Sony;Sony DSLR-A900;35.9;usercontribution
 Sony;Sony FDR-X1000V;6.19;usercontribution
 Sony;Sony FDR-X3000;5.744;dpreview
+Sony;Sony FX30;23.4;dpreview
 Sony;Sony HDR-AS300;5.744;dpreview
 Sony;Sony HDR-HC7e;4.98;usercontribution
 Sony;Sony ILCE 5000;23.2;dpreview
@@ -6693,29 +6842,29 @@ Sony;Sony ILCE-7RM3;35.9;usercontribution
 Sony;Sony ILCE-7RM4;35.7;usercontribution
 Sony;Sony ILCE-QX1;23.2;usercontribution
 Sony;Sony IMX179;6.18;usercontribution
-Sony;Sony IMX298;5.22;dpreview,digicamdb
-Sony;Sony Mavica CD1000;5.312;dpreview,digicamdb
-Sony;Sony Mavica CD200;5.312;dpreview,digicamdb
-Sony;Sony Mavica CD250;5.312;dpreview,digicamdb
-Sony;Sony Mavica CD300;7.144;dpreview,digicamdb
-Sony;Sony Mavica CD350;5.312;dpreview,digicamdb
-Sony;Sony Mavica CD400;7.144;dpreview,digicamdb
-Sony;Sony Mavica CD500;7.144;dpreview,digicamdb
-Sony;Sony Mavica FD-100;5.312;dpreview,digicamdb
-Sony;Sony Mavica FD-200;5.312;dpreview,digicamdb
+Sony;Sony IMX298;5.22;digicamdb,dpreview
+Sony;Sony Mavica CD1000;5.312;digicamdb,dpreview
+Sony;Sony Mavica CD200;5.312;digicamdb,dpreview
+Sony;Sony Mavica CD250;5.312;digicamdb,dpreview
+Sony;Sony Mavica CD300;7.144;digicamdb,dpreview
+Sony;Sony Mavica CD350;5.312;digicamdb,dpreview
+Sony;Sony Mavica CD400;7.144;digicamdb,dpreview
+Sony;Sony Mavica CD500;7.144;digicamdb,dpreview
+Sony;Sony Mavica FD-100;5.312;digicamdb,dpreview
+Sony;Sony Mavica FD-200;5.312;digicamdb,dpreview
 Sony;Sony Mavica FD-71;6.4;digicamdb
 Sony;Sony Mavica FD-73;6.4;digicamdb
 Sony;Sony Mavica FD-75;7.11;digicamdb
-Sony;Sony Mavica FD-81;4.8;dpreview,digicamdb
-Sony;Sony Mavica FD-83;4.8;dpreview,digicamdb
-Sony;Sony Mavica FD-85;5.312;dpreview,digicamdb
-Sony;Sony Mavica FD-87;5.312;dpreview,digicamdb
+Sony;Sony Mavica FD-81;4.8;digicamdb,dpreview
+Sony;Sony Mavica FD-83;4.8;digicamdb,dpreview
+Sony;Sony Mavica FD-85;5.312;digicamdb,dpreview
+Sony;Sony Mavica FD-87;5.312;digicamdb,dpreview
 Sony;Sony Mavica FD-88;4.8;digicamdb
-Sony;Sony Mavica FD-90;5.312;dpreview,digicamdb
-Sony;Sony Mavica FD-91;4.8;dpreview,digicamdb
-Sony;Sony Mavica FD-92;5.312;dpreview,digicamdb
-Sony;Sony Mavica FD-95;5.312;dpreview,digicamdb
-Sony;Sony Mavica FD-97;5.312;dpreview,digicamdb
+Sony;Sony Mavica FD-90;5.312;digicamdb,dpreview
+Sony;Sony Mavica FD-91;4.8;digicamdb,dpreview
+Sony;Sony Mavica FD-92;5.312;digicamdb,dpreview
+Sony;Sony Mavica FD-95;5.312;digicamdb,dpreview
+Sony;Sony Mavica FD-97;5.312;digicamdb,dpreview
 Sony;Sony NEX-3N;23.5;dxomark
 Sony;Sony NEX-5N;23.5;dxomark
 Sony;Sony NEX-5R;23.5;dxomark
@@ -6801,6 +6950,8 @@ Sony;Sony Xperia Z5 Premium Dual;6.17;devicespecifications
 Sony;Sony Xperia ZL;4.69;devicespecifications
 Sony;Sony Xperia ZL2 SOL25;6.17;devicespecifications
 Sony;Sony ZV-1;13.2;digicamdb
+Sony;Sony ZV-1F;13.2;imaging-resource
+Sony;Sony ZV-E10;23.5;digicamdb
 Sony;Venice;36.2;usercontribution
 Spice;Spice Stellar 519;3.68;devicespecifications
 Starmobile;Starmobile Up Max;4.69;devicespecifications
@@ -7041,14 +7192,14 @@ Vivitar;Vivitar ViviCam 8625;7.11;digicamdb
 Vivitar;Vivitar ViviCam V8025;7.11;digicamdb
 Vivitar;Vivitar ViviCam X30;7.11;digicamdb
 Vivitar;Vivitar ViviCam X60;7.11;digicamdb
-Vivo;Vivo iQOO 3;6.4;;devicespecifications,usercontribution
-Vivo;Vivo iQOO 3 5G;6.4;;devicespecifications,usercontribution
-Vivo;Vivo iQOO Neo 3;6.4;;devicespecifications,usercontribution
+Vivo;Vivo iQOO 3;6.4;devicespecifications,usercontribution
+Vivo;Vivo iQOO 3 5G;6.4;devicespecifications,usercontribution
+Vivo;Vivo iQOO Neo 3;6.4;devicespecifications,usercontribution
 Vivo;Vivo S5;6.4;kimovil
-Vivo;Vivo S6;6.4;;devicespecifications,usercontribution
-Vivo;Vivo V19;6.4;;devicespecifications,usercontribution
-Vivo;Vivo V1962A;6.4;;devicespecifications,usercontribution
-Vivo;Vivo V1981A;6.4;;devicespecifications,usercontribution
+Vivo;Vivo S6;6.4;devicespecifications,usercontribution
+Vivo;Vivo V19;6.4;devicespecifications,usercontribution
+Vivo;Vivo V1962A;6.4;devicespecifications,usercontribution
+Vivo;Vivo V1981A;6.4;devicespecifications,usercontribution
 Vivo;Vivo V7;4.74;devicespecifications
 Vivo;Vivo V7Plus;4.74;devicespecifications
 Vivo;Vivo X27;6.4;kimovil
@@ -7075,7 +7226,7 @@ Vivo;Vivo Y29L;4.69;devicespecifications
 Vivo;Vivo Y69;4.69;devicespecifications
 Vivo;Vivo Y79;4.74;devicespecifications
 Vivo;Vivo Z10;4.74;devicespecifications
-Vivo;Vivo Z6;6.4;;devicespecifications,usercontribution
+Vivo;Vivo Z6;6.4;devicespecifications,usercontribution
 Vkworld;Vkworld S8;4.82;devicespecifications
 Vkworld;Vkworld T1 Plus;4.71;devicespecifications
 Voto;Voto X6;4.82;devicespecifications
@@ -7118,7 +7269,7 @@ Xgody;Xgody Y20;3.68;devicespecifications
 Xiaomi;Black Shark 2 Pro;6.4;kimovil
 Xiaomi;CC9;6.4;kimovil
 Xiaomi;m2007j20cg;7.4;devicespecifications
-Xiaomi;M2102J20SG (vayu);6.4;usercontribution
+Xiaomi;M2102J20SG;6.4;usercontribution
 Xiaomi;MI 9;6.4;devicespecifications
 Xiaomi;Mi A1;5.11;devicespecifications
 Xiaomi;Mi A3;6.4;devicespecifications
@@ -7139,7 +7290,7 @@ Xiaomi;Xiaomi Mi 5s;6.25;devicespecifications
 Xiaomi;Xiaomi Mi 5s Plus;4.71;devicespecifications
 Xiaomi;Xiaomi Mi 5X;5.11;devicespecifications
 Xiaomi;Xiaomi Mi 6;4.96;devicespecifications
-Xiaomi;Xiaomi Mi 8;5.64;usercontribution,kimovil
+Xiaomi;Xiaomi Mi 8;5.64;kimovil,usercontribution
 Xiaomi;Xiaomi Mi 9;6.4;kimovil
 Xiaomi;Xiaomi Mi 9 Lite;6.4;kimovil
 Xiaomi;Xiaomi Mi 9 Pro;6.4;kimovil
@@ -7178,9 +7329,9 @@ Xiaomi;Xiaomi Redmi 5;5.11;devicespecifications
 Xiaomi;Xiaomi Redmi 5 Plus;5.11;devicespecifications
 Xiaomi;Xiaomi Redmi 5A;4.71;devicespecifications
 Xiaomi;Xiaomi Redmi 6 Pro;2.98;devicespecifications
-Xiaomi;Xiaomi Redmi 7;4.96;usercontribution,kimovil
-Xiaomi;Xiaomi Redmi 7 Pro;5.54;usercontribution,kimovil
-Xiaomi;Xiaomi Redmi 7A;4.96;usercontribution,kimovil
+Xiaomi;Xiaomi Redmi 7;4.96;kimovil,usercontribution
+Xiaomi;Xiaomi Redmi 7 Pro;5.54;kimovil,usercontribution
+Xiaomi;Xiaomi Redmi 7A;4.96;kimovil,usercontribution
 Xiaomi;Xiaomi Redmi K20;6.4;kimovil
 Xiaomi;Xiaomi Redmi K20 Pro;6.4;kimovil
 Xiaomi;Xiaomi Redmi Note;4.6;devicespecifications
@@ -7202,12 +7353,13 @@ Xiaomi;Xiaomi Redmi Note 5A Standard Edition;4.69;devicespecifications
 Xiaomi;Xiaomi Redmi Note 7;6.4;devicespecifications
 Xiaomi;Xiaomi Redmi Note 7 Pro;6.4;kimovil
 Xiaomi;Xiaomi Redmi Note 8;6.4;usercontribution
-Xiaomi;Xiaomi Redmi Note 8 Pro;7.44;usercontribution,kimovil
+Xiaomi;Xiaomi Redmi Note 8 Pro;7.44;kimovil,usercontribution
 Xiaomi;Xiaomi Redmi Note MT6592M;4.6;devicespecifications
 Xiaomi;Xiaomi Redmi Pro Exclusive Edition;4.71;devicespecifications
 Xiaomi;Xiaomi Redmi Pro High Edition;4.71;devicespecifications
 Xiaomi;Xiaomi Redmi Pro Standard Edition;4.71;devicespecifications
 Xiaomi;Xiaomi Redmi Y1 Lite;2.9;devicespecifications
+Xiaomi;Xiaomi vayu;6.4;usercontribution
 Xiaomi;YDXJ 2;7.70;usercontribution
 Xiaomi;YDXJ01FM;7.04;usercontribution
 Xolo;Xolo Black 1X;4.69;devicespecifications
@@ -7253,8 +7405,9 @@ Yu;Yu Yureka Note;4.82;devicespecifications
 Yu;Yu Yureka Plus;4.69;devicespecifications
 Yu;Yu Yureka S;4.82;devicespecifications
 Yu;Yu Yutopia;5.99;devicespecifications
-YUNEEC;CGO3+ 3.2.34(E);6.16;usercontribution
+YUNEEC;CGO3+ 3.2.34;6.16;usercontribution
 YUNEEC;YUNEEC Breeze 4K;4.7;dxomark
+YUNEEC;YUNEEC E;6.16;usercontribution
 Z Cam;E2;19.0;usercontribution
 Z Cam;E2-F6;37.09;usercontribution
 Z Cam;E2-M4;19.0;usercontribution

--- a/src/aliceVision/sensorDB/sensorDatabaseSort.py
+++ b/src/aliceVision/sensorDB/sensorDatabaseSort.py
@@ -24,13 +24,19 @@ parser.add_argument('-o', '--output', metavar='outputSensorDatabase.txt', requir
 args = parser.parse_args()
 
 # read
-file = open(args.input, "r")
-database = file.readlines()
-file.close()
+with open(args.input, 'r') as file:
+	database = file.readlines()
 
-# process
+# sorting process
+# 1st step: sort lines
 sensors = [entry.split(';')  for entry in database]
 sensors.sort(key=lambda t : tuple(s.lower() if isinstance(s, basestring) else s for s in t))
+# 2nd step: in each line, sort the list of sources
+for entry in sensors:
+	sources = entry[-1][:-1] # omit the newline character for sorting
+	sources = sources.split(',')
+	sources.sort()
+	entry[-1] = ','.join(sources) + '\n'
 outDatabase = ""
 for entry in sensors:
 	outDatabase += ';'.join(entry)


### PR DESCRIPTION
## Description

In this PR we update the camera sensor database with the latest sensor data from dxomark, dpreview, imagingresource and digicamdb.