### PR TITLE
Keyframe Selection: Add support for SfMData files as inputs and outputs

### DIFF
--- a/src/aliceVision/dataio/CMakeLists.txt
+++ b/src/aliceVision/dataio/CMakeLists.txt
@@ -3,6 +3,7 @@ set(dataio_files_headers
   FeedProvider.hpp
   IFeed.hpp
   ImageFeed.hpp
+  SfMDataFeed.hpp
 )
 
 # Sources
@@ -10,6 +11,7 @@ set(dataio_files_sources
   FeedProvider.cpp
   IFeed.cpp
   ImageFeed.cpp
+  SfMDataFeed.cpp
 )
 
 if(ALICEVISION_HAVE_OPENCV)

--- a/src/aliceVision/dataio/FeedProvider.cpp
+++ b/src/aliceVision/dataio/FeedProvider.cpp
@@ -7,6 +7,7 @@
 #include "FeedProvider.hpp"
 #include <aliceVision/config.hpp>
 #include "ImageFeed.hpp"
+#include "SfMDataFeed.hpp"
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
 #include "VideoFeed.hpp"
 #endif
@@ -27,6 +28,7 @@ namespace dataio
 FeedProvider::FeedProvider(const std::string& feedPath, const std::string& calibPath)
     : _isVideo(false)
     , _isLiveFeed(false)
