### PR TITLE
[cmake] Update CXX standard from 14 to 17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ SpaceBeforeParens: Never
 SpaceBeforeAssignmentOperators: true
 SpacesInParentheses: false
 AlwaysBreakTemplateDeclarations: true
-Standard: Cpp11
+Standard: Cpp17
 AccessModifierOffset: -4
 IncludeCategories:
   - Regex:           '^".*"'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option(AV_BUILD_OSI "Enable building an embedded Osi" ON)
 option(AV_BUILD_CLP "Enable building an embedded Clp" ON)
 option(AV_BUILD_PCL "Enable building an embedded PointCloud library" ON)
 option(AV_BUILD_ALICEVISION "Enable building of AliceVision" ON)
-option(AV_EIGEN_MEMORY_ALIGNMENT "Enable Eigen memory alignment" OFF)
+option(AV_EIGEN_MEMORY_ALIGNMENT "Enable Eigen memory alignment" ON)
 
 option(AV_USE_CUDA "Enable CUDA" ON)
 # disable by default for AppleClang
@@ -256,23 +256,10 @@ ExternalProject_Add(${TBB_TARGET}
 set(TBB_CMAKE_FLAGS -DTBB_DIR:PATH=${CMAKE_INSTALL_PREFIX}/lib/cmake/TBB)
 
 # Eigen requires overaligned buffers for maximum efficiency (e.g. on AVX512 buffers may need to
-# be aligned to 64 bytes). AliceVision currently does not support this. Fortunately this is fixed
-# in C++17. While we can't upgrade to C++17 just yet, some compilers support overaligned
-# allocation feature with a separate flag, so use it if alignment is enabled in Eigen.
+# be aligned to 64 bytes). Fortunately this is fixed in C++17.
 # See https://eigen.tuxfamily.org/dox/group__TopicUnalignedArrayAssert.html
-if(AV_EIGEN_MEMORY_ALIGNMENT)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)
-    set(EIGEN_CMAKE_ALIGNMENT_FLAGS "-DCMAKE_CXX_FLAGS:STRING=-faligned-new")
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0)
-    set(EIGEN_CMAKE_ALIGNMENT_FLAGS "-DCMAKE_CXX_FLAGS:STRING=-faligned-new")
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
-    set(EIGEN_CMAKE_ALIGNMENT_FLAGS "-DCMAKE_CXX_FLAGS:STRING=-faligned-new")
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.12)
-    set(EIGEN_CMAKE_ALIGNMENT_FLAGS "-DCMAKE_CXX_FLAGS:STRING=/Zc:alignedNew")
-  else()
-    message(FATAL_ERROR "AV_EIGEN_MEMORY_ALIGNMENT is only supported starting GCC 7.1, Clang 6.0 and MSVC 2017 15.5")
-  endif()
-else()
+# Only change this option to disable it for older compilers or for debug purposes.
+if(NOT AV_EIGEN_MEMORY_ALIGNMENT)
   set(EIGEN_CMAKE_ALIGNMENT_FLAGS
       "-DCMAKE_CXX_FLAGS:STRING=-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_MAX_STATIC_ALIGN_BYTES=0"
       "-DCMAKE_C_FLAGS:STRING=-DEIGEN_MAX_ALIGN_BYTES=0 -DEIGEN_MAX_STATIC_ALIGN_BYTES=0")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ Build instructions
 Required tools:
 * CMake >= 3.11
 * Git
-* C/C++ compiler (gcc or visual studio or clang) with C++14 support (i.e. gcc >= 5, clang >= 3.4, msvc >= 19.10, cuda >= 9.0).
+* C/C++ compiler (gcc or visual studio or clang) with C++17 support (i.e. gcc >= 7, clang >= 5, msvc >= 19.15, cuda >= 11.0).
 
 ### Compile the project
 
