### PR TITLE
DCP error management

### DIFF
--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -955,8 +955,7 @@ void DCPProfile::Load(const std::string& filename)
 
     if (file == nullptr)
     {
-        ALICEVISION_LOG_WARNING("Unable to load DCP profile " << filename);
-        return;
+        ALICEVISION_THROW_ERROR("Unable to load DCP profile " << filename);
     }
 
     // read tiff header

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -54,6 +54,7 @@ int aliceVision_main(int argc, char** argv)
     int nbBrackets = 3;
     bool byPass = false;
     int channelQuantizationPower = 10;
+    image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB;
     int offsetRefBracketIndex = 0;
 
     hdr::EFunctionType fusionWeightFunction = hdr::EFunctionType::GAUSSIAN;
@@ -83,6 +84,8 @@ int aliceVision_main(int argc, char** argv)
          "bypass HDR creation and use medium bracket as input for next steps")
         ("channelQuantizationPower", po::value<int>(&channelQuantizationPower)->default_value(channelQuantizationPower),
          "Quantization level like 8 bits or 10 bits.")
+        ("workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
+         ("Working color space: " + image::EImageColorSpace_informations()).c_str())
         ("fusionWeight,W", po::value<hdr::EFunctionType>(&fusionWeightFunction)->default_value(fusionWeightFunction),
          "Weight function used to fuse all LDR images together (gaussian, triangle, plateau).")
         ("offsetRefBracketIndex", po::value<int>(&offsetRefBracketIndex)->default_value(offsetRefBracketIndex),
@@ -253,7 +256,7 @@ int aliceVision_main(int argc, char** argv)
             ALICEVISION_LOG_INFO("Load " << filepath);
 
             image::ImageReadOptions options;
-            options.workingColorSpace = image::EImageColorSpace::SRGB;
+            options.workingColorSpace = workingColorSpace;
             options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
             options.colorProfileFileName = group[i]->getColorProfileFileName();
             image::readImage(filepath, images[i], options);

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -54,6 +54,7 @@ int aliceVision_main(int argc, char** argv)
     std::string outputFolder;
     int nbBrackets = 0;
     int channelQuantizationPower = 10;
+    image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB;
     hdr::Sampling::Params params;
     bool debug = false;
 
@@ -75,6 +76,8 @@ int aliceVision_main(int argc, char** argv)
          "bracket count per HDR image (0 means automatic).")
         ("channelQuantizationPower", po::value<int>(&channelQuantizationPower)->default_value(channelQuantizationPower),
          "Quantization level like 8 bits or 10 bits.")
+        ("workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
+         ("Working color space: " + image::EImageColorSpace_informations()).c_str())
         ("blockSize", po::value<int>(&params.blockSize)->default_value(params.blockSize),
          "Size of the image tile to extract a sample.")
         ("radius", po::value<int>(&params.radius)->default_value(params.radius),
@@ -209,7 +212,7 @@ int aliceVision_main(int argc, char** argv)
         std::vector<double> exposures = getExposures(exposuresSetting);
 
         image::ImageReadOptions imgReadOptions;
-        imgReadOptions.workingColorSpace = image::EImageColorSpace::SRGB;
+        imgReadOptions.workingColorSpace = workingColorSpace;
         imgReadOptions.rawColorInterpretation = rawColorInterpretation;
         imgReadOptions.colorProfileFileName = colorProfileFileName;
 

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -162,7 +162,7 @@ int aliceVision_main(int argc, char **argv)
 
   bool allowSingleView = false;
   bool errorOnMissingColorProfile = true;
-  image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawNoWhiteBalancing;
+  image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
 
 
   po::options_description requiredParams("Required parameters");
@@ -452,6 +452,8 @@ int aliceVision_main(int argc, char **argv)
 
     std::string imgFormat = in->format_name();
 
+    bool dcpError = false;
+
     // if a color profile is required check if a dcp database exists and if one is available inside 
     // if yes and if metadata exist and image format is raw then update metadata with DCP info
     if((rawColorInterpretation == image::ERawColorInterpretation::DcpLinearProcessing ||
@@ -465,7 +467,7 @@ int aliceVision_main(int argc, char **argv)
             // No color profile available
             boost::atomic_ref<char>{allColorProfilesFound} = 0;
         }
-        else if (!dcpDatabase.empty())
+        else if (!dcpDatabase.empty() || (dcpDatabase.empty() && !errorOnMissingColorProfile))
         {
             image::DCPProfile dcpProf;
 
@@ -476,17 +478,29 @@ int aliceVision_main(int argc, char **argv)
                 #pragma omp critical
                 viewsWithDCPMetadata++;
             }
-            else if (allColorProfilesFound)
+            else 
             {
-                // there is a missing color profile for one image or more
-                boost::atomic_ref<char>{allColorProfilesFound} = 0;
+                dcpError = true;
+                if (allColorProfilesFound)
+                {
+                    // there is a missing color profile for one image or more
+                    boost::atomic_ref<char>{allColorProfilesFound} = 0;
+                }
             }
         }
     }
 
     // Store the color interpretation mode choosed for raw images in metadata,
     // so all future loads of this image will be interpreted in the same way.
-    view.addMetadata("AliceVision:rawColorInterpretation", image::ERawColorInterpretation_enumToString(rawColorInterpretation));
+    if (!dcpError)
+    {
+        view.addMetadata("AliceVision:rawColorInterpretation", image::ERawColorInterpretation_enumToString(rawColorInterpretation));
+    }
+    else
+    {
+        view.addMetadata("AliceVision:rawColorInterpretation", image::ERawColorInterpretation_enumToString(image::ERawColorInterpretation::LibRawWhiteBalancing));
+        ALICEVISION_LOG_WARNING("DCP Profile not found. Use LibRawWhiteBalancing option for raw color processing.");
+    }
 
     // check if the view intrinsic is already defined
     if(intrinsicId != UndefinedIndexT)
@@ -752,6 +766,7 @@ int aliceVision_main(int argc, char **argv)
       else
       {
           ALICEVISION_LOG_WARNING("Can't find color profile for at least one input image.");
+          ALICEVISION_LOG_WARNING("Images without color profiles have been decoded with the LibRawWhiteBalancing option.");
       }
   }
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Throw an error instead of a warning when trying to load a non existing DCP profile.

cameraInit: rawColorInterpretation automatically switch to librawWhiteBalancing mode and throw a warning when a DCP profile is required but no error is requested if it is missing and no database or an erroneous one is given as parameter or if the expected profile does not exist in the database.

Add working color space as a parameter in sampling and merging HDR exec.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

