### PR TITLE
ColorTemperatureAsImageProcessingParameter

### DIFF
--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -2176,6 +2176,7 @@ DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeu
     if (cct <= 0.0)
     {
         getColorTemperatureAndTintFromNeutral(asShotNeutral, cctLocal, tintLocal);
+        getChromaticityCoordinates(cctLocal, tintLocal, x, y);
         cct = cctLocal;
         ALICEVISION_LOG_TRACE("Estimated illuminant (cct; tint) : (" << cctLocal << "; " << tintLocal << ")");
         if (sourceIsRaw)

--- a/src/aliceVision/image/dcp.cpp
+++ b/src/aliceVision/image/dcp.cpp
@@ -1768,7 +1768,7 @@ void DCPProfile::setChromaticityCoordinates(const double x, const double y, doub
             du /= len;
             dv /= len;
 
-            tint = (uu * du + vv * dv) * 3000.f;
+            tint = (uu * du + vv * dv) * (-3000.f);
 
             break;
         }
@@ -2164,23 +2164,61 @@ DCPProfile::Matrix DCPProfile::getCameraToSrgbLinearMatrix(const double x, const
     return cameraToSrgbLinear;
 }
 
-DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw, const bool useColorMatrixOnly) const
+DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw, const bool useColorMatrixOnly, const double cct) const
 {
     const Triple asShotNeutralInv = { 1.0 / asShotNeutral[0] , 1.0 / asShotNeutral[1] , 1.0 / asShotNeutral[2] };
 
+    Triple cctNeutral = { 1.0, 1.0, 1.0 };
+
+    double cctLocal, tintLocal;
+    Matrix invNeutralFromCct = IdentityMatrix;
     double x, y;
-    getChromaticityCoordinatesFromCameraNeutral(IdentityMatrix, asShotNeutralInv, x, y);
-    double cct, tint;
-    setChromaticityCoordinates(x, y, cct, tint);
-
-    ALICEVISION_LOG_INFO("Estimated illuminant (cct; tint) : (" << cct << "; " << tint << ")");
-
     Matrix neutral = IdentityMatrix;
-    if (sourceIsRaw)
+
+    if (cct <= 0.0)
     {
-        neutral[0][0] = asShotNeutral[0];
-        neutral[1][1] = asShotNeutral[1];
-        neutral[2][2] = asShotNeutral[2];
+        getChromaticityCoordinatesFromCameraNeutral(IdentityMatrix, asShotNeutralInv, x, y);
+        setChromaticityCoordinates(x, y, cctLocal, tintLocal);
+        ALICEVISION_LOG_TRACE("Estimated illuminant (cct; tint) : (" << cctLocal << "; " << tintLocal << ")");
+        if (sourceIsRaw)
+        {
+            // set neutral value from asShot metadata
+            neutral[0][0] = asShotNeutral[0];
+            neutral[1][1] = asShotNeutral[1];
+            neutral[2][2] = asShotNeutral[2];
+        }
+    }
+    else
+    {
+        cctLocal = cct;
+        tintLocal = 0.0;
+        getChromaticityCoordinates(cctLocal, tintLocal, x, y);
+        if (!useColorMatrixOnly && info.has_forward_matrix_1)
+        {
+            // compute neutral from cct
+            Triple xyz = getXyzFromChromaticityCoordinates(x, y);
+            Matrix xyzToCamera = getInterpolatedMatrix(cct, "color");
+            cctNeutral = matMult(xyzToCamera, xyz);
+            cctNeutral[0] = cctNeutral[1] / cctNeutral[0];
+            cctNeutral[1] = 1.0;
+            cctNeutral[2] = cctNeutral[1] / cctNeutral[2];
+            ALICEVISION_LOG_TRACE("Estimated neutral from cct : " << cctNeutral);
+            // The forward matrix will be used. Data must be white balanced before applying the matrix.
+            if (sourceIsRaw)
+            {
+                // set neutral value from cct
+                neutral[0][0] = cctNeutral[0];
+                neutral[1][1] = cctNeutral[1];
+                neutral[2][2] = cctNeutral[2];
+            }
+            else
+            {
+                // replace asShot neutral value with cct neutral value
+                neutral[0][0] = cctNeutral[0] / asShotNeutral[0];
+                neutral[1][1] = cctNeutral[1] / asShotNeutral[1];
+                neutral[2][2] = cctNeutral[2] / asShotNeutral[2];
+            }
+        }
     }
 
     Matrix cameraToXyzD50 = IdentityMatrix;
@@ -2190,7 +2228,7 @@ DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeu
         Matrix xyzToCamera = IdentityMatrix;
         if (info.has_color_matrix_1 && info.has_color_matrix_2)
         {
-            xyzToCamera = getInterpolatedMatrix(cct, "color");
+            xyzToCamera = getInterpolatedMatrix(cctLocal, "color");
         }
         else if (info.has_color_matrix_1)
         {
@@ -2216,7 +2254,7 @@ DCPProfile::Matrix DCPProfile::getCameraToACES2065Matrix(const Triple& asShotNeu
     }
     else if ((info.has_forward_matrix_1) && (info.has_forward_matrix_2))
     {
-        cameraToXyzD50 = matMult(getInterpolatedMatrix(cct, "forward"), neutral);
+        cameraToXyzD50 = matMult(getInterpolatedMatrix(cctLocal, "forward"), neutral);
     }
     else if (info.has_forward_matrix_1)
     {
@@ -2341,9 +2379,9 @@ void DCPProfile::setMatricesFromStrings(const std::string& type, std::vector<std
     setMatrices(type, v_Mat);
 }
 
-void DCPProfile::applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const bool sourceIsRaw, const bool useColorMatrixOnly) const
+void DCPProfile::applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const bool sourceIsRaw, const bool useColorMatrixOnly, const double cct) const
 {
-    const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw, useColorMatrixOnly);
+    const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw, useColorMatrixOnly, cct);
 
     ALICEVISION_LOG_INFO("cameraToACES2065Matrix : " << cameraToACES2065Matrix);
 
