### PR TITLE
[hdr] Compute the center exposure of the hdr automatically

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -130,7 +130,7 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
         {
             lines.push_back(line);
         }
-        if ((lines.size() < 2) || (atoi(lines[0].c_str()) != groups.size()) || (atoi(lines[1].c_str()) < groups[0].size()))
+        if ((lines.size() < 3) || (atoi(lines[0].c_str()) != groups.size()) || (atoi(lines[1].c_str()) < groups[0].size()))
         {
             ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
         }
@@ -144,10 +144,11 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
             double lumaMeanMean = 0.0;
             for (int j = 0; j < nbGroup; ++j)
             {
-                std::istringstream iss(lines[2 + j * nbExp + i]);
+                std::istringstream iss(lines[3 + j * nbExp + i]);
+                aliceVision::IndexT srcId;
                 int exposure, nbItem;
                 double lumaMean, lumaMin, lumaMax;
-                if (!(iss >> exposure >> nbItem >> lumaMean >> lumaMin >> lumaMax))
+                if (!(iss >> srcId >> exposure >> nbItem >> lumaMean >> lumaMin >> lumaMax))
                 {
                     ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
                 }

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -110,48 +110,36 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
     // For even number, we arbitrarily choose the more exposed view (as we usually have more under-exposed images than over-exposed).
     const int viewNumberPerGroup = groups[0].size();
     const int middleIndex = viewNumberPerGroup / 2;
-    const int targetIndex = middleIndex + offsetRefBracketIndex;
+    int targetIndex = middleIndex + offsetRefBracketIndex;
+
+    out_targetViews.clear();
 
     if ((targetIndex >= 0) && (targetIndex < viewNumberPerGroup))
     {
         ALICEVISION_LOG_INFO("Use offsetRefBracketIndex parameter");
-        for(auto & group : groups)
-        {
-            out_targetViews.push_back(group[targetIndex]);
-        }
     }
-    else // try to use indexes in the file
+    else // try to use the index in the file
     {
-        ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter out of range, read file containing target indexes");
-        std::vector<int> targetIndexes;
+        ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter out of range, read file containing the target index");
         std::ifstream file(targetIndexesFilename);
         if (!file)
         {
-            ALICEVISION_LOG_WARNING("Unable to open the file " << targetIndexesFilename << " with the selection of exposures. This file would be needed to select the optimal exposure for the creation of the HDR images. Use clamped offsetRefBracketIndex parameter.");
-            for (int i = 0; i < groups.size(); ++i)
-            {
-                targetIndexes.push_back(clamp(targetIndex, 0, int(groups[i].size()) - 1));
-            }
+            return; 
         }
         else
         {
-            while (file)
+            std::string line;
+            if (getline(file, line))
             {
-                std::string line;
-                if (!getline(file, line)) break;
-                targetIndexes.push_back(atoi(line.c_str()));
+                targetIndex = atoi(line.c_str());
+                file.close();
             }
-            file.close();
-
-            if (targetIndexes.size() != groups.size())
+            else
             {
-                ALICEVISION_LOG_WARNING("Non consistent number of reference indexes in file " << targetIndexesFilename << ", use clamped offsetRefBracketIndex parameter");
-                for (int i = 0; i < groups.size(); ++i)
-                {
-                    targetIndexes.push_back(clamp(targetIndex, 0, int(groups[i].size()) - 1));
-                }
+                return;
             }
         }
+    }
 
         //Set the ldr ancestors id
         for (auto v : group)
@@ -164,7 +152,8 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
             out_targetViews.push_back(groups[i][targetIndexes[i]]);
         }
     }
-
+    return;
 }
+
 }
 }

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -200,12 +200,12 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
                     targetIndex = k;
                 }
             }
