### PR TITLE
Split SFMData between reconstructed and other views

### DIFF
--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -194,6 +194,18 @@ alicevision_add_software(aliceVision_sfmTransform
         Boost::program_options
 )
 
+# SfM split reconstructed
+alicevision_add_software(aliceVision_sfmSplitReconstructed
+  SOURCE main_sfmSplitReconstructed.cpp
+  FOLDER ${FOLDER_SOFTWARE_UTILS}
+  LINKS aliceVision_system
+        aliceVision_feature
+        aliceVision_sfm
+        aliceVision_sfmData
+        aliceVision_sfmDataIO
+        Boost::program_options
+)
+
 # SfM color harmonize
 alicevision_add_software(aliceVision_sfmColorHarmonize
   SOURCE main_sfmColorHarmonize.cpp

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -199,8 +199,7 @@ alicevision_add_software(aliceVision_sfmSplitReconstructed
   SOURCE main_sfmSplitReconstructed.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
-        aliceVision_feature
-        aliceVision_sfm
+        aliceVision_cmdline
         aliceVision_sfmData
         aliceVision_sfmDataIO
         Boost::program_options

--- a/src/software/utils/main_sfmSplitReconstructed.cpp
+++ b/src/software/utils/main_sfmSplitReconstructed.cpp
@@ -1,5 +1,5 @@
 // This file is part of the AliceVision project.
-// Copyright (c) 2017 AliceVision contributors.
+// Copyright (c) 2023 AliceVision contributors.
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,7 +7,7 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/utils/main_sfmSplitReconstructed.cpp
+++ b/src/software/utils/main_sfmSplitReconstructed.cpp
@@ -1,0 +1,103 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2017 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/config.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string outRSfMDataFilename;
+    std::string outNRSfMDataFilename;
+
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file to align.")
+        ("reconstructedOutput", po::value<std::string>(&outRSfMDataFilename)->required(), "Output SfMData scene.")
+        ("notReconstructedOutput", po::value<std::string>(&outNRSfMDataFilename)->required(), "Output SfMData scene.");
+
+    CmdLine cmdline("AliceVision sfmTransform");
+    cmdline.add(requiredParams);
+    if(!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // Load input scene
+    sfmData::SfMData sfmData;
+    if(!sfmDataIO::Load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    //Create reconstructed only sfmData
+    {
+        sfmData::SfMData outReconstructed = sfmData;
+        auto & views = outReconstructed.getViews();
+        for (auto it = views.begin(); it != views.end(); it++)
+        {
+            if (sfmData.isPoseAndIntrinsicDefined(it->first))
+            {
+                continue;
+            }
+
+            it = views.erase(it);
+        }
+
+        // Export the SfMData scene in the expected format
+        if(!sfmDataIO::Save(outReconstructed, outRSfMDataFilename, sfmDataIO::ESfMData::ALL))
+        {
+            ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outRSfMDataFilename << "'");
+            return EXIT_FAILURE;
+        }
+    }
+
+    //Create non reconstructed only sfmData
+    {
+        sfmData::SfMData outNonReconstructed = sfmData;
+        outNonReconstructed.getConstraints2D().clear();
+        outNonReconstructed.getRotationPriors().clear();
+        outNonReconstructed.getLandmarks().clear();
+        auto & views = outNonReconstructed.getViews();
+        for (auto it = views.begin(); it != views.end(); it++)
+        {
+            if (sfmData.isPoseAndIntrinsicDefined(it->first))
+            {
+                it = views.erase(it);
+            }
+        }
+
+        // Export the SfMData scene in the expected format
+        if(!sfmDataIO::Save(outNonReconstructed, outNRSfMDataFilename, sfmDataIO::ESfMData::ALL))
+        {
+            ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outNRSfMDataFilename << "'");
+            return EXIT_FAILURE;
+        }
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_sfmSplitReconstructed.cpp
+++ b/src/software/utils/main_sfmSplitReconstructed.cpp
@@ -58,10 +58,13 @@ int aliceVision_main(int argc, char** argv)
     {
         sfmData::SfMData outReconstructed = sfmData;
         auto & views = outReconstructed.getViews();
-        for (auto it = views.begin(); it != views.end(); it++)
+
+        auto it = views.begin();
+        while (it != views.end())
         {
             if (sfmData.isPoseAndIntrinsicDefined(it->first))
             {
+                it++;
                 continue;
             }
 
@@ -83,13 +86,19 @@ int aliceVision_main(int argc, char** argv)
         outNonReconstructed.getRotationPriors().clear();
         outNonReconstructed.getLandmarks().clear();
         auto & views = outNonReconstructed.getViews();
-        for (auto it = views.begin(); it != views.end(); it++)
+
+        auto it = views.begin();
+        while (it != views.end())
         {
-            if (sfmData.isPoseAndIntrinsicDefined(it->first))
+            if (!sfmData.isPoseAndIntrinsicDefined(it->first))
             {
-                it = views.erase(it);
+                it++;
+                continue;
             }
+
+            it = views.erase(it);
         }
+
 
         // Export the SfMData scene in the expected format
         if(!sfmDataIO::Save(outNonReconstructed, outNRSfMDataFilename, sfmDataIO::ESfMData::ALL))


### PR DESCRIPTION
Take an input sfmdata

- Create 1 sfmdata with reconstructed views only (and landmarks)
- Create 1 sfmdata with non reconstructed views only (without landmarks)

TCSR-305