### PR TITLE
[cmake] fix for `ALICEVISION_HAVE_OPENCV_CONTRIB`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -471,6 +471,7 @@ endif()
 # ==============================================================================
 set(ALICEVISION_HAVE_OPENCV 0)
 set(ALICEVISION_HAVE_OCVSIFT 0)
+set(ALICEVISION_HAVE_OPENCV_CONTRIB 0)
 
 if(ALICEVISION_BUILD_SFM)
   if(NOT ALICEVISION_USE_OPENCV STREQUAL "OFF")


### PR DESCRIPTION
When checking for ocv contrib module, `ALICEVISION_HAVE_OPENCV_CONTRIB` was never initialized to 0.
This should solve #1338 if the user do not ask explicitly to build with OpenCV.
If it is not the case, then `ALICEVISION_HAVE_OPENCV_CONTRIB` is never set while later on in the software module is checked to build or not some of the programs