### PR TITLE
Move cmdline from system to dedicated module

### DIFF
--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_subdirectory(image)
 add_subdirectory(numeric)
 add_subdirectory(system)
+add_subdirectory(cmdline)
 add_subdirectory(stl)
 add_subdirectory(utils)
 add_subdirectory(panorama)

--- a/src/aliceVision/cmdline/CMakeLists.txt
+++ b/src/aliceVision/cmdline/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Sources
+set(cmdline_files_sources
+  cmdline.cpp
+)
+
+alicevision_add_library(aliceVision_cmdline
+  SOURCES ${cmdline_files_sources}
+  PUBLIC_LINKS
+    Boost::program_options
+  PRIVATE_LINKS
+    aliceVision_system
+)

--- a/src/aliceVision/cmdline/cmdline.cpp
+++ b/src/aliceVision/cmdline/cmdline.cpp
@@ -1,7 +1,7 @@
 #include "cmdline.hpp"
 
-#include "cpu.hpp"
-#include "MemoryInfo.hpp"
+#include <aliceVision/system/cpu.hpp>
+#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/alicevision_omp.hpp>
 
 namespace aliceVision {
@@ -17,7 +17,13 @@ bool CmdLine::execute(int argc, char** argv)
     _allParams.add(logParams);
 
     boost::program_options::options_description hardwareParams("Hardware parameters");
-    _hContext.setupFromCommandLine(hardwareParams);
+    
+    size_t uma = _hContext.getUserMaxMemoryAvailable();
+    unsigned int uca = _hContext.getUserMaxCoresAvailable();
+
+    hardwareParams.add_options()
+        ("maxMemoryAvailable", boost::program_options::value<size_t>(&uma)->default_value(uma), "User specified available RAM")
+        ("maxCoresAvailable", boost::program_options::value<unsigned int>(&uca)->default_value(uca), "User specified available number of cores");
 
     _allParams.add(hardwareParams);
 
@@ -52,6 +58,8 @@ bool CmdLine::execute(int argc, char** argv)
     // set verbose level
     system::Logger::get()->setLogLevel(verboseLevel);
 
+    _hContext.setUserMaxMemoryAvailable(uma);
+    _hContext.setUserMaxCoresAvailable(uca);
     _hContext.displayHardware();
 
     return true;

--- a/src/aliceVision/cmdline/cmdline.hpp
+++ b/src/aliceVision/cmdline/cmdline.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "Logger.hpp"
-#include "Timer.hpp"
-#include "hardwareContext.hpp"
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/Timer.hpp>
+#include <aliceVision/system/hardwareContext.hpp>
 
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/option.hpp>

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -19,7 +19,6 @@ set(system_files_sources
   Logger.cpp
   ProgressDisplay.cpp
   nvtx.cpp
-  cmdline.cpp
   hardwareContext.cpp
 )
 
@@ -31,7 +30,6 @@ alicevision_add_library(aliceVision_system
     Boost::thread
     Boost::system
     Boost::date_time
-    Boost::program_options
     ${ALICEVISION_NVTX_LIBRARY}
   PRIVATE_LINKS
     Boost::boost

--- a/src/aliceVision/system/hardwareContext.cpp
+++ b/src/aliceVision/system/hardwareContext.cpp
@@ -6,12 +6,6 @@
 
 namespace aliceVision {
 
-void HardwareContext::setupFromCommandLine(boost::program_options::options_description & options)
-{
-    options.add_options()
-        ("maxMemoryAvailable", boost::program_options::value<size_t>(&_maxUserMemoryAvailable)->default_value(_maxUserMemoryAvailable), "User specified available RAM")
-        ("maxCoresAvailable", boost::program_options::value<unsigned int>(&_maxUserCoresAvailable)->default_value(_maxUserCoresAvailable), "User specified available number of cores");
-}
 
 void HardwareContext::displayHardware()
 {

--- a/src/aliceVision/system/hardwareContext.hpp
+++ b/src/aliceVision/system/hardwareContext.hpp
@@ -9,7 +9,6 @@
 #include "Logger.hpp"
 #include "Timer.hpp"
 
-#include <boost/program_options/options_description.hpp>
 
 namespace aliceVision {
 
@@ -23,17 +22,25 @@ public:
         return _maxUserMemoryAvailable;
     }
 
+    void setUserMaxMemoryAvailable(size_t val)
+    {
+        _maxUserCoresAvailable = val;
+    }
+
     unsigned int getUserMaxCoresAvailable() const
     {
         return _maxUserCoresAvailable;
+    }
+
+    void setUserMaxCoresAvailable(unsigned int val)
+    {
+        _maxUserCoresAvailable = val;
     }
 
     void setUserCoresLimit(unsigned int coresLimit)
     {
         _limitUserCores = coresLimit;
     }
-
-    void setupFromCommandLine(boost::program_options::options_description & options);
 
     unsigned int getMaxThreads() const;
 

--- a/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
+++ b/src/samples/featuresRepeatability/main_repeatabilityDataset.cpp
@@ -14,7 +14,7 @@
 #include <aliceVision/matching/RegionsMatcher.hpp>
 
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 

--- a/src/samples/imageCaching/CMakeLists.txt
+++ b/src/samples/imageCaching/CMakeLists.txt
@@ -3,5 +3,6 @@ alicevision_add_software(aliceVision_samples_imageCaching
   FOLDER ${FOLDER_SAMPLES}
   LINKS aliceVision_system
         aliceVision_image
+        aliceVision_cmdline
         Boost::program_options
 )

--- a/src/samples/imageCaching/main_imageCaching.cpp
+++ b/src/samples/imageCaching/main_imageCaching.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/image/ImageCache.hpp>
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/samples/kvldFilter/CMakeLists.txt
+++ b/src/samples/kvldFilter/CMakeLists.txt
@@ -3,7 +3,7 @@ add_definitions(-DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 alicevision_add_software(aliceVision_samples_kvldFilter
   SOURCE main_kvldFilter.cpp
   FOLDER ${FOLDER_SAMPLES}
-  LINKS aliceVision_system
+  LINKS aliceVision_cmdline
         aliceVision_image
         aliceVision_multiview
         aliceVision_kvld

--- a/src/samples/multiBandBlending/main_multibandtest.cpp
+++ b/src/samples/multiBandBlending/main_multibandtest.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision//mvsData/Color.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 
 #include <boost/program_options.hpp>
 

--- a/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
+++ b/src/samples/robustHomographyGrowing/main_robustHomographyGrowing.cpp
@@ -14,7 +14,7 @@
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 

--- a/src/samples/texturing/main_evcorrection.cpp
+++ b/src/samples/texturing/main_evcorrection.cpp
@@ -6,7 +6,7 @@
  
 #include <aliceVision/sfmData/SfMData.hpp> 
 #include <aliceVision/system/Logger.hpp> 
-#include <aliceVision/system/cmdline.hpp> 
+#include <aliceVision/cmdline/cmdline.hpp> 
 #include <aliceVision/image/io.hpp> 
 #include <aliceVision/image/pixelTypes.hpp> 
  

--- a/src/software/convert/CMakeLists.txt
+++ b/src/software/convert/CMakeLists.txt
@@ -10,6 +10,7 @@ alicevision_add_software(aliceVision_convertSfMFormat
   SOURCE main_convertSfMFormat.cpp
   FOLDER ${FOLDER_SOFTWARE_CONVERT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfmData
         aliceVision_sfmDataIO
@@ -24,6 +25,7 @@ alicevision_add_software(aliceVision_convertFloatDescriptorToUchar
   FOLDER ${FOLDER_SOFTWARE_CONVERT}
   LINKS aliceVision_localization
         aliceVision_feature
+        aliceVision_cmdline        
         Boost::program_options
         Boost::filesystem
         Boost::boost
@@ -37,6 +39,7 @@ alicevision_add_software(aliceVision_importKnownPoses
         aliceVision_feature
         aliceVision_sfmData
         aliceVision_sfmDataIO
+        aliceVision_cmdline
         Boost::program_options
         Boost::filesystem
         Boost::boost
@@ -50,6 +53,7 @@ alicevision_add_software(aliceVision_convertRAW
   FOLDER ${FOLDER_SOFTWARE_CONVERT}
   LINKS aliceVision_system
         aliceVision_image
+        aliceVision_cmdline
         Boost::program_options
         Boost::filesystem
 )
@@ -62,6 +66,7 @@ alicevision_add_software(aliceVision_convertMesh
   FOLDER ${FOLDER_SOFTWARE_CONVERT}
   LINKS aliceVision_system
         aliceVision_numeric
+        aliceVision_cmdline
 	aliceVision_mesh
         ${Boost_LIBRARIES}
 )

--- a/src/software/convert/main_convertFloatDescriptorToUchar.cpp
+++ b/src/software/convert/main_convertFloatDescriptorToUchar.cpp
@@ -6,7 +6,7 @@
 
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/filesystem.hpp>

--- a/src/software/convert/main_convertMesh.cpp
+++ b/src/software/convert/main_convertMesh.cpp
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/mesh/Texturing.hpp>

--- a/src/software/convert/main_convertRAW.cpp
+++ b/src/software/convert/main_convertRAW.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -8,7 +8,7 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/stl/regex.hpp>
 #include <aliceVision/config.hpp>

--- a/src/software/convert/main_importKnownPoses.cpp
+++ b/src/software/convert/main_importKnownPoses.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/utils/regexFilter.hpp>

--- a/src/software/export/CMakeLists.txt
+++ b/src/software/export/CMakeLists.txt
@@ -11,6 +11,7 @@ if(ALICEVISION_HAVE_ALEMBIC)
     SOURCE main_exportAnimatedCamera.cpp
     FOLDER ${FOLDER_SOFTWARE_EXPORT}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_sfmData
           aliceVision_sfmDataIO
           Boost::program_options
@@ -25,6 +26,7 @@ alicevision_add_software(aliceVision_exportKeypoints
   SOURCE main_exportKeypoints.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
@@ -40,6 +42,7 @@ alicevision_add_software(aliceVision_exportMatches
   SOURCE main_exportMatches.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
@@ -55,6 +58,7 @@ alicevision_add_software(aliceVision_exportTracks
   SOURCE main_exportTracks.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
@@ -70,6 +74,7 @@ alicevision_add_software(aliceVision_exportPMVS
   SOURCE main_exportPMVS.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfmData
@@ -85,6 +90,7 @@ alicevision_add_software(aliceVision_exportColmap
         SOURCE main_exportColmap.cpp
         FOLDER ${FOLDER_SOFTWARE_EXPORT}
         LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfmData
@@ -101,6 +107,7 @@ alicevision_add_software(aliceVision_exportColoredPointCloud
   SOURCE main_exportColoredPointCloud.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfmData
@@ -114,6 +121,7 @@ if(ALICEVISION_HAVE_ALEMBIC) # maya can read alembic file
     SOURCE main_exportMeshroomMaya.cpp
     FOLDER ${FOLDER_SOFTWARE_EXPORT}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_feature
           aliceVision_sfmData
@@ -131,6 +139,7 @@ alicevision_add_software(aliceVision_exportMVE2
   SOURCE main_exportMVE2.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfmData
@@ -146,6 +155,7 @@ alicevision_add_software(aliceVision_exportMeshlab
   SOURCE main_exportMeshlab.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfmData
@@ -161,6 +171,7 @@ alicevision_add_software(aliceVision_exportMVSTexturing
   SOURCE main_exportMVSTexturing.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfmData
@@ -174,6 +185,7 @@ alicevision_add_software(aliceVision_exportMatlab
   SOURCE main_exportMatlab.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfmData
@@ -189,6 +201,7 @@ alicevision_add_software(aliceVision_exportCameraFrustums
   SOURCE main_exportCameraFrustums.cpp
   FOLDER ${FOLDER_SOFTWARE_EXPORT}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>

--- a/src/software/export/main_exportCameraFrustums.cpp
+++ b/src/software/export/main_exportCameraFrustums.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/export/main_exportColmap.cpp
+++ b/src/software/export/main_exportColmap.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/sfmDataIO/colmap.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>

--- a/src/software/export/main_exportColoredPointCloud.cpp
+++ b/src/software/export/main_exportColoredPointCloud.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmData/colorize.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/export/main_exportKeypoints.cpp
+++ b/src/software/export/main_exportKeypoints.cpp
@@ -13,7 +13,7 @@
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/image/all.hpp>
 

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 

--- a/src/software/export/main_exportMVSTexturing.cpp
+++ b/src/software/export/main_exportMVSTexturing.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 

--- a/src/software/export/main_exportMatches.cpp
+++ b/src/software/export/main_exportMatches.cpp
@@ -15,7 +15,7 @@
 #include <aliceVision/matching/svgVisualization.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/convertion.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 

--- a/src/software/export/main_exportMeshlab.cpp
+++ b/src/software/export/main_exportMeshlab.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 

--- a/src/software/export/main_exportMeshroomMaya.cpp
+++ b/src/software/export/main_exportMeshroomMaya.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 

--- a/src/software/export/main_exportTracks.cpp
+++ b/src/software/export/main_exportTracks.cpp
@@ -18,7 +18,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <software/utils/sfmHelper/sfmIOHelper.hpp>

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -12,6 +12,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_cameraInit.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_sensorDB
           aliceVision_image
           aliceVision_feature
@@ -31,6 +32,7 @@ if(ALICEVISION_BUILD_SFM)
       LINKS aliceVision_image
             aliceVision_imageMasking
             aliceVision_system
+            aliceVision_cmdline
             aliceVision_sfmData
             aliceVision_sfmDataIO
             ${OpenCV_LIBRARIES}
@@ -43,6 +45,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaPrepareImages.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_sensorDB
           aliceVision_image
           aliceVision_feature
@@ -58,6 +61,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_featureExtraction.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_gpu
           aliceVision_image
           aliceVision_feature
@@ -77,6 +81,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_imageMatching.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_imageMatching
           aliceVision_matchingImageCollection
           aliceVision_sfm
@@ -93,6 +98,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_featureMatching.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_feature
           aliceVision_multiview
           aliceVision_matchingImageCollection
@@ -108,6 +114,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_incrementalSfM.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_feature
           aliceVision_sfm
@@ -122,6 +129,7 @@ if(ALICEVISION_BUILD_SFM)
   SOURCE main_sfmTriangulation.cpp
   FOLDER ${FOLDER_SOFTWARE_PIPELINE}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfm
@@ -136,6 +144,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_globalSfM.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_feature
           aliceVision_sfm
@@ -150,6 +159,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaEstimation.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_feature
           aliceVision_sfm
@@ -161,6 +171,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaWarping.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_feature
           aliceVision_sfm
@@ -173,6 +184,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaMerging.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_sfmData
           aliceVision_sfmDataIO
@@ -183,6 +195,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaPostProcessing.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           ${Boost_LIBRARIES}
   )
@@ -190,6 +203,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaCompositing.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_sfmData
           aliceVision_sfmDataIO
@@ -200,6 +214,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaSeams.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_sfmData
           aliceVision_sfmDataIO
@@ -210,6 +225,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_panoramaInit.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_feature
           aliceVision_sfm
@@ -222,6 +238,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_computeStructureFromKnownPoses.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_feature
           aliceVision_sfm
           aliceVision_sfmData
@@ -239,6 +256,7 @@ if(ALICEVISION_BUILD_SFM)
             aliceVision_image
             aliceVision_calibration
             aliceVision_system
+            aliceVision_cmdline
             Boost::program_options
             Boost::filesystem
             Boost::boost
@@ -252,6 +270,7 @@ if(ALICEVISION_BUILD_SFM)
           aliceVision_image
           aliceVision_calibration
           aliceVision_system
+          aliceVision_cmdline
           aliceVision_sfmDataIO
           Boost::program_options
           Boost::filesystem
@@ -267,6 +286,7 @@ if(ALICEVISION_BUILD_SFM)
           aliceVision_dataio
           aliceVision_image
           aliceVision_feature
+          aliceVision_cmdline
           Boost::program_options
           Boost::filesystem
           Boost::boost
@@ -281,6 +301,7 @@ if(ALICEVISION_BUILD_SFM)
           aliceVision_calibration
           aliceVision_system
           aliceVision_sfmDataIO
+          aliceVision_cmdline
           Boost::program_options
           Boost::filesystem
           Boost::boost
@@ -299,6 +320,7 @@ if(ALICEVISION_BUILD_SFM)
           aliceVision_dataio
           aliceVision_image
           aliceVision_feature
+          aliceVision_cmdline
           Boost::program_options
           Boost::filesystem
           Boost::boost
@@ -318,6 +340,7 @@ if(ALICEVISION_BUILD_SFM)
           aliceVision_rig
           aliceVision_image
           aliceVision_feature
+          aliceVision_cmdline
           Boost::program_options
           Boost::filesystem
           Boost::boost
@@ -333,6 +356,7 @@ if(ALICEVISION_BUILD_SFM)
     SOURCE main_prepareDenseScene.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_feature
           aliceVision_sfmData
@@ -353,6 +377,7 @@ if(ALICEVISION_BUILD_MVS)
       SOURCE main_depthMapEstimation.cpp
       FOLDER ${FOLDER_SOFTWARE_PIPELINE}
       LINKS aliceVision_system
+          aliceVision_cmdline
             aliceVision_gpu
             aliceVision_mvsData
             aliceVision_mvsUtils
@@ -368,6 +393,7 @@ if(ALICEVISION_BUILD_MVS)
       SOURCE main_depthMapFiltering.cpp
       FOLDER ${FOLDER_SOFTWARE_PIPELINE}
       LINKS aliceVision_system
+            aliceVision_cmdline
             aliceVision_mvsData
             aliceVision_mvsUtils
             aliceVision_fuseCut
@@ -384,6 +410,7 @@ if(ALICEVISION_BUILD_MVS)
     SOURCE main_meshing.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_mvsData
           aliceVision_mvsUtils
           aliceVision_mesh
@@ -401,6 +428,7 @@ if(ALICEVISION_BUILD_MVS)
       SOURCE main_meshDenoising.cpp
       FOLDER ${FOLDER_SOFTWARE_PIPELINE}
       LINKS aliceVision_system
+            aliceVision_cmdline
             aliceVision_mvsUtils
             MeshSDLibrary
             Eigen3::Eigen
@@ -413,6 +441,7 @@ if(ALICEVISION_BUILD_MVS)
       SOURCE main_meshDecimate.cpp
       FOLDER ${FOLDER_SOFTWARE_PIPELINE}
       LINKS aliceVision_system
+            aliceVision_cmdline
             aliceVision_mvsUtils
             OpenMesh
             Boost::program_options
@@ -425,6 +454,7 @@ if(ALICEVISION_BUILD_MVS)
     SOURCE main_meshFiltering.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_mvsUtils
           aliceVision_mesh
           Boost::program_options
@@ -436,6 +466,7 @@ if(ALICEVISION_BUILD_MVS)
     SOURCE main_meshMasking.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_sfmMvsUtils
           aliceVision_mvsUtils
           aliceVision_mesh
@@ -450,6 +481,7 @@ if(ALICEVISION_BUILD_MVS)
     SOURCE main_meshResampling.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_mvsUtils
           Geogram::geogram
           Boost::program_options
@@ -461,6 +493,7 @@ if(ALICEVISION_BUILD_MVS)
     SOURCE main_texturing.cpp
     FOLDER ${FOLDER_SOFTWARE_PIPELINE}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_mvsData
           aliceVision_sfmMvsUtils
           aliceVision_mvsUtils
@@ -479,6 +512,7 @@ alicevision_add_software(aliceVision_LdrToHdrSampling
   SOURCE main_LdrToHdrSampling.cpp
   FOLDER ${FOLDER_SOFTWARE_PIPELINE}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_hdr
         aliceVision_sfmData
@@ -492,6 +526,7 @@ alicevision_add_software(aliceVision_LdrToHdrCalibration
   SOURCE main_LdrToHdrCalibration.cpp
   FOLDER ${FOLDER_SOFTWARE_PIPELINE}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_hdr
         aliceVision_sfmData
@@ -504,6 +539,7 @@ alicevision_add_software(aliceVision_LdrToHdrMerge
   SOURCE main_LdrToHdrMerge.cpp
   FOLDER ${FOLDER_SOFTWARE_PIPELINE}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_hdr
         aliceVision_sfmData

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <OpenImageIO/imagebufalgo.h>
 
@@ -93,7 +93,7 @@ void computeLuminanceStatFromSamples(const std::vector<hdr::ImageSample>& sample
 
 void computeLuminanceInfoFromImage(image::Image<image::RGBfColor>& image, luminanceInfo& lumaInfo)
 {
-    // Luminance statistics are calculated from a subsampled square, centered and rotated by 45°.
+    // Luminance statistics are calculated from a subsampled square, centered and rotated by 45ï¿½.
     // 2 vertices of this square are the centers of the longest sides of the image.
     // Such a shape is suitable for both fisheye and classic images.
 

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -93,7 +93,7 @@ void computeLuminanceStatFromSamples(const std::vector<hdr::ImageSample>& sample
 
 void computeLuminanceInfoFromImage(image::Image<image::RGBfColor>& image, luminanceInfo& lumaInfo)
 {
-    // Luminance statistics are calculated from a subsampled square, centered and rotated by 45�.
+    // Luminance statistics are calculated from a subsampled square, centered and rotated by 45 degree.
     // 2 vertices of this square are the centers of the longest sides of the image.
     // Such a shape is suitable for both fisheye and classic images.
 

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <OpenImageIO/imagebufalgo.h>
 

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 // SFMData

--- a/src/software/pipeline/main_cameraCalibration.cpp
+++ b/src/software/pipeline/main_cameraCalibration.cpp
@@ -15,7 +15,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -12,7 +12,7 @@
 #include <aliceVision/lensCorrectionProfile/lcp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/image/io.cpp>
 #include <aliceVision/image/dcp.hpp>
 

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -21,7 +21,7 @@
 #include <aliceVision/robustEstimation/estimators.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/utils/convert.hpp>
 
 #include <boost/filesystem.hpp>

--- a/src/software/pipeline/main_checkerboardDetection.cpp
+++ b/src/software/pipeline/main_checkerboardDetection.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
+++ b/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
@@ -13,7 +13,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/pipeline/main_depthMapEstimation.cpp
+++ b/src/software/pipeline/main_depthMapEstimation.cpp
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>

--- a/src/software/pipeline/main_depthMapFiltering.cpp
+++ b/src/software/pipeline/main_depthMapFiltering.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/mvsData/StaticVector.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/mvsUtils/MultiViewParams.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_distortionCalibration.cpp
+++ b/src/software/pipeline/main_distortionCalibration.cpp
@@ -10,7 +10,7 @@
 #include <boost/filesystem.hpp>
 #include <sstream>
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -19,7 +19,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -29,7 +29,7 @@
 #include <aliceVision/matching/io.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/graph/graph.hpp>
 #include <aliceVision/stl/stl.hpp>
 

--- a/src/software/pipeline/main_globalSfM.cpp
+++ b/src/software/pipeline/main_globalSfM.cpp
@@ -13,7 +13,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>

--- a/src/software/pipeline/main_imageMasking.cpp
+++ b/src/software/pipeline/main_imageMasking.cpp
@@ -11,7 +11,7 @@
 #include <aliceVision/imageMasking/imageMasking.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -12,7 +12,7 @@
 #include <aliceVision/sfm/FrustumFilter.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/config.hpp>
 
 #include <Eigen/Core>

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -13,7 +13,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/track/TracksBuilder.hpp>

--- a/src/software/pipeline/main_meshDecimate.cpp
+++ b/src/software/pipeline/main_meshDecimate.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_meshDenoising.cpp
+++ b/src/software/pipeline/main_meshDenoising.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/mesh/Mesh.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/sfmMvsUtils/visibility.hpp>

--- a/src/software/pipeline/main_meshResampling.cpp
+++ b/src/software/pipeline/main_meshResampling.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -17,7 +17,7 @@
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/mvsUtils/MultiViewParams.hpp>
 #include <aliceVision/mvsUtils/fileIO.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -23,7 +23,7 @@
 
 // Reading command line options
 #include <boost/program_options.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 // Numeric utils

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -14,7 +14,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/image/all.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -1,5 +1,5 @@
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>

--- a/src/software/pipeline/main_panoramaMerging.cpp
+++ b/src/software/pipeline/main_panoramaMerging.cpp
@@ -18,7 +18,7 @@
 
 // Reading command line options
 #include <boost/program_options.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 // IO

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -14,7 +14,7 @@
 
 // Reading command line options
 #include <boost/program_options.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <aliceVision/stl/mapUtils.hpp>

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <OpenImageIO/imagebufalgo.h>
 

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -22,7 +22,7 @@
 
 // Reading command line options
 #include <boost/program_options.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 // IO

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -7,7 +7,7 @@
 // Reading command line options
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 // Image related

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>

--- a/src/software/pipeline/main_rigCalibration.cpp
+++ b/src/software/pipeline/main_rigCalibration.cpp
@@ -17,7 +17,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/robustEstimation/estimators.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/utils/convert.hpp>
 

--- a/src/software/pipeline/main_rigLocalization.cpp
+++ b/src/software/pipeline/main_rigLocalization.cpp
@@ -17,7 +17,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/robustEstimation/estimators.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/utils/convert.hpp>
 

--- a/src/software/pipeline/main_sfmTriangulation.cpp
+++ b/src/software/pipeline/main_sfmTriangulation.cpp
@@ -12,7 +12,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/track/TracksBuilder.hpp>

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -15,7 +15,7 @@
 #include <aliceVision/mvsUtils/MultiViewParams.hpp>
 #include <aliceVision/mvsUtils/ImagesCache.hpp>
 #include <aliceVision/sfmMvsUtils/visibility.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -10,6 +10,7 @@ alicevision_add_software(aliceVision_hardwareResources
   SOURCE main_hardwareResources.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_gpu
         Boost::program_options
 )
@@ -23,6 +24,7 @@ if(ALICEVISION_HAVE_UNCERTAINTYTE)
       FOLDER ${FOLDER_SOFTWARE_UTILS}
       LINKS aliceVision_sfm
             aliceVision_system
+            aliceVision_cmdline
             ${CUDA_LIBRARIES}
             ${CUDA_CUBLAS_LIBRARIES}
             ${CUDA_cusparse_LIBRARY}
@@ -40,6 +42,7 @@ alicevision_add_software(aliceVision_imageProcessing
     SOURCE main_imageProcessing.cpp
     FOLDER ${FOLDER_SOFTWARE_UTILS}
     LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_sfm
@@ -61,6 +64,7 @@ alicevision_add_software(aliceVision_importMiddlebury
         aliceVision_sfmData
         aliceVision_sfmDataIO
         aliceVision_system
+        aliceVision_cmdline
         ${Boost_LIBRARIES}
         )
 
@@ -73,6 +77,7 @@ alicevision_add_software(aliceVision_voctreeCreation
         aliceVision_sfmData
         aliceVision_sfmDataIO
         aliceVision_system
+        aliceVision_cmdline
         Boost::program_options
 )
 
@@ -85,6 +90,7 @@ alicevision_add_software(aliceVision_voctreeQueryUtility
         aliceVision_sfmData
         aliceVision_sfmDataIO
         aliceVision_system
+        aliceVision_cmdline
         Boost::program_options
         Boost::boost
         Boost::timer
@@ -97,6 +103,7 @@ alicevision_add_software(aliceVision_voctreeStatistics
   LINKS aliceVision_voctree
         aliceVision_sfmData
         aliceVision_system
+        aliceVision_cmdline
         aliceVision_sfmDataIO
         Boost::program_options
         Boost::boost
@@ -107,6 +114,7 @@ alicevision_add_software(aliceVision_frustumFiltering
   SOURCE main_frustumFiltering.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_matchingImageCollection
         aliceVision_sfm
@@ -127,6 +135,7 @@ if(ALICEVISION_HAVE_ALEMBIC)
           aliceVision_dataio
           aliceVision_rig
           aliceVision_system
+          aliceVision_cmdline
           Boost::program_options
           Boost::filesystem
   )
@@ -138,6 +147,7 @@ alicevision_add_software(aliceVision_qualityEvaluation
   SOURCE main_qualityEvaluation.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfmData
         aliceVision_sfmDataIO
@@ -150,6 +160,7 @@ alicevision_add_software(aliceVision_sfmAlignment
   SOURCE main_sfmAlignment.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
@@ -162,6 +173,7 @@ alicevision_add_software(aliceVision_sfmTransfer
   SOURCE main_sfmTransfer.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
@@ -174,6 +186,7 @@ alicevision_add_software(aliceVision_sfmTransform
   SOURCE main_sfmTransform.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
@@ -187,6 +200,7 @@ alicevision_add_software(aliceVision_sfmColorHarmonize
          sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp # TODO
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_image
         aliceVision_feature
         aliceVision_kvld
@@ -208,6 +222,7 @@ alicevision_add_software(aliceVision_sfmLocalization
   SOURCE main_sfmLocalization.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
@@ -223,6 +238,7 @@ if(ALICEVISION_HAVE_OPENCV)
     SOURCE main_keyframeSelection.cpp
     FOLDER ${FOLDER_SOFTWARE_UTILS}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_image
           aliceVision_keyframe
           ${OPENIMAGEIO_LIBRARIES}
@@ -240,6 +256,7 @@ alicevision_add_software(aliceVision_sfmDistances
         aliceVision_sfmData
         aliceVision_sfmDataIO
         aliceVision_system
+        aliceVision_cmdline
         ${Boost_LIBRARIES}
 )
 
@@ -248,6 +265,7 @@ alicevision_add_software(aliceVision_split360Images
   SOURCE main_split360Images.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_numeric
         aliceVision_image
         aliceVision_panorama
@@ -262,6 +280,7 @@ alicevision_add_software(aliceVision_fisheyeProjection
   SOURCE main_fisheyeProjection.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_numeric
         aliceVision_image
         ${OPENIMAGEIO_LIBRARIES}
@@ -273,6 +292,7 @@ alicevision_add_software(aliceVision_lightingEstimation
   SOURCE main_lightingEstimation.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_numeric
         aliceVision_sfmData
         aliceVision_sfmDataIO
@@ -288,6 +308,7 @@ alicevision_add_software(aliceVision_generateSampleScene
   SOURCE main_generateSampleScene.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_numeric
         aliceVision_sfmData
         aliceVision_sfmDataIO
@@ -302,6 +323,7 @@ if(ALICEVISION_HAVE_OPENCV_CONTRIB)
     SOURCE main_colorCheckerDetection.cpp
     FOLDER ${FOLDER_SOFTWARE_UTILS}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_sfmData
           aliceVision_sfmDataIO
           Boost::program_options
@@ -318,6 +340,7 @@ if(ALICEVISION_HAVE_OPENCV_CONTRIB)
     SOURCE main_colorCheckerCorrection.cpp
     FOLDER ${FOLDER_SOFTWARE_UTILS}
     LINKS aliceVision_system
+          aliceVision_cmdline
           aliceVision_sfmData
           aliceVision_sfmDataIO
           Boost::program_options
@@ -336,6 +359,7 @@ alicevision_add_software(aliceVision_mergeMeshes
   SOURCE main_mergeMeshes.cpp
   FOLDER ${FOLDER_SOFTWARE_UTILS}
   LINKS aliceVision_system
+        aliceVision_cmdline
         aliceVision_numeric
 	Geogram::geogram
         ${Boost_LIBRARIES}

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -11,7 +11,7 @@
 #include <aliceVision/utils/regexFilter.hpp>
 #include <aliceVision/utils/filesIO.hpp>
 
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -8,7 +8,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/utils/filesIO.hpp>

--- a/src/software/utils/main_computeUncertainty.cpp
+++ b/src/software/utils/main_computeUncertainty.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/sfm/BundleAdjustmentCeres.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/utils/main_fisheyeProjection.cpp
+++ b/src/software/utils/main_fisheyeProjection.cpp
@@ -10,7 +10,7 @@
 #include <aliceVision/image/Sampler.hpp>
 #include <aliceVision/image/convertion.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/camera/camera.hpp>
 

--- a/src/software/utils/main_frustumFiltering.cpp
+++ b/src/software/utils/main_frustumFiltering.cpp
@@ -11,7 +11,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/matchingImageCollection/ImagePairListIO.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_generateSampleScene.cpp
+++ b/src/software/utils/main_generateSampleScene.cpp
@@ -6,7 +6,7 @@
 
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/sceneSample.hpp>

--- a/src/software/utils/main_hardwareResources.cpp
+++ b/src/software/utils/main_hardwareResources.cpp
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/gpu/gpu.hpp>

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1,5 +1,5 @@
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/numeric/numeric.hpp>

--- a/src/software/utils/main_importMiddlebury.cpp
+++ b/src/software/utils/main_importMiddlebury.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -7,7 +7,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/keyframe/KeyframeSelector.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 

--- a/src/software/utils/main_lightingEstimation.cpp
+++ b/src/software/utils/main_lightingEstimation.cpp
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>

--- a/src/software/utils/main_mergeMeshes.cpp
+++ b/src/software/utils/main_mergeMeshes.cpp
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
 

--- a/src/software/utils/main_qualityEvaluation.cpp
+++ b/src/software/utils/main_qualityEvaluation.cpp
@@ -8,7 +8,7 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/utils/main_rigTransform.cpp
+++ b/src/software/utils/main_rigTransform.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmDataIO/AlembicExporter.hpp>
 #include <aliceVision/rig/Rig.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 

--- a/src/software/utils/main_sfmAlignment.cpp
+++ b/src/software/utils/main_sfmAlignment.cpp
@@ -8,7 +8,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/utils/main_sfmColorHarmonize.cpp
+++ b/src/software/utils/main_sfmColorHarmonize.cpp
@@ -7,7 +7,7 @@
 
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp>

--- a/src/software/utils/main_sfmDistances.cpp
+++ b/src/software/utils/main_sfmDistances.cpp
@@ -8,7 +8,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/config.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_sfmLocalization.cpp
+++ b/src/software/utils/main_sfmLocalization.cpp
@@ -13,7 +13,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp>

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -8,7 +8,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/utils/alignment.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/Sampler.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>

--- a/src/software/utils/main_voctreeCreation.cpp
+++ b/src/software/utils/main_voctreeCreation.cpp
@@ -12,7 +12,7 @@
 #include <aliceVision/voctree/descriptorLoader.hpp>
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <Eigen/Core>

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -13,7 +13,7 @@
 #include <aliceVision/voctree/descriptorLoader.hpp>
 #include <aliceVision/matching/IndMatch.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/utils/convert.hpp>

--- a/src/software/utils/main_voctreeStatistics.cpp
+++ b/src/software/utils/main_voctreeStatistics.cpp
@@ -11,7 +11,7 @@
 #include <aliceVision/voctree/VocabularyTree.hpp>
 #include <aliceVision/voctree/descriptorLoader.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/cmdline.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 
 #include <boost/program_options.hpp> 


### PR DESCRIPTION
Move command line management code from alicevision_system to the new module alicevision_cmdline.

Avoid polluting alicevision_system with cmdline libraries