### PR TITLE
[software] ldrTohdrSampling: fix error when using jpg, rawColorInterpretation was wrongly interpreted

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -279,7 +279,7 @@ ERawColorInterpretation ERawColorInterpretation_stringToEnum(const std::string& 
     std::string type = rawColorInterpretation;
     std::transform(type.begin(), type.end(), type.begin(), ::tolower); //tolower
 
-    if (type == "none")
+    if (type == "none" || type == "")
         return ERawColorInterpretation::None;
     if (type == "librawnowhitebalancing")
         return ERawColorInterpretation::LibRawNoWhiteBalancing;

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -211,7 +211,7 @@ int aliceVision_main(int argc, char** argv)
             rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(rawColorInterpretation_str);
             colorProfileFileName = v->getColorProfileFileName();
 
-            ALICEVISION_LOG_INFO("Image: " << paths.back() << ", exposure: " << exposuresSetting.back() << ", raw color interpretation: " << rawColorInterpretation_str);
+            ALICEVISION_LOG_INFO("Image: " << paths.back() << ", exposure: " << exposuresSetting.back() << ", raw color interpretation: " << ERawColorInterpretation_enumToString(rawColorInterpretation));
         }
         if(!sfmData::hasComparableExposures(exposuresSetting))
         {


### PR DESCRIPTION
Fix crash when using ldrTohdrSampling with non raw images (rawColorInterpretation was wrongly interpreted)