### PR TITLE
Add Google Pixel 7/7 Pro main camera to cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -2197,6 +2197,8 @@ Google;Pixel 4a;5.56;usercontribution
 Google;Pixel 5;5.56;usercontribution
 Google;Pixel 6;9.79;usercontribution
 Google;Pixel 6 Pro;9.79;usercontribution
+Google;Pixel 7;9.79;usercontribution
+Google;Pixel 7 Pro;9.79;usercontribution
 GoPro;GoPro Fusion;6.17;dpreview
 GoPro;GoPro Hero 2018;6.17;dpreview
 GoPro;GoPro Hero3-Silver Edition;5.37;usercontribution


### PR DESCRIPTION
The Pixel 7 family uses the same Samsung GN1 sensor as the Pixel 6.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

