### PR TITLE
Add a new optional command to export textured mesh to a USD format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(AV_BUILD_COINUTILS "Enable building an embedded CoinUtils" ON)
 option(AV_BUILD_OSI "Enable building an embedded Osi" ON)
 option(AV_BUILD_CLP "Enable building an embedded Clp" ON)
 option(AV_BUILD_PCL "Enable building an embedded PointCloud library" ON)
+option(AV_BUILD_USD "Enable building an embedded USD library" OFF)
 option(AV_BUILD_ALICEVISION "Enable building of AliceVision" ON)
 option(AV_EIGEN_MEMORY_ALIGNMENT "Enable Eigen memory alignment" ON)
 
@@ -85,6 +86,7 @@ message(STATUS "AV_BUILD_COINUTILS: ${AV_BUILD_COINUTILS}")
 message(STATUS "AV_BUILD_OSI: ${AV_BUILD_OSI}")
 message(STATUS "AV_BUILD_CLP: ${AV_BUILD_CLP}")
 message(STATUS "AV_BUILD_PCL: ${AV_BUILD_PCL}")
+message(STATUS "AV_BUILD_USD: ${AV_BUILD_USD}")
 message(STATUS "AV_BUILD_DEPENDENCIES_PARALLEL: ${AV_BUILD_DEPENDENCIES_PARALLEL}")
 message(STATUS "")
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
@@ -1056,6 +1058,40 @@ if(AV_BUILD_PCL)
 
 endif()
 
