### PR TITLE
Fix building without opencv

### DIFF
--- a/src/aliceVision/dataio/FeedProvider.cpp
+++ b/src/aliceVision/dataio/FeedProvider.cpp
@@ -40,21 +40,22 @@ FeedProvider::FeedProvider(const std::string &feedPath, const std::string &calib
     }
     else
     {
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
       if(VideoFeed::isSupported(extension))
       {
-#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
+
         // let's try it with a video
         _feeder.reset(new VideoFeed(feedPath, calibPath));
         _isVideo = true;
-#else
-        throw std::invalid_argument("Unsupported mode! If you intended to use a video"
-                                  " please add OpenCV support");
-#endif
       }
       else
       {
         throw std::invalid_argument("Unsupported file format: " + feedPath);
       }
+#else
+      throw std::invalid_argument("Unsupported mode! If you intended to use a video"
+                                  " please add OpenCV support");
+#endif
     }
   }
   // parent_path() returns "/foo/bar/" when input path equals to "/foo/bar/"


### PR DESCRIPTION
When building Alicevision without relying on opencv, you will encounter compilation errors. I checked the problem and found that the static function isSupported() of VideoFeed was called, but VideoFeed did not compile because it did not depend on the opencv library.
I have provided a way to fix this problem, please review it if you have time.@fabiencastan 

## Features list

- [1 ] Feature one. Fix building without opencv



