### PR TITLE
Fix and harmonize command lines' descriptions

### DIFF
--- a/src/software/convert/main_convertFloatDescriptorToUchar.cpp
+++ b/src/software/convert/main_convertFloatDescriptorToUchar.cpp
@@ -44,8 +44,8 @@ int aliceVision_main( int argc, char** argv )
     ("sanityCheck,s", po::value<bool>(&doSanityCheck)->default_value(doSanityCheck),
        "Perform a sanity check to check that the conversion and the genrated files are the same.");
 
-  CmdLine cmdline("This program is used to convert SIFT features from float representation to unsigned char representation\n"
-                  "AliceVision convertRAW");
+  CmdLine cmdline("This program is used to convert SIFT features from float representation to unsigned char representation.\n"
+                  "AliceVision convertFloatDescriptorToUchar");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/convert/main_convertMesh.cpp
+++ b/src/software/convert/main_convertMesh.cpp
@@ -49,8 +49,8 @@ int aliceVision_main(int argc, char** argv)
       ("output,o", po::value<std::string>(&outputFilePath)->default_value(outputFilePath),
         "Output file path for the new mesh file (*.obj, *.mesh, *.meshb, *.ply, *.off, *.stl)");
 
-    CmdLine cmdline("AliceVision convertMesh\n"
-                    "The program allows to convert a mesh to another mesh format.");
+    CmdLine cmdline("The program allows to convert a mesh to another mesh format.\n"
+                    "AliceVision convertMesh");
     cmdline.add(requiredParams);
     if (!cmdline.execute(argc, argv))
     {

--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -74,7 +74,7 @@ int aliceVision_main(int argc, char **argv)
     ("observations", po::value<bool>(&flagObservations)->default_value(flagObservations),
       "Export observations.");
 
-  CmdLine cmdline("AliceVision convert sfm format");
+  CmdLine cmdline("AliceVision convertSfMFormat");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/convert/main_importKnownPoses.cpp
+++ b/src/software/convert/main_importKnownPoses.cpp
@@ -145,7 +145,7 @@ int aliceVision_main(int argc, char **argv)
       ("sfmData", po::value<std::string>(&sfmDataFilePath)->required(), "SfmData filepath.")
       ("output,o", po::value<std::string>(&outputFilename)->required(), "Output sfmData filepath.");
 
-  CmdLine cmdline("AliceVision import known poses");
+  CmdLine cmdline("AliceVision importKnownPoses");
   cmdline.add(requiredParams);
   if (!cmdline.execute(argc, argv))
   {

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -139,7 +139,7 @@ int aliceVision_main(int argc, char** argv)
     ("undistortedImageType", po::value<std::string>(&outImageFileTypeName)->default_value(outImageFileTypeName),
       image::EImageFileType_informations().c_str());
 
-  CmdLine cmdline("AliceVision Export Animated Camera");
+  CmdLine cmdline("AliceVision exportAnimatedCamera");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/export/main_exportCameraFrustums.cpp
+++ b/src/software/export/main_exportCameraFrustums.cpp
@@ -40,7 +40,7 @@ int aliceVision_main(int argc, char **argv)
     ("output,o", po::value<std::string>(&plyOutFilename)->required(),
       "PLY file to store the camera frustums as triangle meshes.");
 
-  CmdLine cmdline("Export camera frustrums as a triangle PLY file\n"
+  CmdLine cmdline("Export camera frustrums as a triangle PLY file.\n"
                   "AliceVision exportCameraFrustums");
   cmdline.add(requiredParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/export/main_exportColmap.cpp
+++ b/src/software/export/main_exportColmap.cpp
@@ -46,7 +46,8 @@ int aliceVision_main(int argc, char* argv[])
              "folder.");
 
     CmdLine cmdline("Export an AV sfmdata to a Colmap scene, creating the folder structure and "
-                    "the scene files that can be used for running a MVS step");
+                    "the scene files that can be used for running a MVS step.\n"
+                    "AliceVision exportColmap");
     cmdline.add(requiredParams);
     if (!cmdline.execute(argc, argv))
     {

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -148,7 +148,7 @@ int aliceVision_main(int argc, char** argv)
          "can be managed by the calibration step (in term of computation time and memory usage).")
         ;
 
-    CmdLine cmdline("Recover the Camera Response Function (CRF) from samples extracted from LDR images with multi-bracking.\n"
+    CmdLine cmdline("This program recovers the Camera Response Function (CRF) from samples extracted from LDR images with multi-bracketing.\n"
                     "AliceVision LdrToHdrCalibration");
                   
     cmdline.add(requiredParams);

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -99,7 +99,7 @@ int aliceVision_main(int argc, char** argv)
         ("rangeSize", po::value<int>(&rangeSize)->default_value(rangeSize),
           "Range size.");
 
-    CmdLine cmdline("Merge LDR images into HDR images.\n"
+    CmdLine cmdline("This program merges LDR images into HDR images.\n"
                     "AliceVision LdrToHdrMerge");
                   
     cmdline.add(requiredParams);

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -88,7 +88,7 @@ int aliceVision_main(int argc, char** argv)
         ("rangeSize", po::value<int>(&rangeSize)->default_value(rangeSize),
           "Range size.");
 
-    CmdLine cmdline("Extract stable samples from multiple LDR images with different bracketing.\n"
+    CmdLine cmdline("This program extracts stable samples from multiple LDR images with different bracketing.\n"
                     "AliceVision LdrToHdrSampling");
                   
     cmdline.add(requiredParams);

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -207,7 +207,7 @@ int aliceVision_main(int argc, char **argv)
       "Allow the program to process a single view.\n"
       "Warning: if a single view is process, the output file can't be use in many other programs.");
 
-  CmdLine cmdline("CameraInit");
+  CmdLine cmdline("AliceVision cameraInit");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -232,7 +232,8 @@ int aliceVision_main(int argc, char** argv)
   
 
   CmdLine cmdline("This program takes as input a media (image, image sequence, video) and a database (vocabulary tree, 3D scene data) \n"
-                  "and returns for each frame a pose estimation for the camera.");
+                  "and returns for each frame a pose estimation for the camera.\n"
+                  "AliceVision cameraLocalization");
   cmdline.add(inputParams);
   cmdline.add(outputParams);
   cmdline.add(commonParams);

--- a/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
+++ b/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
@@ -65,7 +65,7 @@ int aliceVision_main(int argc, char **argv)
         "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
     ;
 
-  CmdLine cmdline("AliceVision compute structure from known poses");
+  CmdLine cmdline("AliceVision computeStructureFromKnownPoses");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_depthMapEstimation.cpp
+++ b/src/software/pipeline/main_depthMapEstimation.cpp
@@ -132,8 +132,8 @@ int aliceVision_main(int argc, char* argv[])
         ("nbGPUs", po::value<int>(&nbGPUs)->default_value(nbGPUs),
             "Number of GPUs to use (0 means use all GPUs).");
 
-    CmdLine cmdline("AliceVision depthMapEstimation\n"
-                        "Estimate depth map for each input image");
+    CmdLine cmdline("This program estimates depth maps for each input image.\n"
+                    "AliceVision depthMapEstimation");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_depthMapFiltering.cpp
+++ b/src/software/pipeline/main_depthMapFiltering.cpp
@@ -88,8 +88,8 @@ int aliceVision_main(int argc, char* argv[])
         ("computeNormalMaps", po::value<bool>(&computeNormalMaps)->default_value(computeNormalMaps),
             "Compute normal maps per depth map");
 
-    CmdLine cmdline("AliceVision depthMapFiltering\n"
-                    "Filter depth map to remove values that are not consistent with other depth maps");
+    CmdLine cmdline("This program filters depth maps to remove values that are not consistent with other depth maps.\n"
+                    "AliceVision depthMapFiltering");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_distortionCalibration.cpp
+++ b/src/software/pipeline/main_distortionCalibration.cpp
@@ -479,8 +479,8 @@ int aliceVision_main(int argc, char* argv[])
     ("outSfMData,o", po::value<std::string>(&sfmOutputDataFilepath)->required(), "SfMData file output.")
     ;
 
-    CmdLine cmdline("Calibrate camera distortion.\n"
-                    "AliceVision Distortion Calibration");
+    CmdLine cmdline("This program calibrates camera distortion.\n"
+                    "AliceVision distortionCalibration");
     cmdline.add(requiredParams);
     if (!cmdline.execute(argc, argv))
     {

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -92,7 +92,7 @@ int aliceVision_main(int argc, char **argv)
     ("maxThreads", po::value<int>(&maxThreads)->default_value(maxThreads),
       "Specifies the maximum number of threads to run simultaneously (0 for automatic mode).");
 
-  CmdLine cmdline("Alicevision feature extraction");
+  CmdLine cmdline("AliceVision featureExtraction");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -186,7 +186,7 @@ int aliceVision_main(int argc, char **argv)
       "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
     ;
 
-  CmdLine cmdline("Compute corresponding features between a series of views:\n"
+  CmdLine cmdline("This program computes corresponding features between a series of views:\n"
                   "- Load view images description (regions: features & descriptors)\n"
                   "- Compute putative local feature matches (descriptors matching)\n"
                   "- Compute geometric coherent feature matches (robust model estimation from putative matches)\n"

--- a/src/software/pipeline/main_globalSfM.cpp
+++ b/src/software/pipeline/main_globalSfM.cpp
@@ -81,7 +81,7 @@ int aliceVision_main(int argc, char **argv)
       "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
     ;
 
-  CmdLine cmdline("Implementation of the paper\n"
+  CmdLine cmdline("This program is an implementation of the paper\n"
                   "\"Global Fusion of Relative Motions for "
                   "Robust, Accurate and Scalable Structure from Motion.\"\n"
                   "Pierre Moulon, Pascal Monasse and Renaud Marlet ICCV 2013.\n"

--- a/src/software/pipeline/main_imageMasking.cpp
+++ b/src/software/pipeline/main_imageMasking.cpp
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
             "Compute a sub-range of N images (N=rangeSize).")
         ;
 
-    CmdLine cmdline("AliceVision masking");
+    CmdLine cmdline("AliceVision imageMasking");
     cmdline.add(requiredParams);
     cmdline.add(hsvParams);
     cmdline.add(optionalParams);

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -178,8 +178,8 @@ int aliceVision_main(int argc, char **argv)
       "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
     ;
 
-  CmdLine cmdline("Sequential/Incremental reconstruction\n"
-                  "Perform incremental SfM (Initial Pair Essential + Resection)\n"
+  CmdLine cmdline("Sequential/Incremental reconstruction.\n"
+                  "This program performs incremental SfM (Initial Pair Essential + Resection).\n"
                   "AliceVision incrementalSfM");
                   
   cmdline.add(requiredParams);

--- a/src/software/pipeline/main_meshDecimate.cpp
+++ b/src/software/pipeline/main_meshDecimate.cpp
@@ -63,7 +63,7 @@ int aliceVision_main(int argc, char* argv[])
         ("flipNormals", po::value<bool>(&flipNormals)->default_value(flipNormals),
             "Option to flip face normals. It can be needed as it depends on the vertices order in triangles and the convention change from one software to another.");
 
-    CmdLine cmdline("AliceVision mesh decimate");
+    CmdLine cmdline("AliceVision meshDecimate");
                   
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);

--- a/src/software/pipeline/main_meshDenoising.cpp
+++ b/src/software/pipeline/main_meshDenoising.cpp
@@ -74,7 +74,7 @@ int aliceVision_main(int argc, char* argv[])
             "* ITERATIVE_UPDATE(" BOOST_PP_STRINGIZE(SDFilter::MeshFilterParameters::ITERATIVE_UPDATE) ") (default): ShapeUp styled iterative solver\n"
             "* POISSON_UPDATE(" BOOST_PP_STRINGIZE(SDFilter::MeshFilterParameters::POISSON_UPDATE) "): Poisson-based update from [Wang et al. 2015] \"Rolling guidance normal filter for geometric processing\"\n");
 
-    CmdLine cmdline("AliceVision meshdenoising");
+    CmdLine cmdline("AliceVision meshDenoising");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -144,7 +144,7 @@ int aliceVision_main(int argc, char* argv[])
         ("filterTrianglesRatio", po::value<double>(&filterTrianglesRatio)->default_value(filterTrianglesRatio),
             "Remove all triangles by ratio (largest edge /smallest edge). Put zero to disable it.");
 
-    CmdLine cmdline("AliceVision mesh filtering");
+    CmdLine cmdline("AliceVision meshFiltering");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -541,7 +541,7 @@ int main(int argc, char **argv)
             "Use the points visibilities from the meshing to filter triangles. Example: when they are occluded, back-face, etc.")
         ;
 
-    CmdLine cmdline("AliceVision mesh masking");
+    CmdLine cmdline("AliceVision meshMasking");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_meshResampling.cpp
+++ b/src/software/pipeline/main_meshResampling.cpp
@@ -68,7 +68,7 @@ int aliceVision_main(int argc, char* argv[])
         ("flipNormals", po::value<bool>(&flipNormals)->default_value(flipNormals),
             "Option to flip face normals. It can be needed as it depends on the vertices order in triangles and the convention change from one software to another.");
 
-    CmdLine cmdline("AliceVision mesh resampling");
+    CmdLine cmdline("AliceVision meshResampling");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -586,8 +586,8 @@ int aliceVision_main(int argc, char** argv)
         ("maxThreads", po::value<int>(&maxThreads)->default_value(maxThreads), "max number of threads to use.")
         ("labels,l", po::value<std::string>(&labelsFilepath)->required(), "Labels image from seams estimation.");
 
-    CmdLine cmdline("Perform panorama stiching of cameras around a nodal point for 360° panorama creation. \n"
-                    "AliceVision PanoramaCompositing");
+    CmdLine cmdline("This program performs panorama stiching of cameras around a nodal point for 360° panorama creation. \n"
+                    "AliceVision panoramaCompositing");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -105,8 +105,8 @@ int aliceVision_main(int argc, char **argv)
       "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.")
     ;
 
-  CmdLine cmdline("Perform estimation of cameras orientation around a nodal point for 360° panorama.\n"
-                  "AliceVision PanoramaEstimation");
+  CmdLine cmdline("This program performs estimation of cameras orientation around a nodal point for 360° panorama.\n"
+                  "AliceVision panoramaEstimation");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -668,8 +668,8 @@ int main(int argc, char * argv[])
         ;
 
 
-    CmdLine cmdline("Parse external information about cameras used in a panorama.\n"
-                    "AliceVision PanoramaInit");
+    CmdLine cmdline("This program parses external information about cameras used in a panorama.\n"
+                    "AliceVision panoramaInit");
     cmdline.add(requiredParams);
     cmdline.add(motorizedHeadParams);
     cmdline.add(fisheyeParams);

--- a/src/software/pipeline/main_panoramaMerging.cpp
+++ b/src/software/pipeline/main_panoramaMerging.cpp
@@ -60,8 +60,8 @@ int aliceVision_main(int argc, char** argv)
     optionalParams.add_options()
         ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType), ("Storage data type: " + image::EStorageDataType_informations()).c_str());
 
-    CmdLine cmdline("Perform panorama stiching of cameras around a nodal point for 360° panorama creation. \n"
-                    "AliceVision PanoramaCompositing");
+    CmdLine cmdline("This program performs panorama stiching of cameras around a nodal point for 360° panorama creation. \n"
+                    "AliceVision panoramaMerging");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -77,7 +77,7 @@ int aliceVision_main(int argc, char* argv[])
         ("output,o", po::value<std::string>(&sfmOutputDataFilename)->required(),
          "SfMData file output.");
 
-    CmdLine cmdline("Prepare images set for use in panorama.\n"
+    CmdLine cmdline("This program prepares images set for use in panorama.\n"
                     "AliceVision panoramaPrepareImages");
     cmdline.add(requiredParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -182,7 +182,7 @@ int aliceVision_main(int argc, char** argv)
         ("maxWidth", po::value<int>(&maxPanoramaWidth)->required(), "Max Panorama Width.")
         ("useGraphCut,g", po::value<bool>(&useGraphCut)->default_value(useGraphCut), "Enable graphcut algorithm to improve seams.");
 
-    CmdLine cmdline("AliceVision Panorama Seams");
+    CmdLine cmdline("AliceVision panoramaSeams");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -125,8 +125,8 @@ int aliceVision_main(int argc, char** argv)
 				("rangeStart", po::value<int>(&rangeStart)->default_value(rangeStart), "Range image index start.")
 				("rangeSize", po::value<int>(&rangeSize)->default_value(rangeSize), "Range size.");
 
-		CmdLine cmdline("Perform panorama stiching of cameras around a nodal point for 360° panorama creation. \n"
-						"AliceVision PanoramaWarping");
+		CmdLine cmdline("This program computes the image warping for each input image in the panorama coordinate system.\n"
+						"AliceVision panoramaWarping");
 		cmdline.add(requiredParams);
 		cmdline.add(optionalParams);
 		if (!cmdline.execute(argc, argv))

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -190,7 +190,8 @@ int aliceVision_main(int argc, char** argv)
     
   CmdLine cmdline("This program is used to calibrate a camera rig composed of internally calibrated cameras."
                   "It takes as input a synchronized sequence of N cameras and it saves the estimated "
-                  "rig calibration to a text file");
+                  "rig calibration to a text file.\n"
+                  "AliceVision rigCalibration");
   cmdline.add(ioParams);
   cmdline.add(outputParams);
   cmdline.add(commonParams);

--- a/src/software/pipeline/main_rigLocalization.cpp
+++ b/src/software/pipeline/main_rigLocalization.cpp
@@ -196,7 +196,8 @@ int aliceVision_main(int argc, char** argv)
 #endif
           ;
 
-  CmdLine cmdline("This program is used to localize a camera rig composed of internally calibrated cameras");
+  CmdLine cmdline("This program is used to localize a camera rig composed of internally calibrated cameras.\n"
+                  "AliceVision rigLocalization");
   cmdline.add(inputParams);
   cmdline.add(outputParams);
   cmdline.add(commonParams);

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -157,7 +157,7 @@ int aliceVision_main(int argc, char** argv)
         "extension", po::value<std::string>(&extension)->default_value(extension),
          "Output image extension (like exr, or empty to keep the original source file format.");
 
-    CmdLine cmdline("This program is used to perform color correction based on a color checker\n"
+    CmdLine cmdline("This program is used to perform color correction based on a color checker.\n"
                     "AliceVision colorCheckerCorrection");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);

--- a/src/software/utils/main_computeUncertainty.cpp
+++ b/src/software/utils/main_computeUncertainty.cpp
@@ -55,7 +55,7 @@ int aliceVision_main(int argc, char **argv)
     ("verboseLevel,v", po::value<std::string>(&verboseLevel)->default_value(verboseLevel),
       "verbosity level (fatal,  error, warning, info, debug, trace).");
 
-  CmdLine cmdline("AliceVision Uncertainty");
+  CmdLine cmdline("AliceVision computeUncertainty");
   cmdline.add(params);
   if (!cmdline.execute(argc, argv))
   {

--- a/src/software/utils/main_fisheyeProjection.cpp
+++ b/src/software/utils/main_fisheyeProjection.cpp
@@ -281,7 +281,7 @@ int aliceVision_main(int argc, char** argv)
     ("zRotation,z", po::value<std::vector<double>>(&zRotation)->multitoken(),
       "Angles to rotate each image on axis z : depth axis on the panorama.");
 
-  CmdLine cmdline("This program is used to stitch multiple fisheye images into an equirectangular 360° panorama\n"
+  CmdLine cmdline("This program is used to stitch multiple fisheye images into an equirectangular 360° panorama.\n"
                   "AliceVision fisheyeProjection");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);

--- a/src/software/utils/main_frustumFiltering.cpp
+++ b/src/software/utils/main_frustumFiltering.cpp
@@ -89,8 +89,8 @@ int aliceVision_main(int argc, char **argv)
     ("zFar", po::value<double>(&zFar)->default_value(zFar),
       "Distance of the far camera plane.");
 
-  CmdLine cmdline("Compute camera cones that share some putative visual content.\n"
-                  "AliceVision FrustumFiltering");
+  CmdLine cmdline("This program computes camera cones that share some putative visual content.\n"
+                  "AliceVision frustumFiltering");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/utils/main_generateSampleScene.cpp
+++ b/src/software/utils/main_generateSampleScene.cpp
@@ -33,7 +33,8 @@ int aliceVision_main(int argc, char** argv)
     requiredParams.add_options()("output,o", po::value<std::string>(&sfmOutputDataFilepath)->required(),
                                  "Output sfm file to generate.");
 
-    CmdLine cmdline("This program is used to generate a sample scene and save at to a given file path");
+    CmdLine cmdline("This program is used to generate a sample scene and save it to a given file path.\n"
+                    "AliceVision generateSampleScene");
     cmdline.add(requiredParams);
     if (!cmdline.execute(argc, argv))
     {

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -578,8 +578,7 @@ int aliceVision_main(int argc, char * argv[])
          "Output image extension (like exr, or empty to keep the source file format.")
         ;
 
-    CmdLine cmdline("Parse external information about cameras used in a panorama.\n"
-                    "AliceVision PanoramaExternalInfo");
+    CmdLine cmdline("AliceVision imageProcessing");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/utils/main_importMiddlebury.cpp
+++ b/src/software/utils/main_importMiddlebury.cpp
@@ -67,7 +67,8 @@ int aliceVision_main(int argc, char** argv)
          "Set the poses to locked, so they will not be refined in the sfm step")
         ;
 
-    CmdLine cmdline("This program generate an SfMData from the configuration files of the Middlebury dataset: https://vision.middlebury.edu/mview/data");
+    CmdLine cmdline("This program generates an SfMData from the configuration files of the Middlebury dataset: https://vision.middlebury.edu/mview/data\n"
+                    "AliceVision importMiddlebury");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -93,7 +93,8 @@ int aliceVision_main(int argc, char** argv)
         "maximum number of output frames (0 = no limit)");
 
 
-  aliceVision::CmdLine cmdline("This program is used to extract keyframes from single camera or a camera rig");
+  aliceVision::CmdLine cmdline("This program is used to extract keyframes from single camera or a camera rig.\n"
+                               "AliceVision keyframeSelection");
   cmdline.add(inputParams);
   cmdline.add(metadataParams);
   cmdline.add(algorithmParams);

--- a/src/software/utils/main_mergeMeshes.cpp
+++ b/src/software/utils/main_mergeMeshes.cpp
@@ -152,8 +152,8 @@ int aliceVision_main(int argc, char** argv)
       ("postProcess", po::value<bool>(&postProcess)->default_value(postProcess),
         "Post-process output mesh in order to avoid future geometric errors");
 
-    CmdLine cmdline("AliceVision mergeMeshes\n"
-                    "The program takes two meshes and applies a boolean operation on them.");
+    CmdLine cmdline("The program takes two meshes and applies a boolean operation on them.\n"
+                    "AliceVision mergeMeshes");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/utils/main_rigTransform.cpp
+++ b/src/software/utils/main_rigTransform.cpp
@@ -60,7 +60,7 @@ int aliceVision_main(int argc, char** argv)
     ("rigFile,e", po::value<std::string>(&rigFile)->required(),
         "Rig calibration file that will be  applied to input.");
 
-  CmdLine cmdline("Program to deduce the pose of the not localized cameras of the RIG.\n"
+  CmdLine cmdline("This program is used to deduce the pose of the not localized cameras of the RIG.\n"
                   "Use if you have localized a single camera from an acquisition with a RIG of cameras.\n"
                   "AliceVision rigTransform");
   cmdline.add(requiredParams);

--- a/src/software/utils/main_sfmDistances.cpp
+++ b/src/software/utils/main_sfmDistances.cpp
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
       + feature::EImageDescriberType_informations()).c_str())
     ;
 
