### PR TITLE
[doc] INSTALL: replace geogram broken link

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ AliceVision depends on external libraries:
 * [Boost >= 1.74.0](https://www.boost.org)
 * [Ceres >= 1.10.0](https://github.com/ceres-solver/ceres-solver)
 * [Eigen >= 3.3.4](https://gitlab.com/libeigen/eigen)
-* [Geogram >= 1.7.5](https://gforge.inria.fr/frs/?group_id=5833)
+* [Geogram >= 1.7.5](https://github.com/BrunoLevy/geogram)
 * [OpenEXR >= 2.5](https://github.com/AcademySoftwareFoundation/openexr)
 * [OpenImageIO >= 2.1.0](https://github.com/OpenImageIO/oiio)
 * [zlib](https://www.zlib.net)


### PR DESCRIPTION
[doc] INSTALL: replace geogram broken link

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->fix
## Description
Change geogram install broken link from https://gforge.inria.fr/frs/?group_id=5833 to https://github.com/BrunoLevy/geogram


