### PR TITLE
Allow parameters to limit the number of Cores used and Memory available information

### DIFF
--- a/src/aliceVision/depthMap/computeOnMultiGPUs.cpp
+++ b/src/aliceVision/depthMap/computeOnMultiGPUs.cpp
@@ -14,7 +14,7 @@ namespace depthMap {
 void computeOnMultiGPUs(mvsUtils::MultiViewParams& mp, const std::vector<int>& cams, GPUJob gpujob, int nbGPUsToUse)
 {
     const int nbGPUDevices = listCUDADevices(true);
-    const int nbCPUThreads = omp_get_num_procs();
+    const int nbCPUThreads = omp_get_max_threads();
 
     ALICEVISION_LOG_INFO("Number of GPU devices: " << nbGPUDevices << ", number of CPU threads: " << nbCPUThreads);
 
@@ -35,6 +35,8 @@ void computeOnMultiGPUs(mvsUtils::MultiViewParams& mp, const std::vector<int>& c
     }
     else
     {
+        //backup max threads to keep potentially previously set value
+        int previous_count_threads = omp_get_max_threads();
         omp_set_num_threads(nbThreads); // create as many CPU threads as there are CUDA devices
 #pragma omp parallel
         {
@@ -61,6 +63,7 @@ void computeOnMultiGPUs(mvsUtils::MultiViewParams& mp, const std::vector<int>& c
 
             gpujob(cudaDeviceIndex, mp, subcams);
         }
+        omp_set_num_threads(previous_count_threads);
     }
 }
 

--- a/src/aliceVision/feature/FeatureExtractor.hpp
+++ b/src/aliceVision/feature/FeatureExtractor.hpp
@@ -7,7 +7,7 @@
 #include "ImageDescriber.hpp"
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmData/View.hpp>
-
+#include <aliceVision/system/hardwareContext.hpp>
 namespace aliceVision {
 namespace feature {
 
@@ -79,11 +79,6 @@ public:
       _rangeSize = rangeSize;
     }
 
-    void setMaxThreads(int maxThreads)
-    {
-      _maxThreads = maxThreads;
-    }
-
     void setMasksFolder(const std::string& folder)
     {
       _masksFolder = folder;
@@ -99,12 +94,7 @@ public:
       _imageDescribers.push_back(imageDescriber);
     }
 
-    void setMaxMemory(size_t maxMemory)
-    {
-        _maxMemory = maxMemory;
-    }
-
-    void process();
+    void process(const HardwareContext & hcontext);
 
 private:
 
@@ -116,8 +106,6 @@ private:
     std::string _outputFolder;
     int _rangeStart = -1;
     int _rangeSize = -1;
-    int _maxThreads = -1;
-    size_t _maxMemory = std::numeric_limits<size_t>::max();
 };
 
 } // namespace feature

--- a/src/aliceVision/feature/FeatureExtractor.hpp
+++ b/src/aliceVision/feature/FeatureExtractor.hpp
@@ -99,6 +99,11 @@ public:
       _imageDescribers.push_back(imageDescriber);
     }
 
+    void setMaxMemory(size_t maxMemory)
+    {
+        _maxMemory = maxMemory;
+    }
+
     void process();
 
 private:
@@ -112,6 +117,7 @@ private:
     int _rangeStart = -1;
     int _rangeSize = -1;
     int _maxThreads = -1;
