### PR TITLE
[utils] split360Images: support SfMData input and output

### DIFF
--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -269,6 +269,8 @@ alicevision_add_software(aliceVision_split360Images
         aliceVision_numeric
         aliceVision_image
         aliceVision_panorama
+        aliceVision_sfmData
+        aliceVision_sfmDataIO
         ${OPENIMAGEIO_LIBRARIES}
         Boost::program_options
         Boost::filesystem

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -271,6 +271,7 @@ alicevision_add_software(aliceVision_split360Images
         aliceVision_panorama
         aliceVision_sfmData
         aliceVision_sfmDataIO
+        aliceVision_camera
         ${OPENIMAGEIO_LIBRARIES}
         Boost::program_options
         Boost::filesystem

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -35,7 +35,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -469,9 +469,8 @@ int aliceVision_main(int argc, char** argv)
         }
     }
 
+    // Gather filepaths of all images to process
     std::vector<std::string> imagePaths;
-    std::vector<std::string> badPaths;
-
     {
         const fs::path path = fs::absolute(inputPath);
         if (fs::exists(path))
@@ -563,17 +562,8 @@ int aliceVision_main(int argc, char** argv)
 
         if (!hasCorrectPath)
         {
-            #pragma omp critical (split360Images_badPaths)
-            badPaths.push_back(imagePath);
+            ALICEVISION_LOG_ERROR("Error: Failed to process image " << imagePath);
         }
-    }
-
-    // Log filepath for images that could not be split
-    if (!badPaths.empty())
-    {
-        ALICEVISION_LOG_ERROR("Error: Can't open image file(s) below");
-        for (const std::string& imagePath : imagePaths)
-            ALICEVISION_LOG_ERROR("\t - " << imagePath);
     }
 
 


### PR DESCRIPTION
## Description

The goal of this PR is to add support for using SfMData files for the input and output of the `aliceVision_split360Images` software.

Corresponding Meshroom PR: https://github.com/alicevision/Meshroom/pull/1939

## Implementation remarks

The output SfMData file created by `aliceVision_split360Images` has the following characteristics:
- all views belong to the same rig
- this rig's ID is 0
- all views share the same intrinsic
- this intrinsic's ID is 0
- the camera model for the intrinsic is radial3 for equirectangular split and either fisheye4 or equidistant_r3 for dual fisheye (user choice)
- the intrinsic's sensor size is always 36mm x 36mm
- in dual fisheye mode, if no focal metadata is found, an initial guess on the field of view if made with the value 170 degrees.