### PR TITLE
Stereo Photometry: Add robustness to unexpected inputs

### DIFF
--- a/src/aliceVision/image/resampling.hpp
+++ b/src/aliceVision/image/resampling.hpp
@@ -47,37 +47,6 @@ namespace image {
       }
   }
 
-  template <typename ImageType>
-  void downscaleImageInplace(ImageType& inout, int downscale)
-  {
-      if(downscale <= 1)
-          return;
-      ALICEVISION_LOG_TRACE("downscaleImageInplace in: " << inout.Width() << "x" << inout.Height());
-
-      {
-          // Rely on OpenImageIO to do the downscaling
-          const unsigned int w = inout.Width();
-          const unsigned int h = inout.Height();
-          const unsigned int nchannels = inout.Channels();
-
-          const unsigned int nw = (unsigned int)(floor(float(w) / downscale));
-          const unsigned int nh = (unsigned int)(floor(float(h) / downscale));
-
-          ImageType rescaled(nw, nh);
-
-          const oiio::ImageSpec imageSpecOrigin(w, h, nchannels, ColorTypeInfo<typename ImageType::Tpixel>::typeDesc);
-          const oiio::ImageSpec imageSpecResized(nw, nh, nchannels, ColorTypeInfo<typename ImageType::Tpixel>::typeDesc);
-
-          const oiio::ImageBuf inBuf(imageSpecOrigin, inout.data());
-          oiio::ImageBuf outBuf(imageSpecResized, rescaled.data());
-
-          oiio::ImageBufAlgo::resize(outBuf, inBuf);
-
-          inout.swap(rescaled);
-      }
-      ALICEVISION_LOG_TRACE("downscaleImageInplace out: " << inout.Width() << "x" << inout.Height());
-  }
-
   /**
    ** Half sample an image (ie reduce its size by a factor 2) using bilinear interpolation
    ** @param[in] src input image

--- a/src/aliceVision/lightingEstimation/augmentedNormals.hpp
+++ b/src/aliceVision/lightingEstimation/augmentedNormals.hpp
@@ -25,125 +25,124 @@ using Eigen::MatrixXf;
  */
 class AugmentedNormal : public Eigen::Matrix<float, 9, 1, 0, 9, 1>
 {
-  using T = float;
-  typedef Eigen::Matrix<T, 9, 1, 0, 9, 1> BaseMatrix;
-  typedef T TBase;
+    using T = float;
+    typedef Eigen::Matrix<T, 9, 1, 0, 9, 1> BaseMatrix;
+    typedef T TBase;
+
 public:
 
-  AugmentedNormal() = default;
+    AugmentedNormal() = default;
 
-  /**
-  * @brief Constructor from a normal value
-  */
-  inline AugmentedNormal(T nx, T ny, T nz)
-  {
-      (*this)(0) = nx;
-      (*this)(1) = ny;
-      (*this)(2) = nz;
-      (*this)(3) = 1;
-      (*this)(4) = nx*ny;
-      (*this)(5) = nx*nz;
-      (*this)(6) = ny*nz;
-      (*this)(7) = nx*nx - ny*ny;
-      (*this)(8) = 3 * nz * nz - 1;
-  }
+    /**
+     * @brief Constructor from a normal value
+     */
+    inline AugmentedNormal(T nx, T ny, T nz)
+    {
+        (*this)(0) = nx;
+        (*this)(1) = ny;
+        (*this)(2) = nz;
+        (*this)(3) = 1;
+        (*this)(4) = nx * ny;
+        (*this)(5) = nx * nz;
+        (*this)(6) = ny * nz;
+        (*this)(7) = nx * nx - ny * ny;
+        (*this)(8) = 3 * nz * nz - 1;
+    }
 
-  /**
-  * @brief Constructor from eigen Matrix
-  */
-  explicit inline AugmentedNormal(const BaseMatrix& m)
-    : BaseMatrix(m)
-  {
-  }
+    /**
+     * @brief Constructor from eigen Matrix
+     */
+    explicit inline AugmentedNormal(const BaseMatrix& m)
+      : BaseMatrix(m)
+    {
+    }
 
-  explicit inline AugmentedNormal(const Eigen::Matrix<T, 3, 1, 0, 3, 1>& m)
-    : AugmentedNormal(m(0), m(1), m(2))
-  {
-  }
+    explicit inline AugmentedNormal(const Eigen::Matrix<T, 3, 1, 0, 3, 1>& m)
+      : AugmentedNormal(m(0), m(1), m(2))
+    {
+    }
 
-  inline const T& nx() const
-  {
-    return ( *this )( 0 );
-  }
-  inline T& nx()
-  {
-    return ( *this )( 0 );
-  }
+    inline const T& nx() const
+    {
+        return (*this)(0);
+    }
+    inline T& nx()
+    {
+        return (*this)(0);
+    }
 
-  inline const T& ny() const
-  {
-    return ( *this )( 1 );
-  }
-  inline T& ny()
-  {
-    return ( *this )( 1 );
-  }
+    inline const T& ny() const
+    {
+        return (*this)(1);
+    }
+    inline T& ny()
+    {
+        return (*this)(1);
+    }
 
-  inline const T& nz() const
-  {
-    return ( *this )( 2 );
-  }
-  inline T& nz()
-  {
-    return ( *this )( 2 );
-  }
+    inline const T& nz() const
+    {
+        return (*this)(2);
+    }
+    inline T& nz()
+    {
+        return (*this)(2);
+    }
 
-  inline const T& nambiant() const
-  {
-    return ( *this )( 3 );
-  }
-  inline T& nambiant()
-  {
-    return ( *this )( 3 );
-  }
+    inline const T& nambiant() const
+    {
+        return (*this)(3);
+    }
+    inline T& nambiant()
+    {
+        return (*this)(3);
+    }
 
-  inline const T& nx_ny() const
-  {
-    return ( *this )( 4 );
-  }
-  inline T& nx_ny()
-  {
-    return ( *this )( 4 );
-  }
+    inline const T& nx_ny() const
+    {
+        return (*this)(4);
+    }
+    inline T& nx_ny()
+    {
+        return (*this)(4);
+    }
 
-  inline const T& nx_nz() const
-  {
-    return ( *this )( 5 );
-  }
-  inline T& nx_nz()
-  {
-    return ( *this )( 5 );
-  }
+    inline const T& nx_nz() const
+    {
+        return (*this)(5);
+    }
+    inline T& nx_nz()
+    {
+        return (*this)(5);
+    }
 
-  inline const T& ny_nz() const
-  {
-    return ( *this )( 6 );
-  }
-  inline T& ny_nz()
-  {
-    return ( *this )( 6 );
-  }
+    inline const T& ny_nz() const
+    {
+        return (*this)(6);
+    }
+    inline T& ny_nz()
+    {
+        return (*this)(6);
+    }
 
-  inline const T& nx2_ny2() const
-  {
-    return ( *this )( 7 );
-  }
-  inline T& nx2_ny2()
-  {
-    return ( *this )( 7 );
-  }
+    inline const T& nx2_ny2() const
+    {
+        return (*this)(7);
+    }
+    inline T& nx2_ny2()
+    {
+        return (*this)(7);
+    }
 
-  inline const T& nz2() const
-  {
-    return ( *this )( 8 );
-  }
-  inline T& nz2()
-  {
-    return ( *this )( 8 );
-  }
-
+    inline const T& nz2() const
+    {
+        return (*this)(8);
+    }
+    inline T& nz2()
+    {
+        return (*this)(8);
+    }
 };
-
 
 }
 }