+    size_t _maxMemory = std::numeric_limits<size_t>::max();
 };
 
 } // namespace feature

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -18,6 +18,7 @@ set(system_files_sources
   Logger.cpp
   ProgressDisplay.cpp
   nvtx.cpp
+  cmdline.cpp
 )
 
 alicevision_add_library(aliceVision_system

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -8,6 +8,7 @@ set(system_files_headers
   Logger.hpp
   ProgressDisplay.hpp
   nvtx.hpp
+  hardwareContext.hpp
 )
 
 # Sources
@@ -19,6 +20,7 @@ set(system_files_sources
   ProgressDisplay.cpp
   nvtx.cpp
   cmdline.cpp
+  hardwareContext.cpp
 )
 
 alicevision_add_library(aliceVision_system

--- a/src/aliceVision/system/cmdline.cpp
+++ b/src/aliceVision/system/cmdline.cpp
@@ -17,9 +17,7 @@ bool CmdLine::execute(int argc, char** argv)
     _allParams.add(logParams);
 
     boost::program_options::options_description hardwareParams("Hardware parameters");
-    hardwareParams.add_options()
-        ("maxMemoryAvailable", boost::program_options::value<size_t>(&_maxMemoryAvailable)->default_value(_maxMemoryAvailable), "User specified available RAM")
-        ("maxCoresAvailable", boost::program_options::value<unsigned int>(&_maxCoresAvailable)->default_value(_maxCoresAvailable), "User specified available number of cores");
+    _hContext.setOptions(hardwareParams);
 
     _allParams.add(hardwareParams);
 
@@ -54,37 +52,9 @@ bool CmdLine::execute(int argc, char** argv)
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
-    // Limit globally the maximum number of core used by openmp
-    omp_set_num_threads(std::min(_maxCoresAvailable, unsigned int(system::get_total_cpus())));
-
-    displayHardware();
+    _hContext.displayHardware();
 
     return true;
-}
-
-void CmdLine::displayHardware()
-{
-    std::cout << "Hardware : " << std::endl;
-    
-    std::cout << "\tDetected core count : " << system::get_total_cpus() << std::endl;
-
-    if (_maxMemoryAvailable < std::numeric_limits<size_t>::max())
-    {
-        std::cout << "\tUser upper limit on core count : " << _maxCoresAvailable << std::endl;
-    }
-
-    std::cout << "\tOpenMP will use " << omp_get_max_threads() << " cores" << std::endl;
-
-    auto meminfo = system::getMemoryInfo();
-    
-    std::cout << "\tDetected available memory : " << meminfo.availableRam / (1024 * 1024)  << " Mo" << std::endl;
-
-    if (_maxCoresAvailable < std::numeric_limits<unsigned int>::max())
-    {
-        std::cout << "\tUser upper limit on memory available : " << _maxMemoryAvailable / (1024 * 1024) << " Mo" << std::endl;
-    }
-
-    std::cout << std::endl;
 }
 
 }

--- a/src/aliceVision/system/cmdline.cpp
+++ b/src/aliceVision/system/cmdline.cpp
@@ -17,7 +17,7 @@ bool CmdLine::execute(int argc, char** argv)
     _allParams.add(logParams);
 
     boost::program_options::options_description hardwareParams("Hardware parameters");
-    _hContext.setOptions(hardwareParams);
+    _hContext.setupFromCommandLine(hardwareParams);
 
     _allParams.add(hardwareParams);
 

--- a/src/aliceVision/system/cmdline.cpp
+++ b/src/aliceVision/system/cmdline.cpp
@@ -1,0 +1,90 @@
+#include "cmdline.hpp"
+
+#include "cpu.hpp"
+#include "MemoryInfo.hpp"
+#include <aliceVision/alicevision_omp.hpp>
+
+namespace aliceVision {
+
+bool CmdLine::execute(int argc, char** argv)
+{
+    std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+
+    boost::program_options::options_description logParams("Log parameters");
+    logParams.add_options()
+        ("verboseLevel,v", boost::program_options::value<std::string>(&verboseLevel)->default_value(verboseLevel), "verbosity level (fatal, error, warning, info, debug, trace).");
+
+    _allParams.add(logParams);
+
+    boost::program_options::options_description hardwareParams("Hardware parameters");
+    hardwareParams.add_options()
+        ("maxMemoryAvailable", boost::program_options::value<size_t>(&_maxMemoryAvailable)->default_value(_maxMemoryAvailable), "User specified available RAM")
+        ("maxCoresAvailable", boost::program_options::value<unsigned int>(&_maxCoresAvailable)->default_value(_maxCoresAvailable), "User specified available number of cores");
+
+    _allParams.add(hardwareParams);
+
+    boost::program_options::variables_map vm;
+    try
+    {
+        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, _allParams), vm);
+
+        if (vm.count("help") || (argc == 1))
+        {
+            ALICEVISION_COUT(_allParams);
+            return false;
+        }
+        boost::program_options::notify(vm);
+    }
+    catch (boost::program_options::required_option& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << _allParams);
+        return false;
+    }
+    catch (boost::program_options::error& e)
+    {
+        ALICEVISION_CERR("ERROR: " << e.what());
+        ALICEVISION_COUT("Usage:\n\n" << _allParams);
+        return false;
+    }
+
+    ALICEVISION_COUT("Program called with the following parameters:");
+    ALICEVISION_COUT(vm);
+
+    // set verbose level
+    system::Logger::get()->setLogLevel(verboseLevel);
+
+    // Limit globally the maximum number of core used by openmp
+    omp_set_num_threads(std::min(_maxCoresAvailable, unsigned int(system::get_total_cpus())));
+
+    displayHardware();
+
+    return true;
+}
+
+void CmdLine::displayHardware()
+{
+    std::cout << "Hardware : " << std::endl;
+    
+    std::cout << "\tDetected core count : " << system::get_total_cpus() << std::endl;
+
+    if (_maxMemoryAvailable < std::numeric_limits<size_t>::max())
+    {
+        std::cout << "\tUser upper limit on core count : " << _maxCoresAvailable << std::endl;
+    }
+
+    std::cout << "\tOpenMP will use " << omp_get_max_threads() << " cores" << std::endl;
+
+    auto meminfo = system::getMemoryInfo();
+    
+    std::cout << "\tDetected available memory : " << meminfo.availableRam / (1024 * 1024)  << " Mo" << std::endl;
+
+    if (_maxCoresAvailable < std::numeric_limits<unsigned int>::max())
+    {
+        std::cout << "\tUser upper limit on memory available : " << _maxMemoryAvailable / (1024 * 1024) << " Mo" << std::endl;
+    }
+
+    std::cout << std::endl;
+}
+
+}