@@ -2367,9 +2405,9 @@ void DCPProfile::applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const
         }
 }
 
-void DCPProfile::applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, const bool sourceIsRaw, const bool useColorMatrixOnly) const
+void DCPProfile::applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, const bool sourceIsRaw, const bool useColorMatrixOnly, const double cct) const
 {
-    const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw, useColorMatrixOnly);
+    const Matrix cameraToACES2065Matrix = getCameraToACES2065Matrix(neutral, sourceIsRaw, useColorMatrixOnly, cct);
 
     ALICEVISION_LOG_INFO("cameraToACES2065Matrix : " << cameraToACES2065Matrix);
 

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -206,21 +206,21 @@ public:
      * @brief applyLinear applies the linear part of a DCP profile on an OIIO image buffer
      * param[in] image The OIIO image on which the profile must be applied
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
+     * param[in] cct indicates the scene illuminant Correlated Color Temperature in Kelvin (if <=0.0, the value extracted from metadata is used)
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      * param[in] useColorMatrixOnly indicates to apply a DCP profile computed only from the color matrices
-     * param[in] cct indicates the scene illuminant Correlated Color Temperature in Kelvin (if <=0.0, the value extracted from metadata is used)
      */
-    void applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = true, const double cct = -1.0) const;
+    void applyLinear(OIIO::ImageBuf& image, const Triple& neutral, double& cct, const bool sourceIsRaw = false, const bool useColorMatrixOnly = true) const;
 
     /**
      * @brief applyLinear applies the linear part of a DCP profile on an aliceVision image
      * param[in] image The aliceVision image on which the profile must be applied
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
+     * param[in] cct indicates the scene illuminant Correlated Color Temperature in Kelvin (if <=0.0, the value extracted from metadata is used)
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      * param[in] useColorMatrixOnly indicates to apply a DCP profile computed only from the color matrices
-     * param[in] cct indicates the scene illuminant Correlated Color Temperature in Kelvin (if <=0.0, the value extracted from metadata is used)
      */
-    void applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false, const double cct = -1.0) const;
+    void applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, double& cct, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false) const;
 
     /**
      * @brief apply applies the non linear part of a DCP profile on an OIIO image buffer
@@ -234,6 +234,14 @@ public:
      * param[in] params contains the application parameters indicating which parts of the profile must be applied
      */
     void apply(float* rgb, const DCPProfileApplyParams& params) const;
+
+    /**
+     * @brief compute color temperature and tint from neutral
+     * param[in] neutral The neutral triplet value
+     * param[out] cct The computed correlated color temperature value in Kelvin
+     * param[out] tint The computed tint value
+     */
+    void getColorTemperatureAndTintFromNeutral(const Triple& neutral, double& cct, double& tint) const;
 
 private:
     struct HsbModify
@@ -280,7 +288,7 @@ private:
     Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget) const;
     Matrix getCameraToXyzD50Matrix(const double x, const double y) const;
     Matrix getCameraToSrgbLinearMatrix(const double x, const double y) const;
