### PR TITLE
Add a Lock option for each intrinsic variable

### DIFF
--- a/src/aliceVision/camera/IntrinsicsScaleOffset.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffset.hpp
@@ -245,11 +245,41 @@ public:
     return _ratioLocked;
   }
 
+  /**
+   * @brief lock the Scale
+   * @param lock is the scale locked
+   */
+  void setScaleLocked(bool lock) 
+  {
+    _scaleLocked = lock;
+  }
+
+  bool isScaleLocked() const
+  {
+    return _scaleLocked;
+  }
+
+  /**
+   * @brief lock the offset
+   * @param lock is the offset locked
+   */
+  void setOffsetLocked(bool lock) 
+  {
+    _offsetLocked = lock;
+  }
+
+  bool isOffsetLocked() const
+  {
+    return _offsetLocked;
+  }
+
 protected:
   Vec2 _scale{1.0, 1.0};
   Vec2 _offset{0.0, 0.0};
   Vec2 _initialScale{-1.0, -1.0};
   bool _ratioLocked{true};
+  bool _scaleLocked{false};
+  bool _offsetLocked{false};
 };
 
 } // namespace camera

--- a/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
@@ -257,6 +257,20 @@ public:
       return _pDistortion;
   }
 
+   /**
+   * @brief lock the distortion
+   * @param lock is the distortion locked
+   */
+  void setDistortionLocked(bool lock) 
+  {
+    _distortionLocked = lock;
+  }
+
+  bool isDistortionLocked() const
+  {
+    return _distortionLocked;
+  }
+
   ~IntrinsicsScaleOffsetDisto() override = default;
 
 protected:
@@ -270,6 +284,7 @@ protected:
   }
 
   std::shared_ptr<Distortion> _pDistortion;
+  bool _distortionLocked{false};
 };
 
 } // namespace camera

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -218,8 +218,16 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
     ODoubleArrayProperty(userProps, "mvg_intrinsicParams").set(intrinsicCasted->getParams());
     OBoolProperty(userProps, "mvg_intrinsicLocked").set(intrinsicCasted->isLocked());
     OBoolProperty(userProps, "mvg_intrinsicPixelRatioLocked").set(intrinsicCasted->isRatioLocked());
+    OBoolProperty(userProps, "mvg_intrinsicScaleLocked").set(intrinsicCasted->isScaleLocked());
+    OBoolProperty(userProps, "mvg_intrinsicOffsetLocked").set(intrinsicCasted->isOffsetLocked());
 
     camObj.getSchema().set(camSample);
+  }
+
+  std::shared_ptr<camera::IntrinsicsScaleOffsetDisto> intrinsicWithDistoEnabled = std::dynamic_pointer_cast<camera::IntrinsicsScaleOffsetDisto>(intrinsic);
+  if(intrinsicWithDistoEnabled)
+  {
+    OBoolProperty(userProps, "mvg_intrinsicDistortionLocked").set(intrinsicWithDistoEnabled->isDistortionLocked());
   }
 
   std::shared_ptr<camera::EquiDistant> intrinsicEquiCasted = std::dynamic_pointer_cast<camera::EquiDistant>(intrinsic);

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -418,6 +418,9 @@ bool readCamera(const Version & abcVersion, const ICamera& camera, const M44d& m
   bool poseLocked = false;
   bool poseIndependant = true;
   bool lockRatio = true;
+  bool lockScale = false;
+  bool lockOffset = false;
+  bool lockDistortion = false;
 
   if(userProps)
   {
@@ -461,6 +464,18 @@ bool readCamera(const Version & abcVersion, const ICamera& camera, const M44d& m
       if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_intrinsicPixelRatioLocked"))
       {
         lockRatio = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_intrinsicPixelRatioLocked", sampleFrame);
+      }
+      if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_intrinsicScaleLocked"))
+      {
+        lockScale = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_intrinsicScaleLocked", sampleFrame);
+      }
+      if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_intrinsicOffsetLocked"))
+      {
+        lockOffset = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_intrinsicOffsetLocked", sampleFrame);
+      }
+      if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_intrinsicDistortionLocked"))
+      {
+        lockDistortion = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_intrinsicDistortionLocked", sampleFrame);
       }
       if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_poseLocked"))
       {
@@ -572,6 +587,14 @@ bool readCamera(const Version & abcVersion, const ICamera& camera, const M44d& m
       initialFocalLengthPix(1) = (initialFocalLengthPix(0) > 0)? initialFocalLengthPix(0) * mvg_intrinsicParams[1] / mvg_intrinsicParams[0] : -1;
       intrinsicScale->setInitialScale(initialFocalLengthPix);
       intrinsicScale->setRatioLocked(lockRatio);
+      intrinsicScale->setScaleLocked(lockScale);
+      intrinsicScale->setOffsetLocked(lockOffset);
+    }
+
+    std::shared_ptr<camera::IntrinsicsScaleOffsetDisto> intrinsicScaleDisto = std::dynamic_pointer_cast<camera::IntrinsicsScaleOffsetDisto>(intrinsic);
+    if (intrinsicScaleDisto)
+    {
+      intrinsicScaleDisto->setDistortionLocked(lockDistortion);
     }
 
     std::shared_ptr<camera::EquiDistant> casted = std::dynamic_pointer_cast<camera::EquiDistant>(intrinsic);

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -139,6 +139,8 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
     intrinsicTree.put("focalLength", focalLengthMM);
     intrinsicTree.put("pixelRatio", pixelRatio);
     intrinsicTree.put("pixelRatioLocked", intrinsicScaleOffset->isRatioLocked());
+    intrinsicTree.put("scaleLocked", intrinsicScaleOffset->isScaleLocked());
+    intrinsicTree.put("offsetLocked", intrinsicScaleOffset->isOffsetLocked());
 
     saveMatrix("principalPoint", intrinsicScaleOffset->getOffset(), intrinsicTree);
   }
@@ -156,6 +158,7 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
     }
 
     intrinsicTree.add_child("distortionParams", distParamsTree);
+    intrinsicTree.put("distortionLocked", intrinsicScaleOffsetDisto->isDistortionLocked());
   }
 
   std::shared_ptr<camera::EquiDistant> intrinsicEquidistant = std::dynamic_pointer_cast<camera::EquiDistant>(intrinsic);
@@ -252,6 +255,8 @@ void loadIntrinsic(const Version & version, IndexT& intrinsicId, std::shared_ptr
 
       intrinsicWithScale->setInitialScale(initialFocalLengthPx);
       intrinsicWithScale->setRatioLocked(intrinsicTree.get<bool>("pixelRatioLocked"));
+      intrinsicWithScale->setScaleLocked(intrinsicTree.get<bool>("scaleLocked", false));
+      intrinsicWithScale->setOffsetLocked(intrinsicTree.get<bool>("offsetLocked", false));
     }
   }
 
@@ -266,6 +271,7 @@ void loadIntrinsic(const Version & version, IndexT& intrinsicId, std::shared_ptr
     //ensure that we have the right number of params
     distortionParams.resize(intrinsicWithDistoEnabled->getDistortionParams().size(), 0.0);
     intrinsicWithDistoEnabled->setDistortionParams(distortionParams);
+    intrinsicWithDistoEnabled->setDistortionLocked(intrinsicTree.get<bool>("distortionLocked", false));
   }
 
   // Load EquiDistant params


### PR DESCRIPTION
We want to be able to control which variable of the intrinsic is optimized or not.

This PR add one boolean per intrinsic variable to lock it :

    scale
    offset
    distortion

Linked to PR #https://github.com/alicevision/Meshroom/pull/1885