### PR TITLE
[cameraSensors] fix Samsung SM-G998B

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5910,7 +5910,7 @@ Samsung;Samsung SM-G9880;10.82;devicespecifications
 Samsung;Samsung SM-G988B;10.82;devicespecifications
 Samsung;Samsung SM-G988N;10.82;devicespecifications
 Samsung;Samsung SM-G991B;7.26;usercontribution
-Samsung;Samsung SM-G998B;6.70;usercontribution
+Samsung;Samsung SM-G998B;19.10;devicespecifications
 Samsung;Samsung SM-M315F;7.42;devicespecifications
 Samsung;Samsung SM-N985F;9.6;devicespecifications
 Samsung;Samsung SM-N986B;9.6;devicespecifications

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5910,7 +5910,7 @@ Samsung;Samsung SM-G9880;10.82;devicespecifications
 Samsung;Samsung SM-G988B;10.82;devicespecifications
 Samsung;Samsung SM-G988N;10.82;devicespecifications
 Samsung;Samsung SM-G991B;7.26;usercontribution
-Samsung;Samsung SM-G998B;19.10;devicespecifications
+Samsung;Samsung SM-G998B;9.6;usercontribution
 Samsung;Samsung SM-M315F;7.42;devicespecifications
 Samsung;Samsung SM-N985F;9.6;devicespecifications
 Samsung;Samsung SM-N986B;9.6;devicespecifications


### PR DESCRIPTION
Apologies for my previous mistake, had confounded focal length with sensor width for the Samsung S21 Ultra 108MP lens. This should now be correct based on Samsung Device Specifications: https://www.samsung.com/uk/support/mobile-devices/what-are-the-latest-features-of-the-galaxy-s21-series-camera/

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

