### PR TITLE
[sfmColorHarmonize] update selection method enum and command-line argument

### DIFF
--- a/src/software/utils/main_sfmColorHarmonize.cpp
+++ b/src/software/utils/main_sfmColorHarmonize.cpp
@@ -58,7 +58,7 @@ int aliceVision_main( int argc, char **argv )
     ("referenceImage", po::value<int>(&imgRef)->required(),
       "Reference image id.")
     ("selectionMethod", po::value<EHistogramSelectionMethod>(&selectionMethod)->required(), 
-      "Histogram selection method");
+      EHistogramSelectionMethod_description().c_str());
 
   po::options_description optionalParams("Optional parameters");
   optionalParams.add_options()

--- a/src/software/utils/main_sfmColorHarmonize.cpp
+++ b/src/software/utils/main_sfmColorHarmonize.cpp
@@ -38,7 +38,7 @@ int aliceVision_main( int argc, char **argv )
   std::vector<std::string> featuresFolders;
   std::vector<std::string> matchesFolders;
   std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
-  int selectionMethod;
+  EHistogramSelectionMethod selectionMethod;
   int imgRef;
 
   // user optional parameters
@@ -57,10 +57,8 @@ int aliceVision_main( int argc, char **argv )
       "Path to folder(s) in which computed matches are stored.")
     ("referenceImage", po::value<int>(&imgRef)->required(),
       "Reference image id.")
-    ("selectionMethod", po::value<int>(&selectionMethod)->required(),
-      "- 0: FullFrame\n"
-      "- 1: Matched Points\n"
-      "- 2: VLD Segment");
+    ("selectionMethod", po::value<EHistogramSelectionMethod>(&selectionMethod)->required(), 
+      "Histogram selection method");
 
   po::options_description optionalParams("Optional parameters");
   optionalParams.add_options()

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -117,7 +117,6 @@ inline void pauseProcess()
 
 bool ColorHarmonizationEngineGlobal::Process()
 {
-  const std::string vec_selectionMethod[ 3 ] = { "fullFrame", "matchedPoints", "KVLD" };
   const std::string vec_harmonizeMethod[ 1 ] = { "quantifiedGainCompensation" };
   const int harmonizeMethod = 0;
 
@@ -437,8 +436,7 @@ bool ColorHarmonizationEngineGlobal::Process()
       }
     }
 
-    const int selectionMethodIdx = static_cast<int>(_selectionMethod);
-    const std::string out_folder = (fs::path(_outputDirectory) / (vec_selectionMethod[ selectionMethodIdx ] + "_" + vec_harmonizeMethod[ harmonizeMethod ])).string();
+    const std::string out_folder = (fs::path(_outputDirectory) / (EHistogramSelectionMethod_enumToString(_selectionMethod) + "_" + vec_harmonizeMethod[ harmonizeMethod ])).string();
     if(!fs::exists(out_folder))
       fs::create_directory(out_folder);
     const std::string out_filename = (fs::path(out_folder) / fs::path(_fileNames[ imaNum ]).filename() ).string();

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
@@ -23,6 +23,14 @@ enum class EHistogramSelectionMethod
     eHistogramHarmonizeVLDSegment
 };
 
+inline std::string EHistogramSelectionMethod_description()
+{
+  return "Histogram selection method: \n"
+         "* full frame \n"
+         "* matched points \n"
+         "* VLD segments\n";
+}
+
 EHistogramSelectionMethod EEHistogramSelectionMethod_stringToEnum(const std::string& histogramSelectionMethod);
 std::string EHistogramSelectionMethod_enumToString(const EHistogramSelectionMethod histogramSelectionMethod);
 std::ostream& operator<<(std::ostream& os, EHistogramSelectionMethod p);

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
@@ -16,12 +16,17 @@
 
 namespace aliceVision {
 
-enum EHistogramSelectionMethod
+enum class EHistogramSelectionMethod
 {
-    eHistogramHarmonizeFullFrame     = 0,
-    eHistogramHarmonizeMatchedPoints = 1,
-    eHistogramHarmonizeVLDSegment    = 2,
+    eHistogramHarmonizeFullFrame = 0,
+    eHistogramHarmonizeMatchedPoints,
+    eHistogramHarmonizeVLDSegment
 };
+
+EHistogramSelectionMethod EEHistogramSelectionMethod_stringToEnum(const std::string& histogramSelectionMethod);
+std::string EHistogramSelectionMethod_enumToString(const EHistogramSelectionMethod histogramSelectionMethod);
+std::ostream& operator<<(std::ostream& os, EHistogramSelectionMethod p);
+std::istream& operator>>(std::istream& in, EHistogramSelectionMethod& p);
 
 /**
  * @brief The ColorHarmonizationEngineGlobal class
@@ -40,8 +45,8 @@ public:
     const std::vector<std::string>& matchesFolders,
     const std::string& outputDirectory,
     const std::vector<feature::EImageDescriberType>& descTypes,
-    int selectionMethod = -1,
-    int imgRef = -1);
+    EHistogramSelectionMethod selectionMethod,
+    int imgRef = 0);
 
   ~ColorHarmonizationEngineGlobal();
 

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
@@ -26,9 +26,9 @@ enum class EHistogramSelectionMethod
 inline std::string EHistogramSelectionMethod_description()
 {
   return "Histogram selection method: \n"
-         "* full frame \n"
-         "* matched points \n"
-         "* VLD segments\n";
+         "* full_frame \n"
+         "* matched_points \n"
+         "* VLD_segments\n";
 }
 
 EHistogramSelectionMethod EEHistogramSelectionMethod_stringToEnum(const std::string& histogramSelectionMethod);


### PR DESCRIPTION
## Description

In this PR we update the `enum` system used for the `selectionMethod` argument of `sfmColorHarmonize` to use an `enum class` that works the same way as other `aliceVision` executables instead.