### PR TITLE
IncrementalSfM: expose nbOutliersThreshold param

### DIFF
--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -700,7 +700,7 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
     refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;
 
   const int nbOutliersThreshold =
-    (isInitialPair && _params.bundleAdjustmentMaxOutliers >= 0) ? 0 : _params.bundleAdjustmentMaxOutliers;
+    (isInitialPair) ? 0 : _params.bundleAdjustmentMaxOutliers;
   std::size_t iteration = 0;
   std::size_t nbOutliers = 0;
   bool enableLocalStrategy = false;

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -699,7 +699,8 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
   if(!isInitialPair && !_params.lockAllIntrinsics)
     refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;
 
-  const std::size_t nbOutliersThreshold = (isInitialPair) ? 0 : _params.bundleAdjustmentMaxOutliers;
+  const int nbOutliersThreshold =
+    (isInitialPair && _params.bundleAdjustmentMaxOutliers >= 0) ? 0 : _params.bundleAdjustmentMaxOutliers;
   std::size_t iteration = 0;
   std::size_t nbOutliers = 0;
   bool enableLocalStrategy = false;
@@ -794,7 +795,7 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
     ALICEVISION_LOG_INFO("Bundle adjustment iteration: " << iteration << " took " << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - chronoItStart).count() << " msec.");
     ++iteration;
   }
-  while(nbOutliers > nbOutliersThreshold);
+  while(nbOutliersThreshold >= 0 && nbOutliers > nbOutliersThreshold);
 
   ALICEVISION_LOG_INFO("Bundle adjustment with " << iteration << " iterations took " << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - chronoStart).count() << " msec.");
   return true;

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -699,7 +699,7 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
   if(!isInitialPair && !_params.lockAllIntrinsics)
     refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;
 
-  const std::size_t nbOutliersThreshold = (isInitialPair) ? 0 : 50;
+  const std::size_t nbOutliersThreshold = (isInitialPair) ? 0 : _params.bundleAdjustmentMaxOutliers;
   std::size_t iteration = 0;
   std::size_t nbOutliers = 0;
   bool enableLocalStrategy = false;

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -85,6 +85,10 @@ public:
     /// we don't add too much data in one step without bundle adjustment.
     std::size_t maxImagesPerGroup = 30;
 
+    /// Threshold for the maximum number of outliers allowed at the end of a BA iteration.
+    /// If the limit is not met, another BA iteration is performed.
+    std::size_t bundleAdjustmentMaxOutliers = 50;
+
     // Local Bundle Adjustment data
 
     /// The minimum number of shared matches to create an edge between two views (nodes)

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -87,7 +87,8 @@ public:
 
     /// Threshold for the maximum number of outliers allowed at the end of a BA iteration.
     /// If the limit is not met, another BA iteration is performed.
-    std::size_t bundleAdjustmentMaxOutliers = 50;
+    /// Using a negative value for this threshold will disable BA iterations.
+    int bundleAdjustmentMaxOutliers = 50;
 
     // Local Bundle Adjustment data
 

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -160,8 +160,9 @@ int aliceVision_main(int argc, char **argv)
     ("maxImagesPerGroup", po::value<std::size_t>(&sfmParams.maxImagesPerGroup)->default_value(sfmParams.maxImagesPerGroup),
       "Maximum number of cameras that can be added before the bundle adjustment is performed. This prevents adding too much data "
       "at once without performing the bundle adjustment.")
-    ("bundleAdjustmentMaxOutliers", po::value<std::size_t>(&sfmParams.bundleAdjustmentMaxOutliers)->default_value(sfmParams.bundleAdjustmentMaxOutliers),
-      "Threshold for the maximum number of outliers allowed at the end of a bundle adjustment iteration.")
+    ("bundleAdjustmentMaxOutliers", po::value<int>(&sfmParams.bundleAdjustmentMaxOutliers)->default_value(sfmParams.bundleAdjustmentMaxOutliers),
+      "Threshold for the maximum number of outliers allowed at the end of a bundle adjustment iteration."
+      "Using a negative value for this threshold will disable BA iterations.")
     ("localizerEstimator", po::value<robustEstimation::ERobustEstimator>(&sfmParams.localizerEstimator)->default_value(sfmParams.localizerEstimator),
       "Estimator type used to localize cameras (acransac (default), ransac, lsmeds, loransac, maxconsensus)")
     ("localizerEstimatorError", po::value<double>(&sfmParams.localizerEstimatorError)->default_value(0.0),

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -27,7 +27,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 2
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 3
 
 using namespace aliceVision;
 
@@ -160,6 +160,8 @@ int aliceVision_main(int argc, char **argv)
     ("maxImagesPerGroup", po::value<std::size_t>(&sfmParams.maxImagesPerGroup)->default_value(sfmParams.maxImagesPerGroup),
       "Maximum number of cameras that can be added before the bundle adjustment is performed. This prevents adding too much data "
       "at once without performing the bundle adjustment.")
+    ("bundleAdjustmentMaxOutliers", po::value<std::size_t>(&sfmParams.bundleAdjustmentMaxOutliers)->default_value(sfmParams.bundleAdjustmentMaxOutliers),
+      "Threshold for the maximum number of outliers allowed at the end of a bundle adjustment iteration.")
     ("localizerEstimator", po::value<robustEstimation::ERobustEstimator>(&sfmParams.localizerEstimator)->default_value(sfmParams.localizerEstimator),
       "Estimator type used to localize cameras (acransac (default), ransac, lsmeds, loransac, maxconsensus)")
     ("localizerEstimatorError", po::value<double>(&sfmParams.localizerEstimatorError)->default_value(0.0),


### PR DESCRIPTION
## Description

The goal of this PR is to expose an internal variable used in the sequential SfM reconstruction engine called `nbOutliersThreshold`.

This variable is now accessible through the parameters of the reconstruction engine and the incremental SfM command line.