### PR TITLE
Fix .clang-format after updating CXX standard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ SpaceBeforeParens: Never
 SpaceBeforeAssignmentOperators: true
 SpacesInParentheses: false
 AlwaysBreakTemplateDeclarations: true
-Standard: Cpp17
+Standard: c++17
 AccessModifierOffset: -4
 IncludeCategories:
   - Regex:           '^".*"'


### PR DESCRIPTION
Error with Visual Studio 2022 Community while formatting with clang format

![image](https://github.com/alicevision/AliceVision/assets/72821992/f7dce7cf-1bab-45e9-8fa8-24946402ed4e)
