### PR TITLE
[Meshing] Fix to avoid small holes in the final mesh

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2721,36 +2721,7 @@ void DelaunayGraphCut::graphCutPostProcessing(const Point3d hexah[8], const std:
         }
         ALICEVISION_LOG_WARNING("Declare empty around camera centers: " << nbModifiedCells << " cells changed to empty within " << _cellIsFull.size() << " cells.");
     }
-
-
-    // Set cells that have a point outside hexahedron as empty
-    if(hexah != nullptr)
-    {
-        int nbModifiedCells = 0;
-        Point3d hexahinf[8];
-        mvsUtils::inflateHexahedron(hexah, hexahinf, 1.001);
-        for(CellIndex ci = 0; ci < _cellIsFull.size(); ++ci)
-        {
-            if(isInvalidOrInfiniteCell(ci) || !_cellIsFull[ci])
-                continue;
-
-            const Point3d& pa = _verticesCoords[_tetrahedralization->cell_vertex(ci, 0)];
-            const Point3d& pb = _verticesCoords[_tetrahedralization->cell_vertex(ci, 1)];
-            const Point3d& pc = _verticesCoords[_tetrahedralization->cell_vertex(ci, 2)];
-            const Point3d& pd = _verticesCoords[_tetrahedralization->cell_vertex(ci, 3)];
-
-            if((!mvsUtils::isPointInHexahedron(pa, hexahinf)) ||
-               (!mvsUtils::isPointInHexahedron(pb, hexahinf)) ||
-               (!mvsUtils::isPointInHexahedron(pc, hexahinf)) ||
-               (!mvsUtils::isPointInHexahedron(pd, hexahinf)))
-            {
-                _cellIsFull[ci] = false;
-                ++nbModifiedCells;
-            }
-        }
-        ALICEVISION_LOG_WARNING("Full cells with a vertex outside the BBox are changed to empty: " << nbModifiedCells << " cells changed to empty.");
-    }
-
+    
     if(doRemoveDust)
     {
         removeDust(minSegmentSize);


### PR DESCRIPTION
When a surface is close to the specified bounding box, a lot of small holes in the corresponding mesh appear. Additionally, there's a double surface phenomena that is created where an irregular surface appears behind the actual surface in question.

| ![image](https://github.com/alicevision/AliceVision/assets/72821992/c3ae27a8-570b-4e96-8b8c-91c0627e6665)<br>*Without manual bounding box (before fix)* | ![image](https://github.com/alicevision/AliceVision/assets/72821992/5e936a0b-77d1-4ee7-ac58-fd88966de8f5)<br>*With manual bounding box (before fix)* |
|:--:|:--:|
| ![image](https://github.com/alicevision/AliceVision/assets/72821992/7387c4ab-64b5-4e18-b6d5-d97ed7815564)<br>*Without manual bounding box (after fix)* | ![image](https://github.com/alicevision/AliceVision/assets/72821992/e1999bc4-d7e2-41ec-9f68-05d8f11626e7)<br>*With manual bounding box (after fix)* |

