### PR TITLE
[software] applyCalibration: simply copy input data when calibrated data filename is empty

### DIFF
--- a/src/software/utils/main_applyCalibration.cpp
+++ b/src/software/utils/main_applyCalibration.cpp
@@ -58,6 +58,21 @@ int aliceVision_main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
+    // Special case to handle:
+    // If calibrated SfMData filename is an empty string
+    // simply copy the input SfMData
+    if (sfmDataCalibratedFilename.empty())
+    {
+        // Save sfmData to disk
+        if (!sfmDataIO::Save(sfmData, outSfMDataFilename, sfmDataIO::ESfMData(sfmDataIO::ALL)))
+        {
+            ALICEVISION_LOG_ERROR("The output SfMData file '" << outSfMDataFilename << "' cannot be written.");
+            return EXIT_FAILURE;
+        }
+
+        return EXIT_SUCCESS;
+    }
+
     // Load calibrated scene
     sfmData::SfMData sfmDataCalibrated;
     if (!sfmDataIO::Load(sfmDataCalibrated, sfmDataCalibratedFilename, sfmDataIO::ESfMData::INTRINSICS))


### PR DESCRIPTION
## Description

In the special case where the `calibration` input of the `applyCalibration` software is empty, simply pass on the input instead of failing.

This is useful for the new camera tracking pipeline in Meshroom  when users want to disconnect the calibration pipeline (for example if there is no lens grid).