--- a/src/aliceVision/system/cmdline.hpp
+++ b/src/aliceVision/system/cmdline.hpp
@@ -8,13 +8,13 @@
 
 #include "Logger.hpp"
 #include "Timer.hpp"
+#include "hardwareContext.hpp"
 
-// This file is header only, so the module don't need to have program_options as a dependency
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/option.hpp>
 #include <boost/program_options/errors.hpp>
-#include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
+#include <boost/program_options/options_description.hpp>
 
 #include <functional>
 #include <ostream>
@@ -173,8 +173,6 @@ public:
     CmdLine(const std::string& name) :
         _allParams(name)
     {
-        _maxMemoryAvailable = std::numeric_limits<size_t>::max();
-        _maxCoresAvailable = std::numeric_limits<unsigned int>::max();
     }
 
     void add(const boost::program_options::options_description& options)
@@ -184,24 +182,14 @@ public:
 
     bool execute(int argc, char** argv);
 
-    size_t getUserMaxMemoryAvailable()
+    HardwareContext getHardwareContext()
     {
-        return _maxMemoryAvailable;
+        return _hContext;
     }
-
-    unsigned int getUserMaxCoresAvailable()
-    {
-        return _maxCoresAvailable;
-    }
-
-private:
-    void displayHardware();
 
 private:
     boost::program_options::options_description _allParams;
-
-    size_t _maxMemoryAvailable;
-    unsigned int _maxCoresAvailable;
+    HardwareContext _hContext;
 };
 
 }

--- a/src/aliceVision/system/cmdline.hpp
+++ b/src/aliceVision/system/cmdline.hpp
@@ -173,6 +173,8 @@ public:
     CmdLine(const std::string& name) :
         _allParams(name)
     {
+        _maxMemoryAvailable = std::numeric_limits<size_t>::max();
+        _maxCoresAvailable = std::numeric_limits<unsigned int>::max();
     }
 
     void add(const boost::program_options::options_description& options)
@@ -180,52 +182,26 @@ public:
         _allParams.add(options);
     }
 
-    bool execute(int argc, char** argv)
+    bool execute(int argc, char** argv);
+
+    size_t getUserMaxMemoryAvailable()
     {
-        std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+        return _maxMemoryAvailable;
+    }
 
