### PR TITLE
Fix crash when output extension is missing in image processing

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -607,7 +607,7 @@ void readImage(const std::string& path,
             neutral[i] = v_mult[i] / v_mult[1];
         }
 
-        ALICEVISION_LOG_INFO("Apply DCP Linear processing with neutral = " << neutral);
+        ALICEVISION_LOG_TRACE("Apply DCP Linear processing with neutral = " << neutral);
 
         dcpProfile.applyLinear(inBuf, neutral, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly);
     }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -478,7 +478,7 @@ void readImage(const std::string& path,
             }
         }
 
-        ALICEVISION_LOG_INFO("Neutral from camera = {" << neutral[0] << ", " << neutral[1] << ", " << neutral[2] << "}");
+        ALICEVISION_LOG_TRACE("Neutral from camera = {" << neutral[0] << ", " << neutral[1] << ", " << neutral[2] << "}");
 
         // libRAW configuration
         // See https://openimageio.readthedocs.io/en/master/builtinplugins.html#raw-digital-camera-files

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -988,10 +988,14 @@ int aliceVision_main(int argc, char * argv[])
             const std::string viewPath = viewIt.second;
             sfmData::View& view = sfmData.getView(viewId);
 
+            const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(viewPath));
+            const std::string imgFormat = in->format_name();
+            const bool isRAW = imgFormat.compare("raw") == 0;
+
             const fs::path fsPath = viewPath;
             const std::string fileName = fsPath.stem().string();
             const std::string fileExt = fsPath.extension().string();
-            const std::string outputExt = extension.empty() ? fileExt : (std::string(".") + extension);
+            const std::string outputExt = extension.empty() ? (isRAW ? ".exr" : fileExt) : (std::string(".") + extension);
             const std::string outputfilePath = (fs::path(outputPath) / ((pParams.keepImageFilename ? fileName : std::to_string(viewId)) + outputExt)).generic_string();
 
             ALICEVISION_LOG_INFO(++i << "/" << size << " - Process view '" << viewId << "'.");
@@ -1002,10 +1006,6 @@ int aliceVision_main(int argc, char * argv[])
             {
                 ALICEVISION_LOG_WARNING("A dcp profile will be applied on an image containing non raw data!");
             }
-
-            const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(viewPath));
-            const std::string imgFormat = in->format_name();
-            const bool isRAW = imgFormat.compare("raw") == 0;
 
             image::ImageReadOptions options;
             options.workingColorSpace = pParams.applyDcpMetadata ? image::EImageColorSpace::NO_CONVERSION : workingColorSpace;
@@ -1157,10 +1157,14 @@ int aliceVision_main(int argc, char * argv[])
         int i = 0;
         for (const std::string& inputFilePath : filesStrPaths)
         {
+            const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(inputFilePath));
+            const std::string imgFormat = in->format_name();
+            const bool isRAW = imgFormat.compare("raw") == 0;
+
             const fs::path path = fs::path(inputFilePath);
             const std::string filename = path.stem().string();
             const std::string fileExt = path.extension().string();
-            const std::string outputExt = extension.empty() ? fileExt : (std::string(".") + extension);
+            const std::string outputExt = extension.empty() ? (isRAW ? ".exr" : fileExt) : (std::string(".") + extension);
 
             ALICEVISION_LOG_INFO(++i << "/" << size << " - Process image '" << filename << fileExt << "'.");
 
@@ -1190,10 +1194,6 @@ int aliceVision_main(int argc, char * argv[])
             int width, height;
             const auto metadata = image::readImageMetadata(inputFilePath, width, height);
             view.setMetadata(image::getMapFromMetadata(metadata));
-
-            const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(inputFilePath));
-            const std::string imgFormat = in->format_name();
-            const bool isRAW = imgFormat.compare("raw") == 0;
 
             if (isRAW && (rawColorInterpretation == image::ERawColorInterpretation::DcpLinearProcessing ||
                           rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata))


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Set ".exr" as default output extension if input image is in a raw file format in imageProcessing.

Replace some INFOs with TRACEs in read image.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

