### PR TITLE
Updates for compatibility with recent ceres versions

### DIFF
--- a/src/aliceVision/multiview/rotationAveraging/l2.cpp
+++ b/src/aliceVision/multiview/rotationAveraging/l2.cpp
@@ -261,7 +261,9 @@ bool L2RotationAveraging_Refine(
   ceres::Solver::Options solverOptions;
   // Since the problem is sparse, use a sparse solver
   if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::SUITE_SPARSE) ||
+#if ALICEVISION_CERES_HAS_CXSPARSE
       ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CX_SPARSE) ||
+#endif
       ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::EIGEN_SPARSE))
   {
     solverOptions.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;

--- a/src/aliceVision/multiview/translationAveraging/solverL1Soft.cpp
+++ b/src/aliceVision/multiview/translationAveraging/solverL1Soft.cpp
@@ -181,7 +181,9 @@ bool solve_translations_problem_softl1
   ceres::Solver::Options options;
   options.minimizer_progress_to_stdout = false;
   if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::SUITE_SPARSE) ||
+#if ALICEVISION_CERES_HAS_CXSPARSE
       ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CX_SPARSE) ||
+#endif
       ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::EIGEN_SPARSE))
   {
     options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;

--- a/src/aliceVision/multiview/translationAveraging/solverL2Chordal.cpp
+++ b/src/aliceVision/multiview/translationAveraging/solverL2Chordal.cpp
@@ -116,7 +116,9 @@ bool solve_translations_problem_l2_chordal(
   options.function_tolerance = function_tolerance;
   options.parameter_tolerance = parameter_tolerance;
   if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::SUITE_SPARSE) ||
+#if ALICEVISION_CERES_HAS_CXSPARSE
       ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CX_SPARSE) ||
+#endif
       ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::EIGEN_SPARSE))
   {
     options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -314,12 +314,14 @@ void BundleAdjustmentCeres::CeresOptions::setSparseBA()
     linearSolverType = ceres::SPARSE_SCHUR;
     ALICEVISION_LOG_DEBUG("BundleAdjustment[Ceres]: SPARSE_SCHUR, SUITE_SPARSE");
   }
+#if ALICEVISION_CERES_HAS_CXSPARSE
   else if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CX_SPARSE))
   {
     sparseLinearAlgebraLibraryType = ceres::CX_SPARSE;
     linearSolverType = ceres::SPARSE_SCHUR;
     ALICEVISION_LOG_DEBUG("BundleAdjustment[Ceres]: SPARSE_SCHUR, CX_SPARSE");
   }
+#endif
   else if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::EIGEN_SPARSE))
   {
     sparseLinearAlgebraLibraryType = ceres::EIGEN_SPARSE;

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
@@ -253,12 +253,14 @@ void BundleAdjustmentPanoramaCeres::CeresOptions::setSparseBA()
     linearSolverType = ceres::SPARSE_SCHUR;
     ALICEVISION_LOG_DEBUG("BundleAdjustmentParnorama[Ceres]: SPARSE_SCHUR, SUITE_SPARSE");
   }
+#if ALICEVISION_CERES_HAS_CXSPARSE
   else if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CX_SPARSE))
   {
     sparseLinearAlgebraLibraryType = ceres::CX_SPARSE;
     linearSolverType = ceres::SPARSE_SCHUR;
     ALICEVISION_LOG_DEBUG("BundleAdjustmentParnorama[Ceres]: SPARSE_SCHUR, CX_SPARSE");
   }
+#endif
   else if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::EIGEN_SPARSE))
   {
     sparseLinearAlgebraLibraryType = ceres::EIGEN_SPARSE;

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -332,12 +332,14 @@ void BundleAdjustmentSymbolicCeres::CeresOptions::setSparseBA()
     linearSolverType = ceres::SPARSE_SCHUR;
     ALICEVISION_LOG_DEBUG("BundleAdjustmentSymbolic[Ceres]: SPARSE_SCHUR, SUITE_SPARSE");
   }
+#if ALICEVISION_CERES_HAS_CXSPARSE
   else if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CX_SPARSE))
   {
     sparseLinearAlgebraLibraryType = ceres::CX_SPARSE;
     linearSolverType = ceres::SPARSE_SCHUR;
     ALICEVISION_LOG_DEBUG("BundleAdjustmentSymbolic[Ceres]: SPARSE_SCHUR, CX_SPARSE");
   }
+#endif
   else if (ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::EIGEN_SPARSE))
   {
     sparseLinearAlgebraLibraryType = ceres::EIGEN_SPARSE;

--- a/src/aliceVision/utils/CeresUtils.hpp
+++ b/src/aliceVision/utils/CeresUtils.hpp
@@ -17,6 +17,10 @@ namespace utils {
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
 #define ALICEVISION_CERES_HAS_MANIFOLD ((CERES_VERSION_MAJOR * 100 + CERES_VERSION_MINOR) >= 201)
 
+// Ceres has removed support for CXSPARSE after 2.1
+// See https://github.com/ceres-solver/ceres-solver/commit/2335b5b4b7a4703ca9458aa275ca878945763a34
+#define ALICEVISION_CERES_HAS_CXSPARSE ((CERES_VERSION_MAJOR * 100 + CERES_VERSION_MINOR) <= 201)
+
 #if ALICEVISION_CERES_HAS_MANIFOLD
 using CeresManifold = ceres::Manifold;
 #else


### PR DESCRIPTION
Ceres has removed support for CXSPARSE, see https://github.com/ceres-solver/ceres-solver/commit/2335b5b4b7a4703ca9458aa275ca878945763a34