### PR TITLE
Stitching color space

### DIFF
--- a/src/aliceVision/feature/FeatureExtractor.cpp
+++ b/src/aliceVision/feature/FeatureExtractor.cpp
@@ -55,7 +55,7 @@ FeatureExtractor::FeatureExtractor(const sfmData::SfMData& sfmData) :
 
 FeatureExtractor::~FeatureExtractor() = default;
 
-void FeatureExtractor::process(const HardwareContext & hContext)
+void FeatureExtractor::process(const HardwareContext & hContext, const image::EImageColorSpace workingColorSpace)
 {
     size_t maxAvailableMemory = hContext.getUserMaxMemoryAvailable();
     unsigned int maxAvailableCores = hContext.getMaxThreads();
@@ -160,23 +160,23 @@ void FeatureExtractor::process(const HardwareContext & hContext)
 
 #pragma omp parallel for num_threads(nbThreads)
         for (int i = 0; i < cpuJobs.size(); ++i)
-            computeViewJob(cpuJobs.at(i), false);
+            computeViewJob(cpuJobs.at(i), false, workingColorSpace);
     }
 
     if (!gpuJobs.empty())
     {
         for (const auto& job : gpuJobs)
-            computeViewJob(job, true);
+            computeViewJob(job, true, workingColorSpace);
     }
 }
 
-void FeatureExtractor::computeViewJob(const FeatureExtractorViewJob& job, bool useGPU)
+void FeatureExtractor::computeViewJob(const FeatureExtractorViewJob& job, bool useGPU, const image::EImageColorSpace workingColorSpace)
 {
     image::Image<float> imageGrayFloat;
     image::Image<unsigned char> imageGrayUChar;
     image::Image<unsigned char> mask;
 
-    image::readImage(job.view().getImagePath(), imageGrayFloat, image::EImageColorSpace::SRGB);
+    image::readImage(job.view().getImagePath(), imageGrayFloat, workingColorSpace);
 
     if (!_masksFolder.empty() && fs::exists(_masksFolder))
     {

--- a/src/aliceVision/feature/FeatureExtractor.hpp
+++ b/src/aliceVision/feature/FeatureExtractor.hpp
@@ -94,11 +94,11 @@ public:
       _imageDescribers.push_back(imageDescriber);
     }
 
-    void process(const HardwareContext & hcontext);
+    void process(const HardwareContext & hcontext, const image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB);
 
 private:
 
-    void computeViewJob(const FeatureExtractorViewJob& job, bool useGPU);
+    void computeViewJob(const FeatureExtractorViewJob& job, bool useGPU, const image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB);
 
     const sfmData::SfMData& _sfmData;
     std::vector<std::shared_ptr<feature::ImageDescriber>> _imageDescribers;

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -160,6 +160,9 @@ int aliceVision_main(int argc, char** argv)
 
     const std::size_t channelQuantization = std::pow(2, channelQuantizationPower);
 
+    // Fusion always produces linear image. sRGB is the only non linear color space that must be changed to linear (sRGB linear). 
+    image::EImageColorSpace mergedColorSpace = (workingColorSpace == image::EImageColorSpace::SRGB) ? image::EImageColorSpace::LINEAR : workingColorSpace;
+
     // Make groups
     std::vector<std::vector<std::shared_ptr<sfmData::View>>> groupedViews;
     if (!hdr::estimateBracketsFromSfmData(groupedViews, sfmData, nbBrackets))
@@ -271,6 +274,7 @@ int aliceVision_main(int argc, char** argv)
                 const std::string hdrImagePath = getHdrImagePath(outputPath, g, keepSourceImageName ? p.stem().string() : "");
                 hdrView->setImagePath(hdrImagePath);
             }
+            hdrView->addMetadata("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(mergedColorSpace));
             outputSfm.getViews()[hdrView->getViewId()] = hdrView;
         }
 
@@ -313,6 +317,10 @@ int aliceVision_main(int argc, char** argv)
             options.workingColorSpace = workingColorSpace;
             options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
             options.colorProfileFileName = group[i]->getColorProfileFileName();
