### PR TITLE
Disable libraw flip 

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -523,7 +523,6 @@ void readImage(const std::string& path,
 
     const bool isRawImage = isRawFormat(path);
     image::DCPProfile::Triple neutral = {1.0,1.0,1.0};
-  configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of buffer
 
     if (isRawImage)
     {
@@ -560,8 +559,8 @@ void readImage(const std::string& path,
         // See https://openimageio.readthedocs.io/en/master/builtinplugins.html#raw-digital-camera-files
 
 #if OIIO_VERSION > (10000 * 2 + 100 * 4 + 5) // OIIO_VERSION > 2.4.5
-	// To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
-	// so we can disable the auto orientation and keep the metadata.
+	    // To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
+	    // so we can disable the auto orientation and keep the metadata.
         configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of the image buffer
 #endif
 

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -420,7 +420,11 @@ oiio::ParamValueList readImageMetadata(const std::string& path, int& width, int&
 oiio::ImageSpec readImageSpec(const std::string& path)
 {
   oiio::ImageSpec configSpec;
-  configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of buffer
+#if OIIO_VERSION > (10000 * 2 + 100 * 4 + 5) // OIIO_VERSION > 2.4.5
+    // To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
+    // so we can disable the auto orientation and keep the metadata.
+    configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of the image buffer
+#endif 
 
   std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path, &configSpec));
   oiio::ImageSpec spec = in->spec();
@@ -554,6 +558,12 @@ void readImage(const std::string& path,
 
         // libRAW configuration
         // See https://openimageio.readthedocs.io/en/master/builtinplugins.html#raw-digital-camera-files
+
+#if OIIO_VERSION > (10000 * 2 + 100 * 4 + 5) // OIIO_VERSION > 2.4.5
+	// To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
+	// so we can disable the auto orientation and keep the metadata.
+        configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of the image buffer
+#endif
 
         if (imageReadOptions.rawColorInterpretation == ERawColorInterpretation::None)
         {

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -420,7 +420,7 @@ oiio::ParamValueList readImageMetadata(const std::string& path, int& width, int&
 oiio::ImageSpec readImageSpec(const std::string& path)
 {
   oiio::ImageSpec configSpec;
-#if OIIO_VERSION > (10000 * 2 + 100 * 4 + 5) // OIIO_VERSION > 2.4.5
+#if OIIO_VERSION >= (10000 * 2 + 100 * 4 + 12) // OIIO_VERSION >= 2.4.12
     // To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
     // so we can disable the auto orientation and keep the metadata.
     configSpec.attribute("raw:user_flip", 0); // disable auto rotation of the image buffer but keep exif metadata orientation valid  
@@ -558,7 +558,7 @@ void readImage(const std::string& path,
         // libRAW configuration
         // See https://openimageio.readthedocs.io/en/master/builtinplugins.html#raw-digital-camera-files
 
-#if OIIO_VERSION > (10000 * 2 + 100 * 4 + 5) // OIIO_VERSION > 2.4.5
+#if OIIO_VERSION >= (10000 * 2 + 100 * 4 + 12) // OIIO_VERSION >= 2.4.12
 	    // To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
 	    // so we can disable the auto orientation and keep the metadata.
         configSpec.attribute("raw:user_flip", 0); // disable auto rotation of the image buffer but keep exif metadata orientation valid 

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -423,7 +423,7 @@ oiio::ImageSpec readImageSpec(const std::string& path)
 #if OIIO_VERSION > (10000 * 2 + 100 * 4 + 5) // OIIO_VERSION > 2.4.5
     // To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
     // so we can disable the auto orientation and keep the metadata.
-    configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of the image buffer
+    configSpec.attribute("raw:user_flip", 0); // disable auto rotation of the image buffer but keep exif metadata orientation valid  
 #endif 
 
   std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path, &configSpec));
@@ -561,7 +561,7 @@ void readImage(const std::string& path,
 #if OIIO_VERSION > (10000 * 2 + 100 * 4 + 5) // OIIO_VERSION > 2.4.5
 	    // To disable the application of the orientation, we need the PR https://github.com/OpenImageIO/oiio/pull/3669,
 	    // so we can disable the auto orientation and keep the metadata.
-        configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of the image buffer
+        configSpec.attribute("raw:user_flip", 0); // disable auto rotation of the image buffer but keep exif metadata orientation valid 
 #endif
 
         if (imageReadOptions.rawColorInterpretation == ERawColorInterpretation::None)
@@ -667,9 +667,6 @@ void readImage(const std::string& path,
     {
         // Check orientation metadata. If image is mirrored, mirror it back and update orientation metadata
         int orientation = imgMetadata.get_int("orientation", -1);
-
-        float red[] = {1, 0, 0, 1};
-        oiio::ImageBufAlgo::render_text(inBuf, 1000, 1000, std::to_string(orientation), 200, "Arial", red);
 
         if (orientation == 2 || orientation == 4 || orientation == 5 || orientation == 7)
         {

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -419,7 +419,10 @@ oiio::ParamValueList readImageMetadata(const std::string& path, int& width, int&
 
 oiio::ImageSpec readImageSpec(const std::string& path)
 {
-  std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path));
+  oiio::ImageSpec configSpec;
+  configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of buffer
+
+  std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path, &configSpec));
   oiio::ImageSpec spec = in->spec();
 
   if(!in)
@@ -516,6 +519,7 @@ void readImage(const std::string& path,
 
     const bool isRawImage = isRawFormat(path);
     image::DCPProfile::Triple neutral = {1.0,1.0,1.0};
+  configSpec.attribute("raw:user_flip", 1); // set flip to 1 to disable auto rotation of buffer
 
     if (isRawImage)
     {


### PR DESCRIPTION
Make sure libraw does not reorient our buffer.

A PR is under review at OiiO to give back the flip value even if its application is disabled.

https://github.com/OpenImageIO/oiio/pull/3669