+    , _isSfmData(false)
 {
     namespace bf = boost::filesystem;
     if(feedPath.empty())
@@ -37,7 +39,12 @@ FeedProvider::FeedProvider(const std::string& feedPath, const std::string& calib
     {
         // Image or video file
         const std::string extension = bf::path(feedPath).extension().string();
-        if(ImageFeed::isSupported(extension))
+        if(SfMDataFeed::isSupported(extension))
+        {
+            _feeder.reset(new SfMDataFeed(feedPath, calibPath));
+            _isSfmData = true;
+        }
+        else if(ImageFeed::isSupported(extension))
         {
             _feeder.reset(new ImageFeed(feedPath, calibPath));
         }

--- a/src/aliceVision/dataio/FeedProvider.cpp
+++ b/src/aliceVision/dataio/FeedProvider.cpp
@@ -19,116 +19,112 @@
 #include <limits>
 #include <ctype.h>
 
-namespace aliceVision{
-namespace dataio{
-
-FeedProvider::FeedProvider(const std::string &feedPath, const std::string &calibPath)
-: _isVideo(false), _isLiveFeed(false)
+namespace aliceVision
 {
-  namespace bf = boost::filesystem;
-  if(feedPath.empty())
-  {
-    throw std::invalid_argument("Empty filepath.");
-  }
-  if(bf::is_regular_file(bf::path(feedPath)))
-  {
-    // Image or video file
-    const std::string extension = bf::path(feedPath).extension().string();
-    if(ImageFeed::isSupported(extension))
+namespace dataio
+{
+
+FeedProvider::FeedProvider(const std::string& feedPath, const std::string& calibPath)
+    : _isVideo(false)
+    , _isLiveFeed(false)
+{
+    namespace bf = boost::filesystem;
+    if(feedPath.empty())
     {
-      _feeder.reset(new ImageFeed(feedPath, calibPath));
+        throw std::invalid_argument("Empty filepath.");
     }
+    if(bf::is_regular_file(bf::path(feedPath)))
+    {
+        // Image or video file
+        const std::string extension = bf::path(feedPath).extension().string();
+        if(ImageFeed::isSupported(extension))
+        {
+            _feeder.reset(new ImageFeed(feedPath, calibPath));
+        }
+        else
+        {
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
+            if(VideoFeed::isSupported(extension))
+            {
+                // let's try it with a video
+                _feeder.reset(new VideoFeed(feedPath, calibPath));
+                _isVideo = true;
+            }
+            else
+            {
+                throw std::invalid_argument("Unsupported file format: " + feedPath);
+            }
+#else
+            throw std::invalid_argument("Unsupported mode! If you intended to use a video"
+                                        " please add OpenCV support");
+#endif
+        }
+    }
+    // parent_path() returns "/foo/bar/" when input path equals to "/foo/bar/"
+    // if the user just gives the relative path as "bar", throws invalid argument exception.
+    else if(bf::is_directory(bf::path(feedPath)) || bf::is_directory(bf::path(feedPath).parent_path()))
+    {
+        // Folder or sequence of images
+        _feeder.reset(new ImageFeed(feedPath, calibPath));
+    }
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
+    else if(isdigit(feedPath[0]))
+    {
+        // let's try it with a video
+        const int deviceNumber = std::stoi(feedPath);
+        _feeder.reset(new VideoFeed(deviceNumber, calibPath));
+        _isVideo = true;
+        _isLiveFeed = true;
+    }
+#endif
     else
     {
-#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
-      if(VideoFeed::isSupported(extension))
-      {
-
-        // let's try it with a video
-        _feeder.reset(new VideoFeed(feedPath, calibPath));
-        _isVideo = true;
-      }
-      else
-      {
-        throw std::invalid_argument("Unsupported file format: " + feedPath);
-      }
-#else
-      throw std::invalid_argument("Unsupported mode! If you intended to use a video"
-                                  " please add OpenCV support");
-#endif
+        throw std::invalid_argument(std::string("Input filepath not supported: ") + feedPath);
     }
-  }
-  // parent_path() returns "/foo/bar/" when input path equals to "/foo/bar/"
-  // if the user just gives the relative path as "bar", throws invalid argument exception.
-  else if(bf::is_directory(bf::path(feedPath)) || bf::is_directory(bf::path(feedPath).parent_path()))
-  {
-    // Folder or sequence of images
-    _feeder.reset(new ImageFeed(feedPath, calibPath));
-  }
-#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
-  else if(isdigit(feedPath[0]))
-  {
-    // let's try it with a video
-    const int deviceNumber =  std::stoi(feedPath);
-    _feeder.reset(new VideoFeed(deviceNumber, calibPath));
-    _isVideo = true;
-    _isLiveFeed = true;
-  }
-#endif
-  else
-  {
-    throw std::invalid_argument(std::string("Input filepath not supported: ") + feedPath);
-  }
 }
 
-bool FeedProvider::readImage(image::Image<image::RGBColor> &imageRGB,
-      camera::PinholeRadialK3 &camIntrinsics,
-      std::string &mediaPath,
-      bool &hasIntrinsics)
+bool FeedProvider::readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                             std::string& mediaPath, bool& hasIntrinsics)
 {
-  return(_feeder->readImage(imageRGB, camIntrinsics, mediaPath, hasIntrinsics));
+    return (_feeder->readImage(imageRGB, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
-bool FeedProvider::readImage(image::Image<float> &imageGray,
-      camera::PinholeRadialK3 &camIntrinsics,
-      std::string &mediaPath,
-      bool &hasIntrinsics)
+bool FeedProvider::readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                             std::string& mediaPath, bool& hasIntrinsics)
 {
-  return(_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+    return (_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
-bool FeedProvider::readImage(image::Image<unsigned char> &imageGray,
-      camera::PinholeRadialK3 &camIntrinsics,
-      std::string &mediaPath,
-      bool &hasIntrinsics)
+bool FeedProvider::readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                             std::string& mediaPath, bool& hasIntrinsics)
 {
-  return(_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+    return (_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
 std::size_t FeedProvider::nbFrames() const
 {
-  if(_isLiveFeed)
-    return std::numeric_limits<std::size_t>::infinity();
+    if(_isLiveFeed)
+        return std::numeric_limits<std::size_t>::infinity();
 
-  return _feeder->nbFrames();
+    return _feeder->nbFrames();
 }
 
 bool FeedProvider::goToFrame(const unsigned int frame)
 {
-  return _feeder->goToFrame(frame);
+    return _feeder->goToFrame(frame);
 }
 
 bool FeedProvider::goToNextFrame()
 {
-  return _feeder->goToNextFrame();
+    return _feeder->goToNextFrame();
 }
 
 bool FeedProvider::isInit() const
 {
-  return(_feeder->isInit());
+    return (_feeder->isInit());
 }
 
-FeedProvider::~FeedProvider( ) { }
+FeedProvider::~FeedProvider() {}
 
-}//namespace dataio
-}//namespace aliceVision
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/FeedProvider.hpp
+++ b/src/aliceVision/dataio/FeedProvider.hpp
@@ -11,113 +11,106 @@
 #include <string>
 #include <memory>
 
-namespace aliceVision{
-namespace dataio{
+namespace aliceVision
+{
+namespace dataio
+{
 
 class FeedProvider
 {
 public:
+    FeedProvider(const std::string& feedPath, const std::string& calibPath = "");
 
-  FeedProvider(const std::string &feedPath, const std::string &calibPath = "");
+    /**
+     * @brief Provide a new RGB image from the feed.
+     *
+     * @param[out] imageRGB The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original media path, for a video is the path to the
+     * file, for an image sequence is the path to the single image.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageRGB.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  /**
-   * @brief Provide a new RGB image from the feed.
-   * 
-   * @param[out] imageRGB The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original media path, for a video is the path to the 
-   * file, for an image sequence is the path to the single image.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageRGB.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<image::RGBColor> &imageRGB,
-        camera::PinholeRadialK3 &camIntrinsics,
-        std::string &mediaPath,
-        bool &hasIntrinsics);
+    /**
+     * @brief Provide a new float grayscale image from the feed.
+     *
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original media path, for a video is the path to the
+     * file, for an image sequence is the path to the single image.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics, std::string& mediaPath,
+                   bool& hasIntrinsics);
 
-  /**
-   * @brief Provide a new float grayscale image from the feed.
-   *
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original media path, for a video is the path to the
-   * file, for an image sequence is the path to the single image.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<float> &imageGray,
-        camera::PinholeRadialK3 &camIntrinsics,
-        std::string &mediaPath,
-        bool &hasIntrinsics);
+    /**
+     * @brief Provide a new grayscale image from the feed.
+     *
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original media path, for a video is the path to the
+     * file, for an image sequence is the path to the single image.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  /**
-   * @brief Provide a new grayscale image from the feed.
-   * 
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original media path, for a video is the path to the 
-   * file, for an image sequence is the path to the single image.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<unsigned char> &imageGray,
-        camera::PinholeRadialK3 &camIntrinsics,
-        std::string &mediaPath,
-        bool &hasIntrinsics);
+    /**
+     * @brief It returns the number of frames contained of the video. It return infinity
+     * if the feed is a live stream.
+     * @return the number of frames of the video or infinity if it is a live stream.
+     */
+    std::size_t nbFrames() const;
 
-  /**
-   * @brief It returns the number of frames contained of the video. It return infinity
-   * if the feed is a live stream.
-   * @return the number of frames of the video or infinity if it is a live stream.
-   */
-  std::size_t nbFrames() const;
+    /**
+     * @brief It retrieve the given frame number. In case
+     * of live feeds, it just give the next available frame.
+     * @return true if successful.
+     */
+    bool goToFrame(const unsigned int frame);
 
-  /**
-   * @brief It retrieve the given frame number. In case
-   * of live feeds, it just give the next available frame.
-   * @return true if successful.
-   */
-  bool goToFrame(const unsigned int frame);
+    /**
+     * @brief It acquires the next available frame.
+     * @return true if successful.
+     */
+    bool goToNextFrame();
 
-  /**
-   * @brief It acquires the next available frame.
-   * @return true if successful.
-   */  
-  bool goToNextFrame();
+    /**
+     * @brief Return true if the feed is correctly initialized.
+     *
+     * @return True if the feed is correctly initialized.
+     */
+    bool isInit() const;
 
-  /**
-   * @brief Return true if the feed is correctly initialized.
-   * 
-   * @return True if the feed is correctly initialized.
-   */  
-  bool isInit() const;
+    /**
+     * @brief Return true if the feed is a video.
+     *
+     * @return True if the feed is a video.
+     */
+    bool isVideo() const { return _isVideo; }
 
-  /**
-   * @brief Return true if the feed is a video.
-   * 
-   * @return True if the feed is a video.
-   */    
-  bool isVideo() const {return _isVideo; }
+    /**
+     * @brief Return true if the feed is a live stream (e.g. a  webcam).
+     *
+     * @return True if the feed is correctly initialized.
+     */
+    bool isLiveFeed() const { return _isLiveFeed; }
 
-  /**
-   * @brief Return true if the feed is a live stream (e.g. a  webcam).
-   * 
-   * @return True if the feed is correctly initialized.
-   */    
-  bool isLiveFeed() const {return _isLiveFeed; }
-
-  virtual ~FeedProvider();
+    virtual ~FeedProvider();
 
 private:
-  std::unique_ptr<IFeed> _feeder;
-  bool _isVideo;
-  bool _isLiveFeed;
-
+    std::unique_ptr<IFeed> _feeder;
+    bool _isVideo;
+    bool _isLiveFeed;
 };
 
-}//namespace dataio
-}//namespace aliceVision
-
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/IFeed.cpp
+++ b/src/aliceVision/dataio/IFeed.cpp
@@ -11,8 +11,10 @@
 #include <fstream>
 #include <exception>
 
-namespace aliceVision{
-namespace dataio{
+namespace aliceVision
+{
+namespace dataio
+{
 
 // the structure of the file is
 // int #image width
@@ -23,31 +25,30 @@ namespace dataio{
 // double #k0
 // double #k1
 // double #k2
-void readCalibrationFromFile(const std::string &filename, camera::PinholeRadialK3 &camIntrinsics)
+void readCalibrationFromFile(const std::string& filename, camera::PinholeRadialK3& camIntrinsics)
 {
-  std::ifstream fs(filename, std::ios::in);
-  if(!fs.is_open())
-  {
-    ALICEVISION_LOG_WARNING("Unable to open the calibration file " << filename);
-    throw std::invalid_argument("Unable to open the calibration file "+filename);
-  }
-  int width = 0;
-  int height = 0;
-  const size_t numParam = 6;
-  std::vector<double> params(numParam, 0);
+    std::ifstream fs(filename, std::ios::in);
+    if(!fs.is_open())
+    {
+        ALICEVISION_LOG_WARNING("Unable to open the calibration file " << filename);
+        throw std::invalid_argument("Unable to open the calibration file " + filename);
+    }
+    int width = 0;
+    int height = 0;
+    const size_t numParam = 6;
+    std::vector<double> params(numParam, 0);
 
-  fs >> width;
-  fs >> height;
-  for(size_t i = 0; i < numParam; ++i)
-  {
-    fs >> params[i];
-  }
-  camIntrinsics = camera::PinholeRadialK3(width, height,
-                                  params[0], params[1], params[2],
-                                  params[3], params[4], params[5]);
+    fs >> width;
+    fs >> height;
+    for(size_t i = 0; i < numParam; ++i)
+    {
+        fs >> params[i];
+    }
+    camIntrinsics =
+        camera::PinholeRadialK3(width, height, params[0], params[1], params[2], params[3], params[4], params[5]);
 
-  fs.close();
+    fs.close();
 }
 
-}//namespace dataio
-}//namespace aliceVision
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/IFeed.hpp
+++ b/src/aliceVision/dataio/IFeed.hpp
@@ -10,70 +10,65 @@
 #include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/pixelTypes.hpp>
 
-namespace aliceVision{
-namespace dataio{
+namespace aliceVision
+{
+namespace dataio
+{
 
 class IFeed
 {
 public:
-  IFeed() { };
-
-  /**
-   * @brief Return true if the feed is correctly initialized.
-   * @return True if the feed is correctly initialized.
-   */
-  virtual bool isInit() const = 0;
+    IFeed(){};
 
     /**
-   * @brief Provide a new RGB image from the feed
-   * @param[out] imageRGB The new RGB image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original media path.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageRGB.
-   * @return True if there is a new image, false otherwise.
-   */
-  virtual bool readImage(image::Image<image::RGBColor> &imageRGB,
-                    camera::PinholeRadialK3 &camIntrinsics,
-                    std::string &mediaPath,
-                    bool &hasIntrinsics) = 0;
+     * @brief Return true if the feed is correctly initialized.
+     * @return True if the feed is correctly initialized.
+     */
+    virtual bool isInit() const = 0;
 
-  /**
-   * @brief Provide a new float grayscale image from the feed
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original media path.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  virtual bool readImage(image::Image<float> &imageGray,
-                    camera::PinholeRadialK3 &camIntrinsics,
-                    std::string &mediaPath,
-                    bool &hasIntrinsics) = 0;
+    /**
+     * @brief Provide a new RGB image from the feed
+     * @param[out] imageRGB The new RGB image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original media path.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageRGB.
+     * @return True if there is a new image, false otherwise.
+     */
+    virtual bool readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                           std::string& mediaPath, bool& hasIntrinsics) = 0;
 
-  /**
-   * @brief Provide a new grayscale image from the feed
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original media path.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  virtual bool readImage(image::Image<unsigned char> &imageGray,
-                    camera::PinholeRadialK3 &camIntrinsics,
-                    std::string &mediaPath,
-                    bool &hasIntrinsics) = 0;
+    /**
+     * @brief Provide a new float grayscale image from the feed
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original media path.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    virtual bool readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                           std::string& mediaPath, bool& hasIntrinsics) = 0;
 
-  virtual std::size_t nbFrames() const = 0;
+    /**
+     * @brief Provide a new grayscale image from the feed
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original media path.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    virtual bool readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                           std::string& mediaPath, bool& hasIntrinsics) = 0;
 
-  virtual bool goToFrame(const unsigned int frame) = 0;
+    virtual std::size_t nbFrames() const = 0;
 
-  virtual bool goToNextFrame() = 0;
+    virtual bool goToFrame(const unsigned int frame) = 0;
 
-  virtual ~IFeed( ) {}
+    virtual bool goToNextFrame() = 0;
 
+    virtual ~IFeed() {}
 };
 
 //@todo to be move somewhere else more appropriated
@@ -82,8 +77,7 @@ public:
  * @param[in] filename The file containing the calibration parameters.
  * @param[out] camIntrinsics The loaded parameters.
  */
-void readCalibrationFromFile(const std::string &filename, camera::PinholeRadialK3 &camIntrinsics);
+void readCalibrationFromFile(const std::string& filename, camera::PinholeRadialK3& camIntrinsics);
 
-}//namespace dataio
-}//namespace aliceVision
-
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/ImageFeed.cpp
+++ b/src/aliceVision/dataio/ImageFeed.cpp
@@ -11,7 +11,7 @@
 #include <aliceVision/utils/regexFilter.hpp>
 
 #include <boost/filesystem.hpp>
-#include <boost/algorithm/string/case_conv.hpp> 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/replace.hpp>
 
 #include <queue>
@@ -22,387 +22,385 @@
 #include <iterator>
 #include <string>
 
-namespace aliceVision{
-namespace dataio{
+namespace aliceVision
+{
+namespace dataio
+{
 
 class ImageFeed::FeederImpl
 {
 public:
-
-  FeederImpl() : _isInit(false) {}
-
-  FeederImpl(const std::string& imagePath, const std::string& calibPath);
-
-  template<typename T>
-  bool readImage(image::Image<T> &image,
-                   camera::PinholeRadialK3 &camIntrinsics,
-                   std::string &imageName,
-                   bool &hasIntrinsics)
-  {
-    if(!_isInit)
+    FeederImpl()
+        : _isInit(false)
     {
-      ALICEVISION_LOG_WARNING("Image feed is not initialized ");
-      return false;
     }
 
-    // dealing with SFM mode
-    if(_sfmMode)
+    FeederImpl(const std::string& imagePath, const std::string& calibPath);
+
+    template <typename T>
+    bool readImage(image::Image<T>& image, camera::PinholeRadialK3& camIntrinsics, std::string& imageName,
+                   bool& hasIntrinsics)
     {
-      return feedWithJson(image, camIntrinsics, imageName, hasIntrinsics);
+        if(!_isInit)
+        {
+            ALICEVISION_LOG_WARNING("Image feed is not initialized ");
+            return false;
+        }
+
+        // dealing with SFM mode
+        if(_sfmMode)
+        {
+            return feedWithJson(image, camIntrinsics, imageName, hasIntrinsics);
+        }
+        else
+        {
+            if(_images.empty())
+                return false;
+            if(_currentImageIndex >= _images.size())
+                return false;
+
+            if(_withCalibration)
+            {
+                // get the calibration
+                camIntrinsics = _camIntrinsics;
+                hasIntrinsics = true;
+            }
+            else
+            {
+                hasIntrinsics = false;
+            }
+            imageName = _images[_currentImageIndex];
+
+            ALICEVISION_LOG_DEBUG(imageName);
+
+            image::readImage(imageName, image, image::EImageColorSpace::NO_CONVERSION);
+            return true;
+        }
+        return true;
     }
-    else
-    {
-      if(_images.empty())
-        return false;
-      if(_currentImageIndex >= _images.size())
-        return false;
 
-      if(_withCalibration)
-      {
-        // get the calibration
-        camIntrinsics = _camIntrinsics;
-        hasIntrinsics = true;
-      }
-      else
-      {
-        hasIntrinsics = false;
-      }
-      imageName = _images[_currentImageIndex];
+    std::size_t nbFrames() const;
 
-      ALICEVISION_LOG_DEBUG(imageName);
+    bool goToFrame(const unsigned int frame);
 
-      image::readImage(imageName, image, image::EImageColorSpace::NO_CONVERSION);
-      return true;
-    }
-    return true;
-  }
+    bool goToNextFrame();
 
-  std::size_t nbFrames() const;
-
-  bool goToFrame(const unsigned int frame);
-
-  bool goToNextFrame();
-
-  bool isInit() const {return _isInit;}
+    bool isInit() const { return _isInit; }
 
 private:
-
-  template<typename T>
-  bool feedWithJson(image::Image<T> &image,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &imageName,
-                     bool &hasIntrinsics)
-  {
-    // if there are no more images to process
-    if(_viewIterator == _sfmdata.getViews().end())
+    template <typename T>
+    bool feedWithJson(image::Image<T>& image, camera::PinholeRadialK3& camIntrinsics, std::string& imageName,
+                      bool& hasIntrinsics)
     {
-      return false;
+        // if there are no more images to process
+        if(_viewIterator == _sfmdata.getViews().end())
+        {
+            return false;
+        }
+
+        namespace bf = boost::filesystem;
+
+        // get the image
+        const sfmData::View* view = _viewIterator->second.get();
+        imageName = view->getImagePath();
+        image::readImage(imageName, image, image::EImageColorSpace::NO_CONVERSION);
+
+        // get the associated Intrinsics
+        if((view->getIntrinsicId() == UndefinedIndexT) || (!_sfmdata.getIntrinsics().count(view->getIntrinsicId())))
+        {
+            ALICEVISION_LOG_DEBUG("Image " << imageName << " does not have associated intrinsics");
+            hasIntrinsics = false;
+        }
+        else
+        {
+            const camera::IntrinsicBase* cam = _sfmdata.getIntrinsics().at(view->getIntrinsicId()).get();
+            if(cam->getType() != camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3)
+            {
+                ALICEVISION_LOG_WARNING("Only PinholeRadialK3 is supported");
+                hasIntrinsics = false;
+            }
+            else
+            {
+                const camera::PinholeRadialK3* intrinsics = dynamic_cast<const camera::PinholeRadialK3*>(cam);
+
+                // simply copy values
+                camIntrinsics = *intrinsics;
+                hasIntrinsics = true;
+            }
+        }
+        ++_viewIterator;
+        return true;
     }
-
-    namespace bf = boost::filesystem;
-
-    // get the image
-    const sfmData::View *view = _viewIterator->second.get();
-    imageName = view->getImagePath();
-    image::readImage(imageName, image, image::EImageColorSpace::NO_CONVERSION);
-
-    // get the associated Intrinsics
-    if((view->getIntrinsicId() == UndefinedIndexT) || (!_sfmdata.getIntrinsics().count(view->getIntrinsicId())))
-    {
-      ALICEVISION_LOG_DEBUG("Image "<< imageName << " does not have associated intrinsics");
-      hasIntrinsics = false;
-    }
-    else
-    {
-      const camera::IntrinsicBase * cam = _sfmdata.getIntrinsics().at(view->getIntrinsicId()).get();
-      if(cam->getType() != camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3)
-      {
-        ALICEVISION_LOG_WARNING("Only PinholeRadialK3 is supported");
-        hasIntrinsics = false;
-      }
-      else
-      {
-        const camera::PinholeRadialK3 * intrinsics = dynamic_cast<const camera::PinholeRadialK3*>(cam);
-
-        // simply copy values
-        camIntrinsics = *intrinsics;
-        hasIntrinsics = true;
-      }
-    }
-    ++_viewIterator;
-    return true;
-  }
 
 private:
-  bool _isInit;
-  bool _withCalibration;
-  // It contains the images to be fed
-  std::vector<std::string> _images;
-  camera::PinholeRadialK3 _camIntrinsics;
+    bool _isInit;
+    bool _withCalibration;
+    // It contains the images to be fed
+    std::vector<std::string> _images;
+    camera::PinholeRadialK3 _camIntrinsics;
 
-  bool _sfmMode = false;
-  sfmData::SfMData _sfmdata;
-  sfmData::Views::const_iterator _viewIterator;
-  unsigned int _currentImageIndex = 0;
+    bool _sfmMode = false;
+    sfmData::SfMData _sfmdata;
+    sfmData::Views::const_iterator _viewIterator;
+    unsigned int _currentImageIndex = 0;
 };
 
 ImageFeed::FeederImpl::FeederImpl(const std::string& imagePath, const std::string& calibPath)
-: _isInit(false)
-, _withCalibration(false)
+    : _isInit(false)
+    , _withCalibration(false)
 {
-  namespace bf = boost::filesystem;
-//    ALICEVISION_LOG_DEBUG(imagePath);
-  // if it is a json, calibPath is neglected
-  if(bf::is_regular_file(imagePath))
-  {
-    const std::string ext = bf::path(imagePath).extension().string();
-    // if it is a sfmdata.json
-    if(ext == ".json")
+    namespace bf = boost::filesystem;
+    //    ALICEVISION_LOG_DEBUG(imagePath);
+    // if it is a json, calibPath is neglected
+    if(bf::is_regular_file(imagePath))
     {
-      // load the json
-      _isInit = sfmDataIO::Load(_sfmdata, imagePath, sfmDataIO::ESfMData(sfmDataIO::ESfMData::VIEWS | sfmDataIO::ESfMData::INTRINSICS));
-      _viewIterator = _sfmdata.getViews().begin();
-      _sfmMode = true;
+        const std::string ext = bf::path(imagePath).extension().string();
+        // if it is a sfmdata.json
+        if(ext == ".json")
+        {
+            // load the json
+            _isInit = sfmDataIO::Load(
+                _sfmdata, imagePath, sfmDataIO::ESfMData(sfmDataIO::ESfMData::VIEWS | sfmDataIO::ESfMData::INTRINSICS));
+            _viewIterator = _sfmdata.getViews().begin();
+            _sfmMode = true;
+        }
+        // if it is an image file
+        else if(image::isSupported(ext) && !image::isVideoExtension(ext))
+        {
+            _images.push_back(imagePath);
+            _withCalibration = !calibPath.empty();
+            _sfmMode = false;
+            _isInit = true;
+        }
+        // if it is an image file
+        else if(ext == ".txt")
+        {
+            // we expect a simple txt file with a list of path to images relative to the
+            // location of the txt file itself
+            std::fstream fs(imagePath, std::ios::in);
+            std::string line;
+            // parse each line of the text file
+            while(getline(fs, line))
+            {
+                // compose the file name as the base path of the inputPath and
+                // the filename just read
+                const std::string filename = (bf::path(imagePath).parent_path() / line).string();
+                _images.push_back(filename);
+            }
+            // Close file
+            fs.close();
+            _withCalibration = !calibPath.empty();
+            _sfmMode = false;
+            _isInit = true;
+        }
+        else
+        {
+            // no other file format are supported
+            throw std::invalid_argument("File or mode not yet implemented");
+        }
     }
-    // if it is an image file
-    else if(image::isSupported(ext) && !image::isVideoExtension(ext))
+    else if(bf::is_directory(imagePath) || bf::is_directory(bf::path(imagePath).parent_path()))
     {
-      _images.push_back(imagePath);
-      _withCalibration = !calibPath.empty();
-      _sfmMode = false;
-      _isInit = true;
-    }
-    // if it is an image file
-    else if(ext == ".txt")
-    {
-      // we expect a simple txt file with a list of path to images relative to the
-      // location of the txt file itself
-      std::fstream fs(imagePath, std::ios::in);
-      std::string line;
-      // parse each line of the text file
-      while(getline(fs, line))
-      {
-        // compose the file name as the base path of the inputPath and
-        // the filename just read
-        const std::string filename = (bf::path(imagePath).parent_path() / line).string();
-        _images.push_back(filename);
-      }
-      // Close file
-      fs.close();
-      _withCalibration = !calibPath.empty();
-      _sfmMode = false;
-      _isInit = true;
+        std::string folder = imagePath;
+        // Recover the pattern : img.@.png (for example)
+        std::string filePattern;
+        std::regex re;
+        if(!bf::is_directory(imagePath))
+        {
+            filePattern = bf::path(imagePath).filename().string();
+            folder = bf::path(imagePath).parent_path().string();
+            ALICEVISION_LOG_DEBUG("filePattern: " << filePattern);
+            std::string regexStr = filePattern;
+            re = utils::filterToRegex(regexStr);
+        }
+        else
+        {
+            ALICEVISION_LOG_DEBUG("folder without expression: " << imagePath);
+        }
+        ALICEVISION_LOG_DEBUG("directory feedImage");
+        // if it is a directory, list all the images and add them to the list
+        bf::directory_iterator iterator(folder);
+        // since some OS will provide the files in a random order, first store them
+        // in a priority queue and then fill the _image queue with the alphabetical
+        // order from the priority queue
+        std::priority_queue<std::string, std::vector<std::string>, std::greater<std::string>> tmpSorter;
+        for(; iterator != bf::directory_iterator(); ++iterator)
+        {
+            // get the extension of the current file to check whether it is an image
+            const std::string ext = iterator->path().extension().string();
+            if(image::isSupported(ext) && !image::isVideoExtension(ext))
+            {
+                const std::string filepath = iterator->path().string();
+                const std::string filename = iterator->path().filename().string();
+                // If we have a filePattern (a sequence of images), we have to match the regex.
+                if(filePattern.empty() || std::regex_match(filename, re))
+                    tmpSorter.push(filepath);
+            }
+            else
+            {
+                ALICEVISION_LOG_WARNING("Unsupported file extension " << ext << " for " << iterator->path().string()
+                                                                      << ".");
+            }
+        }
+        // put all the retrieve files inside the queue
+        while(!tmpSorter.empty())
+        {
+            _images.push_back(tmpSorter.top());
+            tmpSorter.pop();
+        }
+
+        _withCalibration = !calibPath.empty();
+        _sfmMode = false;
+        _isInit = true;
     }
     else
     {
-      // no other file format are supported
-      throw std::invalid_argument("File or mode not yet implemented");
-    }
-  }
-  else if(bf::is_directory(imagePath) || bf::is_directory(bf::path(imagePath).parent_path()))
-  {
-    std::string folder = imagePath;
-    // Recover the pattern : img.@.png (for example)
-    std::string filePattern;
-    std::regex re;
-    if(!bf::is_directory(imagePath))
-    {
-      filePattern = bf::path(imagePath).filename().string();
-      folder = bf::path(imagePath).parent_path().string();
-      ALICEVISION_LOG_DEBUG("filePattern: " << filePattern);
-      std::string regexStr = filePattern;
-      re = utils::filterToRegex(regexStr);
-    }
-    else
-    {
-      ALICEVISION_LOG_DEBUG("folder without expression: " << imagePath);
-    }
-    ALICEVISION_LOG_DEBUG("directory feedImage");
-    // if it is a directory, list all the images and add them to the list
-    bf::directory_iterator iterator(folder);
-    // since some OS will provide the files in a random order, first store them
-    // in a priority queue and then fill the _image queue with the alphabetical
-    // order from the priority queue
-    std::priority_queue<std::string,
-                    std::vector<std::string>,
-                    std::greater<std::string> > tmpSorter;
-    for(; iterator != bf::directory_iterator(); ++iterator)
-    {
-      // get the extension of the current file to check whether it is an image
-      const std::string ext = iterator->path().extension().string();
-      if(image::isSupported(ext) && !image::isVideoExtension(ext))
-      {
-        const std::string filepath = iterator->path().string();
-        const std::string filename = iterator->path().filename().string();
-        // If we have a filePattern (a sequence of images), we have to match the regex.
-        if(filePattern.empty() || std::regex_match(filename, re))
-          tmpSorter.push(filepath);
-      }
-      else
-      {
-        ALICEVISION_LOG_WARNING("Unsupported file extension " << ext << " for " << iterator->path().string() << ".");
-      }
-    }
-    // put all the retrieve files inside the queue
-    while(!tmpSorter.empty())
-    {
-      _images.push_back(tmpSorter.top());
-      tmpSorter.pop();
+        throw std::invalid_argument("File or mode not yet implemented");
     }
 
-    _withCalibration = !calibPath.empty();
-    _sfmMode = false;
-    _isInit = true;
-  }
-  else
-  {
-    throw std::invalid_argument("File or mode not yet implemented");
-  }
-
-  // last thing: if _withCalibration is true it means that it is not a json and
-  // a path to a calibration file has been passed
-  // then load the calibration
-  if(_withCalibration)
-  {
-    // load the calibration from calibPath
-    readCalibrationFromFile(calibPath, _camIntrinsics);
-  }
+    // last thing: if _withCalibration is true it means that it is not a json and
+    // a path to a calibration file has been passed
+    // then load the calibration
+    if(_withCalibration)
+    {
+        // load the calibration from calibPath
+        readCalibrationFromFile(calibPath, _camIntrinsics);
+    }
 }
 
 std::size_t ImageFeed::FeederImpl::nbFrames() const
 {
-  if(!_isInit)
-    return 0;
+    if(!_isInit)
+        return 0;
 
-  if(_sfmMode)
-    return _sfmdata.getViews().size();
+    if(_sfmMode)
+        return _sfmdata.getViews().size();
 
-  return _images.size();
+    return _images.size();
 }
 
 bool ImageFeed::FeederImpl::goToFrame(const unsigned int frame)
 {
-  if(!_isInit)
-  {
-    _currentImageIndex = frame;
-    ALICEVISION_LOG_WARNING("Image feed is not initialized");
-    return false;
-  }
-
-  // Reconstruction mode
-  if(_sfmMode)
-  {
-    if(frame >= _sfmdata.getViews().size())
+    if(!_isInit)
     {
-      _viewIterator = _sfmdata.getViews().end();
-      ALICEVISION_LOG_WARNING("The current frame is out of the range.");
-      return false;
+        _currentImageIndex = frame;
+        ALICEVISION_LOG_WARNING("Image feed is not initialized");
+        return false;
     }
 
-    _viewIterator = _sfmdata.getViews().begin();
-    std::advance(_viewIterator, frame);
-  }
-  else
-  {
-    _currentImageIndex = frame;
-    // Image list mode
-    if(frame >= _images.size())
+    // Reconstruction mode
+    if(_sfmMode)
     {
-      ALICEVISION_LOG_WARNING("The current frame is out of the range.");
-      return false;
+        if(frame >= _sfmdata.getViews().size())
+        {
+            _viewIterator = _sfmdata.getViews().end();
+            ALICEVISION_LOG_WARNING("The current frame is out of the range.");
+            return false;
+        }
+
+        _viewIterator = _sfmdata.getViews().begin();
+        std::advance(_viewIterator, frame);
     }
-    ALICEVISION_LOG_DEBUG("frame " << frame);
-  }
-  return true;
+    else
+    {
+        _currentImageIndex = frame;
+        // Image list mode
+        if(frame >= _images.size())
+        {
+            ALICEVISION_LOG_WARNING("The current frame is out of the range.");
+            return false;
+        }
+        ALICEVISION_LOG_DEBUG("frame " << frame);
+    }
+    return true;
 }
 
 bool ImageFeed::FeederImpl::goToNextFrame()
 {
-  if(_sfmMode)
-  {
-    if(_viewIterator == _sfmdata.getViews().end())
-      return false;
-    ++_viewIterator;
-    if(_viewIterator == _sfmdata.getViews().end())
-      return false;
-  }
-  else
-  {
-    ++_currentImageIndex;
-    ALICEVISION_LOG_DEBUG("next frame " << _currentImageIndex);
-    if(_currentImageIndex >= _images.size())
-      return false;
-  }
-  return true;
+    if(_sfmMode)
+    {
+        if(_viewIterator == _sfmdata.getViews().end())
+            return false;
+        ++_viewIterator;
+        if(_viewIterator == _sfmdata.getViews().end())
+            return false;
+    }
+    else
+    {
+        ++_currentImageIndex;
+        ALICEVISION_LOG_DEBUG("next frame " << _currentImageIndex);
+        if(_currentImageIndex >= _images.size())
+            return false;
+    }
+    return true;
 }
 
 /*******************************************************************************/
 /*                     ImageFeed                                               */
 /*******************************************************************************/
 
-ImageFeed::ImageFeed() : _imageFeed(new FeederImpl()) { }
+ImageFeed::ImageFeed()
+    : _imageFeed(new FeederImpl())
+{
+}
 
 ImageFeed::ImageFeed(const std::string& imagePath, const std::string& calibPath)
-    : _imageFeed( new FeederImpl(imagePath, calibPath) ) { }
-
-bool ImageFeed::readImage(image::Image<image::RGBColor> &imageRGB,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics)
+    : _imageFeed(new FeederImpl(imagePath, calibPath))
 {
-  return(_imageFeed->readImage(imageRGB, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
-bool ImageFeed::readImage(image::Image<float> &imageGray,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics)
+bool ImageFeed::readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                          std::string& mediaPath, bool& hasIntrinsics)
 {
-  return(_imageFeed->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+    return (_imageFeed->readImage(imageRGB, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
-bool ImageFeed::readImage(image::Image<unsigned char> &imageGray,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics)
+bool ImageFeed::readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                          std::string& mediaPath, bool& hasIntrinsics)
 {
-  return(_imageFeed->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+    return (_imageFeed->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+}
+
+bool ImageFeed::readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                          std::string& mediaPath, bool& hasIntrinsics)
+{
+    return (_imageFeed->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
 std::size_t ImageFeed::nbFrames() const
 {
-  return _imageFeed->nbFrames();
+    return _imageFeed->nbFrames();
 }
 
 bool ImageFeed::goToFrame(const unsigned int frame)
 {
-  return _imageFeed->goToFrame(frame);
+    return _imageFeed->goToFrame(frame);
 }
 
 bool ImageFeed::goToNextFrame()
 {
-  return _imageFeed->goToNextFrame();
+    return _imageFeed->goToNextFrame();
 }
 
 bool ImageFeed::isInit() const
 {
-  return(_imageFeed->isInit());
+    return (_imageFeed->isInit());
 }
 
-bool ImageFeed::isSupported(const std::string &extension)
+bool ImageFeed::isSupported(const std::string& extension)
 {
-  std::string ext = boost::to_lower_copy(extension);
-  if(ext == ".json" || ext == ".txt")
-  {
-    return true;
-  }
-  else
-  {
-    return (image::isSupported(ext) && !image::isVideoExtension(ext));
-  }
+    std::string ext = boost::to_lower_copy(extension);
+    if(ext == ".json" || ext == ".txt")
+    {
+        return true;
+    }
+    else
+    {
+        return (image::isSupported(ext) && !image::isVideoExtension(ext));
+    }
 }
 
-ImageFeed::~ImageFeed() { }
+ImageFeed::~ImageFeed() {}
 
-}//namespace dataio
-}//namespace aliceVision
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/ImageFeed.hpp
+++ b/src/aliceVision/dataio/ImageFeed.hpp
@@ -27,11 +27,10 @@ public:
     /**
      * @brief Set up an image based feed from a choice of different sources:
      * 1) a directory containing images
-     * 2) a json file containing a sfm data reconstruction (in that case \p calibPath is ignored)
      * 3) a txt file containing a list of images to use
      * 4) a regex for an image sequence
      *
-     * @param[in] imagePath The source of images, it could be a file (json, txt) or a directory.
+     * @param[in] imagePath The source of images, it could be a txt file or a directory.
      * @param[in] calibPath The source for the camera intrinsics common to each image.
      * The format for the file is
      * int #image width
@@ -103,7 +102,7 @@ public:
 
     /**
      * @brief For a given extension, return true if that file can be used as input
-     * for the feed. ImageFeed supports .json, .txt, and the most common image files.
+     * for the feed. ImageFeed supports .txt and the most common image files.
      *
      * @param extension The file extension to check in ".ext" format (case insensitive)
      * @return True if the file is supported.

--- a/src/aliceVision/dataio/ImageFeed.hpp
+++ b/src/aliceVision/dataio/ImageFeed.hpp
@@ -11,115 +11,109 @@
 #include <string>
 #include <memory>
 
-namespace aliceVision{
-namespace dataio{
+namespace aliceVision
+{
+namespace dataio
+{
 
 class ImageFeed : public IFeed
 {
 public:
-  /**
-   * @brief Empty constructor
-   */	
-  ImageFeed();
+    /**
+     * @brief Empty constructor
+     */
+    ImageFeed();
 
-  /**
-   * @brief Set up an image based feed from a choice of different sources:
-   * 1) a directory containing images
-   * 2) a json file containing a sfm data reconstruction (in that case \p calibPath is ignored)
-   * 3) a txt file containing a list of images to use
-   * 4) a regex for an image sequence
-   * 
-   * @param[in] imagePath The source of images, it could be a file (json, txt) or a directory.
-   * @param[in] calibPath The source for the camera intrinsics common to each image. 
-   * The format for the file is
-   * int #image width
-   * int #image height
-   * double #focal
-   * double #ppx principal point x-coord
-   * double #ppy principal point y-coord
-   * double #k0
-   * double #k1
-   * double #k2
-   * 
-   * @see readCalibrationFromFile()
-   */
-  ImageFeed(const std::string& imagePath, const std::string& calibPath);
+    /**
+     * @brief Set up an image based feed from a choice of different sources:
+     * 1) a directory containing images
+     * 2) a json file containing a sfm data reconstruction (in that case \p calibPath is ignored)
+     * 3) a txt file containing a list of images to use
+     * 4) a regex for an image sequence
+     *
+     * @param[in] imagePath The source of images, it could be a file (json, txt) or a directory.
+     * @param[in] calibPath The source for the camera intrinsics common to each image.
+     * The format for the file is
+     * int #image width
+     * int #image height
+     * double #focal
+     * double #ppx principal point x-coord
+     * double #ppy principal point y-coord
+     * double #k0
+     * double #k1
+     * double #k2
+     *
+     * @see readCalibrationFromFile()
+     */
+    ImageFeed(const std::string& imagePath, const std::string& calibPath);
 
-  /**
-   * @brief Provide a new RGB image from the feed
-   * 
-   * @param[out] imageRGB The new RGB image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The path to the current image.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageRGB.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<image::RGBColor> &imageRGB,
-            camera::PinholeRadialK3 &camIntrinsics,
-            std::string &mediaPath,
-            bool &hasIntrinsics);
+    /**
+     * @brief Provide a new RGB image from the feed
+     *
+     * @param[out] imageRGB The new RGB image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The path to the current image.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageRGB.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  /**
-   * @brief Provide a new float grayscale image from the feed
-   *
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The path to the current image.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<float> &imageGray,
-            camera::PinholeRadialK3 &camIntrinsics,
-            std::string &mediaPath,
-            bool &hasIntrinsics);
+    /**
+     * @brief Provide a new float grayscale image from the feed
+     *
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The path to the current image.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics, std::string& mediaPath,
+                   bool& hasIntrinsics);
 
-  /**
-   * @brief Provide a new grayscale image from the feed
-   * 
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The path to the current image.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<unsigned char> &imageGray,
-            camera::PinholeRadialK3 &camIntrinsics,
-            std::string &mediaPath,
-            bool &hasIntrinsics);
+    /**
+     * @brief Provide a new grayscale image from the feed
+     *
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The path to the current image.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  std::size_t nbFrames() const;
+    std::size_t nbFrames() const;
 
-  bool goToFrame(const unsigned int frame);
+    bool goToFrame(const unsigned int frame);
 
-  bool goToNextFrame();
+    bool goToNextFrame();
 
-  /**
-   * @brief Return true if the feed is correctly initialized.
-   * 
-   * @return True if the feed is correctly initialized.
-   */
-  bool isInit() const;
+    /**
+     * @brief Return true if the feed is correctly initialized.
+     *
+     * @return True if the feed is correctly initialized.
+     */
+    bool isInit() const;
 
-  virtual ~ImageFeed( );
+    virtual ~ImageFeed();
 
-  /**
-   * @brief For a given extension, return true if that file can be used as input
-   * for the feed. ImageFeed supports .json, .txt, and the most common image files. 
-   * 
-   * @param extension The file extension to check in ".ext" format (case insensitive)
-   * @return True if the file is supported.
-   */
-  static bool isSupported(const std::string &extension);
+    /**
+     * @brief For a given extension, return true if that file can be used as input
+     * for the feed. ImageFeed supports .json, .txt, and the most common image files.
+     *
+     * @param extension The file extension to check in ".ext" format (case insensitive)
+     * @return True if the file is supported.
+     */
+    static bool isSupported(const std::string& extension);
 
 private:
-  class FeederImpl;
-  std::unique_ptr<FeederImpl> _imageFeed;
+    class FeederImpl;
+    std::unique_ptr<FeederImpl> _imageFeed;
 };
 
-}//namespace dataio
-}//namespace aliceVision
-
-
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/SfMDataFeed.cpp
+++ b/src/aliceVision/dataio/SfMDataFeed.cpp
@@ -1,0 +1,187 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "SfMDataFeed.hpp"
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/image/io.hpp>
+
+#include <boost/algorithm/string/case_conv.hpp>
+
+#include <exception>
+#include <iterator>
+#include <string>
+
+namespace aliceVision
+{
+namespace dataio
+{
+
+class SfMDataFeed::FeederImpl
+{
+public:
+    FeederImpl()
+        : _isInit(false)
+    {
+    }
+
+    FeederImpl(const std::string& imagePath, const std::string& calibPath);
+
+    template <typename T>
+    bool readImage(image::Image<T>& image, camera::PinholeRadialK3& camIntrinsics, std::string& imageName,
+                   bool& hasIntrinsics)
+    {
+        if(!_isInit)
+        {
+            ALICEVISION_LOG_WARNING("SfMData feed is not initialized ");
+            return false;
+        }
+
+        if(_currentImageIndex >= _views.size())
+        {
+            ALICEVISION_LOG_WARNING("No more images to process");
+            return false;
+        }
+
+        // Get the image path
+        const sfmData::View* view = _views.at(_currentImageIndex);
+        imageName = view->getImagePath();
+        image::readImage(imageName, image, image::EImageColorSpace::NO_CONVERSION);
+
+        return true;
+    }
+
+    std::size_t nbFrames() const;
+
+    bool goToFrame(const unsigned int frame);
+
+    bool goToNextFrame();
+
+    bool isInit() const { return _isInit; }
+
+private:
+    bool _isInit;
+
+    sfmData::SfMData _sfmData;
+    std::vector<const sfmData::View*> _views;
+    unsigned int _currentImageIndex = 0;
+};
+
+SfMDataFeed::FeederImpl::FeederImpl(const std::string& imagePath, const std::string& calibPath)
+    : _isInit(false)
+{
+    _isInit = sfmDataIO::Load(_sfmData, imagePath,
+                              sfmDataIO::ESfMData(sfmDataIO::ESfMData::VIEWS | sfmDataIO::ESfMData::INTRINSICS));
+
+    // Order the views according to the frame ID
+    for(auto it = _sfmData.getViews().begin(); it != _sfmData.getViews().end(); ++it)
+    {
+        _views.push_back(it->second.get());
+    }
+    std::sort(_views.begin(), _views.end(),
+              [](const sfmData::View* v1, const sfmData::View* v2) { return (v1->getFrameId() < v2->getFrameId()); });
+}
+
+std::size_t SfMDataFeed::FeederImpl::nbFrames() const
+{
+    if(!_isInit)
+        return 0;
+
+    return _views.size();
+}
+
+bool SfMDataFeed::FeederImpl::goToFrame(const unsigned int frame)
+{
+    _currentImageIndex = frame;
+    if(!_isInit)
+    {
+        ALICEVISION_LOG_WARNING("SfmData feed is not initialized");
+        return false;
+    }
+
+    if(frame >= _views.size())
+    {
+        ALICEVISION_LOG_WARNING("The current frame is out of the range.");
+        return false;
+    }
+
+    return true;
+}
+
+bool SfMDataFeed::FeederImpl::goToNextFrame()
+{
+    ++_currentImageIndex;
+    ALICEVISION_LOG_DEBUG("next frame " << _currentImageIndex);
+    if(_currentImageIndex >= _views.size())
+        return false;
+
+    return true;
+
+    return true;
+}
+
+/*******************************************************************************/
+/*                     SfMDataFeed                                               */
+/*******************************************************************************/
+
+SfMDataFeed::SfMDataFeed()
+    : _sfmDataFeed(new FeederImpl())
+{
+}
+
+SfMDataFeed::SfMDataFeed(const std::string& imagePath, const std::string& calibPath)
+    : _sfmDataFeed(new FeederImpl(imagePath, calibPath))
+{
+}
+
+bool SfMDataFeed::readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                            std::string& mediaPath, bool& hasIntrinsics)
+{
+    return (_sfmDataFeed->readImage(imageRGB, camIntrinsics, mediaPath, hasIntrinsics));
+}
+
+bool SfMDataFeed::readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                            std::string& mediaPath, bool& hasIntrinsics)
+{
+    return (_sfmDataFeed->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+}
+
+bool SfMDataFeed::readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                            std::string& mediaPath, bool& hasIntrinsics)
+{
+    return (_sfmDataFeed->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+}
+
+std::size_t SfMDataFeed::nbFrames() const
+{
+    return _sfmDataFeed->nbFrames();
+}
+
+bool SfMDataFeed::goToFrame(const unsigned int frame)
+{
+    return _sfmDataFeed->goToFrame(frame);
+}
+
+bool SfMDataFeed::goToNextFrame()
+{
+    return _sfmDataFeed->goToNextFrame();
+}
+
+bool SfMDataFeed::isInit() const
+{
+    return (_sfmDataFeed->isInit());
+}
+
+bool SfMDataFeed::isSupported(const std::string& extension)
+{
+    std::string ext = boost::to_lower_copy(extension);
+    return (ext == ".sfm" || ext == ".abc" || ext == ".json");
+}
+
+SfMDataFeed::~SfMDataFeed() {}
+
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/VideoFeed.cpp
+++ b/src/aliceVision/dataio/VideoFeed.cpp
@@ -18,280 +18,279 @@
 #include <iostream>
 #include <exception>
 
-namespace aliceVision{
-namespace dataio{
+namespace aliceVision
+{
+namespace dataio
+{
 
 class VideoFeed::FeederImpl
 {
 public:
-  FeederImpl() : _isInit(false) { }
+    FeederImpl()
+        : _isInit(false)
+    {
+    }
 
-  FeederImpl(const std::string &videoPath, const std::string &calibPath);
+    FeederImpl(const std::string& videoPath, const std::string& calibPath);
 
-  FeederImpl(int videoDevice, const std::string &calibPath);
+    FeederImpl(int videoDevice, const std::string& calibPath);
 
-  bool isInit() const {return _isInit;}
+    bool isInit() const { return _isInit; }
 
-  bool readImage(image::Image<image::RGBColor> &imageRGB,
-                   camera::PinholeRadialK3 &camIntrinsics,
-                   std::string &mediaPath,
-                   bool &hasIntrinsics);
+    bool readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  bool readImage(image::Image<float> &imageGray,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics);
+    bool readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics, std::string& mediaPath,
+                   bool& hasIntrinsics);
 
-  bool readImage(image::Image<unsigned char> &imageGray,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics);
+    bool readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  bool goToFrame(const unsigned int frame);
+    bool goToFrame(const unsigned int frame);
 
-  bool goToNextFrame();
+    bool goToNextFrame();
 
-  std::size_t nbFrames() const;
+    std::size_t nbFrames() const;
 
 private:
-  bool _isInit;
-  bool _isLive;
-  bool _withIntrinsics;
-  std::string _videoPath;
-  cv::VideoCapture _videoCapture;
-  camera::PinholeRadialK3 _camIntrinsics;
+    bool _isInit;
+    bool _isLive;
+    bool _withIntrinsics;
+    std::string _videoPath;
+    cv::VideoCapture _videoCapture;
+    camera::PinholeRadialK3 _camIntrinsics;
 };
 
-
-VideoFeed::FeederImpl::FeederImpl(const std::string &videoPath, const std::string &calibPath)
-: _isInit(false), _isLive(false), _withIntrinsics(false), _videoPath(videoPath)
+VideoFeed::FeederImpl::FeederImpl(const std::string& videoPath, const std::string& calibPath)
+    : _isInit(false)
+    , _isLive(false)
+    , _withIntrinsics(false)
+    , _videoPath(videoPath)
 {
     // load the video
-  _videoCapture.open(videoPath);
-  if (!_videoCapture.isOpened())
-  {
-    ALICEVISION_LOG_WARNING("Unable to open the video : " << videoPath);
-    throw std::invalid_argument("Unable to open the video : "+videoPath);
-  }
-  // Grab frame 0, so we can call readImage.
-  goToFrame(0);
-
-  // load the calibration path
-  _withIntrinsics = !calibPath.empty();
-  if(_withIntrinsics)
-    readCalibrationFromFile(calibPath, _camIntrinsics);
-
-  _isInit = true;
-}
-
-VideoFeed::FeederImpl::FeederImpl(int videoDevice, const std::string &calibPath)
-: _isInit(false), _isLive(true), _withIntrinsics(false), _videoPath(std::to_string(videoDevice))
-{
-    // load the video
-  _videoCapture.open(videoDevice);
-  if (!_videoCapture.isOpened())
-  {
-    ALICEVISION_LOG_WARNING("Unable to open the video : " << _videoPath);
-    throw std::invalid_argument("Unable to open the video : "+_videoPath);
-  }
-
-  goToNextFrame();
-
-  // load the calibration path
-  _withIntrinsics = !calibPath.empty();
-  if(_withIntrinsics)
-    readCalibrationFromFile(calibPath, _camIntrinsics);
-
-  _isInit = true;
-}
-
-bool VideoFeed::FeederImpl::readImage(image::Image<image::RGBColor> &imageRGB,
-          camera::PinholeRadialK3 &camIntrinsics,
-          std::string &mediaPath,
-          bool &hasIntrinsics)
-{
-  cv::Mat frame;
-  const bool grabStatus = _videoCapture.retrieve(frame);
-
-  if(!grabStatus || !frame.data)
-  {
-    return false;
-  }
-
-  if(frame.channels() == 3)
-  {
-    cv::Mat color;
-    resize(frame, color, cv::Size(frame.cols, frame.rows));
-
-    cv::cvtColor(frame, color, cv::COLOR_BGR2RGB);
-    imageRGB.resize(color.cols, color.rows);
-
-    unsigned char* pixelPtr = (unsigned char*)color.data;
-    for(int i = 0; i < color.rows; i++)
+    _videoCapture.open(videoPath);
+    if(!_videoCapture.isOpened())
     {
-      for(int j = 0; j < color.cols; j++)
-      {
-        const size_t index = i*color.cols*3 + j*3;
-        imageRGB(i,j) = image::RGBColor(pixelPtr[index], pixelPtr[index + 1], pixelPtr[index + 2]);
-      }
+        ALICEVISION_LOG_WARNING("Unable to open the video : " << videoPath);
+        throw std::invalid_argument("Unable to open the video : " + videoPath);
     }
-  }
-  else
-  {
-    ALICEVISION_LOG_WARNING("Error can't read RGB frame " << _videoPath);
-    throw std::invalid_argument("Error can't read RGB frame " + _videoPath);
-  }
+    // Grab frame 0, so we can call readImage.
+    goToFrame(0);
 
-  hasIntrinsics = _withIntrinsics;
-  if(_withIntrinsics)
-    camIntrinsics = _camIntrinsics;
+    // load the calibration path
+    _withIntrinsics = !calibPath.empty();
+    if(_withIntrinsics)
+        readCalibrationFromFile(calibPath, _camIntrinsics);
 
-  mediaPath = _videoPath;
-  return true;
+    _isInit = true;
 }
 
-bool VideoFeed::FeederImpl::readImage(image::Image<float> &imageGray,
-          camera::PinholeRadialK3 &camIntrinsics,
-          std::string &mediaPath,
-          bool &hasIntrinsics)
+VideoFeed::FeederImpl::FeederImpl(int videoDevice, const std::string& calibPath)
+    : _isInit(false)
+    , _isLive(true)
+    , _withIntrinsics(false)
+    , _videoPath(std::to_string(videoDevice))
 {
-  image::Image<unsigned char> imageGrayUChar;
-  if(FeederImpl::readImage(imageGrayUChar, camIntrinsics, mediaPath, hasIntrinsics))
-  {
-    imageGray = (imageGrayUChar.GetMat().cast<float>() / 255.f);
+    // load the video
+    _videoCapture.open(videoDevice);
+    if(!_videoCapture.isOpened())
+    {
+        ALICEVISION_LOG_WARNING("Unable to open the video : " << _videoPath);
+        throw std::invalid_argument("Unable to open the video : " + _videoPath);
+    }
+
+    goToNextFrame();
+
+    // load the calibration path
+    _withIntrinsics = !calibPath.empty();
+    if(_withIntrinsics)
+        readCalibrationFromFile(calibPath, _camIntrinsics);
+
+    _isInit = true;
+}
+
+bool VideoFeed::FeederImpl::readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                                      std::string& mediaPath, bool& hasIntrinsics)
+{
+    cv::Mat frame;
+    const bool grabStatus = _videoCapture.retrieve(frame);
+
+    if(!grabStatus || !frame.data)
+    {
+        return false;
+    }
+
+    if(frame.channels() == 3)
+    {
+        cv::Mat color;
+        resize(frame, color, cv::Size(frame.cols, frame.rows));
+
+        cv::cvtColor(frame, color, cv::COLOR_BGR2RGB);
+        imageRGB.resize(color.cols, color.rows);
+
+        unsigned char* pixelPtr = (unsigned char*)color.data;
+        for(int i = 0; i < color.rows; i++)
+        {
+            for(int j = 0; j < color.cols; j++)
+            {
+                const size_t index = i * color.cols * 3 + j * 3;
+                imageRGB(i, j) = image::RGBColor(pixelPtr[index], pixelPtr[index + 1], pixelPtr[index + 2]);
+            }
+        }
+    }
+    else
+    {
+        ALICEVISION_LOG_WARNING("Error can't read RGB frame " << _videoPath);
+        throw std::invalid_argument("Error can't read RGB frame " + _videoPath);
+    }
+
+    hasIntrinsics = _withIntrinsics;
+    if(_withIntrinsics)
+        camIntrinsics = _camIntrinsics;
+
+    mediaPath = _videoPath;
     return true;
-  }
-  return false;
 }
 
-
-bool VideoFeed::FeederImpl::readImage(image::Image<unsigned char> &imageGray,
-                   camera::PinholeRadialK3 &camIntrinsics,
-                   std::string &mediaPath,
-                   bool &hasIntrinsics)
+bool VideoFeed::FeederImpl::readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                                      std::string& mediaPath, bool& hasIntrinsics)
 {
-  cv::Mat frame;
-  const bool grabStatus = _videoCapture.retrieve(frame);
-
-  if(!grabStatus || !frame.data)
-  {
+    image::Image<unsigned char> imageGrayUChar;
+    if(FeederImpl::readImage(imageGrayUChar, camIntrinsics, mediaPath, hasIntrinsics))
+    {
+        imageGray = (imageGrayUChar.GetMat().cast<float>() / 255.f);
+        return true;
+    }
     return false;
-  }
+}
 
-  if(frame.channels() == 3)
-  {
-    // convert to gray
-    cv::Mat grey;
-    cv::cvtColor(frame, grey, cv::COLOR_BGR2GRAY);
-    imageGray.resize(grey.cols, grey.rows);
-    cv::cv2eigen(grey, imageGray);
-//      ALICEVISION_LOG_DEBUG(grey.channels() << " " << grey.rows << " " << grey.cols);
-//      ALICEVISION_LOG_DEBUG(imageGray.Depth() << " " << imageGray.Height() << " " << imageGray.Width());
-  }
-  else
-  {
-    cv::cv2eigen(frame, imageGray);
-  }
+bool VideoFeed::FeederImpl::readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                                      std::string& mediaPath, bool& hasIntrinsics)
+{
+    cv::Mat frame;
+    const bool grabStatus = _videoCapture.retrieve(frame);
 
-  hasIntrinsics = _withIntrinsics;
-  if(_withIntrinsics)
-    camIntrinsics = _camIntrinsics;
+    if(!grabStatus || !frame.data)
+    {
+        return false;
+    }
 
-  mediaPath = _videoPath;
-  return true;
+    if(frame.channels() == 3)
+    {
+        // convert to gray
+        cv::Mat grey;
+        cv::cvtColor(frame, grey, cv::COLOR_BGR2GRAY);
+        imageGray.resize(grey.cols, grey.rows);
+        cv::cv2eigen(grey, imageGray);
+        //      ALICEVISION_LOG_DEBUG(grey.channels() << " " << grey.rows << " " << grey.cols);
+        //      ALICEVISION_LOG_DEBUG(imageGray.Depth() << " " << imageGray.Height() << " " << imageGray.Width());
+    }
+    else
+    {
+        cv::cv2eigen(frame, imageGray);
+    }
+
+    hasIntrinsics = _withIntrinsics;
+    if(_withIntrinsics)
+        camIntrinsics = _camIntrinsics;
+
+    mediaPath = _videoPath;
+    return true;
 }
 
 std::size_t VideoFeed::FeederImpl::nbFrames() const
 {
-  if (!_videoCapture.isOpened())
-  {
-    ALICEVISION_LOG_WARNING("The video file could not be opened.");
-    return 0;
-  }
-  return _videoCapture.get(cv::CAP_PROP_FRAME_COUNT);
+    if(!_videoCapture.isOpened())
+    {
+        ALICEVISION_LOG_WARNING("The video file could not be opened.");
+        return 0;
+    }
+    return _videoCapture.get(cv::CAP_PROP_FRAME_COUNT);
 }
 
 bool VideoFeed::FeederImpl::goToFrame(const unsigned int frame)
 {
-  if (!_videoCapture.isOpened())
-  {
-    ALICEVISION_LOG_WARNING("We cannot open the video file.");
-    return false;
-  }
+    if(!_videoCapture.isOpened())
+    {
+        ALICEVISION_LOG_WARNING("We cannot open the video file.");
+        return false;
+    }
 
-  if (_isLive)
-    return goToNextFrame();
+    if(_isLive)
+        return goToNextFrame();
 
-  _videoCapture.set(cv::CAP_PROP_POS_FRAMES, frame);
-  return _videoCapture.grab();
+    _videoCapture.set(cv::CAP_PROP_POS_FRAMES, frame);
+    return _videoCapture.grab();
 }
 
 bool VideoFeed::FeederImpl::goToNextFrame()
 {
-  return _videoCapture.grab();
+    return _videoCapture.grab();
 }
 
 /*******************************************************************************/
 /*                                 VideoFeed                                   */
 /*******************************************************************************/
 
-VideoFeed::VideoFeed() : _feeder(new FeederImpl()) { }
-
-VideoFeed::VideoFeed(const std::string &videoPath, const std::string &calibPath)
-  : _feeder(new FeederImpl(videoPath, calibPath))
-{ }
-
-VideoFeed::VideoFeed(int videoDevice, const std::string &calibPath)
-  : _feeder(new FeederImpl(videoDevice, calibPath))
-{ }
-
-bool VideoFeed::readImage(image::Image<image::RGBColor> &imageRGB,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics)
+VideoFeed::VideoFeed()
+    : _feeder(new FeederImpl())
 {
-  return(_feeder->readImage(imageRGB, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
-bool VideoFeed::readImage(image::Image<float> &imageGray,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics)
+VideoFeed::VideoFeed(const std::string& videoPath, const std::string& calibPath)
+    : _feeder(new FeederImpl(videoPath, calibPath))
 {
-  return(_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
-bool VideoFeed::readImage(image::Image<unsigned char> &imageGray,
-                     camera::PinholeRadialK3 &camIntrinsics,
-                     std::string &mediaPath,
-                     bool &hasIntrinsics)
+VideoFeed::VideoFeed(int videoDevice, const std::string& calibPath)
+    : _feeder(new FeederImpl(videoDevice, calibPath))
 {
-  return(_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+}
+
+bool VideoFeed::readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                          std::string& mediaPath, bool& hasIntrinsics)
+{
+    return (_feeder->readImage(imageRGB, camIntrinsics, mediaPath, hasIntrinsics));
+}
+
+bool VideoFeed::readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                          std::string& mediaPath, bool& hasIntrinsics)
+{
+    return (_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
+}
+
+bool VideoFeed::readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                          std::string& mediaPath, bool& hasIntrinsics)
+{
+    return (_feeder->readImage(imageGray, camIntrinsics, mediaPath, hasIntrinsics));
 }
 
 std::size_t VideoFeed::nbFrames() const
 {
-  return _feeder->nbFrames();
+    return _feeder->nbFrames();
 }
 
 bool VideoFeed::goToFrame(const unsigned int frame)
 {
-  return _feeder->goToFrame(frame);
+    return _feeder->goToFrame(frame);
 }
 
 bool VideoFeed::goToNextFrame()
 {
-  return _feeder->goToNextFrame();
+    return _feeder->goToNextFrame();
 }
 
-bool VideoFeed::isInit() const {return(_feeder->isInit()); }
-
-bool VideoFeed::isSupported(const std::string &extension)
+bool VideoFeed::isInit() const
 {
-  return image::isVideoExtension(extension);
+    return (_feeder->isInit());
 }
 
-VideoFeed::~VideoFeed() { }
+bool VideoFeed::isSupported(const std::string& extension)
+{
+    return image::isVideoExtension(extension);
+}
 
-}//namespace dataio
-}//namespace aliceVision
+VideoFeed::~VideoFeed() {}
+
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/dataio/VideoFeed.hpp
+++ b/src/aliceVision/dataio/VideoFeed.hpp
@@ -11,123 +11,119 @@
 #include <string>
 #include <memory>
 
-namespace aliceVision{
-namespace dataio{
+namespace aliceVision
+{
+namespace dataio
+{
 
 class VideoFeed : public IFeed
 {
 public:
-  VideoFeed();
+    VideoFeed();
 
-  /**
-   * @brief Set up an image feed from a video
-   * 
-   * @param[in] videoPath The video source.
-   * @param[in] calibPath The source for the camera intrinsics. 
-   * The format for the file is
-   * int #image width
-   * int #image height
-   * double #focal
-   * double #ppx principal point x-coord
-   * double #ppy principal point y-coord
-   * double #k0
-   * double #k1
-   * double #k2
-   * 
-   * @see readCalibrationFromFile()
-   */  
-  VideoFeed(const std::string &videoPath, const std::string &calibPath);
+    /**
+     * @brief Set up an image feed from a video
+     *
+     * @param[in] videoPath The video source.
+     * @param[in] calibPath The source for the camera intrinsics.
+     * The format for the file is
+     * int #image width
+     * int #image height
+     * double #focal
+     * double #ppx principal point x-coord
+     * double #ppy principal point y-coord
+     * double #k0
+     * double #k1
+     * double #k2
+     *
+     * @see readCalibrationFromFile()
+     */
+    VideoFeed(const std::string& videoPath, const std::string& calibPath);
 
-  /**
-   * @brief Set up an image feed from a video
-   * 
-   * @param[in] videoDevice The device id from which capture the live feed.
-   * @param[in] calibPath The source for the camera intrinsics. 
-   * The format for the file is
-   * int #image width
-   * int #image height
-   * double #focal
-   * double #ppx principal point x-coord
-   * double #ppy principal point y-coord
-   * double #k0
-   * double #k1
-   * double #k2
-   * 
-   * @see readCalibrationFromFile()
-   */    
-  VideoFeed(int videoDevice, const std::string &calibPath);
+    /**
+     * @brief Set up an image feed from a video
+     *
+     * @param[in] videoDevice The device id from which capture the live feed.
+     * @param[in] calibPath The source for the camera intrinsics.
+     * The format for the file is
+     * int #image width
+     * int #image height
+     * double #focal
+     * double #ppx principal point x-coord
+     * double #ppy principal point y-coord
+     * double #k0
+     * double #k1
+     * double #k2
+     *
+     * @see readCalibrationFromFile()
+     */
+    VideoFeed(int videoDevice, const std::string& calibPath);
 
-  /**
-   * @brief Provide a new RGB image from the feed
-   * 
-   * @param[out] imageRGB The new RGB image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original video path.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageRGB.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<image::RGBColor> &imageRGB,
-            camera::PinholeRadialK3 &camIntrinsics,
-            std::string &mediaPath,
-            bool &hasIntrinsics);
+    /**
+     * @brief Provide a new RGB image from the feed
+     *
+     * @param[out] imageRGB The new RGB image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original video path.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageRGB.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<image::RGBColor>& imageRGB, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  /**
-   * @brief Provide a new float grayscale image from the feed
-   *
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original video path.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<float> &imageGray,
-            camera::PinholeRadialK3 &camIntrinsics,
-            std::string &mediaPath,
-            bool &hasIntrinsics);
+    /**
+     * @brief Provide a new float grayscale image from the feed
+     *
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original video path.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<float>& imageGray, camera::PinholeRadialK3& camIntrinsics, std::string& mediaPath,
+                   bool& hasIntrinsics);
 
-  /**
-   * @brief Provide a new grayscale image from the feed
-   * 
-   * @param[out] imageGray The new image from the feed.
-   * @param[out] camIntrinsics The associated camera intrinsics.
-   * @param[out] mediaPath The original video path.
-   * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
-   * is no intrinsics associated to \p imageGray.
-   * @return True if there is a new image, false otherwise.
-   */
-  bool readImage(image::Image<unsigned char> &imageGray,
-            camera::PinholeRadialK3 &camIntrinsics,
-            std::string &mediaPath,
-            bool &hasIntrinsics);
+    /**
+     * @brief Provide a new grayscale image from the feed
+     *
+     * @param[out] imageGray The new image from the feed.
+     * @param[out] camIntrinsics The associated camera intrinsics.
+     * @param[out] mediaPath The original video path.
+     * @param[out] hasIntrinsics True if \p camIntrinsics is valid, otherwise there
+     * is no intrinsics associated to \p imageGray.
+     * @return True if there is a new image, false otherwise.
+     */
+    bool readImage(image::Image<unsigned char>& imageGray, camera::PinholeRadialK3& camIntrinsics,
+                   std::string& mediaPath, bool& hasIntrinsics);
 
-  std::size_t nbFrames() const;
+    std::size_t nbFrames() const;
 
-  bool goToFrame(const unsigned int frame);
+    bool goToFrame(const unsigned int frame);
 
-  bool goToNextFrame();
+    bool goToNextFrame();
 
-  /**
-   * @brief Return true if the feed is correctly initialized.
-   * 
-   * @return True if the feed is correctly initialized.
-   */  
-  bool isInit() const;
+    /**
+     * @brief Return true if the feed is correctly initialized.
+     *
+     * @return True if the feed is correctly initialized.
+     */
+    bool isInit() const;
 
-  virtual ~VideoFeed();
+    virtual ~VideoFeed();
 
-/**
- * @brief For a given extension, return true if that file can be used as input video for the feed.
- * @param extension The file extension to check in ".ext" format (case insensitive).
- * @return True if the file is supported.
- */
-static bool isSupported(const std::string &extension);
+    /**
+     * @brief For a given extension, return true if that file can be used as input video for the feed.
+     * @param extension The file extension to check in ".ext" format (case insensitive).
+     * @return True if the file is supported.
+     */
+    static bool isSupported(const std::string& extension);
 
 private:
-  class FeederImpl;
-  std::unique_ptr<FeederImpl> _feeder;
+    class FeederImpl;
+    std::unique_ptr<FeederImpl> _feeder;
 };
 
-}//namespace dataio 
-}//namespace aliceVision
+} // namespace dataio
+} // namespace aliceVision

--- a/src/aliceVision/keyframe/CMakeLists.txt
+++ b/src/aliceVision/keyframe/CMakeLists.txt
@@ -12,11 +12,11 @@ alicevision_add_library(aliceVision_keyframe
   SOURCES ${keyframe_files_headers} ${keyframe_files_sources}
   PUBLIC_LINKS
     aliceVision_dataio
+    aliceVision_sfmData
+    aliceVision_sfmDataIO
     OpenImageIO::OpenImageIO
   PRIVATE_LINKS
     aliceVision_sensorDB
-    aliceVision_sfmData
-    aliceVision_sfmDataIO
     aliceVision_system
     Boost::filesystem
 )

--- a/src/aliceVision/keyframe/CMakeLists.txt
+++ b/src/aliceVision/keyframe/CMakeLists.txt
@@ -15,6 +15,8 @@ alicevision_add_library(aliceVision_keyframe
     OpenImageIO::OpenImageIO
   PRIVATE_LINKS
     aliceVision_sensorDB
+    aliceVision_sfmData
+    aliceVision_sfmDataIO
     aliceVision_system
     Boost::filesystem
 )

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -86,6 +86,7 @@ KeyframeSelector::KeyframeSelector(const std::vector<std::string>& mediaPaths,
 void KeyframeSelector::processRegular()
 {
     _selectedKeyframes.clear();
+    _selectedFrames.clear();
 
     std::size_t nbFrames = std::numeric_limits<unsigned int>::max();
     std::vector<std::unique_ptr<dataio::FeedProvider>> feeds;
@@ -111,6 +112,10 @@ void KeyframeSelector::processRegular()
         ALICEVISION_THROW(std::invalid_argument, "One or multiple medias can't be found or empty!");
     }
 
+    // All frames are unselected so far
+    _selectedFrames.resize(nbFrames);
+    std::fill(_selectedFrames.begin(), _selectedFrames.end(), '0');
+
     unsigned int step = _minFrameStep;
     if (_maxFrameStep > 0) {
         // By default, if _maxFrameStep is set, set the step to be right between _minFrameStep and _maxFrameStep
@@ -135,6 +140,7 @@ void KeyframeSelector::processRegular()
     for (unsigned int id = 0; id < nbFrames; id += step) {
         ALICEVISION_LOG_INFO("Selecting frame with ID " << id);
         _selectedKeyframes.push_back(id);
+        _selectedFrames.at(id) = '1';
         if (_maxOutFrames > 0 && _selectedKeyframes.size() >= _maxOutFrames)
             break;
     }

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -80,6 +80,11 @@ KeyframeSelector::KeyframeSelector(const std::vector<std::string>& mediaPaths,
 
     scoresMap["Sharpness"] = &_sharpnessScores;
     scoresMap["OpticalFlow"] = &_flowScores;
+
+    // Parse the sensor database if the path is not empty
+    if (!_sensorDbPath.empty() && sensorDB::parseDatabase(_sensorDbPath, _sensorDatabase)) {
+        _parsedSensorDb = true;
+    }
 }
 
 void KeyframeSelector::processRegular()

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -5,6 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "KeyframeSelector.hpp"
+#include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 #include <boost/filesystem.hpp>
@@ -91,6 +92,9 @@ void KeyframeSelector::processRegular()
 {
     _selectedKeyframes.clear();
     _selectedFrames.clear();
+    _keyframesPaths.clear();
+    _outputSfmKeyframes.clear();
+    _outputSfmFrames.clear();
 
     std::size_t nbFrames = std::numeric_limits<unsigned int>::max();
     std::vector<std::unique_ptr<dataio::FeedProvider>> feeds;
@@ -159,6 +163,7 @@ void KeyframeSelector::processSmart(const float pxDisplacement, const std::size_
 {
     _selectedKeyframes.clear();
     _selectedFrames.clear();
+    _keyframesPaths.clear();
     _outputSfmKeyframes.clear();
     _outputSfmFrames.clear();
 
@@ -529,9 +534,11 @@ bool KeyframeSelector::writeSelection(const std::vector<std::string>& brands,
 
             image::writeImage(filepath, image, options, metadata);
             ALICEVISION_LOG_DEBUG("Wrote selected keyframe " << pos);
+
+            _keyframesPaths[id].push_back(filepath);
         }
 
-        if (!writeSfMData(path, feed.isSfMData()))
+        if (!writeSfMData(path, feed, brands, models, mmFocals))
             ALICEVISION_LOG_ERROR("Failed to write the output SfMData files.");
     }
 
@@ -718,7 +725,7 @@ cv::Mat KeyframeSelector::readImage(dataio::FeedProvider &feed, std::size_t widt
     cv::Mat cvRescaled;
     if (cvGrayscale.cols > width && width > 0) {
         cv::resize(cvGrayscale, cvRescaled,
-                   cv::Size(width,double(cvGrayscale.rows) * double(width) / double(cvGrayscale.cols)));
+                   cv::Size(width, double(cvGrayscale.rows) * double(width) / double(cvGrayscale.cols)));
     }
 
     return cvRescaled;
@@ -813,24 +820,58 @@ double KeyframeSelector::estimateFlow(const cv::Ptr<cv::DenseOpticalFlow>& ptrFl
     return findMedian(motionByCell);
 }
 
-bool KeyframeSelector::writeSfMData(const std::string& mediaPath, const bool isSfmInput)
+bool KeyframeSelector::writeSfMData(const std::string& mediaPath, dataio::FeedProvider &feed,
+                                    const std::vector<std::string>& brands, const std::vector<std::string>& models,
+                                    const std::vector<float>& mmFocals)
 {
-    if (!isSfmInput) {
-        ALICEVISION_LOG_INFO("The input was not an SfMData file: no output SfMData file will be written.");
-        return true;
+    bool filledOutputs = false;
+
+    if (!feed.isSfMData()) {
+        filledOutputs = writeSfMDataFromSequences(mediaPath, feed, brands, models, mmFocals);
+    } else {
+        filledOutputs = writeSfMDataFromSfMData(mediaPath);
     }
 
-    sfmData::SfMData inputSfm;
-    std::vector<std::shared_ptr<sfmData::View>> views;
-    if (!sfmDataIO::Load(inputSfm, mediaPath, sfmDataIO::ESfMData::ALL)) {
-        ALICEVISION_THROW_ERROR("Could not open input SfMData file " << mediaPath << ".");
+    if (!filledOutputs) {
+        ALICEVISION_LOG_ERROR("Error while filling the output SfMData files.");
+        return false;
     }
 
+    if (!sfmDataIO::Save(_outputSfmKeyframes, _outputSfmKeyframesPath, sfmDataIO::ESfMData::ALL)) {
+        ALICEVISION_LOG_ERROR("The output SfMData file '" << _outputSfmKeyframesPath << "' could not be written.");
+        return false;
+    }
+
+    if (!feed.isVideo()) {
+        if (!sfmDataIO::Save(_outputSfmFrames, _outputSfmFramesPath, sfmDataIO::ESfMData::ALL)) {
+            ALICEVISION_LOG_ERROR("The output SfMData file '" << _outputSfmFramesPath << "' could not be written.");
+            return false;
+        }
+    } else {
+        ALICEVISION_LOG_DEBUG("The input feed is a video. The SfMData file containing the unselected frames will not"
+                              " be written.");
+    }
+
+    return true;
+}
+
+bool KeyframeSelector::writeSfMDataFromSfMData(const std::string& mediaPath)
+{
     auto& keyframesViews = _outputSfmKeyframes.getViews();
     auto& framesViews = _outputSfmFrames.getViews();
 
     auto& keyframesIntrinsics = _outputSfmKeyframes.getIntrinsics();
     auto& framesIntrinsics = _outputSfmFrames.getIntrinsics();
+
+    IndexT viewId;
+    IndexT intrinsicId;
+
+    sfmData::SfMData inputSfm;
+    std::vector<std::shared_ptr<sfmData::View>> views;
+    if (!sfmDataIO::Load(inputSfm, mediaPath, sfmDataIO::ESfMData::ALL)) {
+        ALICEVISION_LOG_ERROR("Could not open input SfMData file " << mediaPath << ".");
+        return false;
+    }
 
     // Order the views according to the frame ID and the intrinsics serial number
     std::map<std::string, std::vector<std::shared_ptr<sfmData::View>>> viewSequences;
@@ -850,8 +891,6 @@ bool KeyframeSelector::writeSfMData(const std::string& mediaPath, const bool isS
         views.insert(views.end(), view.second.begin(), view.second.end());
     }
 
-    IndexT viewId;
-    IndexT intrinsicId;
     for (int i = 0; i < views.size(); ++i) {
         viewId = views[i]->getViewId();
         intrinsicId = views[i]->getIntrinsicId();
@@ -864,17 +903,179 @@ bool KeyframeSelector::writeSfMData(const std::string& mediaPath, const bool isS
         }
     }
 
-    if (!sfmDataIO::Save(_outputSfmKeyframes, _outputSfmKeyframesPath, sfmDataIO::ESfMData::ALL)) {
-        ALICEVISION_LOG_ERROR("The output SfMData file '" << _outputSfmKeyframesPath << "' could not be written.");
-        return false;
+    return true;
+}
+
+bool KeyframeSelector::writeSfMDataFromSequences(const std::string& mediaPath, dataio::FeedProvider &feed,
+                                                 const std::vector<std::string>& brands,
+                                                 const std::vector<std::string>& models,
+                                                 const std::vector<float>& mmFocals)
+{
+    static std::size_t mediaIndex = 0;
+    static IndexT intrinsicId = 0;
+
+    auto& keyframesViews = _outputSfmKeyframes.getViews();
+    auto& framesViews = _outputSfmFrames.getViews();
+
+    auto& keyframesIntrinsics = _outputSfmKeyframes.getIntrinsics();
+    auto& framesIntrinsics = _outputSfmFrames.getIntrinsics();
+
+    auto& keyframesRigs = _outputSfmKeyframes.getRigs();
+    auto& framesRigs = _outputSfmFrames.getRigs();
+
+    const IndexT rigId = 0;   // 0 by convention
+    IndexT viewId = 0;  // Will be used to distinguish frames coming from videos
+    IndexT previousFrameId = UndefinedIndexT;
+
+    feed.goToFrame(0);
+
+    // Feed provider variables
+    image::Image<image::RGBColor> image;
+    camera::PinholeRadialK3 queryIntrinsics;
+    bool hasIntrinsics = false;
+    std::string currentImgName;
+
+    std::size_t selectedKeyframesCounter = 0;  // Used to find the path of the written images when the feed is video
+    std::shared_ptr<camera::IntrinsicBase> previousIntrinsic = nullptr;
+
+    // Create rig structure if it is needed and does not already exist
+    // A rig structure is needed when there is more than one input path
+    if (_mediaPaths.size() > 1 && keyframesRigs.size() == 0 && framesRigs.size() == 0) {
+        sfmData::Rig rig(_mediaPaths.size());
+        keyframesRigs[rigId] = rig;
+        framesRigs[rigId] = rig;
     }
 
-    if (!sfmDataIO::Save(_outputSfmFrames, _outputSfmFramesPath, sfmDataIO::ESfMData::ALL)) {
-        ALICEVISION_LOG_ERROR("The output SfMData file '" << _outputSfmFramesPath << "' could not be written.");
-        return false;
+    for (std::size_t i = 0; i < feed.nbFrames(); ++i) {
+        // Need to read the image to get its size and path
+        if (!feed.readImage(image, queryIntrinsics, currentImgName, hasIntrinsics)) {
+            ALICEVISION_LOG_ERROR("Error reading image");
+            return false;
+        }
+
+        // Create the view
+        auto view = createView(currentImgName, intrinsicId, previousFrameId, image.Width(), image.Height());
+        previousFrameId = view->getFrameId();
+
+        // If there is a rig, the view's rig and sub-pose IDs need to be set once it has been completed
+        if (keyframesRigs.size() > 0 && framesRigs.size() > 0) {
+            view->setRigAndSubPoseId(rigId, mediaIndex);
+        }
+
+        // Prepare settings for the intrinsics
+        double focalLength = view->getMetadataFocalLength();
+        if (focalLength == -1 && mmFocals[mediaIndex] != 0)
+            focalLength = mmFocals[mediaIndex];
+        std::string make = view->getMetadataMake();
+        if (make.empty() && !brands[mediaIndex].empty())
+            make = brands[mediaIndex];
+        std::string model = view->getMetadataModel();
+        if (model.empty() && !models[mediaIndex].empty())
+            model = models[mediaIndex];
+
+        const double imageRatio = static_cast<double>(image.Width()) / static_cast<double>(image.Height());
+        double sensorWidth = -1.0;
+        sensorDB::Datasheet datasheet;
+
+        if (_parsedSensorDb && !make.empty() && !model.empty() &&
+            sensorDB::getInfo(make, model, _sensorDatabase, datasheet)) {
+            sensorWidth = datasheet._sensorWidth;
+        }
+
+        // Create the intrinsic for the view
+        auto intrinsic = createIntrinsic(*view, focalLength == -1.0 ? 0 : focalLength, sensorWidth, mediaIndex,
+                                         imageRatio);
+
+        // Update intrinsics ID if this is a new one
+        if (previousIntrinsic != nullptr && *previousIntrinsic != *intrinsic)
+            view->setIntrinsicId(++intrinsicId);
+
+        // Fill the SfMData files
+        if (_selectedFrames[i] == '1') {
+            if (feed.isVideo()) {
+                // If the feed is a video, all views will have the same view ID by default, this needs to be fixed
+                view->setViewId(view->getViewId() + viewId++);
+                view->setPoseId(view->getViewId());
+                // The path for the view will be the video's; it needs to be replaced with the corresponding keyframe's
+                view->setImagePath(_keyframesPaths[mediaIndex][selectedKeyframesCounter++]);
+            }
+            keyframesViews[view->getViewId()] = view;
+            keyframesIntrinsics[intrinsicId] = intrinsic;
+        } else {
+            // No rejected frames if the feed is a video one, as they are not written on disk
+            if (!feed.isVideo()) {
+                framesViews[view->getViewId()] = view;
+                framesIntrinsics[intrinsicId] = intrinsic;
+            }
+        }
+
+        previousIntrinsic = intrinsic;
+        feed.goToNextFrame();
     }
+
+    ++mediaIndex;
+    ++intrinsicId;
 
     return true;
+}
+
+std::shared_ptr<sfmData::View> KeyframeSelector::createView(const std::string& imagePath, IndexT intrinsicId,
+                                IndexT previousFrameId, std::size_t imageWidth, std::size_t imageHeight)
+{
+    // Create the View object: most attributes are set with default values and will be updated later on
+    auto view = std::make_shared<sfmData::View>(
+        imagePath,                           // filepath
+        UndefinedIndexT,                     // view ID
+        intrinsicId,                         // intrinsics ID
+        UndefinedIndexT,                     // pose ID
+        imageWidth,                          // image width
+        imageHeight,                         // image height
+        UndefinedIndexT,                     // rig ID
+        UndefinedIndexT,                     // sub-pose ID
+        std::map<std::string, std::string>() // metadata
+    );
+
+    // Complete the View attributes
+    sfmDataIO::EViewIdMethod viewIdMethod = sfmDataIO::EViewIdMethod::METADATA;
+    std::string viewIdRegex = ".*?(\\d+)";
+    sfmDataIO::updateIncompleteView(*(view.get()), viewIdMethod, viewIdRegex);
+
+    // Set the frame ID
+    IndexT frameId;
+    std::string prefix;
+    std::string suffix;
+    // Use the filename to determine the frame ID (if available)
+    if (sfmDataIO::extractNumberFromFileStem(fs::path(view->getImagePath()).stem().string(), frameId, prefix, suffix)) {
+        view->setFrameId(frameId);
+    }
+    // Otherwise, set it fully manually
+    if (view->getFrameId() == 1 && previousFrameId != UndefinedIndexT) {
+        view->setFrameId(previousFrameId + 1);
+    }
+
+    return view;
+}
+
+std::shared_ptr<camera::IntrinsicBase> KeyframeSelector::createIntrinsic(const sfmData::View& view, const double focalLength,
+                const double sensorWidth, const double imageRatio, const std::size_t mediaIndex)
+{
+    auto intrinsic = sfmDataIO::getViewIntrinsic(view, focalLength, sensorWidth);
+    if (imageRatio > 1.0 && sensorWidth > -1.0) {
+        intrinsic->setSensorWidth(sensorWidth);
+        intrinsic->setSensorHeight(sensorWidth / imageRatio);
+    } else if (imageRatio <= 1.0 && sensorWidth > -1.0) {
+        intrinsic->setSensorWidth(sensorWidth);
+        intrinsic->setSensorHeight(sensorWidth * imageRatio);
+    } else {
+        // Set default values for the sensor width and sensor height
+        intrinsic->setSensorWidth(36.0);
+        intrinsic->setSensorHeight(24.0);
+    }
+
+    if (intrinsic->serialNumber().empty())  // Likely to happen with video feeds
+        intrinsic->setSerialNumber(fs::path(view.getImagePath()).parent_path().string() + std::to_string(mediaIndex));
+
+    return intrinsic;
 }
 
 } // namespace keyframe 

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -65,10 +65,14 @@ double findMedian(const std::vector<double>& vec)
 
 KeyframeSelector::KeyframeSelector(const std::vector<std::string>& mediaPaths,
                                    const std::string& sensorDbPath,
-                                   const std::string& outputFolder)
+                                   const std::string& outputFolder,
+                                   const std::string& outputSfmKeyframes,
+                                   const std::string& outputSfmFrames)
     : _mediaPaths(mediaPaths)
     , _sensorDbPath(sensorDbPath)
     , _outputFolder(outputFolder)
+    , _outputSfmKeyframesPath(outputSfmKeyframes)
+    , _outputSfmFramesPath(outputSfmFrames)
 {
     // Check that a least one media file path has been provided
     if (mediaPaths.empty()) {

--- a/src/aliceVision/keyframe/KeyframeSelector.hpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <memory>
 #include <limits>
+
 namespace aliceVision {
 namespace image {
 
@@ -36,13 +37,17 @@ class KeyframeSelector
 public:
     /**
      * @brief KeyframeSelector constructor
-     * @param[in] mediaPath video file path or image sequence directory
+     * @param[in] mediaPath video file path, image sequence directory or SfMData file
      * @param[in] sensorDbPath camera sensor width database path
      * @param[in] outputFolder output keyframes directory
+     * @param[in] outputSfmKeyframes output SfMData file containing the keyframes
+     * @param[in] outputSfmFrames output SfMData file containing all the non-selected frames
      */
     KeyframeSelector(const std::vector<std::string>& mediaPaths,
-                    const std::string& sensorDbPath,
-                    const std::string& outputFolder);
+                     const std::string& sensorDbPath,
+                     const std::string& outputFolder,
+                     const std::string& outputSfmKeyframes,
+                     const std::string& outputSfmFrames);
 
     /**
      * @brief KeyframeSelector copy constructor - NO COPY
@@ -246,6 +251,10 @@ private:
     std::string _sensorDbPath;
     /// Output folder for keyframes
     std::string _outputFolder;
+    /// Path of the output SfMData with keyframes
+    std::string _outputSfmKeyframesPath;
+    /// Path of the output SfMData with non-selected frames
+    std::string _outputSfmFramesPath;
 
     // Parameters common to both the regular and smart methods
     /// Maximum number of output frames (0 = no limit)

--- a/src/aliceVision/keyframe/KeyframeSelector.hpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.hpp
@@ -8,6 +8,7 @@
 
 #include <aliceVision/dataio/FeedProvider.hpp>
 #include <aliceVision/image/all.hpp>
+#include <aliceVision/sensorDB/parseDatabase.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
@@ -296,6 +297,10 @@ private:
     /// Size of the frame (afer rescale, if any is applied)
     unsigned int _frameWidth = 0;
     unsigned int _frameHeight = 0;
+
+    /// Parsed sensor database
+    std::vector<sensorDB::Datasheet> _sensorDatabase;
+    bool _parsedSensorDb = false;
 
     /// Map score vectors with names for export
     std::map<const std::string, const std::vector<double>*> scoresMap;

--- a/src/aliceVision/keyframe/KeyframeSelector.hpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.hpp
@@ -8,6 +8,8 @@
 
 #include <aliceVision/dataio/FeedProvider.hpp>
 #include <aliceVision/image/all.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
 #include <OpenImageIO/imageio.h>
 #include <opencv2/optflow.hpp>
@@ -122,8 +124,9 @@ public:
      * @return true if all the selected keyframes were successfully written, false otherwise
      */
     bool writeSelection(const std::vector<std::string>& brands, const std::vector<std::string>& models,
-                    const std::vector<float>& mmFocals, const bool renameKeyframes, const std::string& outputExtension,
-                    const image::EStorageDataType storageDataType = image::EStorageDataType::Undefined) const;
+                        const std::vector<float>& mmFocals, const bool renameKeyframes,
+                        const std::string& outputExtension,
+                        const image::EStorageDataType storageDataType = image::EStorageDataType::Undefined);
 
     /**
      * @brief Export the computed sharpness and optical flow scores to a CSV file
@@ -242,6 +245,14 @@ private:
     double estimateFlow(const cv::Ptr<cv::DenseOpticalFlow>& ptrFlow, const cv::Mat& grayscaleImage,
                         const cv::Mat& previousGrayscaleImage, const std::size_t cellSize);
 
+    /**
+     * @brief Write the output SfMData files with the selected and non-selected keyframes information.
+     * @param[in] mediaPath input video file path, image sequence directory or SfMData file
+     * @param[in] isSfmInput true if the input file is an SfMData file, false otherwise
+     * @return true if the output SfMData files were written as expected, false otherwise
+     */
+    bool writeSfMData(const std::string& mediaPath, const bool isSfmInput);
+
     /// Selected keyframes IDs
     std::vector<unsigned int> _selectedKeyframes;
 
@@ -276,6 +287,11 @@ private:
     std::vector<double> _flowScores;
     /// Vector containing 1s for frames that have been selected, 0 for those which have not
     std::vector<char> _selectedFrames;
+
+    /// Output SfMData containing the keyframes
+    sfmData::SfMData _outputSfmKeyframes;
+    /// Output SfMData containing the non-selected frames
+    sfmData::SfMData _outputSfmFrames;
 
     /// Size of the frame (afer rescale, if any is applied)
     unsigned int _frameWidth = 0;

--- a/src/aliceVision/keyframe/README.md
+++ b/src/aliceVision/keyframe/README.md
@@ -97,7 +97,9 @@ Debug options specific to the smart selection method are available:
 ```cpp
 KeyframeSelector(const std::vector<std::string>& mediaPaths,
                  const std::string& sensorDbPath,
-                 const std::string& outputFolder);
+                 const std::string& outputFolder,
+                 const std::string& outputSfmKeyframes,
+                 const std::string& outputSfmFrames);
 ```
 - Selection with regular method
 ```cpp

--- a/src/aliceVision/keyframe/README.md
+++ b/src/aliceVision/keyframe/README.md
@@ -2,9 +2,9 @@
 
 This module provides several methods to perform a keyframe selection.
 
-The goal of the keyframe selection is to extract, from an input video or an input sequence of images, keyframes.
+The goal of the keyframe selection is to extract, from an input video, an input sequence of images or an SfMData file, keyframes.
 Two methods are currently supported:
-- a **regular** selection method, which selects keyframes regularly across the input video / sequence according to a set of parameters;
+- a **regular** selection method, which selects keyframes regularly across the input video / sequence / SfMData according to a set of parameters;
 - a **smart** selection method, which analyses the sharpness and motion of all the frames to select those which are deemed the most relevant (a frame is considered relevant if it contains significant motion in comparison to the last selected keyframe while being as sharp as possible).
 
 The selected keyframes can be written as JPG, PNG or EXR images, and the storage data type can be specified when the EXR file extension is selected.
@@ -13,8 +13,15 @@ The keyframe selection module supports the following inputs:
 - a path to a video file (e.g. "/path/to/video.mp4")
 - a path to a folder containing images (e.g. "/path/to/folder/")
 - a path to a folder containing images with a regular expression (e.g. "/path/to/folder/*.exr")
+- a path to an SfMData file (e.g. "/path/to/sfmData.sfm")
 
-Camera rigs are also supported.
+Camera rigs are also supported for all the inputs except the SfMData file.
+
+In addition to writing the selected keyframes on disk, two SfMData files are written:
+- one that contains all the selected keyframes
+- one that contains all the frames that were not selected as keyframes
+
+_N.B: If the input is a video file, the SfMData file which contains the rejected frames will not be written at all, since none of these frames is available on disk. As the selected keyframes will be written at the end of the selection, the SfMData file containing the keyframes **will** be written._
 
 ## Regular selection method
 

--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -18,7 +18,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 4
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;

--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -31,12 +31,14 @@ const std::string supportedExtensions = "exr, jpg, png";
 int aliceVision_main(int argc, char** argv)
 {
     // Command-line parameters
-    std::vector<std::string> mediaPaths;    // media file path list
+    std::vector<std::string> inputPaths;    // media or SfMData file path list
     std::vector<std::string> brands;        // media brand list
     std::vector<std::string> models;        // media model list
     std::vector<float> mmFocals;            // media focal (mm) list
     std::string sensorDbPath;               // camera sensor width database
     std::string outputFolder;               // output folder for keyframes
+    std::string outputSfMDataKeyframes;     // output SfMData file containing the selected keyframes
+    std::string outputSfMDataFrames;        // output SfMData file containing the rejected frames
 
     // Algorithm variables
     bool useSmartSelection = true;          // enable the smart selection instead of the regular one
@@ -65,12 +67,16 @@ int aliceVision_main(int argc, char** argv)
 
     po::options_description inputParams("Required parameters");
     inputParams.add_options()
-        ("mediaPaths", po::value<std::vector<std::string>>(&mediaPaths)->required()->multitoken(),
+        ("inputPaths", po::value<std::vector<std::string>>(&inputPaths)->required()->multitoken(),
             "Input video files or image sequence directories.")
         ("sensorDbPath", po::value<std::string>(&sensorDbPath)->required(),
             "Camera sensor width database path.")
         ("outputFolder", po::value<std::string>(&outputFolder)->required(),
-            "Output folder in which the selected keyframes are written.");
+            "Output folder in which the selected keyframes are written.")
+        ("outputSfMDataKeyframes", po::value<std::string>(&outputSfMDataKeyframes)->required(),
+            "Output SfMData file containing all the selected keyframes.")
+        ("outputSfMDataFrames", po::value<std::string>(&outputSfMDataFrames)->required(),
+            "Output SfMData file containing all the rejected frames.");
 
     po::options_description metadataParams("Metadata parameters");
     metadataParams.add_options()
@@ -157,7 +163,7 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    const std::size_t nbCameras = mediaPaths.size();
+    const std::size_t nbCameras = inputPaths.size();
 
     // Check output folder and update to its absolute path
     {
@@ -202,7 +208,7 @@ int aliceVision_main(int argc, char** argv)
             ALICEVISION_LOG_INFO("Camera rig of " << nbCameras << " cameras.");
 
         for (std::size_t i = 0; i < nbCameras; ++i) {
-            ALICEVISION_LOG_INFO("Camera: "              << mediaPaths.at(i)   << std::endl
+            ALICEVISION_LOG_INFO("Camera: "              << inputPaths.at(i)   << std::endl
                                 << "\t - brand: "        << brands.at(i)       << std::endl
                                 << "\t - model: "        << models.at(i)       << std::endl
                                 << "\t - focal (mm): "   << mmFocals.at(i)     << std::endl);
@@ -210,7 +216,8 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // Initialize KeyframeSelector
-    keyframe::KeyframeSelector selector(mediaPaths, sensorDbPath, outputFolder);
+    keyframe::KeyframeSelector selector(inputPaths, sensorDbPath, outputFolder, outputSfMDataKeyframes,
+                                        outputSfMDataFrames);
 
     // Set frame-related algorithm parameters
     selector.setMinFrameStep(minFrameStep);


### PR DESCRIPTION
## Description

This PR builds on top of #1343 and:
1. Adds the support of `SfMData` files as an input;
2. Outputs two `SfMData` files: one that contains the selected keyframes, and one that contains all the frames that failed to be selected as keyframes.

`SfMData` files can now be provided as inputs for both the regular and smart keyframe selection, and the selection methods remain oblivious to the type of input they are given. **Rigs are not supported with `SfMData` files as inputs.**

Once the keyframes have been written, two `SfMData` files are written, respectively with the keyframes' information and the rejected frames' information. Depending on the type of input, the output `SfMData` files are written with the following specifications:
- If the input is an image sequence (or a rig of image sequences), both the keyframes' and frames' `SfMData` files will be written, with a full rig support;
- If the input is a video (or a rig of videos), only the keyframes `SfMData` file will be written, with a full rig support. Since the frames' `SfMData` file requires the paths of all the rejected frames to be filled and the only available path (beside the keyframes') is the input video's, it is simply ignored;
- If the input is an `SfMData` file, both the keyframes' and frames' `SfMData` files will be written, with **no rig support**. 

While rigs are not supported with `SfMData` files as inputs, it is possible to provide an `SfMData` file that contains several different image sequences. If that occurs, the views will be ordered according to their frame IDs and their intrinsics' serial number, put back-to-back (e.g. for two sequences with 3 frames each in the same `SfMData` file, the views will be sorted as "seq1#id0, seq1#id1, seq1#id2, seq2#id0, seq2#id1, seq2#id2"), and then processed by the selection methods as a single sequence.

Additionally, the dataio module has been reformatted to use 4-space indentations everywhere.

The corresponding Meshroom pull request can be found here: https://github.com/alicevision/Meshroom/pull/1967

## Features list

- [X] Reformat the dataio module;
- [X] Remove the old support for JSON files from the `ImageFeed` in the dataio module;
- [X] Add a specific feeder for `SfMData` files in the dataio module;
- [X] Support `SfMData` files as inputs for the keyframe selection;
- [X] Write one to two `SfMData` files (depending on the input's type) in addition to the selected keyframes.

## Implementation remarks

- A new feed, `SfMDataFeed`, dedicated to `SfMData` files has been added to dataio's `FeedProvider` to read and provide images from any `SfMData` files. It replaces the support for .json files that was provided by the `ImageFeed` feed.
- The partial and outdated support for `SfMData` files (with a .json extension) that was available in the `ImageFeed` feed has been completely removed. `ImageFeed` still supports all types of images as well as .txt files containing a list of paths to images.
- The sensor database, which was provided but never used until now, is loaded and parsed to retrieve sensor-related information during the intrinsics' creation.
- The rig support for the input `SfMData` files is not covered by this pull request, and should be added later in a dedicated one.