-            ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter automaticaly set to " << targetIndex);
+            ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter automaticaly set to " << targetIndex - middleIndex);
         }
         else
         {
             targetIndex = middleIndex;
-            ALICEVISION_LOG_WARNING("Non valid luminance statistics file, offsetRefBracketIndex parameter set to medium exposure " << targetIndex);
+            ALICEVISION_LOG_WARNING("Non valid luminance statistics file, offsetRefBracketIndex parameter set to 0 (medium exposure)");
         }
     }
 

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -110,14 +110,15 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
     // Check exposure consistency between group
     if (v_exposuresSetting.size() > 1)
     {
-        for (int g=1 ; g < v_exposuresSetting.size(); g++)
+        for (int g = 1 ; g < v_exposuresSetting.size(); ++g)
         {
-            for (int e = 0; e < v_exposuresSetting[g].size(); e++)
+            for (int e = 0; e < v_exposuresSetting[g].size(); ++e)
             {
                 if (!(v_exposuresSetting[g][e] == v_exposuresSetting[g - 1][e]))
                 {
-                    ALICEVISION_LOG_ERROR("Non consistant exposures between groups have been detected. Check your dataset metadata.");
-                    return false;
+                    ALICEVISION_LOG_WARNING("Non consistant exposures between poses have been detected. Most likely the dataset has been captured with an automatic exposure mode enabled. Final result can be impacted.");
+                    g = v_exposuresSetting.size();
+                    break;
                 }
             }
         }
@@ -153,12 +154,12 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
         {
             lines.push_back(line);
         }
-        if ((lines.size() < 3) || (atoi(lines[0].c_str()) != groups.size()) || (atoi(lines[1].c_str()) < groups[0].size()))
+        if ((lines.size() < 3) || (std::stoi(lines[0].c_str()) != groups.size()) || (std::stoi(lines[1].c_str()) < groups[0].size()))
         {
             ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
         }
-        int nbGroup = atoi(lines[0].c_str());
-        int nbExp = atoi(lines[1].c_str());
+        int nbGroup = std::stoi(lines[0].c_str());
+        int nbExp = std::stoi(lines[1].c_str());
 
         std::vector<double> v_lumaMeanMean;
 
@@ -169,8 +170,8 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
             {
                 std::istringstream iss(lines[3 + j * nbExp + i]);
                 aliceVision::IndexT srcId;
-                int exposure, nbItem;
-                double lumaMean, lumaMin, lumaMax;
+                int nbItem;
+                double exposure, lumaMean, lumaMin, lumaMax;
                 if (!(iss >> srcId >> exposure >> nbItem >> lumaMean >> lumaMin >> lumaMax))
                 {
                     ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -181,10 +181,17 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
             v_lumaMeanMean.push_back(lumaMeanMean / nbGroup);
         }
 
+        // adjust last index to avoid non increasing luminance curve due to saturation in highlights
+        int lastIdx = v_lumaMeanMean.size() - 1;
+        while ((lastIdx > 1) && ((v_lumaMeanMean[lastIdx] < v_lumaMeanMean[lastIdx - 1]) || (v_lumaMeanMean[lastIdx] < v_lumaMeanMean[lastIdx - 2])))
+        {
+            lastIdx--;
+        }
+
         double minDiffWithLumaTarget = 1000.0;
         targetIndex = 0;
 
-        for (int k = 0; k < v_lumaMeanMean.size(); ++k)
+        for (int k = 0; k < lastIdx; ++k)
         {
             const double diffWithLumaTarget = (v_lumaMeanMean[k] > meanTargetedLuma) ? (v_lumaMeanMean[k] - meanTargetedLuma) : (meanTargetedLuma - v_lumaMeanMean[k]);
             if (diffWithLumaTarget < minDiffWithLumaTarget)

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -129,7 +129,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
 
 void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetViews, const std::vector<std::vector<std::shared_ptr<sfmData::View>>> & groups, int offsetRefBracketIndex, const std::string& lumaStatFilepath, const double meanTargetedLuma)
 {
-    // If targetIndexesFilename cannot be opened or is not valid target views are derived from the middle exposed views
+    // If targetIndexesFilename cannot be opened or is not valid an error is thrown
     // For odd number, there is no ambiguity on the middle image.
     // For even number, we arbitrarily choose the more exposed view (as we usually have more under-exposed images than over-exposed).
     const int viewNumberPerGroup = groups[0].size();
@@ -181,56 +181,19 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
             v_lumaMeanMean.push_back(lumaMeanMean / nbGroup);
         }
 
-        // Makes sure the luminance curve is monotonic
-        int firstvalid = -1;
-        int lastvalid = 0;
-        for (std::size_t k = 1; k < v_lumaMeanMean.size(); ++k)
+        double minDiffWithLumaTarget = 1000.0;
+        targetIndex = 0;
+
+        for (int k = 0; k < v_lumaMeanMean.size(); ++k)
         {
-            bool valid = false;
-
-            if (v_lumaMeanMean[k] > v_lumaMeanMean[k - 1])
+            const double diffWithLumaTarget = (v_lumaMeanMean[k] > meanTargetedLuma) ? (v_lumaMeanMean[k] - meanTargetedLuma) : (meanTargetedLuma - v_lumaMeanMean[k]);
+            if (diffWithLumaTarget < minDiffWithLumaTarget)
             {
-                valid = true;
-            }
-
-            if (valid)
-            {
-                if (firstvalid < 0)
-                {
-                    firstvalid = int(k) - 1;
-                }
-                lastvalid = int(k);
-            }
-            else
-            {
-                if (lastvalid != 0)
-                {
-                    break;
-                }
+                minDiffWithLumaTarget = diffWithLumaTarget;
+                targetIndex = k;
             }
         }
-
-        if (lastvalid >= firstvalid && firstvalid >= 0)
-        {
-            double minDiffWithLumaTarget = 1000.0;
-            targetIndex = 0;
-
-            for (int k = firstvalid; k <= lastvalid; ++k)
-            {
-                const double diffWithLumaTarget = fabs(v_lumaMeanMean[k] - meanTargetedLuma);
-                if (diffWithLumaTarget < minDiffWithLumaTarget)
-                {
-                    minDiffWithLumaTarget = diffWithLumaTarget;
-                    targetIndex = k;
-                }
-            }
-            ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter automaticaly set to " << targetIndex - middleIndex);
-        }
-        else
-        {
-            targetIndex = middleIndex;
-            ALICEVISION_LOG_WARNING("Non valid luminance statistics file, offsetRefBracketIndex parameter set to 0 (medium exposure)");
-        }
+        ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter automaticaly set to " << targetIndex - middleIndex);
     }
 
     for (auto& group : groups)

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -89,6 +89,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         groups.push_back(group);
     }
 