-        boost::program_options::options_description logParams("Log parameters");
-        logParams.add_options()
-            ("verboseLevel,v", boost::program_options::value<std::string>(&verboseLevel)->default_value(verboseLevel), "verbosity level (fatal, error, warning, info, debug, trace).");
-
-        _allParams.add(logParams);
-
-        boost::program_options::variables_map vm;
-        try
-        {
-            boost::program_options::store(boost::program_options::parse_command_line(argc, argv, _allParams), vm);
-
-            if (vm.count("help") || (argc == 1))
-            {
-                ALICEVISION_COUT(_allParams);
-                return false;
-            }
-            boost::program_options::notify(vm);
-        }
-        catch (boost::program_options::required_option& e)
-        {
-            ALICEVISION_CERR("ERROR: " << e.what());
-            ALICEVISION_COUT("Usage:\n\n" << _allParams);
-            return false;
-        }
-        catch (boost::program_options::error& e)
-        {
-            ALICEVISION_CERR("ERROR: " << e.what());
-            ALICEVISION_COUT("Usage:\n\n" << _allParams);
-            return false;
-        }
-
-        ALICEVISION_COUT("Program called with the following parameters:");
-        ALICEVISION_COUT(vm);
-
-        // set verbose level
-        system::Logger::get()->setLogLevel(verboseLevel);
-
-        return true;
+    unsigned int getUserMaxCoresAvailable()
+    {
+        return _maxCoresAvailable;
     }
 
 private:
+    void displayHardware();
+
+private:
     boost::program_options::options_description _allParams;
+
+    size_t _maxMemoryAvailable;
+    unsigned int _maxCoresAvailable;
 };
 
 }

--- a/src/aliceVision/system/hardwareContext.cpp
+++ b/src/aliceVision/system/hardwareContext.cpp
@@ -6,7 +6,7 @@
 
 namespace aliceVision {
 
-void HardwareContext::setOptions(boost::program_options::options_description & options)
+void HardwareContext::setupFromCommandLine(boost::program_options::options_description & options)
 {
     options.add_options()
         ("maxMemoryAvailable", boost::program_options::value<size_t>(&_maxUserMemoryAvailable)->default_value(_maxUserMemoryAvailable), "User specified available RAM")
@@ -50,12 +50,9 @@ unsigned int HardwareContext::getMaxThreads() const
     }
 
     //Get User limit max threads
-    if (_limitUserCores > 0)
+    if (_limitUserCores > 0 && count > _limitUserCores)
     {
-        if (count > _limitUserCores)
-        {
-            count = _limitUserCores;
-        }
+        count = _limitUserCores;
     }
 
     return count;

--- a/src/aliceVision/system/hardwareContext.cpp
+++ b/src/aliceVision/system/hardwareContext.cpp
@@ -1,0 +1,64 @@
+#include "hardwareContext.hpp"
+
+#include "cpu.hpp"
+#include "MemoryInfo.hpp"
+#include <aliceVision/alicevision_omp.hpp>
+
+namespace aliceVision {
+
+void HardwareContext::setOptions(boost::program_options::options_description & options)
+{
+    options.add_options()
+        ("maxMemoryAvailable", boost::program_options::value<size_t>(&_maxUserMemoryAvailable)->default_value(_maxUserMemoryAvailable), "User specified available RAM")
+        ("maxCoresAvailable", boost::program_options::value<unsigned int>(&_maxUserCoresAvailable)->default_value(_maxUserCoresAvailable), "User specified available number of cores");
+}
+
+void HardwareContext::displayHardware()
+{
+    std::cout << "Hardware : " << std::endl;
+    
+    std::cout << "\tDetected core count : " << system::get_total_cpus() << std::endl;
+
+    if (_maxUserCoresAvailable < std::numeric_limits<size_t>::max())
+    {
+        std::cout << "\tUser upper limit on core count : " << _maxUserCoresAvailable << std::endl;
+    }
+
+    std::cout << "\tOpenMP will use " << omp_get_max_threads() << " cores" << std::endl;
+
+    auto meminfo = system::getMemoryInfo();
+    
+    std::cout << "\tDetected available memory : " << meminfo.availableRam / (1024 * 1024)  << " Mo" << std::endl;
+
+    if (_maxUserMemoryAvailable < std::numeric_limits<unsigned int>::max())
+    {
+        std::cout << "\tUser upper limit on memory available : " << _maxUserMemoryAvailable / (1024 * 1024) << " Mo" << std::endl;
+    }
+
+    std::cout << std::endl;
+}
+
+unsigned int HardwareContext::getMaxThreads() const
+{   
+    //Get hardware limit on threads
+    unsigned int count = system::get_total_cpus();
+
+    //Get User max threads
+    if (count > _maxUserCoresAvailable)
+    {
+        count = _maxUserCoresAvailable;
+    }
+
+    //Get User limit max threads
+    if (_limitUserCores > 0)
+    {
+        if (count > _limitUserCores)
+        {
+            count = _limitUserCores;
+        }
+    }
+
+    return count;
+}
+
+}

--- a/src/aliceVision/system/hardwareContext.hpp
+++ b/src/aliceVision/system/hardwareContext.hpp
@@ -1,0 +1,46 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Logger.hpp"
+#include "Timer.hpp"
+
+#include <boost/program_options/options_description.hpp>
+
+namespace aliceVision {
+
+class HardwareContext
+{
+public:
+    void displayHardware();
+
+    size_t getUserMaxMemoryAvailable() const
+    {
+        return _maxUserMemoryAvailable;
+    }
+
+    unsigned int getUserMaxCoresAvailable() const
+    {
+        return _maxUserCoresAvailable;
+    }
+
+    void setUserCoresLimit(unsigned int coresLimit)
+    {
+        _limitUserCores = coresLimit;
+    }
+
+    void setOptions(boost::program_options::options_description & options);
+
+    unsigned int getMaxThreads() const;
+
+private:
+    size_t _maxUserMemoryAvailable = std::numeric_limits<size_t>::max();
+    unsigned int _maxUserCoresAvailable = std::numeric_limits<unsigned int>::max();
+    unsigned int _limitUserCores = std::numeric_limits<unsigned int>::max();
+};
+
+}

--- a/src/aliceVision/system/hardwareContext.hpp
+++ b/src/aliceVision/system/hardwareContext.hpp
@@ -33,13 +33,29 @@ public:
         _limitUserCores = coresLimit;
     }
 
