### PR TITLE
SfM: Expose new parameters to the command line

### DIFF
--- a/src/aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp
+++ b/src/aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp
@@ -40,12 +40,20 @@ inline bool loadPairwiseMatches(
 {
   std::vector<std::string> matchesFolders;
 
+  ALICEVISION_LOG_DEBUG("List of provided match folders:");
+  for (auto it = folders.begin(); it != folders.end(); ++it)
+    ALICEVISION_LOG_DEBUG("\t - " << *it);
+
   if(!useOnlyMatchesFromFolder)
     matchesFolders = sfmData.getMatchesFolders();
   else
     ALICEVISION_LOG_DEBUG("Load only matches from given folder.");
 
   matchesFolders.insert(matchesFolders.end(), folders.begin(), folders.end());
+
+  ALICEVISION_LOG_DEBUG("List of match folders to load:");
+  for (auto it = matchesFolders.begin(); it != matchesFolders.end(); ++it)
+    ALICEVISION_LOG_DEBUG("\t - " << *it);
 
   ALICEVISION_LOG_DEBUG("Loading matches");
   if (!matching::Load(out_pairwiseMatches, sfmData.getViewsKeys(), matchesFolders, descTypes, maxNbMatches, minNbMatches))

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -104,7 +104,7 @@ std::unique_ptr<feature::Regions> loadFeatures(const std::vector<std::string>& f
   if(featFilename.empty())
     throw std::runtime_error("Can't find view " + basename + " features file");
 
-  ALICEVISION_LOG_TRACE("Features filename: " << featFilename);
+  ALICEVISION_LOG_DEBUG("Features filename: " << featFilename);
 
   std::unique_ptr<feature::Regions> regionsPtr;
   imageDescriber.allocate(regionsPtr);
@@ -240,6 +240,14 @@ bool loadFeaturesPerView(feature::FeaturesPerView& featuresPerView,
 {
   std::vector<std::string> featuresFolders = sfmData.getFeaturesFolders(); // add sfm features folders
   featuresFolders.insert(featuresFolders.end(), folders.begin(), folders.end()); // add user features folders
+
+  ALICEVISION_LOG_DEBUG("List of provided feature folders:");
+  for (auto it = folders.begin(); it != folders.end(); ++it)
+    ALICEVISION_LOG_DEBUG("\t - " << *it);
+
+  ALICEVISION_LOG_DEBUG("List of feature folders to load:");
+  for (auto it = featuresFolders.begin(); it != featuresFolders.end(); ++it)
+    ALICEVISION_LOG_DEBUG("\t - " << *it);
 
   auto progressDisplay = system::createConsoleProgressDisplay(sfmData.getViews().size(), std::cout,
                                                               "Loading features\n");

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -63,12 +63,27 @@ public:
     bool filterTrackForks = true;
     robustEstimation::ERobustEstimator localizerEstimator = robustEstimation::ERobustEstimator::ACRANSAC;
     double localizerEstimatorError = std::numeric_limits<double>::infinity();
-    size_t localizerEstimatorMaxIterations = 4096;
+    std::size_t localizerEstimatorMaxIterations = 4096;
 
     // Pyramid scoring
 
     const int pyramidBase = 2;
     const int pyramidDepth = 5;
+
+    // Bundle Adjustment triggering
+
+    /// The beginning of the incremental SfM is a well known risky and
+    /// unstable step which has a big impact on the final result.
+    /// The Bundle Adjustment is an intensive computing step so we only use it
+    /// every N cameras.
+    /// We make an exception for the first 'nbFirstUnstableCameras' cameras
+    /// and perform a BA for each camera because it makes the results
+    /// more stable and it's quite cheap because we have few data.
+    std::size_t nbFirstUnstableCameras = 30;
+
+    /// Limit to a maximum number of cameras added to ensure that
+    /// we don't add too much data in one step without bundle adjustment.
+    std::size_t maxImagesPerGroup = 30;
 
     // Local Bundle Adjustment data
 

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -27,7 +27,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 2
 
 using namespace aliceVision;
 

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -153,6 +153,13 @@ int aliceVision_main(int argc, char **argv)
       "It reduces the reconstruction time, especially for big datasets (500+ images).")
     ("localBAGraphDistance", po::value<int>(&sfmParams.localBundelAdjustementGraphDistanceLimit)->default_value(sfmParams.localBundelAdjustementGraphDistanceLimit),
       "Graph-distance limit setting the Active region in the Local Bundle Adjustment strategy.")
+    ("nbFirstUnstableCameras", po::value<std::size_t>(&sfmParams.nbFirstUnstableCameras)->default_value(sfmParams.nbFirstUnstableCameras),
+      "Number of cameras for which the bundle adjustment is performed every single time a camera is added, leading to more stable "
+      "results while the computations are not too expensive since there is not much data. Past this number, the bundle adjustment "
+      "will only be performed once for N added cameras.")
+    ("maxImagesPerGroup", po::value<std::size_t>(&sfmParams.maxImagesPerGroup)->default_value(sfmParams.maxImagesPerGroup),
+      "Maximum number of cameras that can be added before the bundle adjustment is performed. This prevents adding too much data "
+      "at once without performing the bundle adjustment.")
     ("localizerEstimator", po::value<robustEstimation::ERobustEstimator>(&sfmParams.localizerEstimator)->default_value(sfmParams.localizerEstimator),
       "Estimator type used to localize cameras (acransac (default), ransac, lsmeds, loransac, maxconsensus)")
     ("localizerEstimatorError", po::value<double>(&sfmParams.localizerEstimatorError)->default_value(0.0),


### PR DESCRIPTION
## Description

This PR exposes two previously hard-coded parameters to the Incremental Structure From Motion command line:
- `nbFirstUnstableCameras`, which sets the number of cameras for which the bundle adjustment is performed every time a new camera is added. Past `nbFirstUnstableCameras` cameras, the bundle adjustment is only performed once every N cameras, with N up to `maxImagesPerGroup`;
- `maxImagesPerGroup`, which sets the maximum number of cameras that can be added before the bundle adjustment has to be performed again.  

Additionally, debug logs have been added to monitor the feature and match folders that are provided, and those that are actually loaded. 

Related pull request in Meshroom: https://github.com/alicevision/Meshroom/pull/1980