### PR TITLE
Add "Xiaomi Mi 11T" camera sensor

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -7297,6 +7297,7 @@ Xiaomi;Xiaomi Mi 9 Pro;6.4;kimovil
 Xiaomi;Xiaomi Mi 9 Pro 5G;6.4;kimovil
 Xiaomi;Xiaomi Mi 9 SE;6.4;kimovil
 Xiaomi;Xiaomi Mi 9T Pro;6.4;kimovil
+Xiaomi;Xiaomi Mi 11T;8.42;lapo-luchini
 Xiaomi;Xiaomi Mi A2;4.96;devicespecifications
 Xiaomi;Xiaomi Mi A2 Lite;2.98;devicespecifications
 Xiaomi;Xiaomi Mi Max;4.74;devicespecifications


### PR DESCRIPTION
As reported here:
  The main camera employs a 108MP Samsung ISOCELL HM2 1/1.52" sensor.
https://www.gsmarena.com/xiaomi_11t-review-2324p5.php