--- a/src/aliceVision/lightingEstimation/lightingCalibration.cpp
+++ b/src/aliceVision/lightingEstimation/lightingCalibration.cpp
@@ -35,7 +35,8 @@ namespace aliceVision {
 namespace lightingEstimation {
 
 
-void lightCalibration(const sfmData::SfMData& sfmData, const std::string& inputJSON, const std::string& outputPath, const std::string& method, const bool saveAsModel)
+void lightCalibration(const sfmData::SfMData& sfmData, const std::string& inputJSON, const std::string& outputPath,
+                      const std::string& method, const bool saveAsModel)
 {
     std::vector<std::string> imageList;
     std::vector<std::array<float, 3>> allSpheresParams;
@@ -168,7 +169,9 @@ void lightCalibrationOneImage(const std::string& picturePath, const std::array<f
 
                     normalSphere(currentIndex,0) = (float(j) - radius) / radius;
                     normalSphere(currentIndex,1) = (float(i) - radius) / radius;
-                    normalSphere(currentIndex,2) = -sqrt(1 - normalSphere(currentIndex, 0) * normalSphere(currentIndex, 0) - normalSphere(currentIndex, 1) * normalSphere(currentIndex, 1));
+                    normalSphere(currentIndex, 2) =
+                        -sqrt(1 - normalSphere(currentIndex, 0) * normalSphere(currentIndex, 0) -
+                              normalSphere(currentIndex, 1) * normalSphere(currentIndex, 1));
 
                     ++currentIndex;
                 }
@@ -248,7 +251,8 @@ void cutImage(const image::Image<float>& imageFloat, const std::array<float, 3>&
     {
         for (size_t j = 0; j < patch.cols(); ++j)
         {
-            float distanceToCenter = (i - patch.rows() / 2) * (i - patch.rows() / 2) + (j - patch.cols() / 2) * (j - patch.cols() / 2);
+            float distanceToCenter = (i - patch.rows() / 2) * (i - patch.rows() / 2) +
+                                     (j - patch.cols() / 2) * (j - patch.cols() / 2);
             if (distanceToCenter > radius * radius + 2)
             {
                 patch(i, j) = 0;

--- a/src/aliceVision/lightingEstimation/lightingCalibration.hpp
+++ b/src/aliceVision/lightingEstimation/lightingCalibration.hpp
@@ -18,19 +18,13 @@ namespace aliceVision {
 namespace lightingEstimation {
 
 /**
- * @brief Calibrate lighting direction for a set of images contained in a folder (WIP)
- * @param[in] inputPath Path to the folder containing the images
- * @param[in] outputPath Path to the JSON file in which lights' directions are written
- */
-void lightCalibration(const std::string& inputPath, const std::string& outputPath);
-
-/**
  * @brief Calibrate lighting direction for a set of images from a .sfm file
- * @param[in] sfmData Provided .sfm file to calibrate from
+ * @param[in] sfmData Input .sfm file to calibrate from
  * @param[in] inputJSON Path to the JSON file containing the spheres parameters (see sphereDetection)
  * @param[out] outputPath Path to the JSON file in which lights' directions are written
  */
-void lightCalibration(const sfmData::SfMData& sfmData, const std::string& inputJSON, const std::string& outputPath, const std::string& method, const bool saveAsModel);
+void lightCalibration(const sfmData::SfMData& sfmData, const std::string& inputJSON, const std::string& outputPath,
+                      const std::string& method, const bool saveAsModel);
 
 /**
  * @brief Calibrate lighting direction of an image containing a sphere
@@ -40,7 +34,9 @@ void lightCalibration(const sfmData::SfMData& sfmData, const std::string& inputJ
  * @param[in] method Method used for calibration (only "brightestPoint" for now)
  * @param[out] lightingDirection Output parameter for the estimated lighting direction
  */
-void lightCalibrationOneImage(const std::string& picturePath, const std::array<float, 3>& sphereParam, const float focal, const std::string& method, Eigen::Vector3f& lightingDirection);
+void lightCalibrationOneImage(const std::string& picturePath, const std::array<float, 3>& sphereParam,
+                              const float focal, const std::string& method,
+                              Eigen::Vector3f& lightingDirection);
 
 /**
  * @brief Compute the brightest point on a sphere
@@ -49,7 +45,8 @@ void lightCalibrationOneImage(const std::string& picturePath, const std::array<f
  * @param[in] imageFloat The grayscale image
  * @param[out] brigthestPoint An Eigen::Vector2f vector containing the x and y coordinates of the brightest point on the image
  */
-void detectBrightestPoint(const std::array<float, 3>& sphereParam, const image::Image<float>& imageFloat, Eigen::Vector2f& brigthestPoint);
+void detectBrightestPoint(const std::array<float, 3>& sphereParam, const image::Image<float>& imageFloat,
+                          Eigen::Vector2f& brigthestPoint);
 
 /**
  *  @brief Create a triangle kernel
@@ -65,7 +62,8 @@ void createTriangleKernel(const size_t kernelSize, Eigen::VectorXf& kernel);
  * @param[in] sphereParam An array of 3 floating-point: the coordinates of the sphere center in the picture frame and the radius of the sphere
  * @param[out] currentNormal The normal vector
  */
-void getNormalOnSphere(const float x_picture, const float y_picture, const std::array<float, 3>& sphereParam, Eigen::Vector3f& currentNormal);
+void getNormalOnSphere(const float x_picture, const float y_picture, const std::array<float, 3>& sphereParam,
+                       Eigen::Vector3f& currentNormal);
 
 /**
  * @brief Cut a region around a sphere from a grayscale image
@@ -74,17 +72,21 @@ void getNormalOnSphere(const float x_picture, const float y_picture, const std::
  * @param[out] patch The extracted region around the sphere.
  * @param[out] patchOrigin An array containing the x and y coordinates of the origin of the extracted region.
  */
-void cutImage(const image::Image<float>& imageFloat, const std::array<float, 3>& sphereParam, image::Image<float>& patch, std::array<float, 2>& patchOrigin);
+void cutImage(const image::Image<float>& imageFloat, const std::array<float, 3>& sphereParam,
+              image::Image<float>& patch, std::array<float, 2>& patchOrigin);
 
 /**
  * @brief Write a JSON file containing light information
  * @param[in] fileName The path to the JSON file to generate
- * @param[in] imageList Paths to the input images
+ * @param[in] sfmData Input .SfM file to calibrate from
+ * @param[in] imageList Paths to the input images used for the calibration
  * @param[in] lightMat A matrix containing the directions of the light sources
  * @param[in] intList A vector of arrays containing the intensity of the light sources
  * @param[in] saveAsModel True to save the light IDs instead of the view IDs, false otherwise
  */
-void writeJSON(const std::string& fileName, const sfmData::SfMData& sfmData, const Eigen::MatrixXf& lightMat, const std::vector<float>& intList, const bool saveAsModel);
+void writeJSON(const std::string& fileName, const sfmData::SfMData& sfmData,
+               const std::vector<std::string>& imageList, const Eigen::MatrixXf& lightMat,
+               const std::vector<float>& intList, const bool saveAsModel);
 
 }
 }

--- a/src/aliceVision/lightingEstimation/lightingEstimation.cpp
+++ b/src/aliceVision/lightingEstimation/lightingEstimation.cpp
@@ -20,26 +20,27 @@ namespace lightingEstimation {
 /**
  * @brief Evaluate albedo and normal product for one channel
  */
-void albedoNormalsProduct(MatrixXf& rhoTimesN, const MatrixXf& albedoChannel, const image::Image<AugmentedNormal>& augmentedNormals)
+void albedoNormalsProduct(MatrixXf& rhoTimesN, const MatrixXf& albedoChannel,
+                          const image::Image<AugmentedNormal>& augmentedNormals)
 {
     std::size_t validIndex = 0;
     for (int i = 0; i < augmentedNormals.size(); ++i)
     {
-      // If the normal is undefined
-      if(augmentedNormals(i).nx() == -1.0f && augmentedNormals(i).ny() == -1.0f && augmentedNormals(i).nz() == -1.0f)
-      {
-        continue;
-      }
-      rhoTimesN(validIndex, 0) = albedoChannel(i) * augmentedNormals(i).nx();
-      rhoTimesN(validIndex, 1) = albedoChannel(i) * augmentedNormals(i).ny();
-      rhoTimesN(validIndex, 2) = albedoChannel(i) * augmentedNormals(i).nz();
-      rhoTimesN(validIndex, 3) = albedoChannel(i) * augmentedNormals(i).nambiant();
-      rhoTimesN(validIndex, 4) = albedoChannel(i) * augmentedNormals(i).nx_ny();
-      rhoTimesN(validIndex, 5) = albedoChannel(i) * augmentedNormals(i).nx_nz();
-      rhoTimesN(validIndex, 6) = albedoChannel(i) * augmentedNormals(i).ny_nz();
-      rhoTimesN(validIndex, 7) = albedoChannel(i) * augmentedNormals(i).nx2_ny2();
-      rhoTimesN(validIndex, 8) = albedoChannel(i) * augmentedNormals(i).nz2();
-      ++validIndex;
+        // If the normal is undefined
+        if (augmentedNormals(i).nx() == -1.0f && augmentedNormals(i).ny() == -1.0f && augmentedNormals(i).nz() == -1.0f)
+        {
+            continue;
+        }
+        rhoTimesN(validIndex, 0) = albedoChannel(i) * augmentedNormals(i).nx();
+        rhoTimesN(validIndex, 1) = albedoChannel(i) * augmentedNormals(i).ny();
+        rhoTimesN(validIndex, 2) = albedoChannel(i) * augmentedNormals(i).nz();
+        rhoTimesN(validIndex, 3) = albedoChannel(i) * augmentedNormals(i).nambiant();
+        rhoTimesN(validIndex, 4) = albedoChannel(i) * augmentedNormals(i).nx_ny();
+        rhoTimesN(validIndex, 5) = albedoChannel(i) * augmentedNormals(i).nx_nz();
+        rhoTimesN(validIndex, 6) = albedoChannel(i) * augmentedNormals(i).ny_nz();
+        rhoTimesN(validIndex, 7) = albedoChannel(i) * augmentedNormals(i).nx2_ny2();
+        rhoTimesN(validIndex, 8) = albedoChannel(i) * augmentedNormals(i).nz2();
+        ++validIndex;
     }
 }
 
@@ -49,157 +50,160 @@ void prepareImageData(const MatrixXf& albedo,
                       MatrixXf& rhoTimesN,
                       MatrixXf& colors)
 {
-  std::size_t nbValidPoints = 0;
+    std::size_t nbValidPoints = 0;
 
-  for(int i = 0; i < augmentedNormals.size(); ++i)
-  {
-    // if the normal is undefined
-    if(augmentedNormals(i).nx() == -1.0f && augmentedNormals(i).ny() == -1.0f && augmentedNormals(i).nz() == -1.0f)
-      continue;
-    ++nbValidPoints;
-  }
-
-  rhoTimesN.resize(nbValidPoints, 9);
-  albedoNormalsProduct(rhoTimesN, albedo, augmentedNormals);
-  colors.resize(nbValidPoints, 1);
-
-  {
-    std::size_t validIndex = 0;
-    for(int i = 0; i < augmentedNormals.size(); ++i)
+    for (int i = 0; i < augmentedNormals.size(); ++i)
     {
-      // if the normal is undefined
-      if(augmentedNormals(i).nx() == -1.0f && augmentedNormals(i).ny() == -1.0f && augmentedNormals(i).nz() == -1.0f)
-        continue;
-
-      colors(validIndex++) = picture(i);
+        // if the normal is undefined
+        if (augmentedNormals(i).nx() == -1.0f && augmentedNormals(i).ny() == -1.0f && augmentedNormals(i).nz() == -1.0f)
+            continue;
+        ++nbValidPoints;
     }
-  }
+
+    rhoTimesN.resize(nbValidPoints, 9);
+    albedoNormalsProduct(rhoTimesN, albedo, augmentedNormals);
+    colors.resize(nbValidPoints, 1);
+
+    {
+        std::size_t validIndex = 0;
+        for (int i = 0; i < augmentedNormals.size(); ++i)
+        {
+            // if the normal is undefined
+            if (augmentedNormals(i).nx() == -1.0f && augmentedNormals(i).ny() == -1.0f && augmentedNormals(i).nz() == -1.0f)
+                continue;
+
+            colors(validIndex++) = picture(i);
+        }
+    }
 }
 
-void LighthingEstimator::addImage(const image::Image<float>& albedo, const image::Image<float>& picture, const image::Image<image::RGBfColor>& normals)
+void LighthingEstimator::addImage(const image::Image<float>& albedo, const image::Image<float>& picture,
+                                  const image::Image<image::RGBfColor>& normals)
 {
-  using namespace Eigen;
+    using namespace Eigen;
 
-  // augmented normales
-  image::Image<AugmentedNormal> augmentedNormals(normals.cast<AugmentedNormal>());
+    // augmented normales
+    image::Image<AugmentedNormal> augmentedNormals(normals.cast<AugmentedNormal>());
 
-  const std::size_t nbPixels = augmentedNormals.Width() * augmentedNormals.Height();
+    const std::size_t nbPixels = augmentedNormals.Width() * augmentedNormals.Height();
 
-  MatrixXf rhoTimesN;
-  MatrixXf colors;
-
-  // map albedo, image
-  Map<const MatrixXf> channelAlbedo(albedo.data(), nbPixels, 1);
-  Map<const MatrixXf> channelPicture(picture.data(), nbPixels, 1);
-
-  prepareImageData(channelAlbedo, channelPicture, augmentedNormals, rhoTimesN, colors);
-
-  // store image data
-  _all_rhoTimesN.at(0).push_back(rhoTimesN);
-  _all_pictureChannel.at(0).push_back(colors);
-}
-
-void LighthingEstimator::addImage(const image::Image<image::RGBfColor>& albedo, const image::Image<image::RGBfColor>& picture, const image::Image<image::RGBfColor>& normals)
-{
-  using namespace Eigen;
-
-  // augmented normales
-  image::Image<AugmentedNormal> augmentedNormals(normals.cast<AugmentedNormal>());
-
-  const std::size_t nbPixels = augmentedNormals.Width() * augmentedNormals.Height();
-
-  // estimate lighting per channel
-  for(std::size_t channel = 0; channel < 3; ++channel)
-  {
     MatrixXf rhoTimesN;
     MatrixXf colors;
 
     // map albedo, image
-    Map<const MatrixXf, 0, InnerStride<3>> channelAlbedo(static_cast<const float*>(&(albedo(0,0)(channel))), nbPixels, 1);
-    Map<const MatrixXf, 0, InnerStride<3>> channelPicture(static_cast<const float*>(&(picture(0,0)(channel))), nbPixels, 1);
+    Map<const MatrixXf> channelAlbedo(albedo.data(), nbPixels, 1);
+    Map<const MatrixXf> channelPicture(picture.data(), nbPixels, 1);
 
     prepareImageData(channelAlbedo, channelPicture, augmentedNormals, rhoTimesN, colors);
 
     // store image data
-    _all_rhoTimesN.at(channel).push_back(rhoTimesN);
-    _all_pictureChannel.at(channel).push_back(colors);
-  }
+    _all_rhoTimesN.at(0).push_back(rhoTimesN);
+    _all_pictureChannel.at(0).push_back(colors);
+}
+
+void LighthingEstimator::addImage(const image::Image<image::RGBfColor>& albedo,
+                                  const image::Image<image::RGBfColor>& picture,
+                                  const image::Image<image::RGBfColor>& normals)
+{
+    using namespace Eigen;
+
+    // augmented normales
+    image::Image<AugmentedNormal> augmentedNormals(normals.cast<AugmentedNormal>());
+
+    const std::size_t nbPixels = augmentedNormals.Width() * augmentedNormals.Height();
+
+    // estimate lighting per channel
+    for (std::size_t channel = 0; channel < 3; ++channel)
+    {
+        MatrixXf rhoTimesN;
+        MatrixXf colors;
+
+        // map albedo, image
+        Map<const MatrixXf, 0, InnerStride<3>> channelAlbedo(static_cast<const float*>(&(albedo(0,0)(channel))), nbPixels, 1);
+        Map<const MatrixXf, 0, InnerStride<3>> channelPicture(static_cast<const float*>(&(picture(0,0)(channel))), nbPixels, 1);
+
+        prepareImageData(channelAlbedo, channelPicture, augmentedNormals, rhoTimesN, colors);
+
+        // store image data
+        _all_rhoTimesN.at(channel).push_back(rhoTimesN);
+        _all_pictureChannel.at(channel).push_back(colors);
+    }
 }
 
 void LighthingEstimator::estimateLigthing(LightingVector& lighting) const
 {
-  int nbChannels = 3;
+    int nbChannels = 3;
 
-  // check number of channels
-  for(int channel = 0; channel < 3; ++channel)
-  {
-    if(_all_rhoTimesN.at(channel).empty())
+    // check number of channels
+    for (int channel = 0; channel < 3; ++channel)
     {
-      nbChannels = channel;
-      break;
-    }
-  }
-
-  // for each channel
-  for(int channel = 0; channel < nbChannels; ++channel)
-  {
-    std::size_t nbRows_all_rhoTimesN = 0;
-    std::size_t nbRows_all_pictureChannel = 0;
-
-    // count and check matrices rows
-    {
-      for(const MatrixXf& matrix : _all_rhoTimesN.at(channel))
-        nbRows_all_rhoTimesN += matrix.rows();
-
-      for(const MatrixXf& matrix : _all_pictureChannel.at(channel))
-        nbRows_all_pictureChannel += matrix.rows();
-
-      assert(nbRows_all_rhoTimesN == nbRows_all_pictureChannel);
+        if (_all_rhoTimesN.at(channel).empty())
+        {
+            nbChannels = channel;
+            break;
+        }
     }
 
-    // agglomerate rhoTimesN
-    MatrixXf rhoTimesN(nbRows_all_rhoTimesN, 9);
+    // for each channel
+    for (int channel = 0; channel < nbChannels; ++channel)
     {
-      std::size_t nbRow = 0;
-      for(const MatrixXf& matrix : _all_rhoTimesN.at(channel))
-      {
-        for(int matrixRow = 0; matrixRow < matrix.rows(); ++matrixRow)
-          rhoTimesN.row(nbRow + matrixRow) = matrix.row(matrixRow);
-        nbRow += matrix.rows();
-      }
+        std::size_t nbRows_all_rhoTimesN = 0;
+        std::size_t nbRows_all_pictureChannel = 0;
+
+        // count and check matrices rows
+        {
+            for(const MatrixXf& matrix : _all_rhoTimesN.at(channel))
+                nbRows_all_rhoTimesN += matrix.rows();
+
+            for(const MatrixXf& matrix : _all_pictureChannel.at(channel))
+                nbRows_all_pictureChannel += matrix.rows();
+
+            assert(nbRows_all_rhoTimesN == nbRows_all_pictureChannel);
+        }
+
+        // agglomerate rhoTimesN
+        MatrixXf rhoTimesN(nbRows_all_rhoTimesN, 9);
+        {
+            std::size_t nbRow = 0;
+            for (const MatrixXf& matrix : _all_rhoTimesN.at(channel))
+            {
+                for (int matrixRow = 0; matrixRow < matrix.rows(); ++matrixRow)
+                    rhoTimesN.row(nbRow + matrixRow) = matrix.row(matrixRow);
+                nbRow += matrix.rows();
+            }
+        }
+
+        // agglomerate pictureChannel
+        MatrixXf pictureChannel(nbRows_all_pictureChannel, 1);
+        {
+            std::size_t nbRow = 0;
+            for (const MatrixXf& matrix : _all_pictureChannel.at(channel))
+            {
+                for(int matrixRow = 0; matrixRow < matrix.rows(); ++matrixRow)
+                    pictureChannel.row(nbRow + matrixRow) = matrix.row(matrixRow);
+                nbRow += matrix.rows();
+            }
+        }
+
+        ALICEVISION_LOG_INFO("Estimate ligthing channel: rhoTimesN(" << rhoTimesN.rows() << "x" << rhoTimesN.cols()<< ")");
+        Eigen::Matrix<float, 9, 1> lightingC = rhoTimesN.colPivHouseholderQr().solve(pictureChannel);
+
+        // lighting vectors fusion
+        lighting.col(channel) = lightingC;
+
+        // luminance estimation
+        if (nbChannels == 1)
+        {
+            lighting.col(1) = lightingC;
+            lighting.col(2) = lightingC;
+        }
     }
-
-    // agglomerate pictureChannel
-    MatrixXf pictureChannel(nbRows_all_pictureChannel, 1);
-    {
-      std::size_t nbRow = 0;
-      for(const MatrixXf& matrix : _all_pictureChannel.at(channel))
-      {
-        for(int matrixRow = 0; matrixRow < matrix.rows(); ++matrixRow)
-          pictureChannel.row(nbRow + matrixRow) = matrix.row(matrixRow);
-        nbRow += matrix.rows();
-      }
-    }
-
-    ALICEVISION_LOG_INFO("estimate ligthing channel: rhoTimesN(" << rhoTimesN.rows() << "x" << rhoTimesN.cols()<< ")");
-    Eigen::Matrix<float, 9, 1> lightingC = rhoTimesN.colPivHouseholderQr().solve(pictureChannel);
-
-    // lighting vectors fusion
-    lighting.col(channel) = lightingC;
-
-    // luminance estimation
-    if(nbChannels == 1)
-    {
-      lighting.col(1) = lightingC;
-      lighting.col(2) = lightingC;
-    }
-  }
 }
 
 void LighthingEstimator::clear()
 {
-  _all_rhoTimesN = std::array<std::vector<MatrixXf>, 3>();
-  _all_pictureChannel = std::array<std::vector<MatrixXf>, 3>();
+    _all_rhoTimesN = std::array<std::vector<MatrixXf>, 3>();
+    _all_pictureChannel = std::array<std::vector<MatrixXf>, 3>();
 }
 
 } // namespace lightingEstimation

--- a/src/aliceVision/lightingEstimation/lightingEstimation.hpp
+++ b/src/aliceVision/lightingEstimation/lightingEstimation.hpp
@@ -36,30 +36,38 @@ using LightingVector = Eigen::Matrix<float, 9, 3>;
 class LighthingEstimator
 {
 public:
+    /**
+     * @brief Aggregate image data
+     * @param[in] albedo the corresponding albedo image (float image)
+     * @param[in] picture the corresponding picture (float image)
+     * @param[in] normals the corresponding normals image
+     */
+    void addImage(const image::Image<float>& albedo, const image::Image<float>& picture,
+                  const image::Image<image::RGBfColor>& normals);
 
-  /**
-   * @brief Aggregate image data
-   * @param albedo[in] the corresponding albedo image
-   * @param picture[in] the corresponding picture
-   * @param normals[in] the corresponding normals image
-   */
-  void addImage(const image::Image<float>& albedo, const image::Image<float>& picture, const image::Image<image::RGBfColor>& normals);
-  void addImage(const image::Image<image::RGBfColor>& albedo, const image::Image<image::RGBfColor>& picture, const image::Image<image::RGBfColor>& normals);
+    /**
+     * @brief Aggregate image data
+     * @param[in] albedo the corresponding albedo image (RGBf image)
+     * @param[in] picture the corresponding picture (RGBf image)
+     * @param[in] normals the corresponding normals image
+     */
+    void addImage(const image::Image<image::RGBfColor>& albedo, const image::Image<image::RGBfColor>& picture,
+                  const image::Image<image::RGBfColor>& normals);
 
-  /**
-   * @brief Estimate ligthing from the aggregate image(s) data
-   * @param[out] lighting Estimate ligthing @see LightingVector
-   */
-  void estimateLigthing(LightingVector& lighting) const;
+    /**
+     * @brief Estimate ligthing from the aggregate image(s) data
+     * @param[out] lighting Estimate ligthing @see LightingVector
+     */
+    void estimateLigthing(LightingVector& lighting) const;
 
-  /**
-   * @brief Clear all the aggregate image(s) data
-   */
-  void clear();
+    /**
+     * @brief Clear all the aggregate image(s) data
+     */
+    void clear();
 
 private:
-  std::array<std::vector<MatrixXf>, 3> _all_rhoTimesN;
-  std::array<std::vector<MatrixXf>, 3> _all_pictureChannel;
+    std::array<std::vector<MatrixXf>, 3> _all_rhoTimesN;
+    std::array<std::vector<MatrixXf>, 3> _all_pictureChannel;
 };
 
 } // namespace lightingEstimation

--- a/src/aliceVision/photometricStereo/normalIntegration.cpp
+++ b/src/aliceVision/photometricStereo/normalIntegration.cpp
@@ -20,7 +20,7 @@
 #include <Eigen/Dense>
 
 #include <aliceVision/image/io.hpp>
-#include <aliceVision/image/resampling.hpp>
+#include <aliceVision/image/imageAlgo.hpp>
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -55,8 +55,8 @@ void normalIntegration(const std::string& inputPath, const bool& perspective, co
 
     if (downscale > 1)
     {
-        downscaleImageInplace(normalsImPNG2, downscale);
-        downscaleImageInplace(normalsMask, downscale);
+        imageAlgo::resizeImage(downscale, normalsImPNG2);
+        imageAlgo::resizeImage(downscale, normalsMask);
 
         K = K / downscale;
         K(2, 2) = 1;
@@ -156,8 +156,8 @@ void normalIntegration(const sfmData::SfMData& sfmData, const std::string& input
 
             if (downscale > 1)
             {
-                downscaleImageInplace(normalsImPNG2, downscale);
-                downscaleImageInplace(normalsMask, downscale);
+                imageAlgo::resizeImage(downscale, normalsImPNG2);
+                imageAlgo::resizeImage(downscale, normalsMask);
 
                 K = K / downscale;
                 K(2, 2) = 1;
@@ -238,8 +238,8 @@ void normalIntegration(const sfmData::SfMData& sfmData, const std::string& input
 
         if (downscale > 1)
         {
-            downscaleImageInplace(normalsImPNG2, downscale);
-            downscaleImageInplace(normalsMask, downscale);
+            imageAlgo::resizeImage(downscale, normalsImPNG2);
+            imageAlgo::resizeImage(downscale, normalsMask);
 
             K = K / downscale;
             K(2, 2) = 1;

--- a/src/aliceVision/photometricStereo/normalIntegration.cpp
+++ b/src/aliceVision/photometricStereo/normalIntegration.cpp
@@ -32,7 +32,8 @@
 namespace aliceVision {
 namespace photometricStereo {
 
-void normalIntegration(const std::string& inputPath, const bool& perspective, const int& downscale, const std::string& outputFolder)
+void normalIntegration(const std::string& inputPath, const bool& perspective, const int& downscale,
+                       const std::string& outputFolder)
 {
     std::string normalMapPath = inputPath + "/normals.png";
     std::string pathToK = inputPath + "/K.txt";
@@ -77,7 +78,8 @@ void normalIntegration(const std::string& inputPath, const bool& perspective, co
     image::writeImage(pathToDM, distanceMap, image::ImageWriteOptions().toColorSpace(image::EImageColorSpace::NO_CONVERSION).storageDataType(image::EStorageDataType::Float));
 }
 
-void normalIntegration(const sfmData::SfMData& sfmData, const std::string& inputPath, const bool& perspective, const int& downscale, const std::string& outputFolder)
+void normalIntegration(const sfmData::SfMData& sfmData, const std::string& inputPath, const bool& perspective,
+                       const int& downscale, const std::string& outputFolder)
 {
     image::Image<image::RGBColor> normalsImPNG;
 
@@ -296,7 +298,8 @@ void normalIntegration(const sfmData::SfMData& sfmData, const std::string& input
     }
 }
 
-void DCTIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective, const Eigen::Matrix3f& K, const image::Image<float>& normalsMask)
+void DCTIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective,
+                    const Eigen::Matrix3f& K, const image::Image<float>& normalsMask)
 {
 
     int nbCols = normals.cols();
@@ -375,7 +378,8 @@ void DCTIntegration(const image::Image<image::RGBfColor>& normals, image::Image<
     }
 }
 
-void normal2PQ(const image::Image<image::RGBfColor>& normals, Eigen::MatrixXf& p, Eigen::MatrixXf& q, bool perspective, const Eigen::Matrix3f& K, const image::Image<float>& normalsMask)
+void normal2PQ(const image::Image<image::RGBfColor>& normals, Eigen::MatrixXf& p, Eigen::MatrixXf& q, bool perspective,
+               const Eigen::Matrix3f& K, const image::Image<float>& normalsMask)
 {
     image::Image<float> normalsX(p.cols(), p.rows());
     image::Image<float> normalsY(p.cols(), p.rows());
@@ -532,7 +536,8 @@ void adjustScale(const sfmData::SfMData& sfmData, image::Image<float>& initDepth
 }
 
 
-void getZ0FromLandmarks(const sfmData::SfMData& sfmData, image::Image<float>& z0, image::Image<float>& maskZ0, const size_t viewID, const image::Image<float>& mask)
+void getZ0FromLandmarks(const sfmData::SfMData& sfmData, image::Image<float>& z0, image::Image<float>& maskZ0,
+                        const size_t viewID, const image::Image<float>& mask)
 {
     const sfmData::Landmarks& landmarks = sfmData.getLandmarks();
     const sfmData::LandmarksPerView landmarksPerView = sfmData::getLandmarksPerViews(sfmData);
@@ -560,12 +565,15 @@ void getZ0FromLandmarks(const sfmData::SfMData& sfmData, image::Image<float>& z0
     }
 }
 
-void smoothIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective, const Eigen::Matrix3f& K, const image::Image<float>& mask, const image::Image<float>& z0, const image::Image<float>& maskZ0)
+void smoothIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective,
+                       const Eigen::Matrix3f& K, const image::Image<float>& mask, const image::Image<float>& z0,
+                       const image::Image<float>& maskZ0)
 {
     std::cout << "WIP" << std::endl;
 }
 
-void convertZtoDistance(const aliceVision::image::Image<float>& zMap, aliceVision::image::Image<float>& distanceMap, const Eigen::Matrix3f& K)
+void convertZtoDistance(const aliceVision::image::Image<float>& zMap, aliceVision::image::Image<float>& distanceMap,
+                        const Eigen::Matrix3f& K)
 {
     int nbRows = zMap.rows();
     int nbCols = zMap.cols();
@@ -584,7 +592,8 @@ void convertZtoDistance(const aliceVision::image::Image<float>& zMap, aliceVisio
     }
 }
 
-void convertDistanceToZ(const aliceVision::image::Image<float>& distanceMap, aliceVision::image::Image<float>& zMap, const Eigen::Matrix3f& K)
+void convertDistanceToZ(const aliceVision::image::Image<float>& distanceMap, aliceVision::image::Image<float>& zMap,
+                        const Eigen::Matrix3f& K)
 {
     int nbRows = zMap.rows();
     int nbCols = zMap.cols();
@@ -604,7 +613,9 @@ void convertDistanceToZ(const aliceVision::image::Image<float>& distanceMap, ali
 }
 
 
-void loadNormalMap(aliceVision::image::Image<aliceVision::image::RGBColor> inputNormals, const aliceVision::image::Image<float>& normalsMask, aliceVision::image::Image<aliceVision::image::RGBfColor>& outputNormals)
+void loadNormalMap(aliceVision::image::Image<aliceVision::image::RGBColor> inputNormals,
+                   const aliceVision::image::Image<float>& normalsMask,
+                   aliceVision::image::Image<aliceVision::image::RGBfColor>& outputNormals)
 {
     int nbCols = inputNormals.cols();
     int nbRows = inputNormals.rows();

--- a/src/aliceVision/photometricStereo/normalIntegration.hpp
+++ b/src/aliceVision/photometricStereo/normalIntegration.hpp
@@ -17,13 +17,17 @@
 namespace aliceVision {
 namespace photometricStereo {
 
-void normalIntegration(const std::string& inputPath, const bool& perspective, const int& downscale, const std::string& outputFolder);
+void normalIntegration(const std::string& inputPath, const bool& perspective, const int& downscale,
+                       const std::string& outputFolder);
 
-void normalIntegration(const sfmData::SfMData& sfmData, const std::string& inputPath, const bool& perspective, const int& downscale, const std::string& outputFolder);
+void normalIntegration(const sfmData::SfMData& sfmData, const std::string& inputPath, const bool& perspective,
+                       const int& downscale, const std::string& outputFolder);
 
-void DCTIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective, const Eigen::Matrix3f& K, const image::Image<float>& normalsMask);
+void DCTIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective,
+                    const Eigen::Matrix3f& K, const image::Image<float>& normalsMask);
 
-void normal2PQ(const image::Image<image::RGBfColor>& normals, Eigen::MatrixXf& p, Eigen::MatrixXf& q, bool perspective, const Eigen::Matrix3f& K, const image::Image<float>& normalsMask);
+void normal2PQ(const image::Image<image::RGBfColor>& normals, Eigen::MatrixXf& p, Eigen::MatrixXf& q, bool perspective,
+               const Eigen::Matrix3f& K, const image::Image<float>& normalsMask);
 
 void getDivergenceField(const Eigen::MatrixXf& p, const Eigen::MatrixXf& q, Eigen::MatrixXf& f);
 
@@ -31,15 +35,21 @@ void setBoundaryConditions(const Eigen::MatrixXf& p, const Eigen::MatrixXf& q, E
 
 void adjustScale(const sfmData::SfMData& sfmData, image::Image<float>& initDepth, size_t viewID);
 
-void getZ0FromLandmarks(const sfmData::SfMData& sfmData, image::Image<float>& z0, image::Image<float>& maskZ0, const size_t viewID, const image::Image<float>& mask);
+void getZ0FromLandmarks(const sfmData::SfMData& sfmData, image::Image<float>& z0, image::Image<float>& maskZ0,
+                        const size_t viewID, const image::Image<float>& mask);
 
-void smoothIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective, const Eigen::Matrix3f& K, const image::Image<float>& mask, const image::Image<float>& z0, const image::Image<float>& maskZ0);
+void smoothIntegration(const image::Image<image::RGBfColor>& normals, image::Image<float>& depth, bool perspective,
+                       const Eigen::Matrix3f& K, const image::Image<float>& mask, const image::Image<float>& z0,
+                       const image::Image<float>& maskZ0);
 
-void convertZtoDistance(const image::Image<float>& zMap, image::Image<float>& distanceMap, const Eigen::Matrix3f& K);
+void convertZtoDistance(const image::Image<float>& zMap, image::Image<float>& distanceMap,
+                        const Eigen::Matrix3f& K);
 
-void convertDistanceToZ(const image::Image<float>& distanceMap, image::Image<float>& zMap, const Eigen::Matrix3f& K);
+void convertDistanceToZ(const image::Image<float>& distanceMap, image::Image<float>& zMap,
+                        const Eigen::Matrix3f& K);
 
-void loadNormalMap(image::Image<image::RGBColor> inputNormals, const image::Image<float>& normalsMask, image::Image<image::RGBfColor>& outputNormals);
+void loadNormalMap(image::Image<image::RGBColor> inputNormals, const image::Image<float>& normalsMask,
+                   image::Image<image::RGBfColor>& outputNormals);
 
 }
 }

--- a/src/aliceVision/photometricStereo/photometricDataIO.cpp
+++ b/src/aliceVision/photometricStereo/photometricDataIO.cpp
@@ -236,9 +236,16 @@ void buildLightMatFromJSON(const std::string& fileName, const std::vector<IndexT
 
 void loadMask(std::string const& maskName, image::Image<float>& mask)
 {
-    if (!fs::exists(maskName))
+    if (!fs::exists(maskName) || maskName.empty())
     {
-        std::cout << "Cannot open '" << maskName << "'. Every pixel will be used!" << std::endl;
+        if (maskName.empty())
+        {
+            ALICEVISION_LOG_INFO("No mask folder was provided. Every pixel will be used.");
+        }
+        else
+        {
+            ALICEVISION_LOG_WARNING("Could not open '" << maskName << "'. Every pixel will be used.");
+        }
         Eigen::MatrixXf maskAux(1, 1);
         maskAux(0, 0) = 1;
         mask = maskAux;

--- a/src/aliceVision/photometricStereo/photometricDataIO.cpp
+++ b/src/aliceVision/photometricStereo/photometricDataIO.cpp
@@ -55,7 +55,8 @@ void loadLightIntensities(const std::string& intFileName, std::vector<std::array
     }
 }
 
-void loadLightDirections(const std::string& dirFileName, const Eigen::MatrixXf& convertionMatrix, Eigen::MatrixXf& lightMat)
+void loadLightDirections(const std::string& dirFileName, const Eigen::MatrixXf& convertionMatrix,
+                         Eigen::MatrixXf& lightMat)
 {
     std::stringstream stream;
     std::string line;
@@ -136,7 +137,8 @@ void loadLightHS(const std::string& dirFileName, Eigen::MatrixXf& lightMat)
     }
 }
 
-void buildLightMatFromJSON(const std::string& fileName, const std::vector<std::string>& imageList, Eigen::MatrixXf& lightMat, std::vector<std::array<float, 3>>& intList)
+void buildLightMatFromJSON(const std::string& fileName, const std::vector<std::string>& imageList,
+                           Eigen::MatrixXf& lightMat, std::vector<std::array<float, 3>>& intList)
 {
     // Main tree
     bpt::ptree fileTree;
@@ -174,7 +176,8 @@ void buildLightMatFromJSON(const std::string& fileName, const std::vector<std::s
     }
 }
 
-void buildLightMatFromJSON(const std::string& fileName, const std::vector<IndexT>& indices, Eigen::MatrixXf& lightMat, std::vector<std::array<float, 3>>& intList)
+void buildLightMatFromJSON(const std::string& fileName, const std::vector<IndexT>& indices,
+                           Eigen::MatrixXf& lightMat, std::vector<std::array<float, 3>>& intList)
 {
     // Main tree
     bpt::ptree fileTree;
@@ -236,7 +239,7 @@ void buildLightMatFromJSON(const std::string& fileName, const std::vector<IndexT
 
 void loadMask(std::string const& maskName, image::Image<float>& mask)
 {
-    if (!fs::exists(maskName) || maskName.empty())
+    if (maskName.empty() || !fs::exists(maskName))
     {
         if (maskName.empty())
         {
@@ -292,7 +295,8 @@ void intensityScaling(std::array<float, 3> const& intensities, image::Image<imag
     }
 }
 
-void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const std::vector<int>& indices, Eigen::MatrixXf& imageOut)
+void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const std::vector<int>& indices,
+                    Eigen::MatrixXf& imageOut)
 {
     int nbRows = imageIn.rows();
     int nbCols = imageIn.cols();
@@ -310,7 +314,8 @@ void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const std::ve
     }
 }
 
-void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const image::Image<float>& mask, Eigen::MatrixXf& imageOut)
+void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const image::Image<float>& mask,
+                    Eigen::MatrixXf& imageOut)
 {
     int nbRows = imageIn.rows();
     int nbCols = imageIn.cols();
@@ -334,7 +339,8 @@ void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const image::
     }
 }
 
-void image2PsMatrix(const image::Image<float>& imageIn, const image::Image<float>& mask, Eigen::VectorXf& imageOut)
+void image2PsMatrix(const image::Image<float>& imageIn, const image::Image<float>& mask,
+                    Eigen::VectorXf& imageOut)
 {
     int nbRows = imageIn.rows();
     int nbCols = imageIn.cols();
@@ -373,7 +379,8 @@ void reshapeInImage(const Eigen::MatrixXf& matrixIn, image::Image<image::RGBfCol
     }
 }
 
-void convertNormalMap2png(const image::Image<image::RGBfColor>& normalsIm, image::Image<image::RGBColor>& normalsImPNG)
+void convertNormalMap2png(const image::Image<image::RGBfColor>& normalsIm,
+                          image::Image<image::RGBColor>& normalsImPNG)
 {
     int nbRows = normalsIm.rows();
     int nbCols = normalsIm.cols();
@@ -382,7 +389,8 @@ void convertNormalMap2png(const image::Image<image::RGBfColor>& normalsIm, image
     {
         for (int i = 0; i < nbRows; ++i)
         {
-            if (normalsIm(i, j)(0) * normalsIm(i, j)(0) + normalsIm(i, j)(1) * normalsIm(i, j)(1) + normalsIm(i, j)(2) * normalsIm(i, j)(2) == 0)
+            if (normalsIm(i, j)(0) * normalsIm(i, j)(0) + normalsIm(i, j)(1) * normalsIm(i, j)(1) +
+                    normalsIm(i, j)(2) * normalsIm(i, j)(2) == 0)
             {
                 normalsImPNG(i, j)(0) = 0;
                 normalsImPNG(i, j)(1) = 0;
@@ -421,16 +429,30 @@ void readMatrix(const std::string& fileName, Eigen::MatrixXf& matrix)
     matFile.close();
 }
 
-void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals, const image::Image<image::RGBfColor>& albedo)
+void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals,
+                    const image::Image<image::RGBfColor>& albedo)
 {
-    image::writeImage(outputPath + "/normals.exr", normals, image::ImageWriteOptions().toColorSpace(image::EImageColorSpace::NO_CONVERSION).storageDataType(image::EStorageDataType::Float));
-    image::writeImage(outputPath + "/albedo.exr", albedo, image::ImageWriteOptions().toColorSpace(image::EImageColorSpace::NO_CONVERSION).storageDataType(image::EStorageDataType::Float));
+    image::writeImage(outputPath + "/normals.exr", normals,
+                      image::ImageWriteOptions()
+                          .toColorSpace(image::EImageColorSpace::NO_CONVERSION)
+                          .storageDataType(image::EStorageDataType::Float));
+    image::writeImage(outputPath + "/albedo.exr", albedo,
+                      image::ImageWriteOptions()
+                          .toColorSpace(image::EImageColorSpace::NO_CONVERSION)
+                          .storageDataType(image::EStorageDataType::Float));
 }
 
-void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals, const image::Image<image::RGBfColor>& albedo, const IndexT poseId)
+void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals,
+                    const image::Image<image::RGBfColor>& albedo, const IndexT poseId)
 {
-    image::writeImage(outputPath + "/" + std::to_string(poseId) + "_normals.exr", normals, image::ImageWriteOptions().toColorSpace(image::EImageColorSpace::NO_CONVERSION).storageDataType(image::EStorageDataType::Float));
-    image::writeImage(outputPath + "/" + std::to_string(poseId) + "_albedo.exr", albedo, image::ImageWriteOptions().toColorSpace(image::EImageColorSpace::NO_CONVERSION).storageDataType(image::EStorageDataType::Float));
+    image::writeImage(outputPath + "/" + std::to_string(poseId) + "_normals.exr", normals,
+                      image::ImageWriteOptions()
+                          .toColorSpace(image::EImageColorSpace::NO_CONVERSION)
+                          .storageDataType(image::EStorageDataType::Float));
+    image::writeImage(outputPath + "/" + std::to_string(poseId) + "_albedo.exr", albedo,
+                      image::ImageWriteOptions()
+                          .toColorSpace(image::EImageColorSpace::NO_CONVERSION)
+                          .storageDataType(image::EStorageDataType::Float));
 }
 
 }

--- a/src/aliceVision/photometricStereo/photometricDataIO.hpp
+++ b/src/aliceVision/photometricStereo/photometricDataIO.hpp
@@ -33,7 +33,8 @@ void loadLightIntensities(const std::string& intFileName, std::vector<std::array
  * @param[in] convertionMatrix Matrix describing the optional change of frame
  * @param[out] lightMat Matrix of directions of light
  */
-void loadLightDirections(const std::string& dirFileName, const Eigen::MatrixXf& convertionMatrix, Eigen::MatrixXf& lightMat);
+void loadLightDirections(const std::string& dirFileName, const Eigen::MatrixXf& convertionMatrix,
+                         Eigen::MatrixXf& lightMat);
 
 /**
  * @brief Load light directions from a file to an Eigen matrix when using spherical harmonics
@@ -49,7 +50,8 @@ void loadLightHS(const std::string& dirFileName, Eigen::MatrixXf& lightMat);
  * @param[out] lightMat Matrix of directions of light
  * @param[out] intList Intensities of lights (for each image, intensity in each channel)
  */
-void buildLightMatFromJSON(const std::string& fileName, const std::vector<std::string>& imageList, Eigen::MatrixXf& lightMat, std::vector<std::array<float, 3>>& intList);
+void buildLightMatFromJSON(const std::string& fileName, const std::vector<std::string>& imageList,
+                           Eigen::MatrixXf& lightMat, std::vector<std::array<float, 3>>& intList);
 
 /**
  * @brief Load light data from a JSON file to an Eigen matrix (with a list of indices)
@@ -58,7 +60,8 @@ void buildLightMatFromJSON(const std::string& fileName, const std::vector<std::s
  * @param[out] lightMat Matrix of directions of light
  * @param[out] intList Intensities of lights (for each image, intensity in each channel)
  */
-void buildLightMatFromJSON(const std::string& fileName, const std::vector<IndexT>& indices, Eigen::MatrixXf& lightMat, std::vector<std::array<float, 3>>& intList);
+void buildLightMatFromJSON(const std::string& fileName, const std::vector<IndexT>& indices, Eigen::MatrixXf& lightMat,
+                           std::vector<std::array<float, 3>>& intList);
 
 /**
  * @brief Load a mask
@@ -87,7 +90,8 @@ void intensityScaling(std::array<float, 3> const& intensities, image::Image<imag
  * @param[in] indices The absolute indices of pixels in mask
  * @param[out] imageOut The resulting matrix that can be used in PS solver
  */
-void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const std::vector<int>& indices, Eigen::MatrixXf& imageOut);
+void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const std::vector<int>& indices,
+                    Eigen::MatrixXf& imageOut);
 
 /**
  * @brief Rearrange (masked) values of color images in an Eigen matrix
@@ -95,7 +99,8 @@ void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const std::ve
  * @param[in] mask Input mask
  * @param[out] imageOut The resulting matrix that can be used in PS solver
  */
-void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const image::Image<float>& mask, Eigen::MatrixXf& imageOut);
+void image2PsMatrix(const image::Image<image::RGBfColor>& imageIn, const image::Image<float>& mask,
+                    Eigen::MatrixXf& imageOut);
 
 /**
  * @brief Rearrange (masked) values of gray-level images in an Eigen matrix
@@ -133,7 +138,8 @@ void readMatrix(const std::string& fileName, Eigen::MatrixXf& matrix);
  * @param[in] normals The normal map to save
  * @param[in] albedo The albedo map to save
  */
-void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals, const image::Image<image::RGBfColor>& albedo);
+void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals,
+                    const image::Image<image::RGBfColor>& albedo);
 
 /**
  * @brief Write the PS results in a given folder, using pose ID in the name (multi-view context only)
@@ -142,7 +148,8 @@ void writePSResults(const std::string& outputPath, const image::Image<image::RGB
  * @param[in] albedo The albedo map to save
  * @param[in] poseId The UID associated with the pose of the camera
  */
-void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals, const image::Image<image::RGBfColor>& albedo, const IndexT poseId);
+void writePSResults(const std::string& outputPath, const image::Image<image::RGBfColor>& normals,
+                    const image::Image<image::RGBfColor>& albedo, const IndexT poseId);
 
 }
 }

--- a/src/aliceVision/photometricStereo/photometricStereo.cpp
+++ b/src/aliceVision/photometricStereo/photometricStereo.cpp
@@ -9,7 +9,7 @@
 
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>
-#include <aliceVision/image/resampling.hpp>
+#include <aliceVision/image/imageAlgo.hpp>
 
 // Eigen
 #include <Eigen/Dense>
@@ -215,7 +215,7 @@ void photometricStereo(const std::vector<std::string>& imageList, const std::vec
     {
         if (PSParameters.downscale > 1)
         {
-            downscaleImageInplace(mask, PSParameters.downscale);
+            imageAlgo::resizeImage(PSParameters.downscale, mask);
         }
 
         getIndMask(mask, indices);
@@ -232,7 +232,7 @@ void photometricStereo(const std::vector<std::string>& imageList, const std::vec
 
         if (PSParameters.downscale > 1)
         {
-            downscaleImageInplace(imageFloat, PSParameters.downscale);
+            imageAlgo::resizeImage(PSParameters.downscale, imageFloat);
         }
 
         pictRows = imageFloat.rows();
@@ -256,7 +256,7 @@ void photometricStereo(const std::vector<std::string>& imageList, const std::vec
 
         if (PSParameters.downscale > 1)
         {
-            downscaleImageInplace(imageAmbiant,PSParameters.downscale);
+            imageAlgo::resizeImage(PSParameters.downscale, imageAmbiant);
         }
     }
 
@@ -317,7 +317,7 @@ void photometricStereo(const std::vector<std::string>& imageList, const std::vec
 
             if (PSParameters.downscale > 1)
             {
-                downscaleImageInplace(imageFloat,PSParameters.downscale);
+                imageAlgo::resizeImage(PSParameters.downscale, imageFloat);
             }
 
             if (boost::algorithm::icontains(fs::path(pathToAmbiant).stem().string(), "ambiant"))

--- a/src/aliceVision/photometricStereo/photometricStereo.cpp
+++ b/src/aliceVision/photometricStereo/photometricStereo.cpp
@@ -27,7 +27,9 @@ namespace fs = boost::filesystem;
 namespace aliceVision {
 namespace photometricStereo {
 
-void photometricStereo(const std::string& inputPath, const std::string& lightData, const std::string& outputPath, const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo)
+void photometricStereo(const std::string& inputPath, const std::string& lightData, const std::string& outputPath,
+                       const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals,
+                       image::Image<image::RGBfColor>& albedo)
 {
     size_t dim = 3;
     if (PSParameters.SHOrder == 2)
@@ -76,7 +78,9 @@ void photometricStereo(const std::string& inputPath, const std::string& lightDat
     image::writeImage(outputPath + "/mask.png", mask, image::ImageWriteOptions().toColorSpace(image::EImageColorSpace::NO_CONVERSION));
 }
 
-void photometricStereo(const sfmData::SfMData& sfmData, const std::string& lightData, const std::string& maskPath, const std::string& outputPath, const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo)
+void photometricStereo(const sfmData::SfMData& sfmData, const std::string& lightData, const std::string& maskPath,
+                       const std::string& outputPath, const PhotometricSteroParameters& PSParameters,
+                       image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo)
 {
     bool skipAll = true;
     bool groupedImages = false;
@@ -239,7 +243,10 @@ void photometricStereo(const sfmData::SfMData& sfmData, const std::string& light
     sfmDataIO::Save(normalSfmData, outputPath + "/normalMaps.sfm", sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS|sfmDataIO::EXTRINSICS));
 }
 
-void photometricStereo(const std::vector<std::string>& imageList, const std::vector<std::array<float, 3>>& intList, const Eigen::MatrixXf& lightMat, image::Image<float>& mask, const std::string& pathToAmbiant, const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo)
+void photometricStereo(const std::vector<std::string>& imageList, const std::vector<std::array<float, 3>>& intList,
+                       const Eigen::MatrixXf& lightMat, image::Image<float>& mask, const std::string& pathToAmbiant,
+                       const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals,
+                       image::Image<image::RGBfColor>& albedo)
 {
     size_t maskSize;
     int pictRows;
@@ -432,7 +439,6 @@ void photometricStereo(const std::vector<std::string>& imageList, const std::vec
                 normalsVect.col(currentIdx) = M_channel.col(i) / M_channel.col(i).norm();
             }
 
-
             int currentIdx;
             for (size_t ch = 0; ch < 3; ++ch)
             {
@@ -517,7 +523,8 @@ void photometricStereo(const std::vector<std::string>& imageList, const std::vec
     albedo = albedoIm;
 }
 
-void loadPSData(const std::string& folderPath, const size_t HS_order, std::vector<std::array<float, 3>>& intList, Eigen::MatrixXf& lightMat)
+void loadPSData(const std::string& folderPath, const size_t HS_order, std::vector<std::array<float, 3>>& intList,
+                Eigen::MatrixXf& lightMat)
 {
     std::string intFileName;
     std::string pathToCM;

--- a/src/aliceVision/photometricStereo/photometricStereo.cpp
+++ b/src/aliceVision/photometricStereo/photometricStereo.cpp
@@ -141,7 +141,9 @@ void photometricStereo(const sfmData::SfMData& sfmData, const std::string& light
 
         image::Image<float> mask;
         std::string pictureFolderName = fs::path(sfmData.getView(viewIds[0]).getImagePath()).parent_path().filename().string();
-        std::string currentMaskPath = maskPath + "/" + pictureFolderName.erase(0,3) + ".png";
+        // If no mask folder was provided, do not make up a path anyway
+        std::string currentMaskPath = maskPath.empty() ? maskPath : maskPath + "/" + pictureFolderName.erase(0, 3) + ".png";
+
         loadMask(currentMaskPath, mask);
 
         photometricStereo(imageList, intList, lightMat, mask, pathToAmbiant, PSParameters, normals, albedo);

--- a/src/aliceVision/photometricStereo/photometricStereo.cpp
+++ b/src/aliceVision/photometricStereo/photometricStereo.cpp
@@ -79,6 +79,7 @@ void photometricStereo(const std::string& inputPath, const std::string& lightDat
 void photometricStereo(const sfmData::SfMData& sfmData, const std::string& lightData, const std::string& maskPath, const std::string& outputPath, const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo)
 {
     bool skipAll = true;
+    bool groupedImages = false;
     size_t dim = 3;
     if (PSParameters.SHOrder == 2)
     {
@@ -159,6 +160,8 @@ void photometricStereo(const sfmData::SfMData& sfmData, const std::string& light
             continue;
         }
         skipAll = false;
+        groupedImages = imageList.size() > 1 ? true : false;
+
         image::Image<float> mask;
         std::string pictureFolderName = fs::path(sfmData.getView(viewIds[0]).getImagePath()).parent_path().filename().string();
         // If no mask folder was provided, do not make up a path anyway
@@ -186,6 +189,14 @@ void photometricStereo(const sfmData::SfMData& sfmData, const std::string& light
             "All images were skipped and no photometric stereo could be processed. This might happen if no sphere has "
             "been detected in any of the input images, or if the light could not be calibrated.");
         ALICEVISION_THROW(std::invalid_argument, "No image was processed for the photometric stereo.");
+    }
+
+    if (!groupedImages)
+    {
+        ALICEVISION_LOG_WARNING(
+            "No images shared the same pose ID. "
+            << "Input images need to be located in a folder that starts with 'ps_' to be grouped together using their "
+               "pose ID. The photometric stereo cannot run otherwise.");
     }
 
     sfmData::SfMData albedoSfmData = sfmData;

--- a/src/aliceVision/photometricStereo/photometricStereo.hpp
+++ b/src/aliceVision/photometricStereo/photometricStereo.hpp
@@ -34,7 +34,9 @@ struct PhotometricSteroParameters
  * @param[out] normals Normal map of the scene
  * @param[out] albedo Albedo map of the scene
  */
-void photometricStereo(const std::string& inputPath, const std::string& lightData, const std::string& outputPath, const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo);
+void photometricStereo(const std::string& inputPath, const std::string& lightData, const std::string& outputPath,
+                       const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals,
+                       image::Image<image::RGBfColor>& albedo);
 
 /**
  * @brief Load data from a .sfm file and prepare the PS algorithm parameters
@@ -47,7 +49,9 @@ void photometricStereo(const std::string& inputPath, const std::string& lightDat
  * @param[out] normals Normal map of the scene
  * @param[out] albedo Albedo map of the scene
  */
-void photometricStereo(const sfmData::SfMData& sfmData, const std::string& lightData, const std::string& maskPath, const std::string& outputPath, const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo);
+void photometricStereo(const sfmData::SfMData& sfmData, const std::string& lightData, const std::string& maskPath,
+                       const std::string& outputPath, const PhotometricSteroParameters& PSParameters,
+                       image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo);
 
 /**
  * @brief Apply the PS algorithm for a given set of pictures sharing the same pose
@@ -60,7 +64,10 @@ void photometricStereo(const sfmData::SfMData& sfmData, const std::string& light
  * @param[out] normals Normal map of the scene
  * @param[out] albedo Albedo map of the scene
  */
-void photometricStereo(const std::vector<std::string>& imageList, const std::vector<std::array<float, 3>>& intList, const Eigen::MatrixXf& lightMat, image::Image<float>& mask, const std::string& pathToAmbiant, const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals, image::Image<image::RGBfColor>& albedo);
+void photometricStereo(const std::vector<std::string>& imageList, const std::vector<std::array<float, 3>>& intList,
+                       const Eigen::MatrixXf& lightMat, image::Image<float>& mask, const std::string& pathToAmbiant,
+                       const PhotometricSteroParameters& PSParameters, image::Image<image::RGBfColor>& normals,
+                       image::Image<image::RGBfColor>& albedo);
 
 /**
  * @brief Load data used in the PS algorithm
@@ -69,7 +76,8 @@ void photometricStereo(const std::vector<std::string>& imageList, const std::vec
  * @param[out] intList Intensities of lights
  * @param[out] lightMat Directions of lights
  */
-void loadPSData(const std::string& folderPath, const size_t HS_order, std::vector<std::array<float, 3>>& intList, Eigen::MatrixXf& lightMat);
+void loadPSData(const std::string& folderPath, const size_t HS_order, std::vector<std::array<float, 3>>& intList,
+                Eigen::MatrixXf& lightMat);
 
 /**
  * @brief Get the name of the pictures in a given folder
@@ -101,7 +109,8 @@ void shrink(const Eigen::MatrixXf& mat, const float rho, Eigen::MatrixXf& E);
  */
 void median(const Eigen::MatrixXf& d, float& median);
 
-void slice(const std::vector<int>& inputVector, int start, int numberOfElements, std::vector<int>& currentMaskIndices);
+void slice(const std::vector<int>& inputVector, int start, int numberOfElements,
+           std::vector<int>& currentMaskIndices);
 
 void applyRotation(const Eigen::MatrixXd& rotation, image::Image<image::RGBfColor>& normals);
 }

--- a/src/aliceVision/sphereDetection/sphereDetection.cpp
+++ b/src/aliceVision/sphereDetection/sphereDetection.cpp
@@ -73,7 +73,8 @@ void modelExplore(Ort::Session& session)
         ALICEVISION_LOG_DEBUG("  Type : " << input_type);
 
         std::vector<int64_t> input_shape = inputInfo2.GetShape();
-        size_t input_size = std::accumulate(begin(input_shape), end(input_shape), 1, std::multiplies<float>());
+        size_t input_size =
+            std::accumulate(begin(input_shape), end(input_shape), 1, std::multiplies<float>());
         ALICEVISION_LOG_DEBUG("  Shape: " << input_shape);
         ALICEVISION_LOG_DEBUG("  Size : " << input_size);
     }
@@ -97,7 +98,8 @@ void modelExplore(Ort::Session& session)
         ALICEVISION_LOG_DEBUG("  Type: " << outputType);
 
         std::vector<int64_t> outputShape = outputInfo2.GetShape();
-        size_t outputSize = std::accumulate(begin(outputShape), end(outputShape), 1, std::multiplies<float>());
+        size_t outputSize =
+            std::accumulate(begin(outputShape), end(outputShape), 1, std::multiplies<float>());
         ALICEVISION_LOG_DEBUG("  Shape: " << outputShape);
         ALICEVISION_LOG_DEBUG("  Size: " << outputSize);
     }
@@ -180,7 +182,8 @@ prediction predict(Ort::Session& session, const fs::path imagePath, const float 
     return prediction{bboxes, scores, imageOpencvShape};
 }
 
-void sphereDetection(const sfmData::SfMData& sfmData, Ort::Session& session, fs::path outputPath, const float minScore)
+void sphereDetection(const sfmData::SfMData& sfmData, Ort::Session& session, fs::path outputPath,
+                     const float minScore)
 {
     // Main tree
     bpt::ptree fileTree;
@@ -231,7 +234,8 @@ void sphereDetection(const sfmData::SfMData& sfmData, Ort::Session& session, fs:
     bpt::write_json(outputPath.append("detection.json").string(), fileTree);
 }
 
-void writeManualSphereJSON(const sfmData::SfMData& sfmData, const std::array<float, 3>& sphereParam, fs::path outputPath)
+void writeManualSphereJSON(const sfmData::SfMData& sfmData, const std::array<float, 3>& sphereParam,
+                           fs::path outputPath)
 {
     // Main tree
     bpt::ptree fileTree;

--- a/src/aliceVision/sphereDetection/sphereDetection.hpp
+++ b/src/aliceVision/sphereDetection/sphereDetection.hpp
@@ -46,7 +46,8 @@ void modelExplore(Ort::Session& session);
  * @param outputPath The path to write the JSON with the detected spheres to
  * @return minScore The minimum score for the predictions
  */
-void sphereDetection(const sfmData::SfMData& sfmData, Ort::Session& session, fs::path outputPath, const float minScore);
+void sphereDetection(const sfmData::SfMData& sfmData, Ort::Session& session, fs::path outputPath,
+                     const float minScore);
 
 /**
  * @brief Write JSON for a hand-detected sphere
@@ -55,7 +56,8 @@ void sphereDetection(const sfmData::SfMData& sfmData, Ort::Session& session, fs:
  * @param sphereParam Parameters of the hand-detected sphere
  * @return outputPath Path to the JSON file
  */
-void writeManualSphereJSON(const sfmData::SfMData& sfmData, const std::array<float, 3>& sphereParam, fs::path outputPath);
+void writeManualSphereJSON(const sfmData::SfMData& sfmData, const std::array<float, 3>& sphereParam,
+                           fs::path outputPath);
 
 }
 }

--- a/src/software/pipeline/main_lightingCalibration.cpp
+++ b/src/software/pipeline/main_lightingCalibration.cpp
@@ -77,7 +77,8 @@ int aliceVision_main(int argc, char **argv)
 
     if (fs::is_directory(inputPath))
     {
-        std::cout << "Directory input : WIP" << std::endl;
+        ALICEVISION_LOG_ERROR("Directory input: WIP");
+        ALICEVISION_THROW(std::invalid_argument, "Input directories are not yet supported");
     }
     else
     {
@@ -90,5 +91,5 @@ int aliceVision_main(int argc, char **argv)
         lightingEstimation::lightCalibration(sfmData, inputJSON, ouputJSON, method, saveAsModel);
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/src/software/pipeline/main_lightingCalibration.cpp
+++ b/src/software/pipeline/main_lightingCalibration.cpp
@@ -44,6 +44,8 @@ using namespace aliceVision;
 
 int aliceVision_main(int argc, char **argv)
 {
+    system::Timer timer;
+
     std::string inputPath;
     std::string inputJSON;
     std::string ouputJSON;
@@ -91,5 +93,6 @@ int aliceVision_main(int argc, char **argv)
         lightingEstimation::lightCalibration(sfmData, inputJSON, ouputJSON, method, saveAsModel);
     }
 
+    ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
     return EXIT_SUCCESS;
 }

--- a/src/software/pipeline/main_lightingCalibration.cpp
+++ b/src/software/pipeline/main_lightingCalibration.cpp
@@ -52,14 +52,19 @@ int aliceVision_main(int argc, char **argv)
 
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-        ("inputPath,i", po::value<std::string>(&inputPath)->required(), "Path to input. Could be SfMData file or folder with pictures.")
-        ("inputJSON, j", po::value<std::string>(&inputJSON)->required(), "Path to JSON which describes sphere positions and radius.")
-        ("outputFile, o", po::value<std::string>(&ouputJSON)->required(), "Path to JSON output file.");
+        ("inputPath,i", po::value<std::string>(&inputPath)->required(),
+         "Path to the SfMData input.")
+        ("inputJSON, j", po::value<std::string>(&inputJSON)->required(),
+         "Path to the folder containing the JSON file that describes spheres' positions and radius.")
+        ("outputFile, o", po::value<std::string>(&ouputJSON)->required(),
+         "Path to JSON output file.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
-        ("saveAsModel, s", po::value<bool>(&saveAsModel)->default_value(false), "Calibration used for several datasets.")
-        ("method, m", po::value<std::string>(&method)->default_value("brightestPoint"), "Method for light estimation.");
+        ("saveAsModel, s", po::value<bool>(&saveAsModel)->default_value(false),
+         "Calibration used for several datasets.")
+        ("method, m", po::value<std::string>(&method)->default_value("brightestPoint"),
+         "Method for light estimation.");
 
     CmdLine cmdline("AliceVision lightingCalibration");
     cmdline.add(requiredParams);

--- a/src/software/pipeline/main_normalIntegration.cpp
+++ b/src/software/pipeline/main_normalIntegration.cpp
@@ -100,6 +100,6 @@ int aliceVision_main(int argc, char **argv)
         photometricStereo::normalIntegration(sfmData, inputPath, isPerspective, downscale, outputFolder);
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 };
 

--- a/src/software/pipeline/main_normalIntegration.cpp
+++ b/src/software/pipeline/main_normalIntegration.cpp
@@ -53,6 +53,8 @@ int aliceVision_main(int argc, char **argv)
     namespace po = boost::program_options;
     namespace fs = boost::filesystem;
 
+    system::Timer timer;
+
     bool isPerspective(true);
     std::string outputFolder;
     std::string pathToK;
@@ -100,6 +102,7 @@ int aliceVision_main(int argc, char **argv)
         photometricStereo::normalIntegration(sfmData, inputPath, isPerspective, downscale, outputFolder);
     }
 
+    ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
     return EXIT_SUCCESS;
 };
 

--- a/src/software/pipeline/main_normalIntegration.cpp
+++ b/src/software/pipeline/main_normalIntegration.cpp
@@ -64,13 +64,17 @@ int aliceVision_main(int argc, char **argv)
 
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-        ("inputPath,i", po::value<std::string>(&inputPath)->required(), "Path to the input: a folder containing the normal maps and the masks.")
-        ("outputPath,o", po::value<std::string>(&outputFolder)->required(), "Path to the output folder.");
+        ("inputPath,i", po::value<std::string>(&inputPath)->required(),
+         "Path to the input: a folder containing the normal maps and the masks.")
+        ("outputPath,o", po::value<std::string>(&outputFolder)->required(),
+         "Path to the output folder.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
-        ("sfmDataFile,s", po::value<std::string>(&sfmDataFile)->default_value(""), "Path to the input SfMData file.")
-        ("downscale,d", po::value<int>(&downscale)->default_value(downscale), "Downscale factor for faster results.");
+        ("sfmDataFile,s", po::value<std::string>(&sfmDataFile)->default_value(""),
+         "Path to the input SfMData file.")
+        ("downscale,d", po::value<int>(&downscale)->default_value(downscale),
+         "Downscale factor for faster results.");
 
     CmdLine cmdline("AliceVision normalIntegration");
     cmdline.add(requiredParams);

--- a/src/software/pipeline/main_photometricStereo.cpp
+++ b/src/software/pipeline/main_photometricStereo.cpp
@@ -97,7 +97,7 @@ int aliceVision_main(int argc, char **argv)
     // If the path to light data is empty, set it to inputPath :
     if (pathToLightData.compare("") && fs::is_directory(inputPath))
     {
-        std::cout << "Warning : path to light data has been set to inputpath folder" << std::endl;
+        ALICEVISION_LOG_WARNING("Warning: path to light data has been set to inputpath folder");
         pathToLightData = inputPath;
     }
 
@@ -113,7 +113,7 @@ int aliceVision_main(int argc, char **argv)
         sfmData::SfMData sfmData;
         if (!sfmDataIO::Load(sfmData, inputPath, sfmDataIO::ESfMData(sfmDataIO::VIEWS|sfmDataIO::INTRINSICS|sfmDataIO::EXTRINSICS)))
         {
-            ALICEVISION_LOG_ERROR("The input file '" + inputPath + "' cannot be read");
+            ALICEVISION_LOG_ERROR("The input file '" + inputPath + "' cannot be read.");
             return EXIT_FAILURE;
         }
 

--- a/src/software/pipeline/main_photometricStereo.cpp
+++ b/src/software/pipeline/main_photometricStereo.cpp
@@ -65,17 +65,25 @@ int aliceVision_main(int argc, char **argv)
 
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-        ("inputPath,i", po::value<std::string>(&inputPath)->required(), "Path to the input: could be an SfMData file or a folder with images.");
+        ("inputPath,i", po::value<std::string>(&inputPath)->required(),
+         "Path to the input: could be an SfMData file or a folder with images.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
-        ("outputPath,o", po::value<std::string>(&outputPath)->default_value(""), "Output path.")
-        ("maskPath,m", po::value<std::string>(&maskPath)->default_value(""), "Path to mask folder/file.")
-        ("pathToJSONLightFile,l", po::value<std::string>(&pathToLightData)->default_value("defaultJSON.txt"), "Path to light file (JSON). If empty, .txt files are expected in the image folder.")
-        ("SHOrder,s", po::value<size_t>(&PSParameters.SHOrder)->default_value(0), "Spherical harmonics order, 0 = directional, 1 = directional + ambiant, 2 = second order SH.")
-        ("removeAmbiant,a", po::value<bool>(&PSParameters.removeAmbiant)->default_value(false), "True if the ambiant light is to be removed on PS images, false otherwise.")
-        ("isRobust,r", po::value<bool>(&PSParameters.isRobust)->default_value(false), "True to use the robust algorithm, false otherwise.")
-        ("downscale, d", po::value<int>(&PSParameters.downscale)->default_value(1), "Downscale factor for faster results.");
+        ("outputPath,o", po::value<std::string>(&outputPath)->default_value(""),
+         "Output path.")
+        ("maskPath,m", po::value<std::string>(&maskPath)->default_value(""),
+         "Path to mask folder/file.")
+        ("pathToJSONLightFile,l", po::value<std::string>(&pathToLightData)->default_value("defaultJSON.txt"),
+         "Path to light file (JSON). If empty, .txt files are expected in the image folder.")
+        ("SHOrder,s", po::value<size_t>(&PSParameters.SHOrder)->default_value(0),
+         "Spherical harmonics order, 0 = directional, 1 = directional + ambiant, 2 = second order SH.")
+        ("removeAmbiant,a", po::value<bool>(&PSParameters.removeAmbiant)->default_value(false),
+         "True if the ambiant light is to be removed on PS images, false otherwise.")
+        ("isRobust,r", po::value<bool>(&PSParameters.isRobust)->default_value(false),
+         "True to use the robust algorithm, false otherwise.")
+        ("downscale, d", po::value<int>(&PSParameters.downscale)->default_value(1),
+         "Downscale factor for faster results.");
 
     CmdLine cmdline("AliceVision photometricStereo");
     cmdline.add(requiredParams);

--- a/src/software/pipeline/main_sphereDetection.cpp
+++ b/src/software/pipeline/main_sphereDetection.cpp
@@ -39,6 +39,8 @@ using namespace aliceVision;
 
 int aliceVision_main(int argc, char** argv)
 {
+    system::Timer timer;
+
     std::string inputSfMDataPath;
     std::string inputModelPath;
     std::string outputPath;
@@ -117,5 +119,6 @@ int aliceVision_main(int argc, char** argv)
         sphereDetection::writeManualSphereJSON(sfmData, sphereParam, fsOutputPath);
     }
 
+    ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
     return EXIT_SUCCESS;
 }

--- a/src/software/pipeline/main_sphereDetection.cpp
+++ b/src/software/pipeline/main_sphereDetection.cpp
@@ -50,17 +50,25 @@ int aliceVision_main(int argc, char** argv)
 
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-        ("input,i", po::value<std::string>(&inputSfMDataPath)->required(), "SfMData input path.")
-        ("modelPath,m", po::value<std::string>(&inputModelPath)->required(), "Model input path.")
-        ("autoDetect,a", po::value<bool>(&autoDetect)->required(), "True if the sphere is to be automatically detected, false otherwise.")
-        ("output,o", po::value<std::string>(&outputPath)->required(), "Output path.");
+        ("input,i", po::value<std::string>(&inputSfMDataPath)->required(),
+         "SfMData input path.")
+        ("modelPath,m", po::value<std::string>(&inputModelPath)->required(),
+         "Model input path.")
+        ("autoDetect,a", po::value<bool>(&autoDetect)->required(),
+         "True if the sphere is to be automatically detected, false otherwise.")
+        ("output,o", po::value<std::string>(&outputPath)->required(),
+         "Output path.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
-        ("minScore,s", po::value<float>(&inputMinScore)->default_value(0.0), "Minimum detection score.")
-        ("x,x", po::value<float>(&sphereCenterOffset(0))->default_value(0.0), "Sphere's center offset X (pixels).")
-        ("y,y", po::value<float>(&sphereCenterOffset(1))->default_value(0.0), "Sphere's center offset Y (pixels).")
-        ("sphereRadius,r", po::value<double>(&sphereRadius)->default_value(1.0), "Sphere's radius (pixels).");
+        ("minScore,s", po::value<float>(&inputMinScore)->default_value(0.0),
+         "Minimum detection score.")
+        ("x,x", po::value<float>(&sphereCenterOffset(0))->default_value(0.0),
+         "Sphere's center offset X (pixels).")
+        ("y,y", po::value<float>(&sphereCenterOffset(1))->default_value(0.0),
+         "Sphere's center offset Y (pixels).")
+        ("sphereRadius,r", po::value<double>(&sphereRadius)->default_value(1.0),
+         "Sphere's radius (pixels).");
 
     CmdLine cmdline("AliceVision sphereDetection");
     cmdline.add(requiredParams);

--- a/src/software/pipeline/main_sphereDetection.cpp
+++ b/src/software/pipeline/main_sphereDetection.cpp
@@ -116,5 +116,6 @@ int aliceVision_main(int argc, char** argv)
 
         sphereDetection::writeManualSphereJSON(sfmData, sphereParam, fsOutputPath);
     }
-    return 0;
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Description

This PR builds on top of #999 and adds robustness to several cases that were not handled in the initial version. In particular:
- If the input images were not placed in a folder starting with "ps_", they were not grouped together (using their pose ID), and were all evaluated on their own during the photometric stereo stage, causing crashes;
- If spheres were not detected in some images, they are not written in the final JSON that describes the spheres' positions for every image, and they are not used in later stages;
- If no mask folder is provided for the photometric stereo stage, no path is made up to try and load it (but the result is the same as if a path was provided but the mask failed to be opened: all the pixels in the image will be used);
- Single images are now handled;
- If all the provided images were not meant for stereo photometry, all the stages go through up to the photometric stereo one, which detects that no image was correct, and throws an explicit error. No crash occurs.

The method used to downscale images has also been replaced with an already existing one from the `imageAlgo` module. 

Additionally, some clean-up has been done on the different files:
- 4-space indentation is used everywhere;
- Lines that were too long got split;
- Some logs were fixed;
- Timers have been added for the executables that were lacking one.

## Features list

- [x] Fix crashes when the images are not located in the expected folder;
- [x] Add support for single images;
- [x] Fix crashes when sphere are not detected in the image(s). 
