### PR TITLE
oiio gammaX.Y color spaces management

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -624,6 +624,14 @@ void readImage(const std::string& path,
 
     ALICEVISION_LOG_TRACE("Read image " << path << " (encoded in " << fromColorSpaceName << " colorspace).");
 
+    // Manage oiio GammaX.Y color space assuming that the gamma correction has been applied on an image with sRGB primaries.
+    if (fromColorSpaceName.substr(0, 5) == "Gamma")
+    {
+        // Reverse gamma correction
+        oiio::ImageBufAlgo::pow(inBuf, inBuf, std::stof(fromColorSpaceName.substr(5)));
+        fromColorSpaceName = "linear";
+    }
+
     DCPProfile dcpProf;
     if ((fromColorSpaceName == "no_conversion") && (imageReadOptions.workingColorSpace != EImageColorSpace::NO_CONVERSION))
     {


### PR DESCRIPTION
## Description

Manage openImageIO GammaX.Y color space occuring on some png images by reversing the gamma correction and setting sRGB linear as original color space. The gamma value is obtained by decoding the X.Y substring in the color space name delivered by openImageIO.

Related to: https://github.com/alicevision/AliceVision/issues/1365

## Implementation remarks

Managing GammaX.Y color spaces in this way prevents to update the OCIO configuration file.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