+    std::vector< std::vector<sfmData::ExposureSetting>> v_exposuresSetting;
     for(auto & group : groups)
     {
         // Sort all images by exposure time
@@ -98,6 +99,28 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
                           return true;
                       return (a->getCameraExposureSetting().getExposure() < b->getCameraExposureSetting().getExposure());
                   });
+        std::vector<sfmData::ExposureSetting> exposuresSetting;
+        for (auto& v : group)
+        {
+            exposuresSetting.push_back(v->getCameraExposureSetting());
+        }
+        v_exposuresSetting.push_back(exposuresSetting);
+    }
+
+    // Check exposure consistency between group
+    if (v_exposuresSetting.size() > 1)
+    {
+        for (int g=1 ; g < v_exposuresSetting.size(); g++)
+        {
+            for (int e = 0; e < v_exposuresSetting[g].size(); e++)
+            {
+                if (!(v_exposuresSetting[g][e] == v_exposuresSetting[g - 1][e]))
+                {
+                    ALICEVISION_LOG_ERROR("Non consistant exposures between groups have been detected. Check your dataset metadata.");
+                    return false;
+                }
+            }
+        }
     }
 
     return true;

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -123,22 +123,11 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
         ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter out of range, read file containing the target index");
         std::ifstream file(targetIndexesFilename);
         if (!file)
-        {
-            return; 
-        }
-        else
-        {
-            std::string line;
-            if (getline(file, line))
-            {
-                targetIndex = atoi(line.c_str());
-                file.close();
-            }
-            else
-            {
-                return;
-            }
-        }
+            ALICEVISION_THROW_ERROR("Failed to open file: " << targetIndexesFilename);
+        std::string line;
+        if (!std::getline(file, line))
+            ALICEVISION_THROW_ERROR("Failed to read from file: " << targetIndexesFilename);
+        targetIndex = atoi(line.c_str());
     }
 
         //Set the ldr ancestors id

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -11,6 +11,71 @@
 namespace aliceVision {
 namespace hdr {
 
+enum class ECalibrationMethod
+{
+    LINEAR,
+    DEBEVEC,
+    GROSSBERG,
+    LAGUERRE,
+};
+
+/**
+ * @brief convert an enum ECalibrationMethod to its corresponding string
+ * @param ECalibrationMethod
+ * @return String
+ */
+inline std::string ECalibrationMethod_enumToString(const ECalibrationMethod calibrationMethod)
+{
+    switch (calibrationMethod)
+    {
+    case ECalibrationMethod::LINEAR:
+        return "linear";
+    case ECalibrationMethod::DEBEVEC:
+        return "debevec";
+    case ECalibrationMethod::GROSSBERG:
+        return "grossberg";
+    case ECalibrationMethod::LAGUERRE:
+        return "laguerre";
+    }
+    throw std::out_of_range("Invalid method name enum");
+}
+
+/**
+ * @brief convert a string calibration method name to its corresponding enum ECalibrationMethod
+ * @param ECalibrationMethod
+ * @return String
+ */
+inline ECalibrationMethod ECalibrationMethod_stringToEnum(const std::string& calibrationMethodName)
+{
+    std::string methodName = calibrationMethodName;
+    std::transform(methodName.begin(), methodName.end(), methodName.begin(), ::tolower);
+
+    if (methodName == "linear")
+        return ECalibrationMethod::LINEAR;
+    if (methodName == "debevec")
+        return ECalibrationMethod::DEBEVEC;
+    if (methodName == "grossberg")
+        return ECalibrationMethod::GROSSBERG;
+    if (methodName == "laguerre")
+        return ECalibrationMethod::LAGUERRE;
+
+    throw std::out_of_range("Invalid method name : '" + calibrationMethodName + "'");
+}
+
+inline std::ostream& operator<<(std::ostream& os, ECalibrationMethod calibrationMethodName)
+{
+    os << ECalibrationMethod_enumToString(calibrationMethodName);
+    return os;
+}
+
+inline std::istream& operator>>(std::istream& in, ECalibrationMethod& calibrationMethod)
+{
+    std::string token;
+    in >> token;
+    calibrationMethod = ECalibrationMethod_stringToEnum(token);
+    return in;
+}
+
 /**
  * @brief Estimate brackets information from sfm data
  * @param[out] groups: estimated groups

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -25,8 +25,11 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
  * @param[out] targetViews: estimated target views
  * @param[in] groups: groups of Views corresponding to multi-bracketing. Warning: Needs be sorted by exposure time.
  * @param[in] offsetRefBracketIndex: 0 mean center bracket and you can choose +N/-N to select the reference bracket
+ * @param[in] targetIndexesFilename: in case offsetRefBracketIndex is out of range the number of views in a group target indexes can be read from a text file
+ *                                   if the file cannot be read or does not contain the expected number of values (same as view group number) and
+ *                                   if offsetRefBracketIndex is out of range the number of views then a clamped values of offsetRefBracketIndex is considered
  */
-void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetViews, const std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex);
+void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetViews, const std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex, const std::string& targetIndexesFilename = "");
 
 }
 }

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -29,7 +29,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
  *                                   if the file cannot be read or does not contain the expected number of values (same as view group number) and
  *                                   if offsetRefBracketIndex is out of range the number of views then a clamped values of offsetRefBracketIndex is considered
  */