-  CmdLine cmdline("AliceVision sfmTransform");
+  CmdLine cmdline("AliceVision sfmDistances");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);
   if (!cmdline.execute(argc, argv))

--- a/src/software/utils/main_sfmLocalization.cpp
+++ b/src/software/utils/main_sfmLocalization.cpp
@@ -66,7 +66,7 @@ int aliceVision_main(int argc, char **argv)
     ("maxResidualError", po::value<double>(&maxResidualError)->default_value(maxResidualError),
       "Upper bound of the residual error tolerance.");
 
-  CmdLine cmdline("Image localization in an existing SfM reconstruction\n"
+  CmdLine cmdline("Image localization in an existing SfM reconstruction.\n"
                   "AliceVision sfmLocalization");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -130,7 +130,7 @@ int aliceVision_main(int argc, char **argv)
             "Path of the output SfMData file.")
         ;
 
-    CmdLine cmdline("AliceVision sfmAlignment");
+    CmdLine cmdline("AliceVision sfmTransfer");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -317,7 +317,7 @@ int aliceVision_main(int argc, char** argv)
       "Number of threads.")
     ;
 
-  CmdLine cmdline("This program is used to extract multiple images from equirectangular or dualfisheye images or image folder\n"
+  CmdLine cmdline("This program is used to extract multiple images from equirectangular or dualfisheye images or image folder.\n"
                   "AliceVision split360Images");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);