-    Matrix getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false, const double cct = -1.0) const;
+    Matrix getCameraToACES2065Matrix(const Triple& asShotNeutral, double& cct, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false) const;
 
     Matrix ws_sRGB; // working color space to sRGB
     Matrix sRGB_ws; // sRGB to working color space

--- a/src/aliceVision/image/dcp.hpp
+++ b/src/aliceVision/image/dcp.hpp
@@ -208,8 +208,9 @@ public:
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      * param[in] useColorMatrixOnly indicates to apply a DCP profile computed only from the color matrices
+     * param[in] cct indicates the scene illuminant Correlated Color Temperature in Kelvin (if <=0.0, the value extracted from metadata is used)
      */
-    void applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = true) const;
+    void applyLinear(OIIO::ImageBuf& image, const Triple& neutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = true, const double cct = -1.0) const;
 
     /**
      * @brief applyLinear applies the linear part of a DCP profile on an aliceVision image
@@ -217,8 +218,9 @@ public:
      * param[in] neutral The neutral value calculated from the camera multiplicators contained in the cam_mul OIIO metadata
      * param[in] sourceIsRaw indicates that the image buffer contains data in raw space (no neutralization <=> cam_mul not applied)
      * param[in] useColorMatrixOnly indicates to apply a DCP profile computed only from the color matrices
+     * param[in] cct indicates the scene illuminant Correlated Color Temperature in Kelvin (if <=0.0, the value extracted from metadata is used)
      */