-void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetViews, const std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex, const std::string& targetIndexesFilename = "");
+void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetViews, const std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex, const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4);
 
 }
 }

--- a/src/aliceVision/hdr/hdrTestCommon.hpp
+++ b/src/aliceVision/hdr/hdrTestCommon.hpp
@@ -38,8 +38,14 @@ bool extractSamplesGroups(std::vector<std::vector<ImageSample>>& out_samples,
         imgReadOptions.rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
         imgReadOptions.workingColorSpace = image::EImageColorSpace::LINEAR;
 
+        std::vector<IndexT> viewIds;
+        for (size_t id = 0; id < imagePaths[idGroup].size(); ++id)
+        {
+            viewIds.push_back(id);
+        }
+
         std::vector<ImageSample> groupSamples;
-        if (!Sampling::extractSamplesFromImages(groupSamples, imagePaths[idGroup],
+        if (!Sampling::extractSamplesFromImages(groupSamples, imagePaths[idGroup], viewIds,
                                                 times[idGroup], width, height,
                                                 channelQuantization, imgReadOptions,
                                                 Sampling::Params{}))

--- a/src/aliceVision/hdr/sampling.cpp
+++ b/src/aliceVision/hdr/sampling.cpp
@@ -65,7 +65,8 @@ std::istream & operator>>(std::istream& is, ImageSample & s)
 
 std::ostream & operator<<(std::ostream& os, const PixelDescription & p)
 {
-    os.write((const char *)&p.exposure, sizeof(p.exposure));
+    os.write((const char*)&p.srcId, sizeof(p.srcId));
+    os.write((const char*)&p.exposure, sizeof(p.exposure));
     os.write((const char *)&p.mean.r(), sizeof(p.mean.r()));
     os.write((const char *)&p.mean.g(), sizeof(p.mean.g()));
     os.write((const char *)&p.mean.b(), sizeof(p.mean.b()));
@@ -78,7 +79,8 @@ std::ostream & operator<<(std::ostream& os, const PixelDescription & p)
 
 std::istream & operator>>(std::istream& is, PixelDescription & p)
 {
-    is.read((char *)&p.exposure, sizeof(p.exposure));
+    is.read((char*)&p.srcId, sizeof(p.srcId));
+    is.read((char*)&p.exposure, sizeof(p.exposure));
     is.read((char *)&p.mean.r(), sizeof(p.mean.r()));
     is.read((char *)&p.mean.g(), sizeof(p.mean.g()));
     is.read((char *)&p.mean.b(), sizeof(p.mean.b()));
@@ -146,7 +148,7 @@ void square(image::Image<image::RGBfColor> & dest, const Eigen::Matrix<image::RG
     }
 }
 
-bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string>& imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Sampling::Params params, const bool simplified)
+bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string>& imagePaths, const std::vector<IndexT>& viewIds, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Sampling::Params params, const bool simplified)
 {
     const int radiusp1 = params.radius + 1;
     const int diameter = (params.radius * 2) + 1;
@@ -217,6 +219,7 @@ bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, c
                 {
                     PixelDescription pd;
 
+                    pd.srcId = viewIds[idBracket];
                     pd.exposure = exposure;
                     pd.mean.r() = img(r, c).r();
                     pd.mean.g() = img(r, c).g();
@@ -262,6 +265,7 @@ bool Sampling::extractSamplesFromImages(std::vector<ImageSample>& out_samples, c
 
                         PixelDescription pd;
 
+                        pd.srcId = viewIds[idBracket];
                         pd.exposure = exposure;
                         pd.mean.r() = blockInput(y, x).r();
                         pd.mean.g() = blockInput(y, x).g();

--- a/src/aliceVision/hdr/sampling.hpp
+++ b/src/aliceVision/hdr/sampling.hpp
@@ -66,7 +66,7 @@ public:
     void filter(size_t maxTotalPoints);
     void extractUsefulSamples(std::vector<ImageSample> & out_samples, const std::vector<ImageSample> & samples, int imageIndex) const;
     
-    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Params params);
+    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Params params, const bool simplified = false);
 
 private:
     MapSampleRefList _positions;

--- a/src/aliceVision/hdr/sampling.hpp
+++ b/src/aliceVision/hdr/sampling.hpp
@@ -24,6 +24,7 @@ struct UniqueDescriptor
 
 struct PixelDescription
 {
+    aliceVision::IndexT srcId = 0;
     float exposure;
     image::Rgb<float> mean;
     image::Rgb<float> variance;
@@ -66,7 +67,7 @@ public:
     void filter(size_t maxTotalPoints);
     void extractUsefulSamples(std::vector<ImageSample> & out_samples, const std::vector<ImageSample> & samples, int imageIndex) const;
     
-    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Params params, const bool simplified = false);
+    static bool extractSamplesFromImages(std::vector<ImageSample>& out_samples, const std::vector<std::string> & imagePaths, const std::vector<IndexT>& viewIds, const std::vector<double>& times, const size_t imageWidth, const size_t imageHeight, const size_t channelQuantization, const image::ImageReadOptions & imgReadOptions, const Params params, const bool simplified = false);
 
 private:
     MapSampleRefList _positions;

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -444,20 +444,24 @@ int aliceVision_main(int argc, char** argv)
     response.write(outputResponsePath);
     response.writeHtml(htmlOutput, "response");
 
-    const std::string expRefIndexesFilename = (fs::path(outputResponsePath).parent_path() / (std::string("exposureRefIndexes") + std::string(".txt"))).string();
+    double meanIndex = 0.0;
+    for (int i = 0; i < refIndexes.size(); i++)
+    {
+        meanIndex += static_cast<double>(refIndexes[i]);
+    }
+    const int refIndex = static_cast<int>(std::round(meanIndex /= refIndexes.size()));
 
-    std::ofstream file(expRefIndexesFilename);
+    const std::string expRefIndexFilename = (fs::path(outputResponsePath).parent_path() / (std::string("exposureRefIndex") + std::string(".txt"))).string();
+    std::ofstream file(expRefIndexFilename);
     if (!file)
     {
-        throw std::logic_error("Can't create file for exposure reference Indexes");
+        ALICEVISION_LOG_WARNING("Unable to create file " << expRefIndexFilename << " for storing the exposure reference Index");
     }
-    std::string text = "";
-    for (std::size_t index = 0; index < refIndexes.size(); ++index)
+    else
     {
-        text += std::to_string(refIndexes[index]) + "\n";
+        file << std::to_string(refIndex) + "\n";
+        file.close();
     }
-    file << text;
-    file.close();
 
     return EXIT_SUCCESS;
 }

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -433,27 +433,24 @@ int aliceVision_main(int argc, char** argv)
     response.write(outputResponsePath);
     response.writeHtml(htmlOutput, "response");
 
-    const std::string lumastatFilename = (fs::path(outputResponsePath).parent_path() / (std::string("luminanceStatistics") + std::string(".txt"))).string();
+    const std::string lumastatFilename = (fs::path(outputResponsePath).parent_path() / "luminanceStatistics.txt").string();
     std::ofstream file(lumastatFilename);
     if (!file)
     {
         ALICEVISION_LOG_ERROR("Unable to create file " << lumastatFilename << " for storing luminance statistics");
         return EXIT_FAILURE;
     }
-    else
+
+    file << v_luminanceInfos.size() << std::endl;
+    file << v_luminanceInfos[0].size() << std::endl;
+
+    for (int i = 0; i < v_luminanceInfos.size(); ++i)
     {
-        file << v_luminanceInfos.size() << std::endl;
-        file << v_luminanceInfos[0].size() << std::endl;
-
-        for (int i = 0; i < v_luminanceInfos.size(); ++i)
+        for (auto it = v_luminanceInfos[i].begin(); it != v_luminanceInfos[i].end(); it++)
         {
-            for (auto it = v_luminanceInfos[i].begin(); it != v_luminanceInfos[i].end(); it++)
-            {
-                file << it->first << " " << (it->second).itemNb << " " << (it->second).meanLum / (it->second).itemNb << " ";
-                file << (it->second).minLum << " " << (it->second).maxLum << std::endl;
-            }
+            file << it->first << " " << (it->second).itemNb << " " << (it->second).meanLum / (it->second).itemNb << " ";
+            file << (it->second).minLum << " " << (it->second).maxLum << std::endl;
         }
-
     }
 
     return EXIT_SUCCESS;

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -465,7 +465,6 @@ int aliceVision_main(int argc, char** argv)
     else
     {
         file << std::to_string(refIndex) + "\n";
-        file.close();
     }
 
     return EXIT_SUCCESS;

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -195,6 +195,10 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    if (workingColorSpace != image::EImageColorSpace::SRGB)
+    {
+        meanTargetedLumaForMerging = std::pow((meanTargetedLumaForMerging + 0.055) / 1.055, 2.2);
+    }
     hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, lumaStatFilepath.string(), meanTargetedLumaForMerging);
 
     if ((targetViews.empty() || targetViews.size() != groupedViews.size()) && !isOffsetRefBracketIndexValid)

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -54,8 +54,9 @@ int aliceVision_main(int argc, char** argv)
     int nbBrackets = 3;
     bool byPass = false;
     int channelQuantizationPower = 10;
+    int offsetRefBracketIndex = 1000; // By default, use the automatic selection
+    double meanTargetedLumaForMerging = 0.4;
     image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB;
-    int offsetRefBracketIndex = 1000;
 
     hdr::EFunctionType fusionWeightFunction = hdr::EFunctionType::GAUSSIAN;
     float highlightCorrectionFactor = 0.0f;
@@ -90,6 +91,8 @@ int aliceVision_main(int argc, char** argv)
          "Weight function used to fuse all LDR images together (gaussian, triangle, plateau).")
         ("offsetRefBracketIndex", po::value<int>(&offsetRefBracketIndex)->default_value(offsetRefBracketIndex),
          "Zero to use the center bracket. +N to use a more exposed bracket or -N to use a less exposed backet.")
