### PR TITLE
KeyframeSelection: Add new parameter value to disable the export of keyframes

### DIFF
--- a/src/aliceVision/keyframe/README.md
+++ b/src/aliceVision/keyframe/README.md
@@ -7,7 +7,7 @@ Two methods are currently supported:
 - a **regular** selection method, which selects keyframes regularly across the input video / sequence / SfMData according to a set of parameters;
 - a **smart** selection method, which analyses the sharpness and motion of all the frames to select those which are deemed the most relevant (a frame is considered relevant if it contains significant motion in comparison to the last selected keyframe while being as sharp as possible).
 
-The selected keyframes can be written as JPG, PNG or EXR images, and the storage data type can be specified when the EXR file extension is selected.
+The selected keyframes can be written as JPG, PNG or EXR images, and the storage data type can be specified when the EXR file extension is selected. The selected keyframes will not be written on disk if the selected output extension is `NONE`.
 
 The keyframe selection module supports the following inputs:
 - a path to a video file (e.g. "/path/to/video.mp4")
@@ -21,7 +21,7 @@ In addition to writing the selected keyframes on disk, two SfMData files are wri
 - one that contains all the selected keyframes
 - one that contains all the frames that were not selected as keyframes
 
-_N.B: If the input is a video file, the SfMData file which contains the rejected frames will not be written at all, since none of these frames is available on disk. As the selected keyframes will be written at the end of the selection, the SfMData file containing the keyframes **will** be written._
+_N.B: If the input is a video file, the SfMData file which contains the rejected frames will not be written at all, since none of these frames is available on disk. As the selected keyframes will be written at the end of the selection, the SfMData file containing the keyframes **will** be written. However, if the output extension is set to `NONE`, no SfMData file will be written as even the keyframes will not be available on disk._
 
 ## Regular selection method
 

--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -26,7 +26,7 @@ using namespace aliceVision;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
-const std::string supportedExtensions = "exr, jpg, png";
+const std::string supportedExtensions = "none, exr, jpg, png";
 
 int aliceVision_main(int argc, char** argv)
 {
@@ -51,7 +51,7 @@ int aliceVision_main(int argc, char** argv)
     std::size_t rescaledWidthFlow = 720;    // width of the rescaled frames for the flow; 0 if no rescale is performed (smart selection)
     std::size_t sharpnessWindowSize = 200;  // sliding window's size in sharpness computation (smart selection)
     std::size_t flowCellSize = 90;          // size of the cells within a frame used to compute the optical flow (smart selection)
-    std::string outputExtension = "exr";    // file extension of the written keyframes
+    std::string outputExtension = "exr";    // file extension of the written keyframes (keyframes will not be written if set to "none")
     image::EStorageDataType exrDataType =   // storage data type for EXR output files
         image::EStorageDataType::Float;
     bool renameKeyframes = false;           // name selected keyframes as consecutive frames instead of using their index as a name
@@ -101,7 +101,11 @@ int aliceVision_main(int argc, char** argv)
             "If the selected keyframes should have originally be written as [00015.exr, 00294.exr, 00825.exr], they "
             "will instead be written as [00000.exr, 00001.exr, 00002.exr] if this option is enabled.")
         ("outputExtension", po::value<std::string>(&outputExtension)->default_value(outputExtension),
-            "File extension of the output keyframes.")
+            ("File extension of the output keyframes (e.g. 'exr').\n"
+            "If set to 'none', the keyframes will not be written on disk, and only the SfMData file will be written.\n"
+            "For input videos, 'none' should not be used since written keyframes are used to generate the SfMData "
+            "file.\n"
+            "Supported extensions are: " + supportedExtensions).c_str())
         ("storageDataType", po::value<image::EStorageDataType>(&exrDataType)->default_value(exrDataType),
             ("Storage data type for EXR output files: " + image::EStorageDataType_informations()).c_str());
 
@@ -190,6 +194,8 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // Convert the provided output extension to lowercase before performing any comparison
+    std::transform(outputExtension.begin(), outputExtension.end(), outputExtension.begin(), ::tolower);
     if (supportedExtensions.find(outputExtension) == std::string::npos) {
         ALICEVISION_LOG_ERROR("Unsupported extension for the output file. Supported extensions are: "
                               << supportedExtensions);


### PR DESCRIPTION
## Description

Related Meshroom pull request: https://github.com/alicevision/Meshroom/pull/2036

This PR adds a new supported value to the `outputExtension` parameter, `none`, that disables the export of selected keyframes on disk when it is set.

Up until now, the selected keyframes were always written on disk at the same time as the SfMData files, and there was no way to avoid this. By setting `outputExtension` to `none`, only the two SfMData files (one containing the selected keyframes, one containing the frames that were not selected) will be written.

Not writing the selected keyframes on disk results in a slight performance improvement as less I/O operations are performed.

**Note:** `outputExtension` should not be set to `none` when the input is a video: since the frames from the video are not available on disk, the process expects the keyframes to be written in the output folder to be able to write at least the SfMData file containing the selected keyframes.

## Features list

- [x] Add a new parameter value for `outputExtension` that disables the export of keyframes;
- [x] Update the README.