+            if (options.rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata)
+            {
+                options.doWBAfterDemosaicing = true;
+            }
             image::readImage(filepath, images[i], options);
 
             exposuresSetting[i] = group[i]->getCameraExposureSetting(/*targetView->getMetadataISO(), targetView->getMetadataFNumber()*/);
@@ -360,9 +368,6 @@ int aliceVision_main(int argc, char** argv)
                 targetMetadata.add_or_replace(oiio::ParamValue(meta.first, meta.second));
             }
         }
-
-        // Fusion always produces linear image. sRGB is the only non linear color space that must be changed to linear (sRGB linear). 
-        image::EImageColorSpace mergedColorSpace = (workingColorSpace == image::EImageColorSpace::SRGB) ? image::EImageColorSpace::LINEAR : workingColorSpace;
 
         targetMetadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(mergedColorSpace)));
 

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -317,6 +317,10 @@ int aliceVision_main(int argc, char** argv)
             options.workingColorSpace = workingColorSpace;
             options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
             options.colorProfileFileName = group[i]->getColorProfileFileName();
+            // Whatever the raw color interpretation mode, the default read processing for raw images is to apply white balancing in libRaw, before demosaicing.
+            // The DcpMetadata mode allows to not apply color management after demosaicing.
+            // Because if requested after demosaicing, white balancing is done at color management stage, we can set this option to true to get real raw data,
+            // without any white balancing, when the DcpMetadata mode is selected.
             if (options.rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata)
             {
                 options.doWBAfterDemosaicing = true;

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -32,7 +32,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
@@ -56,6 +56,7 @@ int aliceVision_main(int argc, char **argv)
     int rangeSize = 1;
     int maxThreads = 0;
     bool forceCpuExtraction = false;
+    image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB;
 
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
@@ -81,6 +82,8 @@ int aliceVision_main(int argc, char **argv)
          feature::EFeatureConstrastFiltering_information().c_str())
         ("relativePeakThreshold", po::value<float>(&featDescConfig.relativePeakThreshold)->default_value(featDescConfig.relativePeakThreshold),
          "Peak Threshold relative to median of gradiants.")
+        ("workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
+         ("Working color space: " + image::EImageColorSpace_informations()).c_str())
         ("forceCpuExtraction", po::value<bool>(&forceCpuExtraction)->default_value(forceCpuExtraction),
          "Use only CPU feature extraction methods.")
         ("masksFolder", po::value<std::string>(&masksFolder),
@@ -175,14 +178,14 @@ int aliceVision_main(int argc, char **argv)
         }
     }
 
-  // feature extraction routines
-  // for each View of the SfMData container:
-  // - if regions file exist continue,
-  // - if no file, compute features
+    // feature extraction routines
+    // for each View of the SfMData container:
+    // - if regions file exist continue,
+    // - if no file, compute features
     {
         system::Timer timer;
 
-        extractor.process(hwc);
+        extractor.process(hwc, workingColorSpace);
 
         ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
     }

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -616,6 +616,7 @@ bool processImage(const PanoramaMap& panoramaMap, const sfmData::SfMData& sfmDat
 
     image::writeImage(outputFilePath, output,
                       image::ImageWriteOptions()
+                          .fromColorSpace(image::EImageColorSpace_stringToEnum(colorSpace))
                           .toColorSpace(image::EImageColorSpace_stringToEnum(colorSpace))
                           .storageDataType(storageDataType),
                       metadata);

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -105,6 +105,7 @@ int aliceVision_main(int argc, char** argv)
     int maxPanoramaWidth = 0;
 
     image::EStorageDataType storageDataType = image::EStorageDataType::Float;
+    image::EImageColorSpace outputColorSpace = image::EImageColorSpace::LINEAR;
 
     int rangeStart = -1;
     int rangeSize = 1;
@@ -124,6 +125,8 @@ int aliceVision_main(int argc, char** argv)
         "Max Panorama Width in pixels.")("percentUpscale",
                                          po::value<int>(&percentUpscale)->default_value(percentUpscale),
                                          "Percentage of upscaled pixels.")(
+        "outputColorSpace", po::value<image::EImageColorSpace>(&outputColorSpace)->default_value(outputColorSpace),
+        ("Output color space: " + image::EImageColorSpace_informations()).c_str())(
         "storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
         ("Storage data type: " + image::EStorageDataType_informations()).c_str())(
         "rangeStart", po::value<int>(&rangeStart)->default_value(rangeStart),
@@ -288,7 +291,7 @@ int aliceVision_main(int argc, char** argv)
         const std::string imagePath = view.getImagePath();
         ALICEVISION_LOG_INFO("Load image with path " << imagePath);
         image::Image<image::RGBfColor> source;
-        image::readImage(imagePath, source, image::EImageColorSpace::LINEAR);
+        image::readImage(imagePath, source, outputColorSpace);
 
         for(int idsub = 0; idsub < coarsesBbox.size(); idsub++)
         {
@@ -503,6 +506,10 @@ int aliceVision_main(int argc, char** argv)
             metadata.push_back(oiio::ParamValue("AliceVision:panoramaWidth", panoramaSize.first));
             metadata.push_back(oiio::ParamValue("AliceVision:panoramaHeight", panoramaSize.second));
             metadata.push_back(oiio::ParamValue("AliceVision:tileSize", tileSize));
+            if (outputColorSpace != image::EImageColorSpace::NO_CONVERSION)
+            {
+                metadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(outputColorSpace)));
+            }
 
             // Images will be converted in Panorama coordinate system, so there will be no more extra orientation.
             metadata.remove("Orientation");

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -105,7 +105,7 @@ int aliceVision_main(int argc, char** argv)
     int maxPanoramaWidth = 0;
 
     image::EStorageDataType storageDataType = image::EStorageDataType::Float;