+        ("meanTargetedLumaForMerging", po::value<double>(&meanTargetedLumaForMerging)->default_value(meanTargetedLumaForMerging),
+         "Mean expected luminance after merging step. Must be in the range [0, 1].")
         ("highlightTargetLux", po::value<float>(&highlightTargetLux)->default_value(highlightTargetLux),
          "Highlights maximum luminance.")
         ("highlightCorrectionFactor", po::value<float>(&highlightCorrectionFactor)->default_value(highlightCorrectionFactor),
@@ -98,9 +101,9 @@ int aliceVision_main(int argc, char** argv)
         ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
          ("Storage data type: " + image::EStorageDataType_informations()).c_str())
         ("rangeStart", po::value<int>(&rangeStart)->default_value(rangeStart),
-          "Range image index start.")
+         "Range image index start.")
         ("rangeSize", po::value<int>(&rangeSize)->default_value(rangeSize),
-          "Range size.");
+         "Range size.");
 
     CmdLine cmdline("This program merges LDR images into HDR images.\n"
                     "AliceVision LdrToHdrMerge");
@@ -186,19 +189,19 @@ int aliceVision_main(int argc, char** argv)
         const int targetIndex = middleIndex + offsetRefBracketIndex;
         const bool isOffsetRefBracketIndexValid = (targetIndex >= 0) && (targetIndex < usedNbBrackets);
 
