### PR TITLE
[cameraSensors] OMNIVISION uctronics and gophotonics

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4501,6 +4501,7 @@ OLYMPUS OPTICAL CO.,LTD;X-2;7.176;usercontribution
 OLYMPUS_IMAGING_CORP.;C370Z;5.27;usercontribution
 OLYMPUS_IMAGING_CORP.;D535Z;5.27;usercontribution
 OLYMPUS_IMAGING_CORP.;X450;5.27;usercontribution
+OMNIVISION;OV2640;6.35;usercontribution
 Onda;Onda V975i;3.67;devicespecifications
 Onda;Onda V989;3.68;devicespecifications
 OnePlus;AC2003;6.4;usercontribution

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4501,7 +4501,8 @@ OLYMPUS OPTICAL CO.,LTD;X-2;7.176;usercontribution
 OLYMPUS_IMAGING_CORP.;C370Z;5.27;usercontribution
 OLYMPUS_IMAGING_CORP.;D535Z;5.27;usercontribution
 OLYMPUS_IMAGING_CORP.;X450;5.27;usercontribution
-OMNIVISION;OV2640;6.35;usercontribution
+OMNIVISION;OV2640;3.59;uctronics
+OMNIVISION;OV9734;1.819;gophotonics
 Onda;Onda V975i;3.67;devicespecifications
 Onda;Onda V989;3.68;devicespecifications
 OnePlus;AC2003;6.4;usercontribution


### PR DESCRIPTION
I would need to add the ESP32 CAM sensor, whose module is the Omnivision OV2640 (https://www.uctronics.com/download/OV2640_DS.pdf)

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md). X
 - I have updated the documentation, if applicable. X
 - I have ensured that the change is tested somewhere. X
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance). X

-->
## Description

I would need to add the ESP32 CAM sensor, whose module is the Omnivision OV2640 (https://www.uctronics.com/download/OV2640_DS.pdf)

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