--- a/src/software/utils/main_voctreeCreation.cpp
+++ b/src/software/utils/main_voctreeCreation.cpp
@@ -69,9 +69,9 @@ int aliceVision_main(int argc, char** argv)
     (",L", po::value<uint32_t>(&LEVELS)->default_value(6), "Number of levels of the tree")
     ("sanitycheck,s", po::value<bool>(&sanityCheck)->default_value(sanityCheck), "Perform a sanity check at the end of the creation of the vocabulary tree. The sanity check is a query to the database with the same documents/images useed to train the vocabulary tree");
 
-  CmdLine cmdline("This program is used to load the sift descriptors from a SfMData file and create a vocabulary tree\n"
-                  "It takes as input either a list.txt file containing the a simple list of images (bundler format and older AliceVision version format)\n"
-                  "or a sfm_data file (JSON) containing the list of images. In both cases it is assumed that the .desc to load are in the same folder as the input file\n"
+  CmdLine cmdline("This program is used to load the sift descriptors from a SfMData file and create a vocabulary tree.\n"
+                  "It takes as input either a list.txt file containing a simple list of images (bundler format and older AliceVision version format)\n"
+                  "or a sfm_data file (JSON) containing the list of images. In both cases it is assumed that the .desc to load are in the same folder as the input file.\n"
                   "AliceVision voctreeCreation");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);