-        const fs::path targetIndexFilepath(fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndex.txt")));
+        const fs::path lumaStatFilepath(fs::path(inputResponsePath).parent_path() / (std::string("luminanceStatistics.txt")));
 
-        if (!fs::is_regular_file(targetIndexFilepath) && !isOffsetRefBracketIndexValid)
+        if (!fs::is_regular_file(lumaStatFilepath) && !isOffsetRefBracketIndexValid)
         {
-            ALICEVISION_LOG_ERROR("Unable to open the file " << targetIndexFilepath.string() << " with the selection of exposures. This file is needed to select the optimal exposure for the creation of HDR images.");
+            ALICEVISION_LOG_ERROR("Unable to open the file " << lumaStatFilepath.string() << " with luminance statistics. This file is needed to select the optimal exposure for the creation of HDR images.");
             return EXIT_FAILURE;
         }
 
-        hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, targetIndexFilepath.string());
+        hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, lumaStatFilepath.string(), meanTargetedLumaForMerging);
 
         if (targetViews.empty() && !isOffsetRefBracketIndexValid)
         {
-            ALICEVISION_LOG_ERROR("File " << targetIndexFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
+            ALICEVISION_LOG_ERROR("File " << lumaStatFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
             return EXIT_FAILURE;
         }
     }

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -55,7 +55,7 @@ int aliceVision_main(int argc, char** argv)
     bool byPass = false;
     int channelQuantizationPower = 10;
     image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB;
-    int offsetRefBracketIndex = 0;
+    int offsetRefBracketIndex = 1000;
 
     hdr::EFunctionType fusionWeightFunction = hdr::EFunctionType::GAUSSIAN;
     float highlightCorrectionFactor = 0.0f;
@@ -154,6 +154,7 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    std::size_t usedNbBrackets;
     {
         std::set<std::size_t> sizeOfGroups;
         for(auto& group : groupedViews)
@@ -162,7 +163,7 @@ int aliceVision_main(int argc, char** argv)
         }
         if(sizeOfGroups.size() == 1)
         {
-            std::size_t usedNbBrackets = *sizeOfGroups.begin();
+            usedNbBrackets = *sizeOfGroups.begin();
             if(usedNbBrackets == 1)
             {
                 ALICEVISION_LOG_INFO("No multi-bracketing.");
@@ -179,9 +180,25 @@ int aliceVision_main(int argc, char** argv)
     }
     std::vector<std::shared_ptr<sfmData::View>> targetViews;
 
-    const fs::path targetIndexFilepath(fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndexes.txt")));
+    const int middleIndex = usedNbBrackets / 2;
+    const int targetIndex = middleIndex + offsetRefBracketIndex;
+    const bool isOffsetRefBracketIndexValid = (targetIndex >= 0) && (targetIndex < usedNbBrackets);
+
+    const fs::path targetIndexFilepath(fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndex.txt")));
+
+    if (!fs::is_regular_file(targetIndexFilepath) && !isOffsetRefBracketIndexValid)
+    {
+        ALICEVISION_LOG_ERROR("Unable to open the file " << targetIndexFilepath.string() << " with the selection of exposures. This file is needed to select the optimal exposure for the creation of HDR images.");
+        return EXIT_FAILURE;
+    }
 
     hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, targetIndexFilepath.string());
+
+    if (targetViews.empty() && !isOffsetRefBracketIndexValid)
+    {
+        ALICEVISION_LOG_ERROR("File " << targetIndexFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
+        return EXIT_FAILURE;
+    }
 
     // Define range to compute
     if(rangeStart != -1)

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -180,24 +180,27 @@ int aliceVision_main(int argc, char** argv)
     }
     std::vector<std::shared_ptr<sfmData::View>> targetViews;
 
-    const int middleIndex = usedNbBrackets / 2;
-    const int targetIndex = middleIndex + offsetRefBracketIndex;
-    const bool isOffsetRefBracketIndexValid = (targetIndex >= 0) && (targetIndex < usedNbBrackets);
-
-    const fs::path targetIndexFilepath(fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndex.txt")));
-
-    if (!fs::is_regular_file(targetIndexFilepath) && !isOffsetRefBracketIndexValid)
+    if (!byPass)
     {
-        ALICEVISION_LOG_ERROR("Unable to open the file " << targetIndexFilepath.string() << " with the selection of exposures. This file is needed to select the optimal exposure for the creation of HDR images.");
-        return EXIT_FAILURE;
-    }
+        const int middleIndex = usedNbBrackets / 2;
+        const int targetIndex = middleIndex + offsetRefBracketIndex;
+        const bool isOffsetRefBracketIndexValid = (targetIndex >= 0) && (targetIndex < usedNbBrackets);
 
-    hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, targetIndexFilepath.string());
+        const fs::path targetIndexFilepath(fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndex.txt")));
 
-    if (targetViews.empty() && !isOffsetRefBracketIndexValid)
-    {
-        ALICEVISION_LOG_ERROR("File " << targetIndexFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
-        return EXIT_FAILURE;
+        if (!fs::is_regular_file(targetIndexFilepath) && !isOffsetRefBracketIndexValid)
+        {
+            ALICEVISION_LOG_ERROR("Unable to open the file " << targetIndexFilepath.string() << " with the selection of exposures. This file is needed to select the optimal exposure for the creation of HDR images.");
+            return EXIT_FAILURE;
+        }
+
+        hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, targetIndexFilepath.string());
+
+        if (targetViews.empty() && !isOffsetRefBracketIndexValid)
+        {
+            ALICEVISION_LOG_ERROR("File " << targetIndexFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
+            return EXIT_FAILURE;
+        }
     }
 
     // Define range to compute

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -178,29 +178,10 @@ int aliceVision_main(int argc, char** argv)
         }
     }
     std::vector<std::shared_ptr<sfmData::View>> targetViews;
-    //hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex);
 
-    const std::string targetIndexFilename = (fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndexes") + std::string(".txt"))).string();
+    const fs::path targetIndexFilepath(fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndexes.txt")));
 
-    std::ifstream file(targetIndexFilename);
-    std::vector<int> targetIndexes;
-    if (!file)
-    {
-        throw std::logic_error("Can't open target indexes file");
-    }
-    //create fileData
-    while (file)
-    {
-        std::string line;
-        if (!getline(file, line)) break;
-        targetIndexes.push_back(atoi(line.c_str()));
-    }
-    file.close();
-
-    for (int i = 0; i < groupedViews.size(); ++i)
-    {
-        targetViews.push_back(groupedViews[i][targetIndexes[i]]);
-    }
+    hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, targetIndexFilepath.string());
 
     // Define range to compute
     if(rangeStart != -1)

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -92,7 +92,7 @@ int aliceVision_main(int argc, char** argv)
         ("offsetRefBracketIndex", po::value<int>(&offsetRefBracketIndex)->default_value(offsetRefBracketIndex),
          "Zero to use the center bracket. +N to use a more exposed bracket or -N to use a less exposed backet.")
         ("meanTargetedLumaForMerging", po::value<double>(&meanTargetedLumaForMerging)->default_value(meanTargetedLumaForMerging),
-         "Mean expected luminance after merging step. Must be in the range [0, 1].")
+         "Mean expected luminance after merging step when input LDR images are decoded in sRGB color space. Must be in the range [0, 1].")
         ("highlightTargetLux", po::value<float>(&highlightTargetLux)->default_value(highlightTargetLux),
          "Highlights maximum luminance.")
         ("highlightCorrectionFactor", po::value<float>(&highlightCorrectionFactor)->default_value(highlightCorrectionFactor),
@@ -195,6 +195,7 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // Adjust the targeted luminance level by removing the corresponding gamma if the working color space is not sRGB.
     if (workingColorSpace != image::EImageColorSpace::SRGB)
     {
         meanTargetedLumaForMerging = std::pow((meanTargetedLumaForMerging + 0.055) / 1.055, 2.2);

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -178,7 +178,29 @@ int aliceVision_main(int argc, char** argv)
         }
     }
     std::vector<std::shared_ptr<sfmData::View>> targetViews;
-    hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex);
+    //hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex);
+
+    const std::string targetIndexFilename = (fs::path(inputResponsePath).parent_path() / (std::string("exposureRefIndexes") + std::string(".txt"))).string();
+
+    std::ifstream file(targetIndexFilename);
+    std::vector<int> targetIndexes;
+    if (!file)
+    {
+        throw std::logic_error("Can't open target indexes file");
+    }
+    //create fileData
+    while (file)
+    {
+        std::string line;
+        if (!getline(file, line)) break;
+        targetIndexes.push_back(atoi(line.c_str()));
+    }
+    file.close();
+
+    for (int i = 0; i < groupedViews.size(); ++i)
+    {
+        targetViews.push_back(groupedViews[i][targetIndexes[i]]);
+    }
 
     // Define range to compute
     if(rangeStart != -1)

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -196,6 +196,7 @@ int aliceVision_main(int argc, char** argv)
 
         std::vector<std::string> paths;
         std::vector<sfmData::ExposureSetting> exposuresSetting;
+        std::vector<IndexT> viewIds;
 
         image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
         std::string colorProfileFileName = "";
@@ -204,6 +205,7 @@ int aliceVision_main(int argc, char** argv)
         {
             paths.push_back(v->getImagePath());
             exposuresSetting.push_back(v->getCameraExposureSetting());
+            viewIds.push_back(v->getViewId());
 
             const std::string rawColorInterpretation_str = v->getRawColorInterpretation();
             rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(rawColorInterpretation_str);
@@ -225,7 +227,7 @@ int aliceVision_main(int argc, char** argv)
         const bool simplifiedSampling = byPass || (calibrationMethod == ECalibrationMethod::LINEAR);
 
         std::vector<hdr::ImageSample> out_samples;
-        const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, exposures, width, height, channelQuantization, imgReadOptions, params, simplifiedSampling);
+        const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, viewIds, exposures, width, height, channelQuantization, imgReadOptions, params, simplifiedSampling);
         if (!res)
         {
             ALICEVISION_LOG_ERROR("Error while extracting samples from group " << groupIdx);


### PR DESCRIPTION
Use samples in calibration node to determine the reference exposure for each grouped views. Write results in a text file in the same directory as the response file. In the merge node, read the file containing the reference indexes and use them to compute the HDR image.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
In the calibration node, for all exposure levels of each group of views, the mean, max an min values of luminance are computed from all the mean rgb info contained in the loaded image samples. For each group of views, the index of the reference image is deduced from those stats. The average of those computed indexes is written in a text file located in the same directory as the response file already delivered by the node.
In the merging node, the file is read and the index is used to build the HDR image. A parameter is still there to overide the automaticaly set ref images if needed.




## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

