### PR TITLE
Add record for Samsung Galaxy A33 model

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5992,6 +5992,7 @@ Samsung;SM-N9005;4.69;usercontribution
 Samsung;SM-N960F;5.65;usercontribution
 Samsung;SM-N975F;5.64;usercontribution
 Samsung;SM-N975U;5.72;usercontribution
+Samsung;SM-A336B;12.7;usercontribution
 Santin;Santin Max 4 Pro;4.74;devicespecifications
 Santin;Santin N1;4.71;devicespecifications
 Santin;Santin N1 Max;4.75;devicespecifications


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Wide (main) lens | – 48 MP – Aperture: f/1.8 – Focal length: 26 mm – Pixel size: 0.8 micron-Sony IMX 582 – Sensor: 1/2.0″ (CMOS) – Phase autofocus – Optical stabilization
-- | --


<!--EndFragment-->
</body>
</html>

 1/2.0″ = 12.7mm