### PR TITLE
Update cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -6829,6 +6829,7 @@ Sony;Sony DSLR-A900;35.9;usercontribution
 Sony;Sony FDR-X1000V;6.19;usercontribution
 Sony;Sony FDR-X3000;5.744;dpreview
 Sony;Sony FX30;23.4;dpreview
+Sony;Sony ILME-FX30;23.4;dpreview
 Sony;Sony HDR-AS300;5.744;dpreview
 Sony;Sony HDR-HC7e;4.98;usercontribution
 Sony;Sony ILCE 5000;23.2;dpreview


### PR DESCRIPTION
add sony fx-30 model name used by camera

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

The model name used by the camera is slightly different from that included in database. I've left the current in there as-is in case this differs in other models of camera.


