### PR TITLE
Added Zed2i StereoLabs Zed2i sensor info

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -7475,4 +7475,4 @@ Zuk;Zuk Z1;4.69;devicespecifications
 Zuk;Zuk Z2;4.61;devicespecifications
 Zuk;Zuk Z2 Pro;4.61;devicespecifications
 Zuk;Zuk Z2 Rio Edition;4.54;devicespecifications
-StereoLabs;Zed2i;5.38;devicespecifications
+StereoLabs;Zed2i;5.38;usercontribution

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -7475,3 +7475,4 @@ Zuk;Zuk Z1;4.69;devicespecifications
 Zuk;Zuk Z2;4.61;devicespecifications
 Zuk;Zuk Z2 Pro;4.61;devicespecifications
 Zuk;Zuk Z2 Rio Edition;4.54;devicespecifications
+StereoLabs;Zed2i;5.38;devicespecifications


### PR DESCRIPTION
## Description
I just added the information about the stereo camera Zed2i from StereoLabs.
Camera sensor: 1/3" 4MP CMOS
Effective pixels: 2688 x 1520 
Pixel size: 2μm

Sensor width calculated with this site: https://www.vision-doctor.com/en/camera-calculations/sensor-diagonal-sensor-ratio.html

