### PR TITLE
Add compression option for exr and jpg images

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -210,6 +210,73 @@ std::istream& operator>>(std::istream& in, EStorageDataType& dataType)
     return in;
 }
 
+std::string EImageExrCompression_informations()
+{
+    return EImageExrCompression_enumToString(EImageExrCompression::None) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::Auto) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::RLE) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::ZIP) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::ZIPS) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::PIZ) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::PXR24) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::B44) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::B44A) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::DWAA) + ", " +
+        EImageExrCompression_enumToString(EImageExrCompression::DWAB);
+}
+
+EImageExrCompression EImageExrCompression_stringToEnum(const std::string& exrCompression)
+{
+    std::string type = exrCompression;
+    std::transform(type.begin(), type.end(), type.begin(), ::tolower); //tolower
+
+    if (type == "none")  return EImageExrCompression::None;
+    if (type == "auto")  return EImageExrCompression::Auto;
+    if (type == "rle")   return EImageExrCompression::RLE;
+    if (type == "zip")   return EImageExrCompression::ZIP;
+    if (type == "zips")  return EImageExrCompression::ZIPS;
+    if (type == "piz")   return EImageExrCompression::PIZ;
+    if (type == "pxr24") return EImageExrCompression::PXR24;
+    if (type == "b44")   return EImageExrCompression::B44;
+    if (type == "b44a")  return EImageExrCompression::B44A;
+    if (type == "dwaa")  return EImageExrCompression::DWAA;
+    if (type == "dwab")  return EImageExrCompression::DWAB;
+
+    throw std::out_of_range("Invalid EImageExrCompression: " + exrCompression);
+}
+
+std::string EImageExrCompression_enumToString(const EImageExrCompression exrCompression)
+{
+    switch (exrCompression)
+    {
+    case EImageExrCompression::None:  return "none";
+    case EImageExrCompression::Auto:  return "auto";
+    case EImageExrCompression::RLE:   return "rle";
+    case EImageExrCompression::ZIP:   return "zip";
+    case EImageExrCompression::ZIPS:  return "zips";
+    case EImageExrCompression::PIZ:   return "piz";
+    case EImageExrCompression::PXR24: return "pxr24";
+    case EImageExrCompression::B44:   return "b44";
+    case EImageExrCompression::B44A:  return "b44a";
+    case EImageExrCompression::DWAA:  return "dwaa";
+    case EImageExrCompression::DWAB:  return "dwab";
+    }
+    throw std::out_of_range("Invalid EImageExrCompression enum");
+}
+
+std::ostream& operator<<(std::ostream& os, EImageExrCompression exrCompression)
+{
+    return os << EImageExrCompression_enumToString(exrCompression);
+}
+
+std::istream& operator>>(std::istream& in, EImageExrCompression& exrCompression)
+{
+    std::string token;
+    in >> token;
+    exrCompression = EImageExrCompression_stringToEnum(token);
+    return in;
+}
+
 std::string EImageQuality_informations()
 {
     return "Image quality :\n"
@@ -829,19 +896,49 @@ void writeImage(const std::string& path,
     oiio::ImageSpec imageSpec(image.Width(), image.Height(), nchannels, typeDesc);
     imageSpec.extra_attribs = metadata; // add custom metadata
 
-  imageSpec.attribute("jpeg:subsampling", "4:4:4");           // if possible, always subsampling 4:4:4 for jpeg
-  imageSpec.attribute("compression", isEXR ? "zips" : "none"); // if possible, set compression (zips for EXR, none for the other)
+    imageSpec.attribute("jpeg:subsampling", "4:4:4");           // if possible, always subsampling 4:4:4 for jpeg
 
-  if(displayRoi.defined() && isEXR)
-  {
-      imageSpec.set_roi_full(displayRoi);
-  }
+    std::string compressionMethod = "none";
 
-  if(pixelRoi.defined() && isEXR)
-  {
-      imageSpec.set_roi(pixelRoi);
-  }
+    if (options.getCompressionMethod() == EImageExrCompression::Auto)
+    {
+        compressionMethod = isEXR ? "zips" : "none";
+    }
+    else if (options.getCompressionMethod() != EImageExrCompression::None)
+    {
+        compressionMethod = EImageExrCompression_enumToString(options.getCompressionMethod());
+        if (isEXR)
+        {
+            const int compressionLevel = std::max<int>(options.getCompressionLevel(), 0);
+            if (compressionLevel > 0)
+            {
+                if ((options.getCompressionMethod() == EImageExrCompression::DWAA || options.getCompressionMethod() == EImageExrCompression::DWAB))
+                {
+                    compressionMethod += ":" + std::to_string(compressionLevel);
+                }
+                else if ((options.getCompressionMethod() == EImageExrCompression::ZIP || options.getCompressionMethod() == EImageExrCompression::ZIPS))
+                {
+                    compressionMethod += ":" + std::to_string(std::min<int>(compressionLevel, 9));
+                }
+            }
+        }
+        else if (isJPG)
+        {
+            compressionMethod = "jpeg:" + std::to_string(std::min<int>(std::max<int>(options.getCompressionLevel(), 0), 100));
+        }
+    }
 
+    imageSpec.attribute("compression", compressionMethod);
+
+    if(displayRoi.defined() && isEXR)
+    {
+        imageSpec.set_roi_full(displayRoi);
+    }
+
+    if(pixelRoi.defined() && isEXR)
+    {
+        imageSpec.set_roi(pixelRoi);
+    }
 
     imageSpec.attribute("AliceVision:ColorSpace",
                         (toColorSpace == EImageColorSpace::NO_CONVERSION)

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -142,6 +142,30 @@ std::ostream& operator<<(std::ostream& os, EStorageDataType dataType);
 std::istream& operator>>(std::istream& in, EStorageDataType& dataType);
 
 /**
+* @brief Compression method use to write an exr image
+*/
+enum class EImageExrCompression
+{
+    None,
+    Auto,
+    RLE,
+    ZIP,
+    ZIPS,
+    PIZ,
+    PXR24,
+    B44,
+    B44A,
+    DWAA,
+    DWAB
+};
+
+std::string EImageExrCompression_informations();
+EImageExrCompression EImageExrCompression_stringToEnum(const std::string& dataType);
+std::string EImageExrCompression_enumToString(const EImageExrCompression dataType);
+std::ostream& operator<<(std::ostream& os, EImageExrCompression dataType);
+std::istream& operator>>(std::istream& in, EImageExrCompression& dataType);
+
+/**
  * @brief Available image qualities for pipeline output
  */
 enum class EImageQuality
@@ -222,6 +246,8 @@ public:
     EImageColorSpace getFromColorSpace() const { return _fromColorSpace; }
     EImageColorSpace getToColorSpace() const { return _toColorSpace; }
     EStorageDataType getStorageDataType() const { return _storageDataType; }
+    EImageExrCompression getCompressionMethod() const { return _compressionMethod; }
+    int getCompressionLevel() const { return _compressionLevel; }
 
     ImageWriteOptions& fromColorSpace(EImageColorSpace colorSpace)
     {
@@ -241,10 +267,24 @@ public:
         return *this;
     }
 
+    ImageWriteOptions& compressionMethod(EImageExrCompression compressionMethod)
+    {
+        _compressionMethod = compressionMethod;
+        return *this;
+    }
+
+    ImageWriteOptions& compressionLevel(int compressionLevel)
+    {
+        _compressionLevel = compressionLevel;
+        return *this;
+    }
+
 private:
     EImageColorSpace _fromColorSpace{EImageColorSpace::LINEAR};
     EImageColorSpace _toColorSpace{EImageColorSpace::AUTO};
     EStorageDataType _storageDataType{EStorageDataType::Undefined};
+    EImageExrCompression _compressionMethod{EImageExrCompression::Auto};
+    int _compressionLevel{0};
 };
 
 /**

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -653,8 +653,7 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 }
 
 void saveImage(image::Image<image::RGBAfColor>& image, const std::string& inputPath, const std::string& outputPath, std::map<std::string, std::string> inputMetadata,
-               const std::vector<std::string>& metadataFolders, const image::EImageColorSpace workingColorSpace, const EImageFormat outputFormat,
-               const image::EImageColorSpace outputColorSpace, const image::EStorageDataType storageDataType)
+               const std::vector<std::string>& metadataFolders, const EImageFormat outputFormat, const image::ImageWriteOptions options)
 {
     // Read metadata path
     std::string metadataFilePath;
@@ -715,16 +714,6 @@ void saveImage(image::Image<image::RGBAfColor>& image, const std::string& inputP
         metadata = image::readImageMetadata(inputPath);
     }
 
-    image::ImageWriteOptions options;
-    options.fromColorSpace(workingColorSpace);
-    options.toColorSpace(outputColorSpace);
-
-    if(isEXR)
-    {
-        // Select storage data type
-        options.storageDataType(storageDataType);
-    }
-
     // Save image
     ALICEVISION_LOG_TRACE("Export image: '" << outputPath << "'.");
     
@@ -757,6 +746,8 @@ int aliceVision_main(int argc, char * argv[])
     image::EImageColorSpace workingColorSpace = image::EImageColorSpace::LINEAR;
     image::EImageColorSpace outputColorSpace = image::EImageColorSpace::LINEAR;
     image::EStorageDataType storageDataType = image::EStorageDataType::Float;
+    image::EImageExrCompression compressionMethod = image::EImageExrCompression::Auto;
+    int compressionLevel = 0;
     std::string extension;
     image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::DcpLinearProcessing;
     std::string colorProfileDatabaseDirPath = "";
@@ -889,6 +880,15 @@ int aliceVision_main(int argc, char * argv[])
 
         ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
          ("Storage data type: " + image::EStorageDataType_informations()).c_str())
+
+        ("compressionMethod", po::value<image::EImageExrCompression>(&compressionMethod)->default_value(compressionMethod),
+         ("Compression Method: " + image::EImageExrCompression_informations()).c_str())
+
+        ("compressionLevel", po::value<int>(&compressionLevel)->default_value(compressionLevel),
+         "Compression Level (must be strictly positive to be considered)\n"
+         "Apply only on jpg and exr extensions.\n"
+         "Act as \"Quality\" in range from 1 to 100 for jpeg.\n"
+         "Only dwaa, dwab, zip and zips compression methods are concerned for exr.")
 
         ("extension", po::value<std::string>(&extension)->default_value(extension),
          "Output image extension (like exr, or empty to keep the source file format.")
@@ -1075,8 +1075,21 @@ int aliceVision_main(int argc, char * argv[])
                 workingColorSpace = image::EImageColorSpace::ACES2065_1;
             }
 
+            image::ImageWriteOptions writeOptions;
+
+            writeOptions.fromColorSpace(workingColorSpace);
+            writeOptions.toColorSpace(outputColorSpace);
+            writeOptions.compressionMethod(compressionMethod);
+            writeOptions.compressionLevel(compressionLevel);
+
+            if (boost::to_lower_copy(fs::path(outputPath).extension().string()) == ".exr")
+            {
+                // Select storage data type
+                writeOptions.storageDataType(storageDataType);
+            }
+
             // Save the image
-            saveImage(image, viewPath, outputfilePath, view.getMetadata(), metadataFolders, workingColorSpace, outputFormat, outputColorSpace, storageDataType);
+            saveImage(image, viewPath, outputfilePath, view.getMetadata(), metadataFolders, outputFormat, writeOptions);
 
             // Update view for this modification
             view.setImagePath(outputfilePath);
@@ -1269,8 +1282,21 @@ int aliceVision_main(int argc, char * argv[])
             // Image processing
             processImage(image, pParams, md);
 
+            image::ImageWriteOptions writeOptions;
+
+            writeOptions.fromColorSpace(workingColorSpace);
+            writeOptions.toColorSpace(outputColorSpace);
+            writeOptions.compressionMethod(compressionMethod);
+            writeOptions.compressionLevel(compressionLevel);
+
+            if (boost::to_lower_copy(fs::path(outputPath).extension().string()) == ".exr")
+            {
+                // Select storage data type
+                writeOptions.storageDataType(storageDataType);
+            }
+
             // Save the image
-            saveImage(image, inputFilePath, outputFilePath, md, metadataFolders, workingColorSpace, outputFormat, outputColorSpace, storageDataType);
+            saveImage(image, inputFilePath, outputFilePath, md, metadataFolders, outputFormat, writeOptions);
         }
     }
 


### PR DESCRIPTION


<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Add new input options compressionMethod and compressionLevel in imageProcessing and panoramaPostProcessing.
CompressionLevel acts as "Quality" parameter for jpeg images and relies on selected method or exr images.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