+if(AV_BUILD_USD)
+    set(USD_TARGET pxr)
+    ExternalProject_Add(${USD_TARGET}
+        GIT_REPOSITORY https://github.com/PixarAnimationStudios/USD.git
+        GIT_TAG v23.05
+        PREFIX ${BUILD_DIR}
+        BUILD_IN_SOURCE 0
+        BUILD_ALWAYS 0
+        UPDATE_COMMAND ""
+        CONFIGURE_COMMAND ""
+        INSTALL_COMMAND ""
+        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/usd
+        BINARY_DIR ${BUILD_DIR}/usd_build
+        INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+        BUILD_COMMAND python ${CMAKE_CURRENT_BINARY_DIR}/usd/build_scripts/build_usd.py
+            --build-shared
+            --no-examples
+            --no-tools
+            --no-ptex
+            --no-prman
+            --no-openimageio
+            --no-opencolorio
+            --no-alembic
+            --no-draco
+            --no-materialx
+            --no-tutorials
+            --no-tests
+            --no-docs
+            --no-python
+            <INSTALL_DIR>
+    )
+    set(USD_CMAKE_FLAGS -Dpxr_DIR:PATH=${CMAKE_INSTALL_PREFIX})
+endif()
+
 set(AV_DEPS
   ${ZLIB_TARGET}
   ${ASSIMP_TARGET}
@@ -1084,6 +1120,7 @@ set(AV_DEPS
   ${COINUTILS_TARGET}
   ${OSI_TARGET}
   ${CLP_TARGET}
+  ${USD_TARGET}
 )
 
 if(AV_BUILD_ALICEVISION)
@@ -1128,6 +1165,7 @@ ExternalProject_Add(aliceVision
             ${LZ4_CMAKE_FLAGS}
             ${FLANN_CMAKE_FLAGS}
             ${PCL_CMAKE_FLAGS}
+            ${USD_CMAKE_FLAGS}
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> <SOURCE_DIR>
        DEPENDS ${AV_DEPS}
        )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -554,6 +554,24 @@ if(ALICEVISION_BUILD_SFM) # or ALICEVISION_BUILD_MVS
 endif()
 
 # ==============================================================================
+# USD
+# ==============================================================================
+# - optional, it allows to export the geometry and textures as USD
+# ==============================================================================
+set(ALICEVISION_HAVE_USD 0)
+
+if(NOT ALICEVISION_USE_USD STREQUAL "OFF")
+  find_package(pxr CONFIG)
+
+  if(pxr_FOUND)
+    set(ALICEVISION_HAVE_USD 1)
+    message(STATUS "USD version ${PXR_VERSION} found.")
+  elseif(ALICEVISION_USE_USD STREQUAL "ON")
+    message(SEND_ERROR "Failed to find USD.")
+  endif()
+endif()
+
+# ==============================================================================
 # OpenGV
 # ==============================================================================
 # - optional, it allows to use the generic camera PnP algorithms for rig localization

--- a/src/aliceVision/mesh/CMakeLists.txt
+++ b/src/aliceVision/mesh/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Headers
 set(mesh_files_headers
   geoMesh.hpp
+  Material.hpp
   Mesh.hpp
   MeshAnalyze.hpp
   MeshClean.hpp
@@ -13,6 +14,7 @@ set(mesh_files_headers
 
 # Sources
 set(mesh_files_sources
+  Material.cpp
   Mesh.cpp
   MeshAnalyze.cpp
   MeshClean.cpp

--- a/src/aliceVision/mesh/Material.cpp
+++ b/src/aliceVision/mesh/Material.cpp
@@ -1,0 +1,183 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2017 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Material.hpp"
+
+namespace aliceVision {
+namespace mesh {
+
+void Material::addTexture(TextureType type, const std::string& textureName)
+{
+    // get extension and prefix
+    std::size_t found = textureName.rfind('.');
+    if (found == std::string::npos)
+    {
+        throw std::runtime_error("Texture file name has no extension!");
+    }
+
+    const std::string prefix = textureName.substr(0, found - 4);
+    const std::string extension = textureName.substr(found + 1);
+
+    switch (type)
+    {
+        case TextureType::BUMP:
+            if (_bumpTextures.empty())
+            {
+                bumpPrefix = prefix;
+                bumpType = image::EImageFileType_stringToEnum(extension);
+            }
+            else if (bumpPrefix != prefix || bumpType != image::EImageFileType_stringToEnum(extension))
+            {
+                throw std::runtime_error("All texture tiles must have the same prefix and extension!");
+            }
+            _bumpTextures.push_back(textureName);
+            break;
+        case TextureType::DIFFUSE:
+            if (_diffuseTextures.empty())
+            {
+                diffusePrefix = prefix;
+                diffuseType = image::EImageFileType_stringToEnum(extension);
+            }
+            else if (diffusePrefix != prefix || diffuseType != image::EImageFileType_stringToEnum(extension))
+            {
+                throw std::runtime_error("All texture tiles must have the same prefix and extension!");
+            }
+            _diffuseTextures.push_back(textureName);
+            break;
+        case TextureType::DISPLACEMENT:
+            if (_displacementTextures.empty())
+            {
+                displacementPrefix = prefix;
+                displacementType = image::EImageFileType_stringToEnum(extension);
+            }
+            else if (displacementPrefix != prefix ||
+                    displacementType != image::EImageFileType_stringToEnum(extension))
+            {
+                throw std::runtime_error("All texture tiles must have the same prefix and extension!");
+            }
+            _displacementTextures.push_back(textureName);
+            break;
+        case TextureType::NORMAL:
+            if (_normalTextures.empty())
+            {
+                normalPrefix = prefix;
+                normalType = image::EImageFileType_stringToEnum(extension);
+            }
+            else if (normalPrefix != prefix || normalType != image::EImageFileType_stringToEnum(extension))
+            {
+                throw std::runtime_error("All texture tiles must have the same prefix and extension!");
+            }
+            _normalTextures.push_back(textureName);
+            break;
+        default:
+            throw std::runtime_error("Unknown texture type!");
+    }
+}
+
+const StaticVector<std::string>& Material::getTextures(TextureType type) const
+{
+    switch (type)
+    {
+        case TextureType::BUMP:
+            return _bumpTextures;
+        case TextureType::DIFFUSE:
+            return _diffuseTextures;
+        case TextureType::DISPLACEMENT:
+            return _displacementTextures;
+        case TextureType::NORMAL:
+            return _normalTextures;
+        default:
+            throw std::runtime_error("Unknown texture type!");
+    }
+}
+
+StaticVector<std::string> Material::getAllTextures() const
+{
+    StaticVector<std::string> textures;
+    textures.resize(_bumpTextures.size()
+                    + _diffuseTextures.size()
+                    + _displacementTextures.size()
+                    + _normalTextures.size());
+
+    auto last = std::copy(_bumpTextures.begin(), _bumpTextures.end(), textures.begin());
+    last = std::copy(_diffuseTextures.begin(), _diffuseTextures.end(), last);
+    last = std::copy(_displacementTextures.begin(), _displacementTextures.end(), last);
+    std::copy(_normalTextures.begin(), _normalTextures.end(), last);
+
+    return textures;
+}
+
+bool Material::hasTextures(TextureType type) const
+{
+    switch (type)
+    {
+        case TextureType::BUMP:
+            return bumpType != image::EImageFileType::NONE;
+        case TextureType::DIFFUSE:
+            return diffuseType != image::EImageFileType::NONE;
+        case TextureType::DISPLACEMENT:
+            return displacementType != image::EImageFileType::NONE;
+        case TextureType::NORMAL:
+            return normalType != image::EImageFileType::NONE;
+        default:
+            throw std::runtime_error("Unknown texture type!");
+    }
+}
+
+int Material::numAtlases() const
+{
+    const int num = _diffuseTextures.size();
+
+    if ((!_displacementTextures.empty() && _displacementTextures.size() != num) ||
+       (!_normalTextures.empty() && _normalTextures.size() != num) ||
+       (!_bumpTextures.empty() && _bumpTextures.size() != num))
+    {
+        throw std::runtime_error("All texture maps must have same number of atlases!");
+    }
+
+    return num;
+}
+
+void Material::clear()
+{
+    _diffuseTextures.clear();
+    _normalTextures.clear();
+    _bumpTextures.clear();
+    _displacementTextures.clear();
+}
+
+std::string Material::textureName(TextureType type, int index) const
+{
+    std::string prefix;
+    image::EImageFileType fileType;
+
+    switch (type)
+    {
+        case TextureType::BUMP:
+            prefix = bumpPrefix;
+            fileType = bumpType;
+            break;
+        case TextureType::DIFFUSE:
+            prefix = diffusePrefix;
+            fileType = diffuseType;
+            break;
+        case TextureType::DISPLACEMENT:
+            prefix = displacementPrefix;
+            fileType = displacementType;
+            break;
+        case TextureType::NORMAL:
+            prefix = normalPrefix;
+            fileType = normalType;
+            break;
+        default:
+            throw std::runtime_error("Unknown texture type!");
+    }
+
+    return prefix + textureId(index) + "." + image::EImageFileType_enumToString(fileType);
+}
+
+} // namespace mesh
+} // namespace aliceVision

--- a/src/aliceVision/mesh/Material.hpp
+++ b/src/aliceVision/mesh/Material.hpp
@@ -1,0 +1,88 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2017 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/image/io.hpp>
+#include <aliceVision/mvsData/StaticVector.hpp>
+
+namespace aliceVision {
+namespace mesh {
+
+/// Simple material type that supports only the data written out from Texturing pipeline
+class Material
+{
+public:
+    struct Color
+    {
+        float r = 0.0;
+        float g = 0.0;
+        float b = 0.0;
+    };
+
+    enum class TextureType
+    {
+        BUMP,
+        DIFFUSE,
+        DISPLACEMENT,
+        NORMAL
+    };
+
+    Color diffuse = {0.6, 0.6, 0.6};
+    Color ambient = {0.6, 0.6, 0.6};
+    Color specular = {0.0, 0.0, 0.0};
+    float shininess = 0.0;
+
+    std::string diffusePrefix = "texture_";
+    image::EImageFileType diffuseType = image::EImageFileType::NONE;
+
+    std::string displacementPrefix = "Displacement_";
+    image::EImageFileType displacementType = image::EImageFileType::NONE;
+
+    std::string normalPrefix = "Normal_";
+    image::EImageFileType normalType = image::EImageFileType::NONE;
+
+    std::string bumpPrefix = "Bump_";
+    image::EImageFileType bumpType = image::EImageFileType::NONE;
+
+    /// Add texture to material (assumes UDIM naming convention <prefix><udim>.<ext>)
+    void addTexture(TextureType type, const std::string& textureName);
+
+    /// Get textures by type
+    const StaticVector<std::string>& getTextures(TextureType type) const;
+
+    /// Get all textures used in the material
+    StaticVector<std::string> getAllTextures() const;
+
+    /// Check if material has textures of a given type
+    bool hasTextures(TextureType type) const;
+
+    /// Get number of UV atlases
+    int numAtlases() const;
+
+    /// Clear textures
+    void clear();
+
+    /// Get texture name for a given type
+    std::string textureName(TextureType type, int index) const;
+
+    /// Get texture ID as a string
+    /// Passing a negative index will use the <UDIM> template tag instead of a concrete ID
+    static std::string textureId(int index)
+    {
+        // UDIMs start with 1001 and is conventionally right before extension
+        return index < 0 ? "<UDIM>" : std::to_string(1001 + index);
+    }
+
+private:
+    StaticVector<std::string> _diffuseTextures;
+    StaticVector<std::string> _normalTextures;
+    StaticVector<std::string> _bumpTextures;
+    StaticVector<std::string> _displacementTextures;
+};
+
+} // namespace mesh
+} // namespace aliceVision

--- a/src/aliceVision/mesh/Mesh.hpp
+++ b/src/aliceVision/mesh/Mesh.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <aliceVision/image/Rgb.hpp>
+#include <aliceVision/mesh//Material.hpp>
 #include <aliceVision/mvsData/Matrix3x3.hpp>
 #include <aliceVision/mvsData/Point2d.hpp>
 #include <aliceVision/mvsData/Point3d.hpp>
@@ -168,7 +169,7 @@ public:
 
     bool loadFromBin(const std::string& binFilepath);
     void saveToBin(const std::string& binFilepath);
-    void load(const std::string& filepath);
+    void load(const std::string& filepath, bool mergeCoincidentVerts=false, Material* material=nullptr);
 
     void addMesh(const Mesh& mesh);
 
@@ -210,10 +211,10 @@ public:
                                       double maximalNeighDist = -1.0f);
     void laplacianSmoothPts(float maximalNeighDist = -1.0f);
     void laplacianSmoothPts(StaticVector<StaticVector<int>>& ptsNeighPts, double maximalNeighDist = -1.0f);
-    void computeNormalsForPts(StaticVector<Point3d>& out_nms);
-    void computeNormalsForPts(StaticVector<StaticVector<int>>& ptsNeighTris, StaticVector<Point3d>& out_nms);
+    void computeNormalsForPts(StaticVector<Point3d>& out_nms) const;
+    void computeNormalsForPts(StaticVector<StaticVector<int>>& ptsNeighTris, StaticVector<Point3d>& out_nms) const;
     void smoothNormals(StaticVector<Point3d>& nms, StaticVector<StaticVector<int>>& ptsNeighPts);
-    Point3d computeTriangleNormal(int idTri);
+    Point3d computeTriangleNormal(int idTri) const;
     Point3d computeTriangleCenterOfGravity(int idTri) const;
     double computeTriangleMaxEdgeLength(int idTri) const;
     double computeTriangleMinEdgeLength(int idTri) const;

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -13,6 +13,7 @@
 #include <aliceVision/mvsData/StaticVector.hpp>
 #include <aliceVision/mvsData/Voxel.hpp>
 #include <aliceVision/mvsUtils/ImagesCache.hpp>
+#include <aliceVision/mesh/Material.hpp>
 #include <aliceVision/mesh/Mesh.hpp>
 #include <aliceVision/mesh/meshVisibility.hpp>
 #include <aliceVision/stl/bitmask.hpp>
@@ -107,6 +108,9 @@ struct Texturing
     /// texture atlas to 3D triangle ids
     std::vector<std::vector<int>> _atlases;
 
+    /// Material and texture information
+    Material material;
+
     ~Texturing()
     {
         delete mesh;
@@ -119,6 +123,9 @@ public:
 
     /// Load a mesh from a .obj file and initialize internal structures
     void loadWithAtlas(const std::string& filepath, bool flipNormals=false);
+
+    /// Load a textured mesh from a .obj and .mtl files
+    void loadWithMaterial(const std::string& filepath, bool flipNormals=false);
 
     /**
      * @brief Remap visibilities
@@ -216,9 +223,7 @@ public:
 
     /// Save textured mesh as an OBJ + MTL file
     void saveAs(const bfs::path& dir, const std::string& basename,
-                aliceVision::mesh::EFileType meshFileType = aliceVision::mesh::EFileType::OBJ,
-                image::EImageFileType textureFileType = image::EImageFileType::EXR,
-                const BumpMappingParams& bumpMappingParams = BumpMappingParams());
+                aliceVision::mesh::EFileType meshFileType = aliceVision::mesh::EFileType::OBJ);
 };
 
 } // namespace mesh

--- a/src/software/export/CMakeLists.txt
+++ b/src/software/export/CMakeLists.txt
@@ -210,6 +210,23 @@ alicevision_add_software(aliceVision_exportCameraFrustums
         Boost::filesystem
 )
 
+# Export geometry and textures as USD
+if(ALICEVISION_HAVE_USD)
+  alicevision_add_software(aliceVision_exportUSD
+    SOURCE main_exportUSD.cpp
+    FOLDER ${FOLDER_SOFTWARE_EXPORT}
+    LINKS aliceVision_system
+          aliceVision_cmdline
+          aliceVision_mesh
+          Boost::filesystem
+          Boost::program_options
+          usd
+          usdGeom
+          usdImaging
+          usdShade
+  )
+endif()
+
 # Export distortion to be used in external tools
 alicevision_add_software(aliceVision_exportDistortion
   SOURCE main_exportDistortion.cpp

--- a/src/software/export/main_exportUSD.cpp
+++ b/src/software/export/main_exportUSD.cpp
@@ -1,0 +1,386 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2017 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/mesh/Mesh.hpp>
+#include <aliceVision/mesh/Texturing.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/system/Timer.hpp>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/zipFile.h>
+#include <pxr/usd/usdGeom/mesh.h>
+#include <pxr/usd/usdGeom/metrics.h>
+#include <pxr/usd/usdGeom/primvar.h>
+#include <pxr/usd/usdGeom/primvarsAPI.h>
+#include <pxr/usd/usdGeom/xform.h>
+#include <pxr/usdImaging/usdImaging/tokens.h>
+#include <pxr/usd/usdShade/material.h>
+#include <pxr/usd/usdShade/materialBindingAPI.h>
+#include <pxr/usd/usdShade/shader.h>
+
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace bpo = boost::program_options;
+namespace bfs = boost::filesystem;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+TF_DEFINE_PRIVATE_TOKENS(
+    AvUsdTokens,
+    (bias) \
+    (colorSpace) \
+    (diffuseColor) \
+    (fallback) \
+    (file) \
+    (normal) \
+    (raw) \
+    (Raw) \
+    (result) \
+    (rgb) \
+    (scale) \
+    (sourceColorSpace) \
+    (st) \
+    (varname)
+);
+
+enum class EUSDFileType
+{
+    USDA,
+    USDC,
+    USDZ
+};
+
+std::string EUSDFileType_informations() noexcept
+{
+    return "USD file type :\n"
+           "*.usda\n"
+           "*.usdc\n"
+           "*.usdz";
+}
+
+EUSDFileType EUSDFileType_stringToEnum(const std::string& usdFileType) noexcept
+{
+    const std::string type = boost::to_lower_copy(usdFileType);
+
+    if (type == "usda") return EUSDFileType::USDA;
+    if (type == "usdc") return EUSDFileType::USDC;
+    if (type == "usdz") return EUSDFileType::USDZ;
+
+    return EUSDFileType::USDA;
+}
+
+std::string EUSDFileType_enumToString(const EUSDFileType usdFileType) noexcept
+{
+    switch (usdFileType)
+    {
+        case EUSDFileType::USDZ:
+            return "usdz";
+        case EUSDFileType::USDC:
+            return "usdc";
+        case EUSDFileType::USDA:
+        default:
+            return "usda";
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, EUSDFileType usdFileType)
+{
+    return os << EUSDFileType_enumToString(usdFileType);
+}
+
+std::istream& operator>>(std::istream& in, EUSDFileType& usdFileType)
+{
+    std::string token;
+    in >> token;
+    usdFileType = EUSDFileType_stringToEnum(token);
+    return in;
+}
+
+int aliceVision_main(int argc, char **argv)
+{
+    system::Timer timer;
+
+    // command line parameters
+    std::string inputMeshPath;
+    std::string outputFolderPath;
+    EUSDFileType fileType = EUSDFileType::USDA;
+
+    bpo::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input", bpo::value<std::string>(&inputMeshPath), "Input textured mesh to export.")
+        ("output", bpo::value<std::string>(&outputFolderPath), "Output folder for USD file and textures.")
+        ("fileType", bpo::value<EUSDFileType>(&fileType)->default_value(fileType),
+         EUSDFileType_informations().c_str());
+
+    CmdLine cmdline("The program converts a textured mesh to USD.\nAliceVision exportUSD");
+    cmdline.add(requiredParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // load input mesh and textures
+    mesh::Texturing texturing;
+    texturing.loadWithMaterial(inputMeshPath);
+    const mesh::Mesh* inputMesh = texturing.mesh;
+
+    if (inputMesh == nullptr)
+    {
+        ALICEVISION_LOG_ERROR("Unable to read input mesh from the file: " << inputMeshPath);
+        return EXIT_FAILURE;
+    }
+
+    const std::string extension = fileType == EUSDFileType::USDC || fileType == EUSDFileType::USDZ ? "usdc" : "usda";
+    const bfs::path stagePath = bfs::canonical(outputFolderPath) / ("texturedMesh." + extension);
+    UsdStageRefPtr stage = UsdStage::CreateNew(stagePath.string());
+    if (!stage)
+    {
+        ALICEVISION_LOG_ERROR("Cannot create USD stage");
+        return EXIT_FAILURE;
+    }
+    UsdGeomSetStageUpAxis(stage, UsdGeomTokens->y);
+    UsdGeomSetStageMetersPerUnit(stage, 0.01);
+
+    // create mesh
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/root"));
+    UsdGeomMesh mesh = UsdGeomMesh::Define(stage, SdfPath("/root/mesh"));
+    stage->SetDefaultPrim(xform.GetPrim());
+
+    // write mesh properties
+    UsdAttribute doubleSided = mesh.CreateDoubleSidedAttr();
+    doubleSided.Set(false);
+
+    UsdAttribute subdSchema = mesh.CreateSubdivisionSchemeAttr();
+    subdSchema.Set(UsdGeomTokens->none);
+
+    // write points
+    UsdAttribute points = mesh.CreatePointsAttr();
+
+    VtArray<GfVec3f> pointsData;
+    pointsData.resize(inputMesh->pts.size());
+
+    for (int i = 0; i < inputMesh->pts.size(); ++i)
+    {
+        const Point3d& point = inputMesh->pts[i];
+        pointsData[i] = {static_cast<float>(point.x), static_cast<float>(-point.y), static_cast<float>(-point.z)};
+    }
+
+    points.Set(pointsData);
+
+    // write bounding box
+    const GfBBox3d bounds = mesh.ComputeLocalBound(UsdTimeCode::Default(), UsdGeomTokens->default_);
+    UsdAttribute extent = mesh.CreateExtentAttr();
+
+    const GfVec3d& bboxMin = bounds.GetRange().GetMin();
+    const GfVec3d& bboxMax = bounds.GetRange().GetMax();
+    VtArray<GfVec3f> extentData {
+        {static_cast<float>(bboxMin[0]), static_cast<float>(bboxMin[1]), static_cast<float>(bboxMin[2])},
+        {static_cast<float>(bboxMax[0]), static_cast<float>(bboxMax[1]), static_cast<float>(bboxMax[2])}
+    };
+    extent.Set(extentData);
+
+    // write topology
+    UsdAttribute faceVertexCounts = mesh.CreateFaceVertexCountsAttr();
+    VtArray<int> faceVertexCountsData(inputMesh->tris.size(), 3);
+    faceVertexCounts.Set(faceVertexCountsData);
+
+    UsdAttribute faceVertexIndices = mesh.CreateFaceVertexIndicesAttr();
+    VtArray<int> faceVertexIndicesData;
+    faceVertexIndicesData.resize(inputMesh->tris.size() * 3);
+
+    for (int i = 0; i < inputMesh->tris.size(); ++i)
+    {
+        faceVertexIndicesData[i * 3] = inputMesh->tris[i].v[0];
+        faceVertexIndicesData[i * 3 + 1] = inputMesh->tris[i].v[1];
+        faceVertexIndicesData[i * 3 + 2] = inputMesh->tris[i].v[2];
+    }
+    faceVertexIndices.Set(faceVertexIndicesData);
+
+    // write face varying normals as primvar
+    if (!inputMesh->normals.empty() && !inputMesh->trisNormalsIds.empty())
+    {
+        VtArray<GfVec3f> normalsData;
+        normalsData.resize(inputMesh->normals.size());
+
+        for (int i = 0; i < inputMesh->normals.size(); ++i)
+        {
+            const Point3d& normal = inputMesh->normals[i];
+            normalsData[i] = {static_cast<float>(normal.x),
+                              static_cast<float>(-normal.y),
+                              static_cast<float>(-normal.z)};
+        }
+
+        VtIntArray normalIndices;
+        normalIndices.resize(inputMesh->trisNormalsIds.size() * 3);
+
+        for (int i = 0; i < inputMesh->trisNormalsIds.size(); ++i)
+        {
+            const Voxel& indices = inputMesh->trisNormalsIds[i];
+            normalIndices[i * 3] = indices.x;
+            normalIndices[i * 3 + 1] = indices.y;
+            normalIndices[i * 3 + 2] = indices.z;
+        }
+
+        UsdGeomPrimvarsAPI primvarsApi = UsdGeomPrimvarsAPI(mesh);
+        UsdGeomPrimvar uvs = primvarsApi.CreateIndexedPrimvar(TfToken("normals"),
+                                                              SdfValueTypeNames->Normal3fArray,
+                                                              normalsData,
+                                                              normalIndices,
+                                                              UsdGeomTokens->faceVarying);
+    }
+    else // compute smooth vertex normals
+    {
+        StaticVector<Point3d> normals;
+        inputMesh->computeNormalsForPts(normals);
+
+        VtArray<GfVec3f> normalsData;
+        normalsData.resize(normals.size());
+
+        for (int i = 0; i < normals.size(); ++i)
+        {
+            const Point3d& normal = normals[i];
+            normalsData[i] = {static_cast<float>(normal.x),
+                              static_cast<float>(-normal.y),
+                              static_cast<float>(-normal.z)};
+        }
+
+        UsdAttribute normalsAttr = mesh.CreateNormalsAttr();
+        normalsAttr.Set(normalsData);
+    }
+
+    // write UVs
+    if (!inputMesh->uvCoords.empty())
+    {
+        VtArray<GfVec2f> uvsData;
+        uvsData.resize(inputMesh->uvCoords.size());
+
+        for (int i = 0; i < inputMesh->uvCoords.size(); ++i)
+        {
+            const Point2d& coord = inputMesh->uvCoords[i];
+            uvsData[i] = {static_cast<float>(coord.x), static_cast<float>(coord.y)};
+        }
+
+        VtIntArray uvsIndices;
+        uvsIndices.resize(inputMesh->trisUvIds.size() * 3);
+
+        for (int i = 0; i < inputMesh->trisUvIds.size(); ++i)
+        {
+            const Voxel& indices = inputMesh->trisUvIds[i];
+            uvsIndices[i * 3] = indices.x;
+            uvsIndices[i * 3 + 1] = indices.y;
+            uvsIndices[i * 3 + 2] = indices.z;
+        }
+
+        UsdGeomPrimvarsAPI primvarsApi = UsdGeomPrimvarsAPI(mesh);
+        UsdGeomPrimvar uvs = primvarsApi.CreateIndexedPrimvar(TfToken("st"),
+                                                              SdfValueTypeNames->TexCoord2fArray,
+                                                              uvsData,
+                                                              uvsIndices,
+                                                              UsdGeomTokens->faceVarying);
+    }
+
+    // create material and shaders
+    UsdShadeMaterial material = UsdShadeMaterial::Define(stage, SdfPath("/root/mesh/mat"));
+
+    UsdShadeShader preview = UsdShadeShader::Define(stage, SdfPath("/root/mesh/mat/preview"));
+    preview.CreateIdAttr(VtValue(UsdImagingTokens->UsdPreviewSurface));
+    material.CreateSurfaceOutput().ConnectToSource(preview.ConnectableAPI(), UsdShadeTokens->surface);
+
+    UsdShadeShader uvReader = UsdShadeShader::Define(stage, SdfPath("/root/mesh/mat/uvReader"));
+    uvReader.CreateIdAttr(VtValue(UsdImagingTokens->UsdPrimvarReader_float2));
+    uvReader.CreateInput(AvUsdTokens->varname, SdfValueTypeNames->Token).Set(AvUsdTokens->st);
+
+    // add textures (only supporting diffuse and normal maps)
+    if (texturing.material.hasTextures(mesh::Material::TextureType::DIFFUSE))
+    {
+        SdfAssetPath diffuseTexturePath {texturing.material.textureName(mesh::Material::TextureType::DIFFUSE, -1)};
+        UsdShadeShader diffuseTexture = UsdShadeShader::Define(stage, SdfPath("/root/mesh/mat/diffuseTexture"));
+        diffuseTexture.CreateIdAttr(VtValue(UsdImagingTokens->UsdUVTexture));
+        diffuseTexture.CreateInput(AvUsdTokens->st, SdfValueTypeNames->Float2)
+            .ConnectToSource(uvReader.ConnectableAPI(), AvUsdTokens->result);
+        diffuseTexture.CreateInput(AvUsdTokens->file, SdfValueTypeNames->Asset).Set(diffuseTexturePath);
+        preview.CreateInput(AvUsdTokens->diffuseColor, SdfValueTypeNames->Color3f)
+            .ConnectToSource(diffuseTexture.ConnectableAPI(), AvUsdTokens->rgb);
+    }
+
+    if (texturing.material.hasTextures(mesh::Material::TextureType::NORMAL))
+    {
+        SdfAssetPath normalTexturePath {texturing.material.textureName(mesh::Material::TextureType::NORMAL, -1)};
+        UsdShadeShader normalTexture = UsdShadeShader::Define(stage, SdfPath("/root/mesh/mat/normalTexture"));
+        normalTexture.CreateIdAttr(VtValue(UsdImagingTokens->UsdUVTexture));
+        normalTexture.CreateInput(AvUsdTokens->st, SdfValueTypeNames->Float2)
+            .ConnectToSource(uvReader.ConnectableAPI(), AvUsdTokens->result);
+        UsdShadeInput file = normalTexture.CreateInput(AvUsdTokens->file, SdfValueTypeNames->Asset);
+        file.Set(normalTexturePath);
+        file.GetAttr().SetMetadata(AvUsdTokens->colorSpace, AvUsdTokens->Raw);
+        preview.CreateInput(AvUsdTokens->normal, SdfValueTypeNames->Normal3f)
+            .ConnectToSource(normalTexture.ConnectableAPI(), AvUsdTokens->rgb);
+
+        normalTexture.CreateInput(AvUsdTokens->fallback, SdfValueTypeNames->Float4).Set(GfVec4f{0.5, 0.5, 0.5, 1.0});
+        normalTexture.CreateInput(AvUsdTokens->scale, SdfValueTypeNames->Float4).Set(GfVec4f{2.0, 2.0, 2.0, 0.0});
+        normalTexture.CreateInput(AvUsdTokens->bias, SdfValueTypeNames->Float4).Set(GfVec4f{-1.0, -1.0, -1.0, 1.0});
+        normalTexture.CreateInput(AvUsdTokens->sourceColorSpace, SdfValueTypeNames->Token).Set(AvUsdTokens->raw);
+    }
+
+    mesh.GetPrim().ApplyAPI(UsdShadeTokens->MaterialBindingAPI);
+    UsdShadeMaterialBindingAPI(mesh).Bind(material);
+
+    stage->GetRootLayer()->Save();
+
+    // Copy textures to output folder
+    const bfs::path sourceFolder = bfs::path(inputMeshPath).parent_path();
+    const bfs::path destinationFolder = bfs::canonical(outputFolderPath);
+
+    for (int i = 0; i < texturing.material.numAtlases(); ++i)
+    {
+        for (const auto& texture : texturing.material.getAllTextures())
+        {
+            if (bfs::exists(sourceFolder / texture))
+            {
+                bfs::copy_file(sourceFolder / texture, destinationFolder / texture, bfs::copy_options::update_existing);
+            }
+        }
+    }
+
+    // write out usdz if requested
+    if (fileType == EUSDFileType::USDZ)
+    {
+        const bfs::path usdzPath = bfs::canonical(outputFolderPath) / "texturedMesh.usdz";
+        UsdZipFileWriter writer = UsdZipFileWriter::CreateNew(usdzPath.string());
+
+        if (!writer)
+        {
+            ALICEVISION_LOG_ERROR("Cannot create USDZ archive");
+            return EXIT_FAILURE;
+        }
+
+        writer.AddFile(stagePath.string(), "texturedMesh." + extension);
+        for (int i = 0; i < texturing.material.numAtlases(); ++i)
+        {
+            for (const auto& texture : texturing.material.getAllTextures())
+            {
+                if (bfs::exists(destinationFolder / texture))
+                {
+                    writer.AddFile((destinationFolder / texture).string(), texture);
+                }
+            }
+        }
+        writer.Save();
+    }
+
+    ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
+    return EXIT_SUCCESS;
+}

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -196,12 +196,6 @@ int aliceVision_main(int argc, char* argv[])
         ALICEVISION_LOG_INFO("Unwrapping done.");
     }
 
-    // save final obj file
-    if(!inputMeshFilepath.empty())
-    {
-        mesh.saveAs(outputFolder, "texturedMesh", outputMeshFileType, texParams.textureFileType, bumpMappingParams);
-    }
-
     if(texParams.subdivisionTargetRatio > 0)
     {
         const bool remapVisibilities = false;
@@ -240,6 +234,12 @@ int aliceVision_main(int argc, char* argv[])
         denseMesh.load(inputRefMeshFilepath);
 
         mesh.generateNormalAndHeightMaps(mp, denseMesh, outputFolder, bumpMappingParams);
+    }
+
+    // save final obj file
+    if(!inputMeshFilepath.empty())
+    {
+        mesh.saveAs(outputFolder, "texturedMesh", outputMeshFileType);
     }
 
     ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));


### PR DESCRIPTION
## Description

Add a new **optional** command to export textured mesh to a USD format.

## Features list

- [X] Add new command exportUSD to export mesh and textures to USD
- [X] Add a simple Materials class to capture the small subset of material properties and associated textures that is supported by texturing pipeline
- [X] Update texturing pipeline to make use of new material class
- [X] Fix bug in normal computation (checking for NaN)
- [X] Fix bug in loading mesh data not setting the correct number of atlases and materials used
- [X] Fix bug in loading mesh data using incorrect material ID due to default material
- [X] Add option to merge coincident vertices when loading meshes with multiple materials