-    void setOptions(boost::program_options::options_description & options);
+    void setupFromCommandLine(boost::program_options::options_description & options);
 
     unsigned int getMaxThreads() const;
 
 private:
+    /**
+     * @brief This is the maximum memory available 
+     * This information is passed to the application through command line parameters
+     * if we want to override the system defined information (E.g. cgroups)
+     */
     size_t _maxUserMemoryAvailable = std::numeric_limits<size_t>::max();
+
+    /**
+     * @brief This is the maximum number of cores available to this application
+     * This information is passed to the application through command line parameters
+     * if we want to override the system defined information (E.g. cgroups)
+     */
     unsigned int _maxUserCoresAvailable = std::numeric_limits<unsigned int>::max();
+
+    /**
+     * @brief This is the maximum number of cores the user wants to use for this application
+     * The value will only be used if less than the _maxUserCoresAvailable value
+     */
     unsigned int _limitUserCores = std::numeric_limits<unsigned int>::max();
 };
 

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -158,6 +158,10 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
     // Read sfm data
     sfmData::SfMData sfmData;
     if(!sfmDataIO::Load(sfmData, sfmInputDataFilename, sfmDataIO::ESfMData::ALL))

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -109,6 +109,10 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
     // Analyze path
     boost::filesystem::path path(sfmOutputDataFilepath);
     std::string outputPath = path.parent_path().string();

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -98,6 +98,11 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+
     const std::size_t channelQuantization = std::pow(2, channelQuantizationPower);
 
     // Read sfm data

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -136,8 +136,8 @@ int aliceVision_main(int argc, char **argv)
   extractor.setOutputFolder(outputFolder);
 
   // set maxThreads
-  extractor.setMaxMemory(cmdline.getUserMaxMemoryAvailable());
-  extractor.setMaxThreads(maxThreads);
+  HardwareContext hwc = cmdline.getHardwareContext();
+  hwc.setUserCoresLimit(maxThreads);
 
   // set extraction range
   if(rangeStart != -1)
@@ -177,7 +177,7 @@ int aliceVision_main(int argc, char **argv)
   {
     system::Timer timer;
 
-    extractor.process();
+    extractor.process(hwc);
 
     ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
   }

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -136,6 +136,7 @@ int aliceVision_main(int argc, char **argv)
   extractor.setOutputFolder(outputFolder);
 
   // set maxThreads
+  extractor.setMaxMemory(cmdline.getUserMaxMemoryAvailable());
   extractor.setMaxThreads(maxThreads);
 
   // set extraction range

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -189,6 +189,10 @@ int aliceVision_main(int argc, char **argv)
       return EXIT_FAILURE;
   }
 