--- a/src/software/utils/main_voctreeStatistics.cpp
+++ b/src/software/utils/main_voctreeStatistics.cpp
@@ -77,8 +77,8 @@ int aliceVision_main(int argc, char** argv)
                                                                           "-weightedStrongCommonPoints: strongCommonPoints with weights \n"
                                                                           "-inversedWeightedCommonPoints: strongCommonPoints with inverted weights");
 
-  CmdLine cmdline("This program is used to create a database with a provided dataset of image descriptors using a trained vocabulary tree\n"
-                  "The database is then queried with the same images in order to retrieve for each image the set of most similar images in the dataset\n"
+  CmdLine cmdline("This program is used to create a database with a provided dataset of image descriptors using a trained vocabulary tree.\n"
+                  "The database is then queried with the same images in order to retrieve for each image the set of most similar images in the dataset.\n"
                   "AliceVision voctreeStatistics");
   cmdline.add(requiredParams);
   cmdline.add(optionalParams);


### PR DESCRIPTION
## Description

This PR fixes and harmonizes the description of all the command lines that contained:
- erroneous and/or incorrectly formatted executable's name (for an executable named "aliceVision_doingSomething", the name we want to display in the description of the command line is "AliceVision doingSomething");
- incorrect program description (for example, the description of another command line);
- incorrectly formatted description: if there is a specific description for the command line, it is expected to be placed first, ending with a period and a newline, and followed by the executable's name; if there's no such specific description, only the executable's name is expected.

With this pull request, all command lines' descriptions should look either like this:
```
This program does something.
aliceVision_doingSomething
```
or, if there is no specific description:
```
aliceVision_doingSomething
```

Some specific descriptions have also been rephrased to reduce differences between the different command lines.