-    image::EImageColorSpace outputColorSpace = image::EImageColorSpace::LINEAR;
+    image::EImageColorSpace workingColorSpace = image::EImageColorSpace::LINEAR;
 
     int rangeStart = -1;
     int rangeSize = 1;
@@ -125,7 +125,7 @@ int aliceVision_main(int argc, char** argv)
         "Max Panorama Width in pixels.")("percentUpscale",
                                          po::value<int>(&percentUpscale)->default_value(percentUpscale),
                                          "Percentage of upscaled pixels.")(
-        "outputColorSpace", po::value<image::EImageColorSpace>(&outputColorSpace)->default_value(outputColorSpace),
+        "workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
         ("Output color space: " + image::EImageColorSpace_informations()).c_str())(
         "storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
         ("Storage data type: " + image::EStorageDataType_informations()).c_str())(
@@ -291,7 +291,7 @@ int aliceVision_main(int argc, char** argv)
         const std::string imagePath = view.getImagePath();
         ALICEVISION_LOG_INFO("Load image with path " << imagePath);
         image::Image<image::RGBfColor> source;
-        image::readImage(imagePath, source, outputColorSpace);
+        image::readImage(imagePath, source, workingColorSpace);
 
         for(int idsub = 0; idsub < coarsesBbox.size(); idsub++)
         {
@@ -506,9 +506,9 @@ int aliceVision_main(int argc, char** argv)
             metadata.push_back(oiio::ParamValue("AliceVision:panoramaWidth", panoramaSize.first));
             metadata.push_back(oiio::ParamValue("AliceVision:panoramaHeight", panoramaSize.second));
             metadata.push_back(oiio::ParamValue("AliceVision:tileSize", tileSize));
-            if (outputColorSpace != image::EImageColorSpace::NO_CONVERSION)
+            if (workingColorSpace != image::EImageColorSpace::NO_CONVERSION)
             {
-                metadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(outputColorSpace)));
+                metadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(workingColorSpace)));
             }
 
             // Images will be converted in Panorama coordinate system, so there will be no more extra orientation.

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -26,7 +26,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Enable color space selection at stitching level.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
- [X] Add working color space option for feature extraction instead of forcing sRGB.
- [X] Add output color space option at warping instead of forcing linearwith sRGB primaries. The selected color space will be used for the stitching.
- [X] Update compositing to enable using other color spaces than linear with sRGB primaries.
- [X] If dcpMetadata is selected as raw color processing at HDR merge then read image without white balancing before demosaicing.


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