-    void applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false) const;
+    void applyLinear(Image<image::RGBAfColor>& image, const Triple& neutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false, const double cct = -1.0) const;
 
     /**
      * @brief apply applies the non linear part of a DCP profile on an OIIO image buffer
@@ -278,7 +280,7 @@ private:
     Matrix getChromaticAdaptationMatrix(const Triple& xyzSource, const Triple& xyzTarget) const;
     Matrix getCameraToXyzD50Matrix(const double x, const double y) const;
     Matrix getCameraToSrgbLinearMatrix(const double x, const double y) const;
-    Matrix getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false) const;
+    Matrix getCameraToACES2065Matrix(const Triple& asShotNeutral, const bool sourceIsRaw = false, const bool useColorMatrixOnly = false, const double cct = -1.0) const;
 
     Matrix ws_sRGB; // working color space to sRGB
     Matrix sRGB_ws; // sRGB to working color space

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -610,7 +610,9 @@ void readImage(const std::string& path,
 
         ALICEVISION_LOG_TRACE("Apply DCP Linear processing with neutral = " << neutral);
 
-        dcpProfile.applyLinear(inBuf, neutral, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly, imageReadOptions.correlatedColorTemperature);
+        double cct = imageReadOptions.correlatedColorTemperature;
+
+        dcpProfile.applyLinear(inBuf, neutral, cct, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly);
     }
 
     // color conversion
@@ -656,7 +658,9 @@ void readImage(const std::string& path,
             neutral[i] = v_mult[i] / v_mult[1];
         }
 
-        dcpProf.applyLinear(inBuf, neutral, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly, imageReadOptions.correlatedColorTemperature);
+        double cct = imageReadOptions.correlatedColorTemperature;
+
+        dcpProf.applyLinear(inBuf, neutral, cct, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly);
         fromColorSpaceName = "aces2065-1";
     }
 

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -610,7 +610,7 @@ void readImage(const std::string& path,
 
         ALICEVISION_LOG_TRACE("Apply DCP Linear processing with neutral = " << neutral);
 
-        dcpProfile.applyLinear(inBuf, neutral, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly);
+        dcpProfile.applyLinear(inBuf, neutral, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly, imageReadOptions.correlatedColorTemperature);
     }
 
     // color conversion
@@ -656,7 +656,7 @@ void readImage(const std::string& path,
             neutral[i] = v_mult[i] / v_mult[1];
         }
 
-        dcpProf.applyLinear(inBuf, neutral, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly);
+        dcpProf.applyLinear(inBuf, neutral, imageReadOptions.doWBAfterDemosaicing, imageReadOptions.useDCPColorMatrixOnly, imageReadOptions.correlatedColorTemperature);
         fromColorSpaceName = "aces2065-1";
     }
 

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -195,7 +195,7 @@ struct ImageReadOptions
         ERawColorInterpretation rawColorInterpretation = ERawColorInterpretation::LibRawWhiteBalancing,
         const std::string& colorProfile = "", const bool useDCPColorMatrixOnly = true, const oiio::ROI& roi = oiio::ROI()) :
         workingColorSpace(colorSpace), rawColorInterpretation(rawColorInterpretation), colorProfileFileName(colorProfile), useDCPColorMatrixOnly(useDCPColorMatrixOnly),
-        doWBAfterDemosaicing(false), demosaicingAlgo("AHD"), highlightMode(0), subROI(roi)
+        doWBAfterDemosaicing(false), demosaicingAlgo("AHD"), highlightMode(0), correlatedColorTemperature(-1.0), subROI(roi)
     {
     }
 
@@ -206,6 +206,7 @@ struct ImageReadOptions
     bool doWBAfterDemosaicing;
     std::string demosaicingAlgo;
     int highlightMode;
+    double correlatedColorTemperature;
     //ROI for this image.
     //If the image contains an roi, this is the roi INSIDE the roi.
     oiio::ROI subROI;

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -153,7 +153,8 @@ void colorSpaceTransform(image::Image<image::RGBAfColor>& inputImage, image::EIm
 
     if (fromColorSpace == image::EImageColorSpace::NO_CONVERSION)
     {
-        dcpProf.applyLinear(inBuf, neutral, true, true);
+        double cct;
+        dcpProf.applyLinear(inBuf, neutral, cct, true, true);
         fromColorSpace = image::EImageColorSpace::ACES2065_1;
     }
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -302,6 +302,7 @@ struct ProcessingParams
     bool fixNonFinite = false;
     bool applyDcpMetadata = false;
     bool useDCPColorMatrixOnly = false;
+    double corrColorTemp = -1.0;
 
     LensCorrectionParams lensCorrection =
     {
@@ -648,7 +649,7 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
             neutral[i] = v_mult[i] / v_mult[1];
         }
 
-        dcpProf.applyLinear(image, neutral, true, pParams.useDCPColorMatrixOnly);
+        dcpProf.applyLinear(image, neutral, true, pParams.useDCPColorMatrixOnly, pParams.corrColorTemp);
     }
 }
 
@@ -765,6 +766,7 @@ int aliceVision_main(int argc, char * argv[])
     bool doWBAfterDemosaicing = false;
     std::string demosaicingAlgo = "AHD";
     int highlightMode = 0;
+    double correlatedColorTemperature = -1;
 
     ProcessingParams pParams;
 
@@ -886,6 +888,10 @@ int aliceVision_main(int argc, char * argv[])
         ("highlightMode", po::value<int>(&highlightMode)->default_value(highlightMode),
          "Highlight management (see libRaw documentation).\n"
          "0 = clip (default), 1 = unclip, 2 = blend, 3+ = rebuild.")
+
+        ("correlatedColorTemperature", po::value<double>(&correlatedColorTemperature)->default_value(correlatedColorTemperature),
+         "Correlated Color Temperature in Kelvin of scene illuminant.\n"
+         "If less than or equal to 0.0, value extracted from metadata will be used.")
 
         ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
          ("Storage data type: " + image::EStorageDataType_informations()).c_str())
@@ -1035,6 +1041,7 @@ int aliceVision_main(int argc, char * argv[])
                 options.colorProfileFileName = view.getColorProfileFileName();
                 options.demosaicingAlgo = demosaicingAlgo;
                 options.highlightMode = highlightMode;
+                options.correlatedColorTemperature = correlatedColorTemperature;
             }
 
             if (pParams.lensCorrection.enabled && pParams.lensCorrection.vignetting)
@@ -1252,6 +1259,7 @@ int aliceVision_main(int argc, char * argv[])
                 readOptions.doWBAfterDemosaicing = doWBAfterDemosaicing;
                 readOptions.demosaicingAlgo = demosaicingAlgo;
                 readOptions.highlightMode = highlightMode;
+                readOptions.correlatedColorTemperature = correlatedColorTemperature;
 
                 pParams.useDCPColorMatrixOnly = useDCPColorMatrixOnly;
                 if (pParams.applyDcpMetadata)


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Add color temperature of the scene illuminant in degree Kelvin as parameter dedicated to raw image reading in the imageProcessing executable.
If set to a negative or null value, cam_mul metadata is used to estimate the color temperature of the scene illuminant.
If set to a positive value, cam_mul metadata is ignored.
The specified or computed temperature value is added as metadata in the output image.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

Default value for the parameter is -1.0, leading to the use of the cam_mul metadata for color temperature estimation.
The parameter is ignored if the source image is not a raw image. In that case no metadata is added in the output image.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

