### PR TITLE
read image with missing cam_mul metadata

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -525,8 +525,13 @@ void readImage(const std::string& path,
         image::DCPProfile dcpProfile(imageReadOptions.colorProfileFileName);
 
         oiio::ParamValueList imgMetadata = readImageMetadata(path);
-        std::string cam_mul;
-        imgMetadata.getattribute("raw:cam_mul", cam_mul);
+        std::string cam_mul = "";
+        if (!imgMetadata.getattribute("raw:cam_mul", cam_mul))
+        {
+            cam_mul = "{1024, 1024, 1024, 1024}";
+            ALICEVISION_LOG_WARNING("[readImage]: cam_mul metadata not availbale, the openImageIO version might be too old (>= 2.4.5.0 requested for dcp management).");
+        }
+
         std::vector<float> v_mult;
         size_t last = 1;
         size_t next = 1;


### PR DESCRIPTION
If the version of OIIO is lower than 2.4.5.0, the cam_mul metadata is missing and raw decoding using a dcp profile is not fully possible. Avoid possible crash by setting a default value for cam_mul and add a warning.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

