### PR TITLE
[sensorDB] Add DJI Mavic 3T

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1463,6 +1463,7 @@ DJI;FC7203;6.16;usercontribution
 DJI;FC7303;6.16;usercontribution
 DJI;MAVIC2-ENTERPRISE-ADVANCED;4.8;
 DJI;Mavic3;17.3;dji
+DJI;M3T;6.4;dji
 DJI;Phantom 4;6.3;dxomark
 DJI;Phantom 4 Pro;13.2;dxomark
 DJI;Phantom Vision FC200;6.17;usercontribution


### PR DESCRIPTION
https://www.dji.com/en/mavic-3-enterprise/specs
"DJI Mavic 3T : CMOS 1/2" => 6.4 mm
