### PR TITLE
[sfmDataIO] Alembic Import: initialize intrinsics properly

### DIFF
--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -589,10 +589,11 @@ bool readCamera(const Version & abcVersion, const ICamera& camera, const M44d& m
     // imgHeight = vaperture_cm * 10.0 * mm2pix;
 
     // create intrinsic parameters object
-    std::shared_ptr<camera::IntrinsicBase> intrinsic = createIntrinsic(EINTRINSIC_stringToEnum(mvg_intrinsicType));
+    std::shared_ptr<camera::IntrinsicBase> intrinsic = createIntrinsic(
+        /*intrinsic type*/ EINTRINSIC_stringToEnum(mvg_intrinsicType),
+        /*width*/          sensorSize_pix.at(0),
+        /*height*/         sensorSize_pix.at(1));
 
-    intrinsic->setWidth(sensorSize_pix.at(0));
-    intrinsic->setHeight(sensorSize_pix.at(1));
     intrinsic->setSensorWidth(sensorSize_mm.at(0));
     intrinsic->setSensorHeight(sensorSize_mm.at(1));
     intrinsic->importFromParams(mvg_intrinsicParams, abcVersion);


### PR DESCRIPTION
## Description

Fix bug with undistortion object dimensions not being initialized, leading to NaN values when calculating undistorted positions of feature points.