### PR TITLE
[image] ImageCache improvements

### DIFF
--- a/src/aliceVision/image/ImageCache.hpp
+++ b/src/aliceVision/image/ImageCache.hpp
@@ -335,7 +335,7 @@ std::shared_ptr<Image<TPix>> ImageCache::get(const std::string& filename, int do
     }
 
     // retrieve missing capacity
-    unsigned long long int missingCapacity = memSize + _info.contentSize - _info.capacity;
+    long long int missingCapacity = memSize + _info.contentSize - _info.capacity;
 
     // find unused image with size bigger than missing capacity
     // remove it and add image to cache

--- a/src/aliceVision/image/ImageCache.hpp
+++ b/src/aliceVision/image/ImageCache.hpp
@@ -219,11 +219,12 @@ public:
      * @note This method is thread-safe.
      * @param[in] filename the image's filename on disk
      * @param[in] downscaleLevel the downscale level
+     * @param[in] cachedOnly if true, only return images that are already in the cache
      * @return a shared pointer to the cached image
      * @throws std::runtime_error if the image does not fit in the maximal size of the cache
      */
     template<typename TPix>
-    std::shared_ptr<Image<TPix>> get(const std::string& filename, int downscaleLevel = 1);
+    std::shared_ptr<Image<TPix>> get(const std::string& filename, int downscaleLevel = 1, bool cachedOnly = false);
 
     /**
      * @brief Check if an image at a given downscale level is currently in the cache.
@@ -279,7 +280,7 @@ private:
 // their definition must be given in this header file
 
 template<typename TPix>
-std::shared_ptr<Image<TPix>> ImageCache::get(const std::string& filename, int downscaleLevel)
+std::shared_ptr<Image<TPix>> ImageCache::get(const std::string& filename, int downscaleLevel, bool cachedOnly)
 {
     if (downscaleLevel < 1)
     {
@@ -311,6 +312,10 @@ std::shared_ptr<Image<TPix>> ImageCache::get(const std::string& filename, int do
 
             ALICEVISION_LOG_TRACE("[image] ImageCache: " << toString());
             return _imagePtrs.at(keyReq).get<TPix>();
+        }
+        else if (cachedOnly)
+        {
+            return nullptr;
         }
     }
 


### PR DESCRIPTION
## Description

The goal of this PR is to refine the image caching system previously introduces by adding new functionnalities and improving code quality.

## Features list

- new `contains` method for checking if a given image is in the cache (without affecting LRU ordering)
- new `cachedOnly` flag to retrieve an image only if it is in the cache (i.e no image will be loaded from disk)
- new `lazyCleaning` flag to enable/disable lazy cleaning (= cleaning large images in priority instead of respecting LRU ordering)
- bug fix related to the `missingCapacity` computation