### PR TITLE
HDR luminance statistics bugfix

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -154,7 +154,8 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
         {
             lines.push_back(line);
         }
-        if ((lines.size() < 3) || (std::stoi(lines[0].c_str()) != groups.size()) || (std::stoi(lines[1].c_str()) < groups[0].size()))
+        if ((lines.size() < 3) || (std::stoi(lines[0].c_str()) != groups.size()) || (std::stoi(lines[1].c_str()) < groups[0].size()) ||
+            (lines.size() < 3 + std::stoi(lines[0].c_str()) * std::stoi(lines[1].c_str())))
         {
             ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
         }
@@ -166,6 +167,7 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
         for (int i = 0; i < nbExp; ++i)
         {
             double lumaMeanMean = 0.0;
+            double nbValidViews = 0;
             for (int j = 0; j < nbGroup; ++j)
             {
                 std::istringstream iss(lines[3 + j * nbExp + i]);
@@ -176,9 +178,13 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
                 {
                     ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
                 }
-                lumaMeanMean += lumaMean;
+                if (exposure > 0.0) // discard dummy luminance info (with exposure set to -1.0) added at calibration stage if samples are missing for a view
+                {
+                    lumaMeanMean += lumaMean;
+                    nbValidViews++;
+                }
             }
-            v_lumaMeanMean.push_back(lumaMeanMean / nbGroup);
+            v_lumaMeanMean.push_back(lumaMeanMean / nbValidViews);
         }
 
         // adjust last index to avoid non increasing luminance curve due to saturation in highlights

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -154,13 +154,13 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
         {
             lines.push_back(line);
         }
-        if ((lines.size() < 3) || (std::stoi(lines[0].c_str()) != groups.size()) || (std::stoi(lines[1].c_str()) < groups[0].size()) ||
-            (lines.size() < 3 + std::stoi(lines[0].c_str()) * std::stoi(lines[1].c_str())))
+        if ((lines.size() < 3) || (std::stoi(lines[0]) != groups.size()) || (std::stoi(lines[1]) < groups[0].size()) ||
+            (lines.size() < 3 + std::stoi(lines[0]) * std::stoi(lines[1])))
         {
             ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
         }
-        int nbGroup = std::stoi(lines[0].c_str());
-        int nbExp = std::stoi(lines[1].c_str());
+        int nbGroup = std::stoi(lines[0]);
+        int nbExp = std::stoi(lines[1]);
 
         std::vector<double> v_lumaMeanMean;
 
@@ -181,7 +181,7 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetV
                 if (exposure > 0.0) // discard dummy luminance info (with exposure set to -1.0) added at calibration stage if samples are missing for a view
                 {
                     lumaMeanMean += lumaMean;
-                    nbValidViews++;
+                    ++nbValidViews;
                 }
             }
             v_lumaMeanMean.push_back(lumaMeanMean / nbValidViews);

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -463,7 +463,14 @@ int aliceVision_main(int argc, char** argv)
                 // write in file
                 file << srcIdWithMinimalExposure << " ";
                 file << v_luminanceInfos[i][srcIdWithMinimalExposure].exposure << " " << v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb << " ";
-                file << v_luminanceInfos[i][srcIdWithMinimalExposure].meanLum / v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb << " ";
+                if (v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb > 0)
+                {
+                    file << v_luminanceInfos[i][srcIdWithMinimalExposure].meanLum / v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb << " ";
+                }
+                else
+                {
+                    file << "0.0 ";
+                }
                 file << v_luminanceInfos[i][srcIdWithMinimalExposure].minLum << " " << v_luminanceInfos[i][srcIdWithMinimalExposure].maxLum << std::endl;
                 // erase from map
                 v_luminanceInfos[i].erase(srcIdWithMinimalExposure);

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -309,6 +309,17 @@ int aliceVision_main(int argc, char** argv)
             std::map<int, luminanceInfo> luminanceInfos;
             computeLuminanceStatFromSamples(samples, luminanceInfos);
 
+            // Check that all views in the group have an associated luminance stat info
+            for (auto& v : group)
+            {
+                if (luminanceInfos.find(v->getViewId()) == luminanceInfos.end())
+                {
+                    luminanceInfo lumaInfo;
+                    lumaInfo.exposure = -1.0; // Dummy exposure used later indicating a dummy info
+                    luminanceInfos[v->getViewId()] = lumaInfo;
+                }
+            }
+
             v_luminanceInfos.push_back(luminanceInfos);
 
             ++group_pos;

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -310,7 +310,7 @@ int aliceVision_main(int argc, char** argv)
             computeLuminanceStatFromSamples(samples, luminanceInfos);
 
             // Check that all views in the group have an associated luminance stat info
-            for (auto& v : group)
+            for (const auto& v : group)
             {
                 if (luminanceInfos.find(v->getViewId()) == luminanceInfos.end())
                 {


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

HDR Calibration bug fix at generation of file containing the luminance statistics.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
Guarantee that every views have an associated luminance info.
 In HDR merging node, throw an "invalid file" error when reading the file if it does not contain the expected number of lines.

## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