@@ -40,7 +40,7 @@ Other optional libraries can enable specific features (check "CMake Options" for
 
 * Alembic (data I/O)
 * CCTag (feature extraction/matching and localization on CPU or GPU)
-* Cuda >= 7.0 (feature extraction and depth map computation)
+* Cuda >= 11.0 (feature extraction and depth map computation)
 * Magma (required for UncertaintyTE)
 * Mosek >= 6 (linear programming)
 * OpenCV >= 3.4.11 (feature extraction, calibration module, video IO), >= 4.5 for colorchecker (mcc)
@@ -63,36 +63,20 @@ AliceVision also depends on some embedded libraries:
 Building the project using vcpkg (recommended on Windows)
 --------------------------------
 [Vcpkg](https://github.com/alicevision/vcpkg) is a package manager that helps in acquiring, building, and managing C/C++ libraries.
-AliceVision's required dependencies can be built with it. Follow the [installation guide](https://github.com/alicevision/vcpkg/blob/alicevision_master/README.md#quick-start-windows) to setup vcpkg.
+AliceVision's required dependencies can be built with it.
+Vcpkg evolved from being a Windows-only project to becoming cross-platform.
+In the scope of AliceVision, vcpkg has only been tested on Windows.
 
+1. Install vcpkg itself
+
+See the reference [installation guide](https://github.com/alicevision/vcpkg/blob/alicevision_master/README.md#quick-start-windows) to setup vcpkg.
+We recommend to use our vcpkg fork, where dependencies have been validated by the AliceVision development team but it should work with the latest version.
 ```bash
 git clone https://github.com/alicevision/vcpkg --branch alicevision_master
 cd vcpkg
 .\bootstrap-vcpkg.bat
 ```
 
-**Note**: while started as a Windows only project, vcpkg recently became cross-platform. In the scope of AliceVision, it has only been tested on Windows.
-
-To build AliceVision using vcpkg:
-1. Setup the environment
-
-#### Windows: CUDA and Visual Studio
-* CUDA >= 10.0
-CUDA 10.0 is fully compatible with **Visual Studio 2017 (Update 8)** which allows to use
-the most recent compiler toolset (v141) to build AliceVision and its dependencies.
-VS2015 can also be used in this configuration.
-*This requires a recent version of CMake (tested with 3.12).*
-
-* CUDA < 10.0
-Due to incompatibilities between CUDA and Visual Studio 2017, **Visual 2015 toolset** must be used to build AliceVision.
-Visual Studio 2017 can be used as an IDE, but v140 toolset must be installed and used for this to work.
-To setup a VS2017 command prompt using the v140 toolset:
-```bash
-# Windows: CUDA < 10.0 + VS2017 v140 toolset
-"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.0
-nmake /version
-# should print Version 14.00.xxx
-```
 2. Build the required dependencies
 ```bash
 cd <VCPKG_INSTALL_DIR>
@@ -125,8 +109,7 @@ vcpkg install ^
 cd /path/to/aliceVision/
 mkdir build && cd build
 
-
-# Windows: CUDA >= 10.0 + Visual 2022 + Powershell
+# Windows: CUDA >= 11.0 + Visual 2022 + Powershell
 cmake .. -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT"\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 17 2022" -A x64 -T host=x64
 
 # Windows: CUDA >= 10.0 + Visual 2022
@@ -134,17 +117,12 @@ cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -D
 
 # Windows: CUDA >= 10.0 + Visual 2017
 cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 15 2017" -A x64 -T host=x64
-
-# Windows: CUDA < 10.0 + Visual 2017 v140 (Visual 2015 toolset)
-cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 15 2017" -A x64 -T v140,host=x64
-
-# Windows: CUDA < 10.0 + Visual 2015
-cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 14 2015" -A x64 -T v140,host=x64
-
-# Windows: this generates a "aliceVision.sln" solution inside the build folder
 ```
 
-Building the project with embedded dependencies
+This generates a "aliceVision.sln" solution inside the build folder that you can open in Visual Studio to launch the build. Do not forget to switch the build type to "Release".
+
+
+Building the project with embedded dependencies (recommended on linux)
 -----------------------------------------------
 
 ```bash
@@ -403,21 +381,20 @@ Check the sample in [samples](src/samples/aliceVisionAs3rdParty) for an example 
 
 ### Docker image
 
-A docker image can be built using the CentOS 7 or Ubuntu 18 Dockerfiles.
+A docker image can be built using the CentOS or Ubuntu Dockerfiles.
 The Dockerfiles are based on `nvidia/cuda` images (https://hub.docker.com/r/nvidia/cuda/)
 
+To generate the docker image, just run:
 ```
-docker build --tag alicevision:centos7-cuda7.0 .
-docker build --tag alicevision:ubuntu18.04-cuda9.2 -f Dockerfile_ubuntu .
+./docker/build-centos.sh
 ```
 
-Parameters `OS_TAG` and `CUDA_TAG` can be passed to build the image with a specific OS and CUDA version.
-Use NPROC=8 to select the number of cores to use, 1 by default.
-For example, the first line of below's commands shows the example to create docker for a CentOS 7 with Cuda 9.2 and second line for Ubuntu 16.04 with Cuda 8.0:
+To do it manually, parameters `OS_TAG` and `CUDA_TAG` should be passed to choose the OS and CUDA version.
+For example, the first line of below's commands shows the example to create docker for a CentOS 7 with Cuda 11.3.1 and second line for Ubuntu 16.04 with Cuda 11.0:
 
 ```
-docker build --build-arg OS_TAG=7 --build-arg CUDA_TAG=9.2 --tag alicevision:centos7-cuda9.2 .
-docker build --build-arg OS_TAG=16.04 --build-arg CUDA_TAG=8.0 --build-arg NPROC=8 --tag alicevision:ubuntu16.04-cuda8.0 -f Dockerfile_ubuntu .
+docker build --build-arg OS_TAG=7 --build-arg CUDA_TAG=11.3.1 --tag alicevision:centos7-cuda11.3.1 .
+docker build --build-arg OS_TAG=16.04 --build-arg CUDA_TAG=11.0 --build-arg NPROC=8 --tag alicevision:ubuntu16.04-cuda11.0 -f Dockerfile_ubuntu .
 ```
 
 In order to run the image [nvidia docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) is needed.
@@ -430,7 +407,7 @@ To retrieve the generated files:
 
 ```
 # Create an instance of the image, copy the files and remove the temporary docker instance.
-CID=$(docker create alicevision:centos7-cuda9.2) && docker cp ${CID}:/opt/AliceVision_install . && docker cp ${CID}:/opt/AliceVision_bundle . && docker rm ${CID}
+CID=$(docker create alicevision:centos7-cuda11.3.1) && docker cp ${CID}:/opt/AliceVision_install . && docker cp ${CID}:/opt/AliceVision_bundle . && docker rm ${CID}
 ```
 
 Environment variable

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,13 +109,13 @@ vcpkg install ^
 cd /path/to/aliceVision/
 mkdir build && cd build
 
-# Windows: CUDA >= 11.0 + Visual 2022 + Powershell
+# Windows: Visual 2022 + Powershell
 cmake .. -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT"\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 17 2022" -A x64 -T host=x64
 
-# Windows: CUDA >= 10.0 + Visual 2022
+# Windows: Visual 2022
 cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 17 2022" -A x64 -T host=x64
 
-# Windows: CUDA >= 10.0 + Visual 2017
+# Windows: Visual 2017
 cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 15 2017" -A x64 -T host=x64
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ function(trilean_option NAME DESCRIPTION DEFAULT_VALUE)
   endif()
 endfunction()
 
-# C++14
+# C++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -631,26 +631,17 @@ if(NOT ALICEVISION_USE_CUDA STREQUAL "OFF")
     set(CUDA_USE_STATIC_CUDA_RUNTIME ON)
   endif()
 
-  find_package(CUDA 7.0)
+  find_package(CUDA 11.0)
 
   if(CUDA_FOUND)
     set(ALICEVISION_HAVE_CUDA 1)
     message(STATUS "CUDA found.")
   elseif(ALICEVISION_USE_CUDA STREQUAL "ON")
-    message(SEND_ERROR "Failed to find CUDA (>= 7.0).")
+    message(SEND_ERROR "Failed to find CUDA (>= 11.0).")
   endif()
 endif()
 
 if(ALICEVISION_HAVE_CUDA)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "5.0.0")
-      if(CUDA_VERSION VERSION_LESS "8.0")
-        MESSAGE(STATUS "Found gcc >=5 and CUDA <= 7.5, adding workaround C++ flags")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORCE_INLINES -D_MWAITXINTRIN_H_INCLUDED -D__STRICT_ANSI__")
-      endif()
-    endif()
-  endif()
-
   set(CUDA_SEPARABLE_COMPILATION ON)
   message("Build Mode: ${CMAKE_BUILD_TYPE}")
 
@@ -666,14 +657,8 @@ if(ALICEVISION_HAVE_CUDA)
     set(ALICEVISION_CUDA_CC_LIST_BASIC 35 50 52 60 61 62 70 72 75 80 86)
   elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 11)
     set(ALICEVISION_CUDA_CC_LIST_BASIC 35 50 52 60 61 62 70 72 75 80)
-  elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 10)
-    set(ALICEVISION_CUDA_CC_LIST_BASIC 30 35 50 52 60 61 62 70 72 75)
-  elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 9)
-    set(ALICEVISION_CUDA_CC_LIST_BASIC 30 35 50 52 60 61 62 70)
-  elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 8)
-    set(ALICEVISION_CUDA_CC_LIST_BASIC 20 30 35 50 52 60 61 62)
   else()
-    set(ALICEVISION_CUDA_CC_LIST_BASIC 20 30 35 50 52 )
+    message(SEND_ERROR "Requires CUDA >= 11.0.")
   endif()
   set(ALICEVISION_CUDA_CC_LIST ${ALICEVISION_CUDA_CC_LIST_BASIC}
       CACHE STRING "CUDA CC versions to compile")
@@ -690,28 +675,23 @@ if(ALICEVISION_HAVE_CUDA)
   list(GET ALICEVISION_CUDA_CC_LIST ${ALICEVISION_CC_LIST_LEN} ALICEVISION_CUDA_CC_LIST_LAST)
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-gencode;arch=compute_${ALICEVISION_CUDA_CC_LIST_LAST},code=compute_${ALICEVISION_CUDA_CC_LIST_LAST}")
 
-
-  if(NOT CUDA_VERSION VERSION_LESS 7.0) # cuda >= 7.0
-    set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-std=c++11")
-  endif()
+  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-std=c++17")
 
   # default stream legacy implies that the 0 stream synchronizes all streams
   set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;legacy")
   # default stream per-thread implies that each host thread has one non-synchronizing 0-stream
   # set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;per-thread")
   # print local memory usage per kernel: -Xptxas;-v
-  # CUDA >= 7.5: -Xptxas;--warn-on-local-memory-usage;-Xptxas;--warn-on-spills
+  #   -Xptxas;--warn-on-local-memory-usage;-Xptxas;--warn-on-spills
   message(STATUS "CUDA Version is ${CUDA_VERSION}")
-  if(NOT CUDA_VERSION VERSION_LESS 7.5) # cuda >= 7.5
-    if(UNIX)
-      set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-D_FORCE_INLINES")
-    endif()
-    if(ALICEVISION_NVCC_WARNINGS)
-      set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;-warn-lmem-usage")
-      set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;-warn-spills")
-      set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;--warn-on-local-memory-usage")
-      set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;--warn-on-spills")
-    endif()
+  if(UNIX)
+    set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-D_FORCE_INLINES")
+  endif()
+  if(ALICEVISION_NVCC_WARNINGS)
+    set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;-warn-lmem-usage")
+    set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;-warn-spills")
+    set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;--warn-on-local-memory-usage")
+    set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;--warn-on-spills")
   endif()
 
   # library required for CUDA dynamic parallelism, forgotten by CMake 3.4

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ function(trilean_option NAME DESCRIPTION DEFAULT_VALUE)
 endfunction()
 
 # C++14
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ==============================================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -625,8 +625,6 @@ if(NOT ALICEVISION_USE_CUDA STREQUAL "OFF")
     # Need to declare CUDA_USE_STATIC_CUDA_RUNTIME as an option to ensure that it is not overwritten in FindCUDA.
     option(CUDA_USE_STATIC_CUDA_RUNTIME "Use the static version of the CUDA runtime library if available" OFF)
     set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
-    # Workaround to force deactivation of cuda static runtime for cmake < 3.10
-    set(CUDA_cudart_static_LIBRARY 0)
   else()
     message(STATUS "BUILD_SHARED_LIBS OFF")
     option(CUDA_USE_STATIC_CUDA_RUNTIME "Use the static version of the CUDA runtime library if available" ON)

--- a/src/aliceVision/fuseCut/CMakeLists.txt
+++ b/src/aliceVision/fuseCut/CMakeLists.txt
@@ -29,6 +29,7 @@ alicevision_add_library(aliceVision_fuseCut
     aliceVision_mvsData
     aliceVision_mvsUtils
     aliceVision_mesh
+    aliceVision_sfmData
     aliceVision_system
     Geogram::geogram
     Boost::filesystem

--- a/src/aliceVision/fuseCut/Fuser.hpp
+++ b/src/aliceVision/fuseCut/Fuser.hpp
@@ -12,12 +12,9 @@
 #include <aliceVision/mvsData/StaticVector.hpp>
 #include <aliceVision/mvsData/Universe.hpp>
 #include <aliceVision/mvsData/Voxel.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
 
 namespace aliceVision {
-
-namespace sfmData {
-class SfMData;
-}
 
 namespace fuseCut {
 

--- a/src/aliceVision/hdr/hdrTestCommon.hpp
+++ b/src/aliceVision/hdr/hdrTestCommon.hpp
@@ -94,12 +94,14 @@ bool extractSamplesGroups(std::vector<std::vector<ImageSample>>& out_samples,
     }
 
     const size_t maxCountSample = 100;
+    std::random_device rd;
+    std::mt19937 gen(rd());
     for (auto & list : mapSampleRefList)
     {
         if (list.second.size() > maxCountSample)
         {
              /*Shuffle and ignore the exceeding samples*/
-            std::random_shuffle(list.second.begin(), list.second.end());
+            std::shuffle(list.second.begin(), list.second.end(), gen);
             list.second.resize(maxCountSample);
         }
 

--- a/src/aliceVision/multiview/relativePose/fundamental10PSolver_test.cpp
+++ b/src/aliceVision/multiview/relativePose/fundamental10PSolver_test.cpp
@@ -76,11 +76,24 @@ BOOST_AUTO_TEST_CASE(Fundamental10PSolver_8_solutions)
   if(resF.size() != models.size())
     BOOST_CHECK(false);
 
+  //Results may not be in the same order
   for(Eigen::Index i = 0; i < resF.size(); ++i)
   {
     relativePose::Fundamental10PModel model = models.at(i);
-    BOOST_CHECK(resF.at(i).isApprox(model.getMatrix(), 1e-1));
-    BOOST_CHECK(resL.at(i).isApprox(model.getRadialDistortion(), 1e-1));
+
+    bool oneEqual = false;
+    for (int j = 0; j < resF.size(); j++)
+    {
+        bool testF = resF.at(j).isApprox(model.getMatrix(), 1e-1);
+        bool testL = resL.at(j).isApprox(model.getRadialDistortion(), 1e-1);
+
+        if (testF && testL)
+        {
+            oneEqual = true;
+        }
+    }
+    
+    BOOST_CHECK(oneEqual);
   }
 }
 

--- a/src/aliceVision/track/tracksUtils.hpp
+++ b/src/aliceVision/track/tracksUtils.hpp
@@ -113,7 +113,7 @@ bool getFeatureIdInViewPerTrack(const TracksMap& allTracks,
                                        std::vector<FeatureId>* out_featId);
 
 
-struct FunctorMapFirstEqual : public std::unary_function <TracksMap , bool>
+struct FunctorMapFirstEqual
 {
   std::size_t id;
 

--- a/src/dependencies/flann/src/cpp/flann/util/heap.h
+++ b/src/dependencies/flann/src/cpp/flann/util/heap.h
@@ -105,7 +105,7 @@ public:
         count = 0;
     }
 
-    struct CompareT : public std::binary_function<T,T,bool>
+    struct CompareT
     {
         bool operator()(const T& t_1, const T& t_2) const
         {


### PR DESCRIPTION
## Description

Upgrade to C++ standard from 14 to 17.

Impact:
- CUDA: >= 11.
- GCC: >= 7.0
https://gcc.gnu.org/projects/cxx-status.html#cxx17
- VS: Visual Studio 2017 15.8 (MSVC 19.15) and later supports all C++17 language features.

https://en.cppreference.com/w/cpp/compiler_support/17
