### PR TITLE
Add option to apply DCP metadata in imageProcessing

### DIFF
--- a/src/aliceVision/dataio/FeedProvider.cpp
+++ b/src/aliceVision/dataio/FeedProvider.cpp
@@ -61,7 +61,7 @@ FeedProvider::FeedProvider(const std::string &feedPath, const std::string &calib
   else if(isdigit(feedPath[0]))
   {
     // let's try it with a video
-    const int deviceNumber =  std::atoi(feedPath.c_str());
+    const int deviceNumber =  std::stoi(feedPath);
     _feeder.reset(new VideoFeed(deviceNumber, calibPath));
     _isVideo = true;
     _isLiveFeed = true;

--- a/src/aliceVision/feature/Descriptor.hpp
+++ b/src/aliceVision/feature/Descriptor.hpp
@@ -177,7 +177,7 @@ inline void loadDescsFromFile(
 {
   vec_desc.clear();
 
-  std::ifstream fileIn(sfileNameDescs.c_str());
+  std::ifstream fileIn(sfileNameDescs);
   if(!fileIn.is_open())
     throw std::runtime_error("Can't load descriptor file, can't open '" + sfileNameDescs + "' !");
 
@@ -198,7 +198,7 @@ inline void saveDescsToFile(
   const std::string & sfileNameDescs,
   DescriptorsT & vec_desc)
 {
-  std::ofstream file(sfileNameDescs.c_str());
+  std::ofstream file(sfileNameDescs);
   if(!file.is_open())
     throw std::runtime_error("Can't save descriptor file, can't open '" + sfileNameDescs + "' !");
 
@@ -261,7 +261,7 @@ inline void loadDescsFromBinFile(
   if( !append ) // for compatibility
     vec_desc.clear();
 
-  std::ifstream fileIn(sfileNameDescs.c_str(), std::ios::in | std::ios::binary);
+  std::ifstream fileIn(sfileNameDescs, std::ios::in | std::ios::binary);
 
   if(!fileIn.is_open())
     throw std::runtime_error("Can't load descriptor binary file, can't open '" + sfileNameDescs + "' !");
@@ -304,7 +304,7 @@ inline void saveDescsToBinFile(
 {
   typedef typename DescriptorsT::value_type VALUE;
 
-  std::ofstream file(sfileNameDescs.c_str(), std::ios::out | std::ios::binary);
+  std::ofstream file(sfileNameDescs, std::ios::out | std::ios::binary);
 
   if (!file.is_open())
     throw std::runtime_error("Can't save descriptor binary file, can't open '" + sfileNameDescs + "' !");

--- a/src/aliceVision/feature/PointFeature.hpp
+++ b/src/aliceVision/feature/PointFeature.hpp
@@ -122,7 +122,7 @@ inline void saveFeatsToFile(
   const std::string & sfileNameFeats,
   FeaturesT & vec_feat)
 {
-  std::ofstream file(sfileNameFeats.c_str());
+  std::ofstream file(sfileNameFeats);
 
   if (!file.is_open())
     throw std::runtime_error("Can't save features file, can't open '" + sfileNameFeats + "' !");

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -461,7 +461,7 @@ void DelaunayGraphCut::saveDh(const std::string& fileNameDh, const std::string& 
 
     long t1 = clock();
 
-    // std::ofstream oFileT(fileNameDh.c_str());
+    // std::ofstream oFileT(fileNameDh);
     // oFileT << *_tetrahedralization; // TODO GEOGRAM
 
     mvsUtils::printfElapsedTime(t1);

--- a/src/aliceVision/fuseCut/VoxelsGrid.cpp
+++ b/src/aliceVision/fuseCut/VoxelsGrid.cpp
@@ -635,7 +635,7 @@ void VoxelsGrid::vizualize()
     {
         std::string subFoldeName = getVoxelFolderName(i);
         std::string fname = subFoldeName + "tracks.wrl";
-        if (bfs::is_directory(subFoldeName.c_str()))
+        if (bfs::is_directory(subFoldeName))
         {
             fprintf(f, "Inline{ url [\"%s\"] \n }\n", fname.c_str());
         }

--- a/src/aliceVision/graph/indexedGraphGraphvizExport.hpp
+++ b/src/aliceVision/graph/indexedGraphGraphvizExport.hpp
@@ -131,7 +131,7 @@ bool exportToGraphvizFormat_Image(
 template <typename GraphT>
 void exportToGraphvizData(const std::string& sfile, const GraphT & graph)
 {
-  std::ofstream file(sfile.c_str());
+  std::ofstream file(sfile);
   aliceVision::graph::exportToGraphvizFormat_Nodal(graph, file);
   file.close();
 }

--- a/src/aliceVision/hdr/rgbCurve.cpp
+++ b/src/aliceVision/hdr/rgbCurve.cpp
@@ -553,7 +553,7 @@ void rgbCurve::writeHtml(const std::string& path, const std::string& title) cons
     jsxGraph.close();
 
     // save the reconstruction Log
-    std::ofstream htmlFileStream(path.c_str());
+    std::ofstream htmlFileStream(path);
     htmlFileStream << htmlDocumentStream(title).getDoc();
     htmlFileStream << jsxGraph.toStr();
 }

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -2261,7 +2261,7 @@ void DCPProfile::setMatricesFromStrings(const std::string& type, std::vector<std
         Matrix mat;
         for (int i = 0; i < 3; i++)
             for (int j = 0; j < 3; j++)
-                mat[i][j] = std::stof(v[3*i + j].c_str());
+                mat[i][j] = std::stof(v[3*i + j]);
         v_Mat.push_back(mat);
     }
 

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -2261,14 +2261,14 @@ void DCPProfile::setMatricesFromStrings(const std::string& type, std::vector<std
         Matrix mat;
         for (int i = 0; i < 3; i++)
             for (int j = 0; j < 3; j++)
-                mat[i][j] = atof(v[3*i + j].c_str());
+                mat[i][j] = std::stof(v[3*i + j].c_str());
         v_Mat.push_back(mat);
     }
 
     setMatrices(type, v_Mat);
 }
 
-void DCPProfile::applyLinear(OIIO::ImageBuf& image, Triple neutral, const bool sourceIsRaw)
+void DCPProfile::applyLinear(OIIO::ImageBuf& image, const Triple neutral, const bool sourceIsRaw)
 {
     const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw);
 
@@ -2292,7 +2292,7 @@ void DCPProfile::applyLinear(OIIO::ImageBuf& image, Triple neutral, const bool s
         }
 }
 
-void DCPProfile::applyLinear(Image<image::RGBAfColor>& image, Triple neutral, const bool sourceIsRaw)
+void DCPProfile::applyLinear(Image<image::RGBAfColor>& image, const Triple neutral, const bool sourceIsRaw)
 {
     const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw);
 

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -18,7 +18,7 @@ namespace image {
 using aliceVision::clamp;
 namespace bfs = boost::filesystem;
 
-double calibrationIlluminantToTemperature(LightSource light)
+double calibrationIlluminantToTemperature(const LightSource light)
 {
     // These temperatures are those found in DNG SDK reference code
     switch(light)
@@ -1580,14 +1580,14 @@ inline void DCPProfile::hsdApply(const HsdTableInfo& table_info, const std::vect
     }
 }
 
-DCPProfile::Matrix DCPProfile::getInterpolatedMatrix(const double cct, const std::string& type)
+DCPProfile::Matrix DCPProfile::getInterpolatedMatrix(const double cct, const std::string& type) const
 {
-    double a = 1.e6 / info.temperature_1;
-    double b = 1.e6 / info.temperature_2;
-    double c = 1.e6 / cct;
+    const double a = 1.e6 / info.temperature_1;
+    const double b = 1.e6 / info.temperature_2;
+    const double c = 1.e6 / cct;
 
-    Matrix Ma = (type == "color") ? color_matrix_1 : ((type == "calib") ? camera_calibration_1 : forward_matrix_1);
-    Matrix Mb = (type == "color") ? color_matrix_2 : ((type == "calib") ? camera_calibration_2 : forward_matrix_2);
+    const Matrix Ma = (type == "color") ? color_matrix_1 : ((type == "calib") ? camera_calibration_1 : forward_matrix_1);
+    const Matrix Mb = (type == "color") ? color_matrix_2 : ((type == "calib") ? camera_calibration_2 : forward_matrix_2);
     Matrix interpolatedMatrix;
     for (int i = 0; i < 3; ++i)
     {
@@ -1600,55 +1600,55 @@ DCPProfile::Matrix DCPProfile::getInterpolatedMatrix(const double cct, const std
     return interpolatedMatrix;
 }
 
-DCPProfile::Matrix DCPProfile::matMult(const Matrix& A, const Matrix& B)
+DCPProfile::Matrix DCPProfile::matMult(const Matrix& A, const Matrix& B) const
 {
-    Matrix Res;
+    Matrix res;
     for (int i = 0; i < 3; ++i)
     {
         for (int j = 0; j < 3; ++j)
         {
-            Res[i][j] = 0.f;
+            res[i][j] = 0.f;
             for (int k = 0; k < 3; k++)
             {
-                Res[i][j] += A[i][k] * B[k][j];
+                res[i][j] += A[i][k] * B[k][j];
             }
         }
     }
-    return Res;
+    return res;
 }
-DCPProfile::Triple DCPProfile::matMult(const Matrix& M, const Triple& V)
+DCPProfile::Triple DCPProfile::matMult(const Matrix& M, const Triple& V) const
 {
-    Triple Res;
+    Triple res;
     for (int i = 0; i < 3; ++i)
     {
-        Res[i] = 0.f;
+        res[i] = 0.f;
         for (int k = 0; k < 3; k++)
         {
-            Res[i] += M[i][k] * V[k];
+            res[i] += M[i][k] * V[k];
         }
     }
-    return Res;
+    return res;
 }
-DCPProfile::Matrix DCPProfile::matInv(const Matrix& M)
+DCPProfile::Matrix DCPProfile::matInv(const Matrix& M) const
 {
-    Matrix Inv = M;
+    Matrix inv = M;
 
-    float det = M[0][0]*M[1][1]*M[2][2] + M[0][1]*M[1][2]*M[2][0] + M[0][2]*M[1][0]*M[2][1] - M[2][0]*M[1][1]*M[0][2] - M[1][0]*M[0][1]*M[2][2] - M[0][0]*M[2][1]*M[1][2];
+    const float det = M[0][0]*M[1][1]*M[2][2] + M[0][1]*M[1][2]*M[2][0] + M[0][2]*M[1][0]*M[2][1] - M[2][0]*M[1][1]*M[0][2] - M[1][0]*M[0][1]*M[2][2] - M[0][0]*M[2][1]*M[1][2];
 
     if (det != 0.f)
     {
-        Inv[0][0] = (M[1][1] * M[2][2] - M[2][1] * M[1][2]) / det;
-        Inv[0][1] = (M[0][2] * M[2][1] - M[0][1] * M[2][2]) / det;
-        Inv[0][2] = (M[0][1] * M[1][2] - M[0][2] * M[1][1]) / det;
-        Inv[1][0] = (M[1][2] * M[2][0] - M[1][0] * M[2][2]) / det;
-        Inv[1][1] = (M[0][0] * M[2][2] - M[2][0] * M[0][2]) / det;
-        Inv[1][2] = (M[0][2] * M[1][0] - M[0][0] * M[1][2]) / det;
-        Inv[2][0] = (M[1][0] * M[2][1] - M[1][1] * M[2][0]) / det;
-        Inv[2][1] = (M[0][1] * M[2][0] - M[0][0] * M[2][1]) / det;
-        Inv[2][2] = (M[0][0] * M[1][1] - M[1][0] * M[0][1]) / det;
+        inv[0][0] = (M[1][1] * M[2][2] - M[2][1] * M[1][2]) / det;
+        inv[0][1] = (M[0][2] * M[2][1] - M[0][1] * M[2][2]) / det;
+        inv[0][2] = (M[0][1] * M[1][2] - M[0][2] * M[1][1]) / det;
+        inv[1][0] = (M[1][2] * M[2][0] - M[1][0] * M[2][2]) / det;
+        inv[1][1] = (M[0][0] * M[2][2] - M[2][0] * M[0][2]) / det;
+        inv[1][2] = (M[0][2] * M[1][0] - M[0][0] * M[1][2]) / det;
+        inv[2][0] = (M[1][0] * M[2][1] - M[1][1] * M[2][0]) / det;
+        inv[2][1] = (M[0][1] * M[2][0] - M[0][0] * M[2][1]) / det;
+        inv[2][2] = (M[0][0] * M[1][1] - M[1][0] * M[0][1]) / det;
     }
 
-    return Inv;
+    return inv;
 }
 
 /**
@@ -1668,7 +1668,7 @@ DCPProfile::Matrix DCPProfile::matInv(const Matrix& M)
  *  Returns:
  *      tuple. Temperature, tint
  */
-void DCPProfile::setChromaticityCoordinates(const double x, const double y, double& cct, double& tint)
+void DCPProfile::setChromaticityCoordinates(const double x, const double y, double& cct, double& tint) const
 {
     const double u = 2.0 * x / (1.5 - x + 6.0 * y);
     const double v = 3.0 * y / (1.5 - x + 6.0 * y);
@@ -1734,7 +1734,7 @@ void DCPProfile::setChromaticityCoordinates(const double x, const double y, doub
  *  Returns:
  *      tuple. Chromaticity coordinates.
 */
-void DCPProfile::getChromaticityCoordinates(const double cct, const double tint, double& x, double& y)
+void DCPProfile::getChromaticityCoordinates(const double cct, const double tint, double& x, double& y) const
 {
     const double r = 1.0e6 / cct;
     const double offset = tint * (1.0 / TINT_SCALE);
@@ -1786,13 +1786,13 @@ void DCPProfile::getChromaticityCoordinates(const double cct, const double tint,
 }
 
 
-void DCPProfile::getChromaticityCoordinatesFromXyz(const Triple& xyz, double& x, double& y)
+void DCPProfile::getChromaticityCoordinatesFromXyz(const Triple& xyz, double& x, double& y) const
 {
     x = xyz[0] / (xyz[0] + xyz[1] + xyz[2]);
     y = xyz[1] / (xyz[0] + xyz[1] + xyz[2]);
 }
 
-DCPProfile::Triple DCPProfile::getXyzFromChromaticityCoordinates(const double x, const double y)
+DCPProfile::Triple DCPProfile::getXyzFromChromaticityCoordinates(const double x, const double y) const
 {
     Triple xyz;
     xyz[0] = x * 1.0 / y;
@@ -1801,7 +1801,7 @@ DCPProfile::Triple DCPProfile::getXyzFromChromaticityCoordinates(const double x,
     return xyz;
 }
 
-DCPProfile::Triple DCPProfile::getXyzFromTemperature(const double cct, const double tint)
+DCPProfile::Triple DCPProfile::getXyzFromTemperature(const double cct, const double tint) const
 {
     double x, y;
     getChromaticityCoordinates(cct, tint, x, y);
@@ -1851,7 +1851,7 @@ DCPProfile::Triple DCPProfile::getXyzFromTemperature(const double cct, const dou
  *     Returns :
  * tuple.Chromaticity coordinates.
  */
-void DCPProfile::getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, double& x, double& y)
+void DCPProfile::getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, double& x, double& y) const
 {
     x = 0.24559589702841558;
     y = 0.24240399461846152;
@@ -1925,7 +1925,7 @@ void DCPProfile::getChromaticityCoordinatesFromCameraNeutral(const Matrix& analo
  *     Returns:
  *         Matrix. Chromatic Adaptation matrix ( 3 x 3 ).
  */
-DCPProfile::Matrix DCPProfile::getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget)
+DCPProfile::Matrix DCPProfile::getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget) const
 {
     const Triple pybSource = matMult(CAT02_MATRIX, xyzSource);
     const Triple pybTarget = matMult(CAT02_MATRIX, xyzTarget);
@@ -1996,7 +1996,7 @@ DCPProfile::Matrix DCPProfile::getChromaticAdaptationMatrix(const Triple& xyzSou
  *     Returns:
  *         Matrix.  Camera to XYZ ( D50 ) matrix ( 3 x 3 ).
  */
-DCPProfile::Matrix DCPProfile::getCameraToXyzD50Matrix(const double x, const double y)
+DCPProfile::Matrix DCPProfile::getCameraToXyzD50Matrix(const double x, const double y) const
 {
     double cct, tint;
     setChromaticityCoordinates(x, y, cct, tint);
@@ -2057,7 +2057,7 @@ DCPProfile::Matrix DCPProfile::getCameraToXyzD50Matrix(const double x, const dou
     return cameraToXyzD50;
 }
 
-DCPProfile::Matrix DCPProfile::getCameraToSrgbLinearMatrix(const double x, const double y)
+DCPProfile::Matrix DCPProfile::getCameraToSrgbLinearMatrix(const double x, const double y) const
 {
     double cct, tint;
     setChromaticityCoordinates(x, y, cct, tint);
@@ -2106,7 +2106,7 @@ DCPProfile::Matrix DCPProfile::getCameraToSrgbLinearMatrix(const double x, const
     return cameraToSrgbLinear;
 }
 
-DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw)
+DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw) const
 {
     double x, y;
     getChromaticityCoordinatesFromCameraNeutral(IdentityMatrix, asShotNeutral, x, y);
@@ -2158,7 +2158,7 @@ DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeu
 }
 
 
-void DCPProfile::getMatrices(const std::string& type, std::vector<Matrix>& v_Mat)
+void DCPProfile::getMatrices(const std::string& type, std::vector<Matrix>& v_Mat) const
 {
     v_Mat.clear();
 
@@ -2185,7 +2185,7 @@ void DCPProfile::getMatrices(const std::string& type, std::vector<Matrix>& v_Mat
     }
 }
 
-void DCPProfile::getMatricesAsStrings(const std::string& type, std::vector<std::string>& v_strMat)
+void DCPProfile::getMatricesAsStrings(const std::string& type, std::vector<std::string>& v_strMat) const
 {
     v_strMat.clear();
     std::vector<Matrix> v_Mat;
@@ -2268,7 +2268,7 @@ void DCPProfile::setMatricesFromStrings(const std::string& type, std::vector<std
     setMatrices(type, v_Mat);
 }
 
-void DCPProfile::applyLinear(OIIO::ImageBuf& image, const Triple neutral, const bool sourceIsRaw)
+void DCPProfile::applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const bool sourceIsRaw) const
 {
     const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw);
 
@@ -2292,7 +2292,7 @@ void DCPProfile::applyLinear(OIIO::ImageBuf& image, const Triple neutral, const 
         }
 }
 
-void DCPProfile::applyLinear(Image<image::RGBAfColor>& image, const Triple neutral, const bool sourceIsRaw)
+void DCPProfile::applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, const bool sourceIsRaw) const
 {
     const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw);
 
@@ -2356,7 +2356,7 @@ void DCPDatabase::clear()
     folderName = "";
 }
 
-bool DCPDatabase::getDcpForCamera(const std::string& make, const std::string& model, DCPProfile& dcpProf)
+bool DCPDatabase::retrieveDcpForCamera(const std::string& make, const std::string& model, DCPProfile& dcpProf)
 {
     const std::string dcpKey = make + "_" + model;
 

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -29,12 +29,12 @@ constexpr double sRGB_xyz[3][3] = {
     { -0.9787684,  1.9161415,  0.0334540},
     {0.0719453, -0.2289914,  1.4052427}
 };
-        
+
 constexpr double xyz_prophoto[3][3] = {
     {0.7976749,  0.1351917,  0.0313534},
     {0.2880402,  0.7118741,  0.0000857},
     {0.0000000,  0.0000000,  0.8252100}
-};        
+};
 constexpr double prophoto_xyz[3][3] = {
     {1.3459433, -0.2556075, -0.0511118},
     { -0.5445989,  1.5081673,  0.0205351},
@@ -173,14 +173,14 @@ public:
      * param[in] type The matrices to get, "color" or "forward"
      * param[in] v_Mat A vector of matrices to be populated
      */
-    void getMatrices(const std::string& type, std::vector<Matrix>& v_Mat);
+    void getMatrices(const std::string& type, std::vector<Matrix>& v_Mat) const;
 
     /**
      * @brief getMatricesAsStrings gets some matrices contained in the profile in a string format (one string per matrix)
      * param[in] type The matrices to get, "color" or "forward"
      * param[in] v_strMat A vector of std::string to be populated
      */
-    void getMatricesAsStrings(const std::string& type, std::vector<std::string>& v_strMat);
+    void getMatricesAsStrings(const std::string& type, std::vector<std::string>& v_strMat) const;
 
     /**
      * @brief setMatrices sets some matrices contained in the profile
@@ -202,7 +202,7 @@ public:
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      */
-    void applyLinear(OIIO::ImageBuf& image, const Triple neutral, const bool sourceIsRaw = false);
+    void applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const bool sourceIsRaw = false) const;
 
     /**
      * @brief applyLinear applies the linear part of a DCP profile on an aliceVision image
@@ -210,7 +210,7 @@ public:
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      */
-    void applyLinear(Image<image::RGBAfColor>& image, const Triple neutral, const bool sourceIsRaw = false);
+    void applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, const bool sourceIsRaw = false) const;
 
     /**
      * @brief apply applies the non linear part of a DCP profile on an OIIO image buffer
@@ -256,21 +256,21 @@ private:
 
     void hsdApply(const HsdTableInfo& table_info, const std::vector<HsbModify>& table_base, float& h, float& s, float& v) const;
 
-    Matrix matMult(const Matrix& A, const Matrix& B);
-    Triple matMult(const Matrix& M, const Triple& V);
-    Matrix matInv(const Matrix& M);
+    Matrix matMult(const Matrix& A, const Matrix& B) const;
+    Triple matMult(const Matrix& M, const Triple& V) const;
+    Matrix matInv(const Matrix& M) const;
 
-    Matrix getInterpolatedMatrix(const double cct, const std::string& type);
-    void getChromaticityCoordinatesFromXyz(const Triple& xyz, double& x, double& y);
-    Triple getXyzFromChromaticityCoordinates(const double x, const double y);
-    Triple getXyzFromTemperature(const double cct, const double tint = 0.f);
-    void setChromaticityCoordinates(const double x, const double y, double& cct, double& tint);
-    void getChromaticityCoordinates(const double cct, const double tint, double& x, double& y);
-    void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, double& x, double& y);
-    Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget);
-    Matrix getCameraToXyzD50Matrix(const double x, const double y);
-    Matrix getCameraToSrgbLinearMatrix(const double x, const double y);
-    Matrix getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw = false);
+    Matrix getInterpolatedMatrix(const double cct, const std::string& type) const;
+    void getChromaticityCoordinatesFromXyz(const Triple& xyz, double& x, double& y) const;
+    Triple getXyzFromChromaticityCoordinates(const double x, const double y) const;
+    Triple getXyzFromTemperature(const double cct, const double tint = 0.f) const;
+    void setChromaticityCoordinates(const double x, const double y, double& cct, double& tint) const;
+    void getChromaticityCoordinates(const double cct, const double tint, double& x, double& y) const;
+    void getChromaticityCoordinatesFromCameraNeutral(const Matrix& analogBalance, const Triple& asShotNeutral, double& x, double& y) const;
+    Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget) const;
+    Matrix getCameraToXyzD50Matrix(const double x, const double y) const;
+    Matrix getCameraToSrgbLinearMatrix(const double x, const double y) const;
+    Matrix getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw = false) const;
 
     Matrix ws_sRGB; // working color space to sRGB
     Matrix sRGB_ws; // sRGB to working color space
@@ -335,7 +335,7 @@ public:
     void add_or_replace(DCPProfile& dcpProf, const std::string& make, const std::string& model);
 
     /**
-     * @brief getDcpForCamera gets a DCP profile in the database for a given camera.
+     * @brief retrieveDcpForCamera searches for a DCP profile in the database for a given camera.
      * Search first in the cache. If no DCP profile is found search if an appropriate DCP file exists in the file list.
      * If a dcp file is found then load it and store it in the cache.
      * param[in] make The camera maker
@@ -343,7 +343,7 @@ public:
      * param[in] dcpProf the DCP profile to be filled in
      * return True if a corresponding profile has been found
      */
-    bool getDcpForCamera(const std::string& make, const std::string& model, DCPProfile& dcpProf);
+    bool retrieveDcpForCamera(const std::string& make, const std::string& model, DCPProfile& dcpProf);
 
 private:
 

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -8,6 +8,8 @@
 
 #include <OpenImageIO/imagebuf.h>
 
+#include <aliceVision/image/all.hpp>
+
 namespace aliceVision {
 namespace image {
 
@@ -174,11 +176,25 @@ public:
     void getMatrices(const std::string& type, std::vector<Matrix>& v_Mat);
 
     /**
-     * @brief getMatrices gets some matrices contained in the profile in a string format (one string per matrix)
+     * @brief getMatricesAsStrings gets some matrices contained in the profile in a string format (one string per matrix)
      * param[in] type The matrices to get, "color" or "forward"
-     * param[in] v_Mat A vector of std::string to be populated
+     * param[in] v_strMat A vector of std::string to be populated
      */
     void getMatricesAsStrings(const std::string& type, std::vector<std::string>& v_strMat);
+
+    /**
+     * @brief setMatrices sets some matrices contained in the profile
+     * param[in] type The matrices to set, "color" or "forward"
+     * param[in] v_Mat A vector of matrices
+     */
+    void setMatrices(const std::string& type, std::vector<Matrix>& v_Mat);
+
+    /**
+     * @brief setMatricesFromStrings sets some matrices contained in the profile from strings (one string per matrix)
+     * param[in] type The matrices to set, "color" or "forward"
+     * param[in] v_strMat A vector of std::string
+     */
+    void setMatricesFromStrings(const std::string& type, std::vector<std::string>& v_strMat);
 
     /**
      * @brief applyLinear applies the linear part of a DCP profile on an OIIO image buffer
@@ -187,6 +203,14 @@ public:
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      */
     void applyLinear(OIIO::ImageBuf& image, Triple neutral, const bool sourceIsRaw = false);
+
+    /**
+     * @brief applyLinear applies the linear part of a DCP profile on an aliceVision image
+     * param[in] image The aliceVision image on which the profile must be applied
+     * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
+     * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
+     */
+    void applyLinear(Image<image::RGBAfColor>& image, Triple neutral, const bool sourceIsRaw = false);
 
     /**
      * @brief apply applies the non linear part of a DCP profile on an OIIO image buffer

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -202,7 +202,7 @@ public:
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      */
-    void applyLinear(OIIO::ImageBuf& image, Triple neutral, const bool sourceIsRaw = false);
+    void applyLinear(OIIO::ImageBuf& image, const Triple neutral, const bool sourceIsRaw = false);
 
     /**
      * @brief applyLinear applies the linear part of a DCP profile on an aliceVision image
@@ -210,7 +210,7 @@ public:
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      */
-    void applyLinear(Image<image::RGBAfColor>& image, Triple neutral, const bool sourceIsRaw = false);
+    void applyLinear(Image<image::RGBAfColor>& image, const Triple neutral, const bool sourceIsRaw = false);
 
     /**
      * @brief apply applies the non linear part of a DCP profile on an OIIO image buffer

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -537,10 +537,10 @@ void readImage(const std::string& path,
         size_t next = 1;
         while ((next = cam_mul.find(",", last)) != std::string::npos)
         {
-            v_mult.push_back(atof(cam_mul.substr(last, next - last).c_str()));
+            v_mult.push_back(std::stof(cam_mul.substr(last, next - last)));
             last = next + 1;
         }
-        v_mult.push_back(atof(cam_mul.substr(last, cam_mul.find("}", last) - last).c_str()));
+        v_mult.push_back(std::stof(cam_mul.substr(last, cam_mul.find("}", last) - last)));
 
         image::DCPProfile::Triple neutral;
         for (int i = 0; i < 3; i++)

--- a/src/aliceVision/matching/io.cpp
+++ b/src/aliceVision/matching/io.cpp
@@ -33,7 +33,7 @@ bool LoadMatchFile(PairwiseMatches& matches, const std::string& filepath)
 
   if(ext == ".txt")
   {
-    std::ifstream stream(filepath.c_str());
+    std::ifstream stream(filepath);
     if (!stream.is_open())
       return false;
 
@@ -293,7 +293,7 @@ private:
 
     // write temporary file
     {
-      std::ofstream stream(tmpPath.c_str(), std::ios::out);
+      std::ofstream stream(tmpPath, std::ios::out);
       for(PairwiseMatches::const_iterator match = matchBegin;
         match != matchEnd;
         ++match)

--- a/src/aliceVision/matching/svgVisualization.cpp
+++ b/src/aliceVision/matching/svgVisualization.cpp
@@ -291,7 +291,7 @@ void saveMatches2SVG(const std::string &imagePathLeft,
     }
   }
  
-  std::ofstream svgFile( outputSVGPath.c_str() );
+  std::ofstream svgFile(outputSVGPath);
   svgFile << svgStream.closeSvgFile().str();
   svgFile.close();
 }
@@ -617,7 +617,7 @@ void saveEpipolarGeometry2SVG(const std::string &imagePath,
     svgStream.drawCircle(point(0), point(1), 3 * radius, svg::svgStyle().stroke("red", strokeWidth).fill("red"));
   }
 
-  std::ofstream svgFile(outputSVGPath.c_str());
+  std::ofstream svgFile(outputSVGPath);
   svgFile << svgStream.closeSvgFile().str();
   svgFile.close();
 }
@@ -655,7 +655,7 @@ void saveMatchesAsMotion(const std::string &imagePath,
 
     }
   }
-  std::ofstream svgFile(outputSVGPath.c_str());
+  std::ofstream svgFile(outputSVGPath);
   svgFile << svgStream.closeSvgFile().str();
   svgFile.close();
 }
@@ -868,7 +868,7 @@ void saveCCTagMatches2SVG(const std::string &imagePathLeft,
     }
   }
 
-  std::ofstream svgFile(outputSVGPath.c_str());
+  std::ofstream svgFile(outputSVGPath);
   svgFile << svgStream.closeSvgFile().str();
   svgFile.close();
 }

--- a/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
+++ b/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
@@ -102,7 +102,7 @@ bool loadPairsFromFile(const std::string& sFileName, // filename of the list fil
                        int rangeStart,
                        int rangeSize)
 {
-    std::ifstream in(sFileName.c_str());
+    std::ifstream in(sFileName);
     if (!in.is_open())
     {
         ALICEVISION_LOG_WARNING("loadPairsFromFile: Impossible to read the specified file: \""

--- a/src/aliceVision/multiview/NViewDataSet.cpp
+++ b/src/aliceVision/multiview/NViewDataSet.cpp
@@ -77,7 +77,7 @@ Mat34 NViewDataSet::P(size_t i)const {
 void NViewDataSet::exportToPLY(
   const std::string & out_file_name)const {
   std::ofstream outfile;
-  outfile.open(out_file_name.c_str(), std::ios_base::out);
+  outfile.open(out_file_name, std::ios_base::out);
   if (outfile.is_open()) {
     outfile << "ply"
      << std::endl << "format ascii 1.0"

--- a/src/aliceVision/multiview/translationAveraging/translationAveragingTest.hpp
+++ b/src/aliceVision/multiview/translationAveraging/translationAveragingTest.hpp
@@ -77,7 +77,7 @@ void visibleCamPosToSVGSurface
     }
     std::ostringstream osSvgGT;
     osSvgGT << fileName;
-    std::ofstream svgFileGT( osSvgGT.str().c_str());
+    std::ofstream svgFileGT( osSvgGT.str());
     svgFileGT << svgSurface_GT.closeSvgFile().str();
   }
 }

--- a/src/aliceVision/numeric/lmFunctor_test.cpp
+++ b/src/aliceVision/numeric/lmFunctor_test.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(LM_MimimaSearchViaLM) {
 
     std::ostringstream osSvg;
     osSvg << "exponentialRegression_unit_test.svg";
-    std::ofstream svgFile( osSvg.str().c_str());
+    std::ofstream svgFile(osSvg.str());
     svgFile << svgSurface.closeSvgFile().str();
   }
 }

--- a/src/aliceVision/numeric/numeric.cpp
+++ b/src/aliceVision/numeric/numeric.cpp
@@ -139,7 +139,7 @@ bool exportMatToTextFile(const Mat & mat, const std::string & filename,
 {
   bool bOk = false;
   std::ofstream outfile;
-  outfile.open(filename.c_str(), std::ios_base::out);
+  outfile.open(filename, std::ios_base::out);
   if (outfile.is_open()) {
     outfile << sPrefix << "=[" << std::endl;
     for (int j=0; j < mat.rows(); ++j)  {

--- a/src/aliceVision/sfm/FrustumFilter.cpp
+++ b/src/aliceVision/sfm/FrustumFilter.cpp
@@ -92,7 +92,7 @@ PairSet FrustumFilter::getFrustumIntersectionPairs() const
 // Export defined frustum in PLY file for viewing
 bool FrustumFilter::export_Ply(const std::string & filename) const
 {
-  std::ofstream of(filename.c_str());
+  std::ofstream of(filename);
   if (!of.is_open())
     return false;
   // Vertex count evaluation

--- a/src/aliceVision/sfm/generateReport.cpp
+++ b/src/aliceVision/sfm/generateReport.cpp
@@ -169,7 +169,7 @@ bool generateSfMReport(const sfmData::SfMData& sfmData,
     }
   }
 
-  std::ofstream htmlFileStream(htmlFilename.c_str());
+  std::ofstream htmlFileStream(htmlFilename);
   htmlFileStream << htmlDocStream.getDoc();
   const bool bOk = !htmlFileStream.bad();
   return bOk;

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -60,7 +60,7 @@ ReconstructionEngine_globalSfM::~ReconstructionEngine_globalSfM()
   if(!_loggingFile.empty())
   {
     // Save the reconstruction Log
-    std::ofstream htmlFileStream(_loggingFile.c_str());
+    std::ofstream htmlFileStream(_loggingFile);
     htmlFileStream << _htmlDocStream->getDoc();
   }
 }

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
@@ -243,7 +243,7 @@ ReconstructionEngine_panorama::~ReconstructionEngine_panorama()
   if(!_loggingFile.empty())
   {
     // Save the reconstruction Log
-    std::ofstream htmlFileStream(_loggingFile.c_str());
+    std::ofstream htmlFileStream(_loggingFile);
     htmlFileStream << _htmlDocStream->getDoc();
   }
 }

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -884,7 +884,7 @@ void ReconstructionEngine_sequentialSfM::exportStatistics(double reconstructionT
     _htmlDocStream->pushXYChart(xBinTracks, observationsLengthHistogram.GetHist(),"3DtoTracksSize");
 
     // save the reconstruction Log
-    std::ofstream htmlFileStream(_htmlLogFile.c_str());
+    std::ofstream htmlFileStream(_htmlLogFile);
     htmlFileStream << _htmlDocStream->getDoc();
   }
 

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -569,10 +569,10 @@ public:
       size_t next = 0;
       while ((next = cam_mul.find(" ", last)) != std::string::npos)
       {
-          v_mult.push_back(atoi(cam_mul.substr(last, next - last).c_str()));
+          v_mult.push_back(std::stoi(cam_mul.substr(last, next - last)));
           last = next + 1;
       }
-      v_mult.push_back(atoi(cam_mul.substr(last).c_str()));
+      v_mult.push_back(std::stoi(cam_mul.substr(last)));
 
       return v_mult;
   }

--- a/src/aliceVision/sfmDataIO/alembicIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/alembicIO_test.cpp
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
     {
         BOOST_CHECK(Save(
         sfmData,
-        jsonFile.c_str(),
+        jsonFile,
         ESfMData(flags)));
     }
 
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
     {
         BOOST_CHECK(Save(
         sfmData,
-        abcFile.c_str(),              
+        abcFile,              
         ESfMData(flags)));
     }
 
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
         std::string abcFile2 = "abcToJson.sfm";
         BOOST_CHECK(Save(
         sfmAbcToAbc,
-        abcFile2.c_str(),
+        abcFile2,
         ESfMData(flags)));
         BOOST_CHECK(sfmData == sfmAbcToAbc);
     }
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
     {
         BOOST_CHECK(Save(
         sfmAbcToAbc,
-        abcFile2.c_str(),
+        abcFile2,
         ESfMData(flags)));
     }
 
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
     {
         BOOST_CHECK(Save(
         sfmData,
-        jsonFile3.c_str(),
+        jsonFile3,
         ESfMData(flags)));
     }
 
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
     {
         BOOST_CHECK(Save(
         sfmJsonToABC,
-        abcFile3.c_str(),
+        abcFile3,
         ESfMData(flags)));
     }
 
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
     {
         BOOST_CHECK(Save(
         sfmJsonToABC2,
-        abcFile4.c_str(),
+        abcFile4,
         ESfMData(flags)));
     }
 
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(AlembicImporter_importExport) {
     {
         BOOST_CHECK(Save(
         sfmJsonToABC3,
-        jsonFile4.c_str(),
+        jsonFile4,
         ESfMData(flags)));
     }
 

--- a/src/aliceVision/sfmDataIO/bafIO.cpp
+++ b/src/aliceVision/sfmDataIO/bafIO.cpp
@@ -21,7 +21,7 @@ bool saveBAF(
   const std::string& filename,
   ESfMData partFlag)
 {
-  std::ofstream stream(filename.c_str());
+  std::ofstream stream(filename);
   if (!stream.is_open())
     return false;
 
@@ -103,7 +103,7 @@ bool saveBAF(
   {
     const std::string sFile = (fs::path(filename).parent_path() / (fs::path(filename).stem().string() + "_imgList.txt")).string();
 
-    stream.open(sFile.c_str());
+    stream.open(sFile);
     if (!stream.is_open())
       return false;
     for (sfmData::Views::const_iterator iterV = sfmData.getViews().begin();

--- a/src/aliceVision/sfmDataIO/gtIO.cpp
+++ b/src/aliceVision/sfmDataIO/gtIO.cpp
@@ -25,7 +25,7 @@ bool read_aliceVision_Camera(const std::string& camName, camera::Pinhole& cam, g
   std::vector<double> val;
   if (fs::extension(camName) == ".bin")
   {
-    std::ifstream in(camName.c_str(), std::ios::in|std::ios::binary);
+    std::ifstream in(camName, std::ios::in|std::ios::binary);
     if (!in.is_open())
     {
       ALICEVISION_LOG_ERROR("Failed to open file '" << camName << "' for reading");
@@ -42,7 +42,7 @@ bool read_aliceVision_Camera(const std::string& camName, camera::Pinhole& cam, g
   else
   {
     std::ifstream ifs;
-    ifs.open( camName.c_str(), std::ifstream::in);
+    ifs.open( camName, std::ifstream::in);
     if (!ifs.is_open()) {
       ALICEVISION_LOG_ERROR("Failed to open file '" << camName << "' for reading");
       return false;
@@ -82,7 +82,7 @@ bool read_aliceVision_Camera(const std::string& camName, camera::Pinhole& cam, g
 bool read_Strecha_Camera(const std::string& camName, camera::Pinhole& cam, geometry::Pose3& pose)
 {
   std::ifstream ifs;
-  ifs.open( camName.c_str(), std::ifstream::in);
+  ifs.open(camName, std::ifstream::in);
   if (!ifs.is_open()) {
     ALICEVISION_LOG_ERROR("Failed to open file '" << camName << "' for reading");
     return false;

--- a/src/aliceVision/sfmDataIO/plyIO.cpp
+++ b/src/aliceVision/sfmDataIO/plyIO.cpp
@@ -24,7 +24,7 @@ bool savePLY(
     return false;
 
   //Create the stream and check it is ok
-  std::ofstream stream(filename.c_str());
+  std::ofstream stream(filename);
   if (!stream.is_open())
     return false;
 

--- a/src/aliceVision/stl/mapUtils.hpp
+++ b/src/aliceVision/stl/mapUtils.hpp
@@ -16,17 +16,17 @@
 // m[1] = 1.6;
 // std::vector<int> keys;
 // // Retrieve all keys
-// transform(m.begin(), m.end(), back_inserter(keys), stl::RetrieveKey());
+// transform(m.begin(), m.end(), back_inserter(keys), RetrieveKey());
 // // Log all keys to console
 // copy(keys.begin(), keys.end(), ostream_iterator<int>(cout, "\n"));
 // // Retrieve all values
 // std::vector<double> values;
 // // Retrieve all values
-// transform(m.begin(), m.end(), back_inserter(values), stl::RetrieveValue());
+// transform(m.begin(), m.end(), back_inserter(values), RetrieveValue());
 
 #include <map>
 
-namespace stl{
+namespace stl {
 
 /// Allow to select the Keys of a map.
 struct RetrieveKey
@@ -48,4 +48,25 @@ struct RetrieveValue
   }
 };
 
-} // namespace stl
+}
+
+namespace aliceVision {
+
+template<typename Map>
+const typename Map::mapped_type& map_get_with_default(const Map& m, const typename Map::key_type& key, const typename Map::mapped_type& defval)
+{
+    auto it = m.find(key);
+    if(it == m.end())
+        return defval;
+    return it->second;
+}
+template<typename Map>
+bool map_has_non_empty_value(const Map& m, const typename Map::key_type& key)
+{
+    auto it = m.find(key);
+    if(it == m.end())
+        return false;
+    return !it->second.empty();
+}
+
+}

--- a/src/aliceVision/voctree/Database.cpp
+++ b/src/aliceVision/voctree/Database.cpp
@@ -157,7 +157,7 @@ void Database::computeTfIdfWeights(float default_weight)
 
 void Database::saveWeights(const std::string& file) const
 {
-  std::ofstream out(file.c_str(), std::ios_base::binary);
+  std::ofstream out(file, std::ios_base::binary);
   uint32_t num_words = word_weights_.size();
   out.write((char*) (&num_words), sizeof (uint32_t));
   out.write((char*) (&word_weights_[0]), num_words * sizeof (float));
@@ -170,7 +170,7 @@ void Database::loadWeights(const std::string& file)
 
   try
   {
-    in.open(file.c_str(), std::ios_base::binary);
+    in.open(file, std::ios_base::binary);
     uint32_t num_words = 0;
     in.read((char*) (&num_words), sizeof (uint32_t));
     word_files_.resize(num_words); // Inverted files start out empty

--- a/src/aliceVision/voctree/VocabularyTree.hpp
+++ b/src/aliceVision/voctree/VocabularyTree.hpp
@@ -284,7 +284,7 @@ void VocabularyTree<Feature, Distance, FeatureAllocator>::save(const std::string
   /// @todo Some identifying name for the distance used
   assert(initialized());
 
-  std::ofstream out(file.c_str(), std::ios_base::binary);
+  std::ofstream out(file, std::ios_base::binary);
   out.write((char*) (&k_), sizeof (uint32_t));
   out.write((char*) (&levels_), sizeof (uint32_t));
   uint32_t size = centers_.size();
@@ -304,7 +304,7 @@ void VocabularyTree<Feature, Distance, FeatureAllocator>::load(const std::string
   uint32_t size;
   try
   {
-    in.open(file.c_str(), std::ios_base::binary);
+    in.open(file, std::ios_base::binary);
     in.read((char*) (&k_), sizeof (uint32_t));
     in.read((char*) (&levels_), sizeof (uint32_t));
     in.read((char*) (&size), sizeof (uint32_t));

--- a/src/software/export/main_exportColoredPointCloud.cpp
+++ b/src/software/export/main_exportColoredPointCloud.cpp
@@ -73,7 +73,7 @@ int aliceVision_main(int argc, char **argv)
 
   // export the SfMData scene in the expected format
   ALICEVISION_LOG_INFO("Saving output result to " << outputSfMDataFilename << "...");
-  if(!sfmDataIO::Save(sfmData, outputSfMDataFilename.c_str(), sfmDataIO::ESfMData::ALL))
+  if(!sfmDataIO::Save(sfmData, outputSfMDataFilename, sfmDataIO::ESfMData::ALL))
   {
     ALICEVISION_LOG_ERROR("The output SfMData file '" + sfmDataFilename + "' cannot be save.");
     return EXIT_FAILURE;

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -192,7 +192,7 @@ bool exportToMVE2Format(
         << fileOut.widen('\n')
         << "[view]" << fileOut.widen('\n')
         << "id = " << view_index << fileOut.widen('\n')
-        << "name = " << fs::path(srcImage.c_str()).filename().string() << fileOut.widen('\n');
+        << "name = " << fs::path(srcImage).filename().string() << fileOut.widen('\n');
 
       // To do:  trim any extra separator(s) from aliceVision name we receive, e.g.:
       // '/home/insight/aliceVision_KevinCain/aliceVision_Build/software/SfM/ImageDataset_SceauxCastle/images//100_7100.JPG'

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -223,8 +223,8 @@ bool exportToBundlerFormat(
   const std::string & sOutFile, //Output Bundle.rd.out file
   const std::string & sOutListFile)  //Output Bundler list.txt file
 {
-  std::ofstream os(sOutFile.c_str()	);
-  std::ofstream osList(sOutListFile.c_str()	);
+  std::ofstream os(sOutFile);
+  std::ofstream osList(sOutListFile);
   if (! os.is_open() || ! osList.is_open())
   {
     return false;

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -291,11 +291,15 @@ int aliceVision_main(int argc, char** argv)
         const std::string hdrImagePath = getHdrImagePath(outputPath, g);
 
         // Write an image with parameters from the target view
-        oiio::ParamValueList targetMetadata = image::readImageMetadata(targetView->getImagePath());
-        targetMetadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace",
-                                                       image::EImageColorSpace_enumToString(image::EImageColorSpace::LINEAR)));
-        image::writeImage(hdrImagePath, HDRimage,
-                          image::ImageWriteOptions().storageDataType(storageDataType), targetMetadata);
+        std::map<std::string, std::string> viewMetadata = targetView->getMetadata();
+
+        oiio::ParamValueList targetMetadata;
+        for (const auto& meta : viewMetadata)
+        {
+            targetMetadata.add_or_replace(oiio::ParamValue(meta.first, meta.second));
+        }
+        targetMetadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(image::EImageColorSpace::LINEAR)));
+        image::writeImage(hdrImagePath, HDRimage, image::ImageWriteOptions().storageDataType(storageDataType), targetMetadata);
     }
 
     return EXIT_SUCCESS;

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -471,7 +471,7 @@ int aliceVision_main(int argc, char **argv)
         {
             image::DCPProfile dcpProf;
 
-            if (!dcpDatabase.empty() && dcpDatabase.getDcpForCamera(make, model, dcpProf))
+            if (!dcpDatabase.empty() && dcpDatabase.retrieveDcpForCamera(make, model, dcpProf))
             {
                 view.addDCPMetadata(dcpProf);
 

--- a/src/software/pipeline/main_meshDecimate.cpp
+++ b/src/software/pipeline/main_meshDecimate.cpp
@@ -85,7 +85,7 @@ int aliceVision_main(int argc, char* argv[])
     typedef OpenMesh::Decimater::ModQuadricT< Mesh >::Handle HModQuadric;
 
     Mesh mesh;
-    if(!OpenMesh::IO::read_mesh(mesh, inputMeshPath.c_str()))
+    if(!OpenMesh::IO::read_mesh(mesh, inputMeshPath))
     {
         ALICEVISION_LOG_ERROR("Unable to read input mesh from the file: " << inputMeshPath);
         return EXIT_FAILURE;

--- a/src/software/pipeline/main_meshDenoising.cpp
+++ b/src/software/pipeline/main_meshDenoising.cpp
@@ -89,7 +89,7 @@ int aliceVision_main(int argc, char* argv[])
 
 
     TriMesh inMesh;
-    if(!OpenMesh::IO::read_mesh(inMesh, inputMeshPath.c_str()))
+    if(!OpenMesh::IO::read_mesh(inMesh, inputMeshPath))
     {
         ALICEVISION_LOG_ERROR("Unable to read input mesh from the file: " << inputMeshPath);
         return EXIT_FAILURE;

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -125,7 +125,7 @@ void drawSVG(const cv::Ptr<cv::mcc::CChecker> &checker, const std::string& outpu
             svg::svgStyle().stroke("red", 2));
     }
 
-    std::ofstream svgFile(outputPath.c_str());
+    std::ofstream svgFile(outputPath);
     svgFile << svgSurface.closeSvgFile().str();
     svgFile.close();
 }

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -480,8 +480,8 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 
         if (dcpMetadataOK)
         {
-            colorMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ColorMatrixNumber"].c_str());
-            fwdMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ForwardMatrixNumber"].c_str());
+            colorMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ColorMatrixNumber"]);
+            fwdMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ForwardMatrixNumber"]);
 
             ALICEVISION_LOG_INFO("Matrix Number : " << colorMatrixNb << " ; " << fwdMatrixNb);
 
@@ -499,8 +499,8 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 
         image::DCPProfile dcpProf;
 
-        dcpProf.info.temperature_1 = std::stof(imageMetadata["AliceVision:DCP:Temp1"].c_str());
-        dcpProf.info.temperature_2 = std::stof(imageMetadata["AliceVision:DCP:Temp2"].c_str());
+        dcpProf.info.temperature_1 = std::stof(imageMetadata["AliceVision:DCP:Temp1"]);
+        dcpProf.info.temperature_2 = std::stof(imageMetadata["AliceVision:DCP:Temp2"]);
         dcpProf.info.has_color_matrix_1 = colorMatrixNb > 0;
         dcpProf.info.has_color_matrix_2 = colorMatrixNb > 1;
         dcpProf.info.has_forward_matrix_1 = fwdMatrixNb > 0;
@@ -532,10 +532,10 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
         size_t next = 1;
         while ((next = cam_mul.find(",", last)) != std::string::npos)
         {
-            v_mult.push_back(atof(cam_mul.substr(last, next - last).c_str()));
+            v_mult.push_back(std::stof(cam_mul.substr(last, next - last)));
             last = next + 1;
         }
-        v_mult.push_back(std::stof(cam_mul.substr(last, cam_mul.find("}", last) - last).c_str()));
+        v_mult.push_back(std::stof(cam_mul.substr(last, cam_mul.find("}", last) - last)));
 
         image::DCPProfile::Triple neutral;
         for (int i = 0; i < 3; i++)

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/utils/regexFilter.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/utils/filesIO.hpp>
+#include <aliceVision/stl/mapUtils.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
@@ -306,7 +307,7 @@ struct ProcessingParams
     };
 };
 
-void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams& pParams, std::map<std::string, std::string>& imageMetadata)
+void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams& pParams, const std::map<std::string, std::string>& imageMetadata)
 {
     const unsigned int nchannels = 4;
 
@@ -470,37 +471,40 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 #endif
     }
 
+
     if (pParams.applyDcpMetadata)
     {
-        bool dcpMetadataOK = !imageMetadata["AliceVision:DCP:Temp1"].empty() && !imageMetadata["AliceVision:DCP:Temp2"].empty() &&
-                             !imageMetadata["AliceVision:DCP:ForwardMatrixNumber"].empty() && !imageMetadata["AliceVision:DCP:ColorMatrixNumber"].empty();
+        bool dcpMetadataOK = map_has_non_empty_value(imageMetadata, "AliceVision:DCP:Temp1") &&
+                             map_has_non_empty_value(imageMetadata, "AliceVision:DCP:Temp2") &&
+                             map_has_non_empty_value(imageMetadata, "AliceVision:DCP:ForwardMatrixNumber") &&
+                             map_has_non_empty_value(imageMetadata, "AliceVision:DCP:ColorMatrixNumber");
 
         int colorMatrixNb;
         int fwdMatrixNb;
 
         if (dcpMetadataOK)
         {
-            colorMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ColorMatrixNumber"]);
-            fwdMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ForwardMatrixNumber"]);
+            colorMatrixNb = std::stoi(imageMetadata.at("AliceVision:DCP:ColorMatrixNumber"));
+            fwdMatrixNb = std::stoi(imageMetadata.at("AliceVision:DCP:ForwardMatrixNumber"));
 
             ALICEVISION_LOG_INFO("Matrix Number : " << colorMatrixNb << " ; " << fwdMatrixNb);
 
             dcpMetadataOK = !((colorMatrixNb == 0) ||
-                              ((colorMatrixNb > 0) && imageMetadata["AliceVision:DCP:ColorMat1"].empty()) ||
-                              ((colorMatrixNb > 1) && imageMetadata["AliceVision:DCP:ColorMat2"].empty()) ||
-                              ((fwdMatrixNb > 0) && imageMetadata["AliceVision:DCP:ForwardMat1"].empty()) ||
-                              ((fwdMatrixNb > 1) && imageMetadata["AliceVision:DCP:ForwardMat2"].empty()));
+                              ((colorMatrixNb > 0) && map_has_non_empty_value(imageMetadata, "AliceVision:DCP:ColorMat1")) ||
+                              ((colorMatrixNb > 1) && map_has_non_empty_value(imageMetadata, "AliceVision:DCP:ColorMat2")) ||
+                              ((fwdMatrixNb > 0) && map_has_non_empty_value(imageMetadata, "AliceVision:DCP:ForwardMat1")) ||
+                              ((fwdMatrixNb > 1) && map_has_non_empty_value(imageMetadata, "AliceVision:DCP:ForwardMat2")));
         }
 
         if (!dcpMetadataOK)
         {
-            ALICEVISION_THROW_ERROR("image Processing : All required DCP metadata cannot be found");
+            ALICEVISION_THROW_ERROR("Image Processing: All required DCP metadata cannot be found.\n" << imageMetadata);
         }
 
         image::DCPProfile dcpProf;
 
-        dcpProf.info.temperature_1 = std::stof(imageMetadata["AliceVision:DCP:Temp1"]);
-        dcpProf.info.temperature_2 = std::stof(imageMetadata["AliceVision:DCP:Temp2"]);
+        dcpProf.info.temperature_1 = std::stof(imageMetadata.at("AliceVision:DCP:Temp1"));
+        dcpProf.info.temperature_2 = std::stof(imageMetadata.at("AliceVision:DCP:Temp2"));
         dcpProf.info.has_color_matrix_1 = colorMatrixNb > 0;
         dcpProf.info.has_color_matrix_2 = colorMatrixNb > 1;
         dcpProf.info.has_forward_matrix_1 = fwdMatrixNb > 0;
@@ -508,25 +512,25 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 
         std::vector<std::string> v_str;
 
-        v_str.push_back(imageMetadata["AliceVision:DCP:ColorMat1"]);
+        v_str.push_back(imageMetadata.at("AliceVision:DCP:ColorMat1"));
         if (colorMatrixNb > 1)
         {
-            v_str.push_back(imageMetadata["AliceVision:DCP:ColorMat2"]);
+            v_str.push_back(imageMetadata.at("AliceVision:DCP:ColorMat2"));
         }
         dcpProf.setMatricesFromStrings("color", v_str);
 
         v_str.clear();
         if (fwdMatrixNb > 0)
         {
-            v_str.push_back(imageMetadata["AliceVision:DCP:ForwardMat1"]);
+            v_str.push_back(imageMetadata.at("AliceVision:DCP:ForwardMat1"));
             if (fwdMatrixNb > 1)
             {
-                v_str.push_back(imageMetadata["AliceVision:DCP:ForwardMat2"]);
+                v_str.push_back(imageMetadata.at("AliceVision:DCP:ForwardMat2"));
             }
             dcpProf.setMatricesFromStrings("forward", v_str);
         }
 
-        std::string cam_mul = imageMetadata["raw:cam_mul"];
+        std::string cam_mul = imageMetadata.at("raw:cam_mul");
         std::vector<float> v_mult;
         size_t last = 0;
         size_t next = 1;
@@ -895,13 +899,11 @@ int aliceVision_main(int argc, char * argv[])
                     image(i) = image(i) * exposureCompensation;
             }
 
-            std::map<std::string, std::string> metadata = view.getMetadata();
-
             // Image processing
-            processImage(image, pParams, metadata);
+            processImage(image, pParams, view.getMetadata());
 
             // Save the image
-            saveImage(image, viewPath, outputfilePath, metadata, metadataFolders, workingColorSpace, outputFormat, outputColorSpace, storageDataType);
+            saveImage(image, viewPath, outputfilePath, view.getMetadata(), metadataFolders, workingColorSpace, outputFormat, outputColorSpace, storageDataType);
 
             // Update view for this modification
             view.setImagePath(outputfilePath);
@@ -1027,7 +1029,8 @@ int aliceVision_main(int argc, char * argv[])
                 const std::string& model = view.getMetadataModel();
 
                 // Get DCP profile
-                if (!dcpDatabase.getDcpForCamera(make, model, dcpProf))
+                if (!dcpDatabase.retrieveDcpForCamera(make, model, dcpProf))
+                {
                     if (errorOnMissingColorProfile)
                     {
                         ALICEVISION_LOG_ERROR("The specified DCP database does not contain an appropriate profil for DSLR " << make << " " << model);
@@ -1037,6 +1040,7 @@ int aliceVision_main(int argc, char * argv[])
                     {
                         ALICEVISION_LOG_WARNING("Can't find color profile for input image " << inputFilePath);
                     }
+                }
 
                 // Add color profile info in metadata
                 view.addDCPMetadata(dcpProf);

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -480,8 +480,8 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 
         if (dcpMetadataOK)
         {
-            colorMatrixNb = atoi(imageMetadata["AliceVision:DCP:ColorMatrixNumber"].c_str());
-            fwdMatrixNb = atoi(imageMetadata["AliceVision:DCP:ForwardMatrixNumber"].c_str());
+            colorMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ColorMatrixNumber"].c_str());
+            fwdMatrixNb = std::stoi(imageMetadata["AliceVision:DCP:ForwardMatrixNumber"].c_str());
 
             ALICEVISION_LOG_INFO("Matrix Number : " << colorMatrixNb << " ; " << fwdMatrixNb);
 
@@ -499,8 +499,8 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 
         image::DCPProfile dcpProf;
 
-        dcpProf.info.temperature_1 = atof(imageMetadata["AliceVision:DCP:Temp1"].c_str());
-        dcpProf.info.temperature_2 = atof(imageMetadata["AliceVision:DCP:Temp2"].c_str());
+        dcpProf.info.temperature_1 = std::stof(imageMetadata["AliceVision:DCP:Temp1"].c_str());
+        dcpProf.info.temperature_2 = std::stof(imageMetadata["AliceVision:DCP:Temp2"].c_str());
         dcpProf.info.has_color_matrix_1 = colorMatrixNb > 0;
         dcpProf.info.has_color_matrix_2 = colorMatrixNb > 1;
         dcpProf.info.has_forward_matrix_1 = fwdMatrixNb > 0;
@@ -535,7 +535,7 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
             v_mult.push_back(atof(cam_mul.substr(last, next - last).c_str()));
             last = next + 1;
         }
-        v_mult.push_back(atof(cam_mul.substr(last, cam_mul.find("}", last) - last).c_str()));
+        v_mult.push_back(std::stof(cam_mul.substr(last, cam_mul.find("}", last) - last).c_str()));
 
         image::DCPProfile::Triple neutral;
         for (int i = 0; i < 3; i++)

--- a/src/software/utils/main_sfmLocalization.cpp
+++ b/src/software/utils/main_sfmLocalization.cpp
@@ -201,7 +201,7 @@ int aliceVision_main(int argc, char **argv)
   const std::string out_file_name = (fs::path(outputFolder) / "found_pose_centers.ply").string();
   {
     std::ofstream outfile;
-    outfile.open(out_file_name.c_str(), std::ios_base::out);
+    outfile.open(out_file_name, std::ios_base::out);
     if (outfile.is_open()) {
       outfile << "ply"
        << "\n" << "format ascii 1.0"

--- a/src/software/utils/precisionEvaluationToGt.hpp
+++ b/src/software/utils/precisionEvaluationToGt.hpp
@@ -75,7 +75,7 @@ inline bool exportToPly(const std::vector<Vec3> & vec_camPosGT,
   const std::string & sFileName)
 {
   std::ofstream outfile;
-  outfile.open(sFileName.c_str(), std::ios_base::out);
+  outfile.open(sFileName, std::ios_base::out);
 
   outfile << "ply"
     << '\n' << "format ascii 1.0"

--- a/src/software/utils/sfmHelper/sfmIOHelper.hpp
+++ b/src/software/utils/sfmHelper/sfmIOHelper.hpp
@@ -64,7 +64,7 @@ inline bool loadImageList( std::vector<CameraInfo> & vec_camImageName,
                            const std::string & sFileName,
                            bool bVerbose = true )
 {
-  std::ifstream in(sFileName.c_str());
+  std::ifstream in(sFileName);
   if(!in.is_open())
   {
     std::cerr << std::endl

--- a/src/software/utils/sfmHelper/sfmIOHelper_test.cpp
+++ b/src/software/utils/sfmHelper/sfmIOHelper_test.cpp
@@ -16,7 +16,7 @@ TEST(SfMIOHelper, EmptyFile) {
   os.str("");    
 
   const std::string sListsFile = "./lists.txt";
-  std::ofstream file(sListsFile.c_str());
+  std::ofstream file(sListsFile);
   file << os.str();
   file.close();
 
@@ -37,7 +37,7 @@ TEST(SfMIOHelper, UniqueIntrinsicGroup) {
     << "0.jpg;2592;1936;2052.91;0;1278.59;0;2052.91;958.71;0;0;1";
     
   const std::string sListsFile = "./lists.txt";
-  std::ofstream file(sListsFile.c_str());
+  std::ofstream file(sListsFile);
   file << os.str();
   file.close();
 
@@ -59,7 +59,7 @@ TEST(SfMIOHelper, SameCameraDifferentFocal) {
     << "DSC00403.JPG;4912;3264;6644;EASTMAN KODAK COMPANY;KODAK Z612 ZOOM DIGITAL CAMERA";
     
   const std::string sListsFile = "./lists.txt";
-  std::ofstream file(sListsFile.c_str());
+  std::ofstream file(sListsFile);
   file << os.str();
   file.close();
 
@@ -90,7 +90,7 @@ TEST(SfMIOHelper, ManyCameraDifferentFocal) {
     << "IMG_3212.JPG;5616;3744;Xylus;Junior"; // not known camera
     
   const std::string sListsFile = "./lists.txt";
-  std::ofstream file(sListsFile.c_str());
+  std::ofstream file(sListsFile);
   file << os.str();
   file.close();
 
@@ -117,7 +117,7 @@ TEST(SfMIOHelper, KnowAndUnknowCamera) {
     << "0.jpg;4912;3264;3344.34;0;2456;0;3344.34;1632;0;0;1";
       
   const std::string sListsFile = "./lists.txt";
-  std::ofstream file(sListsFile.c_str());
+  std::ofstream file(sListsFile);
   file << os.str();
   file.close();
 
@@ -144,7 +144,7 @@ TEST(SfMIOHelper, ThreeIntrinsicGroup_KMatrix) {
     << "6.jpg;2592;1936;2044.66;0;1253.00;0;2044.66;981.52;0;0;1";
 
   const std::string sListsFile = "./lists.txt";
-  std::ofstream file(sListsFile.c_str());
+  std::ofstream file(sListsFile);
   file << os.str();
   file.close();
 


### PR DESCRIPTION

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Update dcpProfile by adding some matrix setters and the capability to be applied on an aliceVision image.
Update imageProcessing to decode DCP metadata, build a DCP profile and apply it.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