+  // set maxThreads
+  HardwareContext hwc = cmdline.getHardwareContext();
+  omp_set_num_threads(hwc.getMaxThreads());
+
   const double defaultLoRansacLocalizationError = 4.0;
   if(!robustEstimation::adjustRobustEstimatorThreshold(sfmParams.localizerEstimator, sfmParams.localizerEstimatorError, defaultLoRansacLocalizationError))
   {

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -595,6 +595,11 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    hwc.setUserCoresLimit(maxThreads);
+    omp_set_num_threads(hwc.getMaxThreads());
+
     if (overlayType == "borders" || overlayType == "all")
     {
         showBorders = true;
@@ -677,10 +682,6 @@ int aliceVision_main(int argc, char** argv)
     
     bool succeeded = true;
 
-    if(maxThreads > 0)
-        omp_set_num_threads(std::min(omp_get_max_threads(), maxThreads));
-
-    //#pragma omp parallel for
     for (std::size_t posReference = 0; posReference < chunk.size(); posReference++)
     {
         ALICEVISION_LOG_INFO("processing input region " << posReference + 1 << "/" << chunk.size());

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -190,6 +190,10 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
     // load input scene
     sfmData::SfMData sfmData;
     if(!sfmDataIO::Load(sfmData, sfmDataFilepath,

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -134,6 +134,10 @@ int aliceVision_main(int argc, char** argv)
 			return EXIT_FAILURE;
     	}	
 
+		// set maxThreads
+		HardwareContext hwc = cmdline.getHardwareContext();
+		omp_set_num_threads(hwc.getMaxThreads());
+
 		bool clampHalf = false;
 		oiio::TypeDesc typeColor = oiio::TypeDesc::FLOAT;
 		if (storageDataType == image::EStorageDataType::Half || storageDataType == image::EStorageDataType::HalfFinite) 

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -22,6 +22,7 @@ if(ALICEVISION_HAVE_UNCERTAINTYTE)
       SOURCE main_computeUncertainty.cpp
       FOLDER ${FOLDER_SOFTWARE_UTILS}
       LINKS aliceVision_sfm
+            aliceVision_system
             ${CUDA_LIBRARIES}
             ${CUDA_CUBLAS_LIBRARIES}
             ${CUDA_cusparse_LIBRARY}
@@ -71,6 +72,7 @@ alicevision_add_software(aliceVision_utils_voctreeCreation
         aliceVision_feature
         aliceVision_sfmData
         aliceVision_sfmDataIO
+        aliceVision_system
         Boost::program_options
 )
 
@@ -82,6 +84,7 @@ alicevision_add_software(aliceVision_utils_voctreeQueryUtility
         aliceVision_sfm
         aliceVision_sfmData
         aliceVision_sfmDataIO
+        aliceVision_system
         Boost::program_options
         Boost::boost
         Boost::timer
@@ -93,6 +96,7 @@ alicevision_add_software(aliceVision_utils_voctreeStatistics
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_voctree
         aliceVision_sfmData
+        aliceVision_system
         aliceVision_sfmDataIO
         Boost::program_options
         Boost::boost
@@ -122,6 +126,7 @@ if(ALICEVISION_HAVE_ALEMBIC)
           aliceVision_localization
           aliceVision_dataio
           aliceVision_rig
+          aliceVision_system
           Boost::program_options
           Boost::filesystem
   )
@@ -231,6 +236,7 @@ alicevision_add_software(aliceVision_utils_sfmDistances
   LINKS aliceVision_sfm
         aliceVision_sfmData
         aliceVision_sfmDataIO
+        aliceVision_system
         ${Boost_LIBRARIES}
 )
 


### PR DESCRIPTION
```c
boost::program_options::options_description hardwareParams("Hardware parameters");
hardwareParams.add_options()
        ("maxMemoryAvailable", boost::program_options::value<size_t>(&_maxMemoryAvailable)->default_value(_maxMemoryAvailable), "User specified available RAM")
        ("maxCoresAvailable", boost::program_options::value<unsigned int>(&_maxCoresAvailable)->default_value(_maxCoresAvailable), "User specified available number of cores");
