### PR TITLE
add missing config.hpp include

### DIFF
--- a/src/aliceVision/feature/imageDescriberCommon.cpp
+++ b/src/aliceVision/feature/imageDescriberCommon.cpp
@@ -7,6 +7,7 @@
 
 #include "imageDescriberCommon.hpp"
 #include <aliceVision/types.hpp>
+#include <aliceVision/config.hpp>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/aliceVision/image/convertionOpenCV.hpp
+++ b/src/aliceVision/image/convertionOpenCV.hpp
@@ -6,10 +6,13 @@
 
 #pragma once
 
+#include <aliceVision/config.hpp>
+
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
 
 #include "aliceVision/image/Image.hpp"
 #include <aliceVision/numeric/numeric.hpp>
+
 
 #include <opencv2/core.hpp>
 

--- a/src/aliceVision/sfm/pipeline/ReconstructionEngine.cpp
+++ b/src/aliceVision/sfm/pipeline/ReconstructionEngine.cpp
@@ -6,6 +6,7 @@
 
 #include "ReconstructionEngine.hpp"
 
+#include <aliceVision/config.hpp>
 #include <aliceVision/feature/RegionsPerView.hpp>
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 

--- a/src/aliceVision/sfmDataIO/sfmDataIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIO_test.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/config.hpp>
 
 #include <boost/filesystem.hpp>
 

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -5,6 +5,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include <aliceVision/config.hpp>
 #include <aliceVision/feature/FeatureExtractor.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
@@ -19,7 +20,6 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/cmdline.hpp>
-#include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>


### PR DESCRIPTION
`config.hpp` should be always included ("include what you use") when using Alicevision's macros defined in there. 
