### PR TITLE
Manage LCP in imageProcessing

### DIFF
--- a/src/aliceVision/lensCorrectionProfile/lcp.cpp
+++ b/src/aliceVision/lensCorrectionProfile/lcp.cpp
@@ -889,7 +889,7 @@ void LCPinfo::combine(size_t iLow, size_t iHigh, float weightLow, LCPCorrectionM
     }
 
     case LCPCorrectionMode::CA: {
-        if(p1.hasChromaticParams() && !p1.ChromaticGreenParams.isEmpty && p2.hasChromaticParams() &&
+        if (p1.hasChromaticParams() && !p1.ChromaticGreenParams.isEmpty && p2.hasChromaticParams() &&
            !p2.ChromaticGreenParams.isEmpty)
         {
             pOut.setChromaticParamsStatus(true);

--- a/src/aliceVision/lensCorrectionProfile/lcp.cpp
+++ b/src/aliceVision/lensCorrectionProfile/lcp.cpp
@@ -126,14 +126,47 @@ void XMLCALL LCPinfo::XmlStartHandler(void* pLCPinfo, const char* el, const char
         {
             LCPdata->_currReadingState = LCPReadingState::FillChromaticGreenModel;
             LCPdata->currLensParam.setChromaticParamsStatus(true);
+            if(attr[0])
+            {
+                for(int i = 0; attr[i]; i += 2)
+                {
+                    std::string key(attr[i]);
+                    std::string value(attr[i + 1]);
+
+                    LCPdata->_currText = value;
+                    LCPdata->setRectilinearModel(LCPdata->currLensParam.ChromaticGreenParams, key);
+                }
+            }
         }
         else if (element == "stCamera:ChromaticRedGreenModel")
         {
             LCPdata->_currReadingState = LCPReadingState::FillChromaticRedGreenModel;
+            if(attr[0])
+            {
+                for(int i = 0; attr[i]; i += 2)
+                {
+                    std::string key(attr[i]);
+                    std::string value(attr[i + 1]);
+
+                    LCPdata->_currText = value;
+                    LCPdata->setRectilinearModel(LCPdata->currLensParam.ChromaticRedGreenParams, key);
+                }
+            }
         }
         else if (element == "stCamera:ChromaticBlueGreenModel")
         {
             LCPdata->_currReadingState = LCPReadingState::FillChromaticBlueGreenModel;
+            if(attr[0])
+            {
+                for(int i = 0; attr[i]; i += 2)
+                {
+                    std::string key(attr[i]);
+                    std::string value(attr[i + 1]);
+
+                    LCPdata->_currText = value;
+                    LCPdata->setRectilinearModel(LCPdata->currLensParam.ChromaticBlueGreenParams, key);
+                }
+            }
         }
         else if (attr[0])
         {
@@ -530,6 +563,7 @@ bool LCPinfo::search(settingsInfo& settings, LCPCorrectionMode mode, int& iLow, 
 
     std::vector<bool> v_isDistortionValid;
     std::vector<bool> v_isVignetteValid;
+    std::vector<bool> v_isChromaticValid;
 
     // Search the best focal lengths with respect to the target one in settings
     // At the end of the loop, iLow is the index in v_lensParam of the lens parameter set with the closest focal length, lower or equal to the one in settings.
@@ -544,9 +578,13 @@ bool LCPinfo::search(settingsInfo& settings, LCPCorrectionMode mode, int& iLow, 
 
         v_isDistortionValid.push_back(currParam.isFisheye() ? !currParam.fisheyeParams.isEmpty : !currParam.perspParams.isEmpty);
         v_isVignetteValid.push_back(currParam.hasVignetteParams() && !currParam.vignParams.isEmpty);
+        v_isChromaticValid.push_back(currParam.hasChromaticParams() && !currParam.ChromaticGreenParams.isEmpty &&
+                                     !currParam.ChromaticBlueGreenParams.isEmpty &&
+                                     !currParam.ChromaticRedGreenParams.isEmpty);
 
         bool isCurrentValid = (mode == LCPCorrectionMode::DISTORTION && v_isDistortionValid.back()) ||
-                              (mode == LCPCorrectionMode::VIGNETTE && v_isVignetteValid.back());
+                              (mode == LCPCorrectionMode::VIGNETTE && v_isVignetteValid.back()) ||
+                              (mode == LCPCorrectionMode::CA && v_isChromaticValid.back());
 
         if (isCurrentValid)
         {
@@ -610,7 +648,8 @@ bool LCPinfo::search(settingsInfo& settings, LCPCorrectionMode mode, int& iLow, 
         for (int i = 0; i < v_lensParams.size(); ++i)
         {
             bool isCurrentValid = (mode == LCPCorrectionMode::DISTORTION && v_isDistortionValid[i]) ||
-                                  (mode == LCPCorrectionMode::VIGNETTE && v_isVignetteValid[i]);
+                                  (mode == LCPCorrectionMode::VIGNETTE && v_isVignetteValid[i]) ||
+                                  (mode == LCPCorrectionMode::CA && v_isChromaticValid[i]);
 
             if (isCurrentValid && v_lensParams[i].camData.FocalLength == v_lensParams[iLow].camData.FocalLength)
             {
@@ -767,7 +806,7 @@ bool LCPinfo::search(settingsInfo& settings, LCPCorrectionMode mode, int& iLow, 
             return true;
         }
     }
-    else if ((mode == LCPCorrectionMode::DISTORTION) && (settings.FocusDistance == 0.f))
+    else if ((mode != LCPCorrectionMode::VIGNETTE) && (settings.FocusDistance == 0.f))
     {
         if (v_lensParams[iHigh].camData.FocalLength > v_lensParams[iLow].camData.FocalLength)
         {
@@ -835,6 +874,10 @@ void LCPinfo::combine(size_t iLow, size_t iHigh, float weightLow, LCPCorrectionM
             pOut.perspParams.RadialDistortParam1 = interpolate<float>(weightLow, p1.perspParams.RadialDistortParam1, p2.perspParams.RadialDistortParam1);
             pOut.perspParams.RadialDistortParam2 = interpolate<float>(weightLow, p1.perspParams.RadialDistortParam2, p2.perspParams.RadialDistortParam2);
             pOut.perspParams.RadialDistortParam3 = interpolate<float>(weightLow, p1.perspParams.RadialDistortParam3, p2.perspParams.RadialDistortParam3);
+            pOut.perspParams.TangentialDistortParam1 = interpolate<float>(
+                weightLow, p1.perspParams.TangentialDistortParam1, p2.perspParams.TangentialDistortParam1);
+            pOut.perspParams.TangentialDistortParam2 = interpolate<float>(
+                weightLow, p1.perspParams.TangentialDistortParam2, p2.perspParams.TangentialDistortParam2);
             pOut.perspParams.isEmpty = false;
         }
         else
@@ -846,30 +889,74 @@ void LCPinfo::combine(size_t iLow, size_t iHigh, float weightLow, LCPCorrectionM
     }
 
     case LCPCorrectionMode::CA: {
-        pOut.ChromaticGreenParams.FocalLengthX = interpolate<float>(weightLow, p1.ChromaticGreenParams.FocalLengthX, p2.ChromaticGreenParams.FocalLengthX);
-        pOut.ChromaticGreenParams.FocalLengthY = interpolate<float>(weightLow, p1.ChromaticGreenParams.FocalLengthY, p2.ChromaticGreenParams.FocalLengthY);
-        pOut.ChromaticGreenParams.ImageXCenter = interpolate<float>(weightLow, p1.ChromaticGreenParams.ImageXCenter, p2.ChromaticGreenParams.ImageXCenter);
-        pOut.ChromaticGreenParams.ImageYCenter = interpolate<float>(weightLow, p1.ChromaticGreenParams.ImageYCenter, p2.ChromaticGreenParams.ImageYCenter);
-        pOut.ChromaticGreenParams.RadialDistortParam1 = interpolate<float>(weightLow, p1.ChromaticGreenParams.RadialDistortParam1, p2.ChromaticGreenParams.RadialDistortParam1);
-        pOut.ChromaticGreenParams.RadialDistortParam2 = interpolate<float>(weightLow, p1.ChromaticGreenParams.RadialDistortParam2, p2.ChromaticGreenParams.RadialDistortParam2);
-        pOut.ChromaticGreenParams.RadialDistortParam3 = interpolate<float>(weightLow, p1.ChromaticGreenParams.RadialDistortParam3, p2.ChromaticGreenParams.RadialDistortParam3);
-        pOut.ChromaticGreenParams.isEmpty = false;
-        pOut.ChromaticBlueGreenParams.FocalLengthX = interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.FocalLengthX, p2.ChromaticBlueGreenParams.FocalLengthX);
-        pOut.ChromaticBlueGreenParams.FocalLengthY = interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.FocalLengthY, p2.ChromaticBlueGreenParams.FocalLengthY);
-        pOut.ChromaticBlueGreenParams.ImageXCenter = interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.ImageXCenter, p2.ChromaticBlueGreenParams.ImageXCenter);
-        pOut.ChromaticBlueGreenParams.ImageYCenter = interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.ImageYCenter, p2.ChromaticBlueGreenParams.ImageYCenter);
-        pOut.ChromaticBlueGreenParams.RadialDistortParam1 = interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.RadialDistortParam1, p2.ChromaticBlueGreenParams.RadialDistortParam1);
-        pOut.ChromaticBlueGreenParams.RadialDistortParam2 = interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.RadialDistortParam2, p2.ChromaticBlueGreenParams.RadialDistortParam2);
-        pOut.ChromaticBlueGreenParams.RadialDistortParam3 = interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.RadialDistortParam3, p2.ChromaticBlueGreenParams.RadialDistortParam3);
-        pOut.ChromaticBlueGreenParams.isEmpty = false;
-        pOut.ChromaticRedGreenParams.FocalLengthX = interpolate<float>(weightLow, p1.ChromaticRedGreenParams.FocalLengthX, p2.ChromaticRedGreenParams.FocalLengthX);
-        pOut.ChromaticRedGreenParams.FocalLengthY = interpolate<float>(weightLow, p1.ChromaticRedGreenParams.FocalLengthY, p2.ChromaticRedGreenParams.FocalLengthY);
-        pOut.ChromaticRedGreenParams.ImageXCenter = interpolate<float>(weightLow, p1.ChromaticRedGreenParams.ImageXCenter, p2.ChromaticRedGreenParams.ImageXCenter);
-        pOut.ChromaticRedGreenParams.ImageYCenter = interpolate<float>(weightLow, p1.ChromaticRedGreenParams.ImageYCenter, p2.ChromaticRedGreenParams.ImageYCenter);
-        pOut.ChromaticRedGreenParams.RadialDistortParam1 = interpolate<float>(weightLow, p1.ChromaticRedGreenParams.RadialDistortParam1, p2.ChromaticRedGreenParams.RadialDistortParam1);
-        pOut.ChromaticRedGreenParams.RadialDistortParam2 = interpolate<float>(weightLow, p1.ChromaticRedGreenParams.RadialDistortParam2, p2.ChromaticRedGreenParams.RadialDistortParam2);
-        pOut.ChromaticRedGreenParams.RadialDistortParam3 = interpolate<float>(weightLow, p1.ChromaticRedGreenParams.RadialDistortParam3, p2.ChromaticRedGreenParams.RadialDistortParam3);
-        pOut.ChromaticRedGreenParams.isEmpty = false;
+        if(p1.hasChromaticParams() && !p1.ChromaticGreenParams.isEmpty && p2.hasChromaticParams() &&
+           !p2.ChromaticGreenParams.isEmpty)
+        {
+            pOut.setChromaticParamsStatus(true);
+            pOut.ChromaticGreenParams.FocalLengthX = interpolate<float>(weightLow, p1.ChromaticGreenParams.FocalLengthX,
+                                                                        p2.ChromaticGreenParams.FocalLengthX);
+            pOut.ChromaticGreenParams.FocalLengthY = interpolate<float>(weightLow, p1.ChromaticGreenParams.FocalLengthY,
+                                                                        p2.ChromaticGreenParams.FocalLengthY);
+            pOut.ChromaticGreenParams.ImageXCenter = interpolate<float>(weightLow, p1.ChromaticGreenParams.ImageXCenter,
+                                                                        p2.ChromaticGreenParams.ImageXCenter);
+            pOut.ChromaticGreenParams.ImageYCenter = interpolate<float>(weightLow, p1.ChromaticGreenParams.ImageYCenter,
+                                                                        p2.ChromaticGreenParams.ImageYCenter);
+            pOut.ChromaticGreenParams.ScaleFactor = interpolate<float>(weightLow, p1.ChromaticGreenParams.ScaleFactor, p2.ChromaticGreenParams.ScaleFactor);
+            pOut.ChromaticGreenParams.RadialDistortParam1 = interpolate<float>(
+                weightLow, p1.ChromaticGreenParams.RadialDistortParam1, p2.ChromaticGreenParams.RadialDistortParam1);
+            pOut.ChromaticGreenParams.RadialDistortParam2 = interpolate<float>(
+                weightLow, p1.ChromaticGreenParams.RadialDistortParam2, p2.ChromaticGreenParams.RadialDistortParam2);
+            pOut.ChromaticGreenParams.RadialDistortParam3 = interpolate<float>(
+                weightLow, p1.ChromaticGreenParams.RadialDistortParam3, p2.ChromaticGreenParams.RadialDistortParam3);
+            pOut.ChromaticGreenParams.isEmpty = false;
+            pOut.ChromaticBlueGreenParams.FocalLengthX = interpolate<float>(
+                weightLow, p1.ChromaticBlueGreenParams.FocalLengthX, p2.ChromaticBlueGreenParams.FocalLengthX);
+            pOut.ChromaticBlueGreenParams.FocalLengthY = interpolate<float>(
+                weightLow, p1.ChromaticBlueGreenParams.FocalLengthY, p2.ChromaticBlueGreenParams.FocalLengthY);
+            pOut.ChromaticBlueGreenParams.ImageXCenter = interpolate<float>(
+                weightLow, p1.ChromaticBlueGreenParams.ImageXCenter, p2.ChromaticBlueGreenParams.ImageXCenter);
+            pOut.ChromaticBlueGreenParams.ImageYCenter = interpolate<float>(
+                weightLow, p1.ChromaticBlueGreenParams.ImageYCenter, p2.ChromaticBlueGreenParams.ImageYCenter);
+            pOut.ChromaticBlueGreenParams.ScaleFactor = interpolate<float>(
+                weightLow, p1.ChromaticBlueGreenParams.ScaleFactor, p2.ChromaticBlueGreenParams.ScaleFactor);
+            pOut.ChromaticBlueGreenParams.RadialDistortParam1 =
+                interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.RadialDistortParam1,
+                                   p2.ChromaticBlueGreenParams.RadialDistortParam1);
+            pOut.ChromaticBlueGreenParams.RadialDistortParam2 =
+                interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.RadialDistortParam2,
+                                   p2.ChromaticBlueGreenParams.RadialDistortParam2);
+            pOut.ChromaticBlueGreenParams.RadialDistortParam3 =
+                interpolate<float>(weightLow, p1.ChromaticBlueGreenParams.RadialDistortParam3,
+                                   p2.ChromaticBlueGreenParams.RadialDistortParam3);
+            pOut.ChromaticBlueGreenParams.isEmpty = false;
+            pOut.ChromaticRedGreenParams.FocalLengthX = interpolate<float>(
+                weightLow, p1.ChromaticRedGreenParams.FocalLengthX, p2.ChromaticRedGreenParams.FocalLengthX);
+            pOut.ChromaticRedGreenParams.FocalLengthY = interpolate<float>(
+                weightLow, p1.ChromaticRedGreenParams.FocalLengthY, p2.ChromaticRedGreenParams.FocalLengthY);
+            pOut.ChromaticRedGreenParams.ImageXCenter = interpolate<float>(
+                weightLow, p1.ChromaticRedGreenParams.ImageXCenter, p2.ChromaticRedGreenParams.ImageXCenter);
+            pOut.ChromaticRedGreenParams.ImageYCenter = interpolate<float>(
+                weightLow, p1.ChromaticRedGreenParams.ImageYCenter, p2.ChromaticRedGreenParams.ImageYCenter);
+            pOut.ChromaticRedGreenParams.ScaleFactor = interpolate<float>(
+                weightLow, p1.ChromaticRedGreenParams.ScaleFactor, p2.ChromaticRedGreenParams.ScaleFactor);
+            pOut.ChromaticRedGreenParams.RadialDistortParam1 =
+                interpolate<float>(weightLow, p1.ChromaticRedGreenParams.RadialDistortParam1,
+                                   p2.ChromaticRedGreenParams.RadialDistortParam1);
+            pOut.ChromaticRedGreenParams.RadialDistortParam2 =
+                interpolate<float>(weightLow, p1.ChromaticRedGreenParams.RadialDistortParam2,
+                                   p2.ChromaticRedGreenParams.RadialDistortParam2);
+            pOut.ChromaticRedGreenParams.RadialDistortParam3 =
+                interpolate<float>(weightLow, p1.ChromaticRedGreenParams.RadialDistortParam3,
+                                   p2.ChromaticRedGreenParams.RadialDistortParam3);
+            pOut.ChromaticRedGreenParams.isEmpty = false;
+        }
+        else
+        {
+            pOut.setChromaticParamsStatus(false);
+            pOut.ChromaticGreenParams.isEmpty = true;
+            pOut.ChromaticBlueGreenParams.isEmpty = true;
+            pOut.ChromaticRedGreenParams.isEmpty = true;
+        }
     }
     }
 }
@@ -901,6 +988,21 @@ void LCPinfo::getVignettingParams(const float& focalLength, const float& apertur
     if (search(userSettings, LCPCorrectionMode::VIGNETTE, iLow, iHigh, weightLow))
     {
         combine(iLow, iHigh, weightLow, LCPCorrectionMode::VIGNETTE, lparam);
+    }
+}
+
+void LCPinfo::getChromaticParams(const float& focalLength, const float& focusDistance, LensParam& lparam)
+{
+    settingsInfo userSettings;
+    userSettings.ApertureValue = 0.f;
+    userSettings.FocalLength = focalLength;
+    userSettings.FocusDistance = focusDistance;
+
+    int iLow, iHigh;
+    float weightLow;
+    if(search(userSettings, LCPCorrectionMode::CA, iLow, iHigh, weightLow))
+    {
+        combine(iLow, iHigh, weightLow, LCPCorrectionMode::CA, lparam);
     }
 }
 
@@ -968,9 +1070,9 @@ void LCPinfo::setRectilinearModel(RectilinearModel& model, const std::string& na
     else if (name == "stCamera:RadialDistortParam3")
         model.RadialDistortParam3 = std::stof(_currText.c_str());
     else if (name == "stCamera:TangentiallDistortParam1")
-        model.RadialDistortParam1 = std::stof(_currText.c_str());
+        model.TangentialDistortParam1 = std::stof(_currText.c_str());
     else if (name == "stCamera:TangentiallDistortParam2")
-        model.RadialDistortParam2 = std::stof(_currText.c_str());
+        model.TangentialDistortParam2 = std::stof(_currText.c_str());
     else if (name == "stCamera:ScaleFactor")
         model.ScaleFactor = std::stof(_currText.c_str());
 }

--- a/src/aliceVision/lensCorrectionProfile/lcp.hpp
+++ b/src/aliceVision/lensCorrectionProfile/lcp.hpp
@@ -182,6 +182,12 @@ public:
     void clear();
 
     /**
+     * @brief Indicate that no geometric model is available
+     * @return true if no geometric model is available
+     */
+    bool isEmpty() const { return perspParams.isEmpty && fisheyeParams.isEmpty; }
+
+    /**
      * @brief Indicate that paramaters apply for a fisheye lens
      * @return true if the fisheye model is the valid one
      */

--- a/src/aliceVision/lensCorrectionProfile/lcp.hpp
+++ b/src/aliceVision/lensCorrectionProfile/lcp.hpp
@@ -93,7 +93,7 @@ struct RectilinearModel
         *this = RectilinearModel();
     }
 
-    void distord(const float x, const float y, float& x_d, float& y_d)
+    void distort(const float x, const float y, float& x_d, float& y_d)
     {
         const float rr = x * x + y * y;
         const float p1 = 1.f + rr * (RadialDistortParam1 + rr * (RadialDistortParam2 + rr * RadialDistortParam3));

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -26,6 +26,7 @@ alicevision_add_library(aliceVision_sfmData
     aliceVision_feature
     aliceVision_geometry
     aliceVision_camera
+    aliceVision_sensorDB
     aliceVision_stl
     Boost::filesystem
   PRIVATE_LINKS

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -15,7 +15,7 @@
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/image/dcp.hpp>
 #include <aliceVision/sensorDB/Datasheet.hpp>
-#include <aliceVision/camera/intrinsicInitMode.hpp>
+#include <aliceVision/camera/IntrinsicInitMode.hpp>
 #include <aliceVision/lensCorrectionProfile/lcp.hpp>
 
 namespace aliceVision {

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -14,6 +14,9 @@
 #include <utility>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/image/dcp.hpp>
+#include <aliceVision/sensorDB/Datasheet.hpp>
+#include <aliceVision/camera/intrinsicInitMode.hpp>
+#include <aliceVision/lensCorrectionProfile/lcp.hpp>
 
 namespace aliceVision {
 namespace sfmData {
@@ -295,7 +298,6 @@ public:
   {
     return _intrinsicId;
   }
-
 
   /**
    * @brief Get the pose id
@@ -846,6 +848,35 @@ public:
           addMetadata("AliceVision:DCP:CameraCalibrationMat" + std::to_string(k + 1), v_strCalibMatrix[k]);
       }
   }
+
+
+  /**
+   * @brief Add vignetting model parameters in metadata
+   * @param[in] The lens data extracted from a LCP file
+   */
+  void addVignettingMetadata(LensParam& lensParam)
+  {
+      addMetadata("AliceVision:VignParamFocX", std::to_string(lensParam.vignParams.FocalLengthX));
+      addMetadata("AliceVision:VignParamFocY", std::to_string(lensParam.vignParams.FocalLengthY));
+      addMetadata("AliceVision:VignParamCenterX", std::to_string(lensParam.vignParams.ImageXCenter));
+      addMetadata("AliceVision:VignParamCenterY", std::to_string(lensParam.vignParams.ImageYCenter));
+      addMetadata("AliceVision:VignParam1", std::to_string(lensParam.vignParams.VignetteModelParam1));
+      addMetadata("AliceVision:VignParam2", std::to_string(lensParam.vignParams.VignetteModelParam2));
+      addMetadata("AliceVision:VignParam3", std::to_string(lensParam.vignParams.VignetteModelParam3));
+  }
+
+  /**
+   * @brief Get sensor size by combining info in metadata and in sensor database
+   * @param[in] sensorDatabase The sensor database
+   * @param[out] sensorWidth The sensor width
+   * @param[out] sensorHeight The sensor height
+   * @param[out] focalLengthmm The focal length
+   * @param[out] intrinsicInitMode The intrinsic init mode
+   * @param[in] verbose Enable verbosity
+   * @return A Error or Warning code: 1 - Unkwnown sensor, 2 - No metadata, 3 - Unsure sensor, 4 - Computation from 35mm Focal
+   */
+  int getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatabase, double& sensorWidth, double& sensorHeight, double& focalLengthmm, camera::EInitMode& intrinsicInitMode,
+                    bool verbose = false);
 
 private:
 

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -966,7 +966,7 @@ public:
    * @param[out] focalLengthmm The focal length
    * @param[out] intrinsicInitMode The intrinsic init mode
    * @param[in] verbose Enable verbosity
-   * @return A Error or Warning code: 1 - Unkwnown sensor, 2 - No metadata, 3 - Unsure sensor, 4 - Computation from 35mm Focal
+   * @return An Error or Warning code: 1 - Unknown sensor, 2 - No metadata, 3 - Unsure sensor, 4 - Computation from 35mm Focal
    */
   int getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatabase, double& sensorWidth, double& sensorHeight, double& focalLengthmm, camera::EInitMode& intrinsicInitMode,
                     bool verbose = false);

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -612,20 +612,78 @@ public:
       bool valid = true;
       double value;
 
-      valid = valid && getDoubleMetadata({ "AliceVision:VignParamFocX" }, value);
+      valid = valid && getDoubleMetadata({"AliceVision:VignParamFocX"}, value);
       v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({ "AliceVision:VignParamFocY" }, value);
+      valid = valid && getDoubleMetadata({"AliceVision:VignParamFocY"}, value);
       v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({ "AliceVision:VignParamCenterX" }, value);
+      valid = valid && getDoubleMetadata({"AliceVision:VignParamCenterX"}, value);
       v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({ "AliceVision:VignParamCenterY" }, value);
+      valid = valid && getDoubleMetadata({"AliceVision:VignParamCenterY"}, value);
       v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({ "AliceVision:VignParam1" }, value);
+      valid = valid && getDoubleMetadata({"AliceVision:VignParam1"}, value);
       v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({ "AliceVision:VignParam2" }, value);
+      valid = valid && getDoubleMetadata({"AliceVision:VignParam2"}, value);
       v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({ "AliceVision:VignParam3" }, value);
+      valid = valid && getDoubleMetadata({"AliceVision:VignParam3"}, value);
       v_vignParam.push_back(static_cast<float>(value));
+      return valid;
+  }
+
+  const bool getChromaticAberrationParams(std::vector<float>& v_caGParam, std::vector<float>& v_caBGParam, std::vector<float>& v_caRGParam) const
+  {
+      v_caGParam.clear();
+      v_caBGParam.clear();
+      v_caRGParam.clear();
+      bool valid = true;
+      double value;
+
+      valid = valid && getDoubleMetadata({"AliceVision:CAGreenFocX"}, value);
+      v_caGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CAGreenFocY"}, value);
+      v_caGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CAGreenCenterX"}, value);
+      v_caGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CAGreenCenterY"}, value);
+      v_caGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam1"}, value);
+      v_caGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam2"}, value);
+      v_caGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam3"}, value);
+      v_caGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenFocX"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenFocY"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenCenterX"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenCenterY"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam1"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam2"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam3"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenScaleFactor"}, value);
+      v_caBGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenFocX"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenFocY"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenCenterX"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenCenterY"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam1"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam2"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam3"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenScaleFactor"}, value);
+      v_caRGParam.push_back(static_cast<float>(value));
+
       return valid;
   }
 
@@ -660,6 +718,10 @@ public:
 
     return timecode;
   }
+
+  double getSensorWidth() const { return getDoubleMetadata({"AliceVision:SensorWidth"}); }
+
+  double getSensorHeight() const { return getDoubleMetadata({"AliceVision:SensorHeight"}); }
 
   /**
    * @brief Get the view metadata structure
@@ -863,6 +925,37 @@ public:
       addMetadata("AliceVision:VignParam1", std::to_string(lensParam.vignParams.VignetteModelParam1));
       addMetadata("AliceVision:VignParam2", std::to_string(lensParam.vignParams.VignetteModelParam2));
       addMetadata("AliceVision:VignParam3", std::to_string(lensParam.vignParams.VignetteModelParam3));
+  }
+
+    /**
+   * @brief Add chromatic model parameters in metadata
+   * @param[in] The lens data extracted from a LCP file
+   */
+  void addChromaticMetadata(LensParam& lensParam)
+  {
+      addMetadata("AliceVision:CAGreenFocX", std::to_string(lensParam.ChromaticGreenParams.FocalLengthX));
+      addMetadata("AliceVision:CAGreenFocY", std::to_string(lensParam.ChromaticGreenParams.FocalLengthY));
+      addMetadata("AliceVision:CAGreenCenterX", std::to_string(lensParam.ChromaticGreenParams.ImageXCenter));
+      addMetadata("AliceVision:CAGreenCenterY", std::to_string(lensParam.ChromaticGreenParams.ImageYCenter));
+      addMetadata("AliceVision:CAGreenParam1", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam1));
+      addMetadata("AliceVision:CAGreenParam2", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam2));
+      addMetadata("AliceVision:CAGreenParam3", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam3));
+      addMetadata("AliceVision:CABlueGreenFocX", std::to_string(lensParam.ChromaticBlueGreenParams.FocalLengthX));
+      addMetadata("AliceVision:CABlueGreenFocY", std::to_string(lensParam.ChromaticBlueGreenParams.FocalLengthY));
+      addMetadata("AliceVision:CABlueGreenCenterX", std::to_string(lensParam.ChromaticBlueGreenParams.ImageXCenter));
+      addMetadata("AliceVision:CABlueGreenCenterY", std::to_string(lensParam.ChromaticBlueGreenParams.ImageYCenter));
+      addMetadata("AliceVision:CABlueGreenParam1", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam1));
+      addMetadata("AliceVision:CABlueGreenParam2", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam2));
+      addMetadata("AliceVision:CABlueGreenParam3", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam3));
+      addMetadata("AliceVision:CABlueGreenScaleFactor", std::to_string(lensParam.ChromaticBlueGreenParams.ScaleFactor));
+      addMetadata("AliceVision:CARedGreenFocX", std::to_string(lensParam.ChromaticRedGreenParams.FocalLengthX));
+      addMetadata("AliceVision:CARedGreenFocY", std::to_string(lensParam.ChromaticRedGreenParams.FocalLengthY));
+      addMetadata("AliceVision:CARedGreenCenterX", std::to_string(lensParam.ChromaticRedGreenParams.ImageXCenter));
+      addMetadata("AliceVision:CARedGreenCenterY", std::to_string(lensParam.ChromaticRedGreenParams.ImageYCenter));
+      addMetadata("AliceVision:CARedGreenParam1", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam1));
+      addMetadata("AliceVision:CARedGreenParam2", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam2));
+      addMetadata("AliceVision:CARedGreenParam3", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam3));
+      addMetadata("AliceVision:CARedGreenScaleFactor", std::to_string(lensParam.ChromaticRedGreenParams.ScaleFactor));
   }
 
   /**

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -73,17 +73,16 @@ void updateIncompleteView(sfmData::View& view, EViewIdMethod viewIdMethod = EVie
  * @param[in] defaultFocalRatio
  * @param[in] defaultOffsetX
  * @param[in] defaultOffsetY
+ * @param[in] lensParam Lens data from LCP file
  * @param[in] defaultIntrinsicType (unknown by default) 
  * @param[in] allowedEintrinsics The intrinsics values that can be attributed
  * @return shared_ptr IntrinsicBase
  */
-std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(
-					const sfmData::View& view, double mmFocalLength = -1.0, double sensorWidth = -1,
-					double defaultFocalLength = -1, double defaultFieldOfView = -1,
-                    double defaultFocalRatio = 1.0, double defaultOffsetX = 0.0, double defaultOffsetY = 0.0,
-                    camera::EINTRINSIC lcpIntrinsicType = camera::EINTRINSIC::UNKNOWN,
-					camera::EINTRINSIC defaultIntrinsicType = camera::EINTRINSIC::UNKNOWN,
-					camera::EINTRINSIC allowedEintrinsics = camera::EINTRINSIC::VALID_CAMERA_MODEL);
+std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& view, double mmFocalLength = -1.0, double sensorWidth = -1, double defaultFocalLength = -1,
+                                                        double defaultFieldOfView = -1, double defaultFocalRatio = 1.0, double defaultOffsetX = 0.0, double defaultOffsetY = 0.0,
+                                                        LensParam *lensParam = nullptr,
+                                                        camera::EINTRINSIC defaultIntrinsicType = camera::EINTRINSIC::UNKNOWN,
+                                                        camera::EINTRINSIC allowedEintrinsics = camera::EINTRINSIC::VALID_CAMERA_MODEL);
 
 /**
 * @brief Allows you to retrieve the files paths corresponding to a view by searching through a list of folders.

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -489,11 +489,6 @@ int aliceVision_main(int argc, char **argv)
     const std::string& make = view.getMetadataMake();
     const std::string& model = view.getMetadataModel();
     const bool hasCameraMetadata = (!make.empty() || !model.empty());
-    const bool hasFocalIn35mmMetadata = view.hasDigitMetadata({"Exif:FocalLengthIn35mmFilm", "FocalLengthIn35mmFilm"});
-    const double focalIn35mm = hasFocalIn35mmMetadata ? view.getDoubleMetadata({"Exif:FocalLengthIn35mmFilm", "FocalLengthIn35mmFilm"}) : -1.0;
-    const double imageRatio = static_cast<double>(view.getWidth()) / static_cast<double>(view.getHeight());
-    const double diag24x36 = std::sqrt(36.0 * 36.0 + 24.0 * 24.0);
-    camera::EInitMode intrinsicInitMode = camera::EInitMode::UNKNOWN;
 
     std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(view.getImagePath()));
 
@@ -540,7 +535,7 @@ int aliceVision_main(int argc, char **argv)
 
     if (imgFormat.compare("raw") == 0)
     {
-        // Store the color interpretation mode choosed for raw images in metadata,
+        // Store the color interpretation mode choosen for raw images in metadata,
         // so all future loads of this image will be interpreted in the same way.
         if (!dcpError)
         {
@@ -551,25 +546,6 @@ int aliceVision_main(int argc, char **argv)
             view.addMetadata("AliceVision:rawColorInterpretation", image::ERawColorInterpretation_enumToString(image::ERawColorInterpretation::LibRawWhiteBalancing));
             if (!dcpDatabase.empty())
                 ALICEVISION_LOG_WARNING("DCP Profile not found for image: " << view.getImagePath() << ". Use LibRawWhiteBalancing option for raw color processing.");
-        }
-    }
-
-    // try to find an appropriate Lens Correction Profile
-    LCPinfo* lcpData = nullptr;
-    if (lcpStore.size() == 1)
-    {
-        lcpData = lcpStore.retrieveLCP();
-    }
-    else if (!lcpStore.empty())
-    {
-        // Find an LCP file that matches the camera model and the lens model.
-        const std::string& lensModel = view.getMetadataLensModel();
-        const int lensID = view.getMetadataLensID();
-
-        if (!make.empty() && !lensModel.empty())
-        {
-            #pragma omp critical (lcp)
-            lcpData = lcpStore.findLCP(make, model, lensModel, lensID, 1);
         }
     }
 
@@ -591,185 +567,75 @@ int aliceVision_main(int argc, char **argv)
       }
     }
 
-    // try to find in the sensor width in the database
-    if(hasCameraMetadata)
+    camera::EInitMode intrinsicInitMode = camera::EInitMode::UNKNOWN;
+
+    int errCode = view.getSensorSize(sensorDatabase, sensorWidth, sensorHeight, focalLengthmm, intrinsicInitMode, false);
+
+    // Throw a warning at the end
+    if (errCode == 1)
+    {
+      #pragma omp critical(unknownSensors)
+      unknownSensors.emplace(std::make_pair(make, model), view.getImagePath());
+    }
+    else if (errCode == 2)
+    {
+      #pragma omp critical(noMetadataImagePaths)
+      noMetadataImagePaths.emplace_back(view.getImagePath());
+    }
+    else if (errCode == 3)
     {
       sensorDB::Datasheet datasheet;
-      if(sensorDB::getInfo(make, model, sensorDatabase, datasheet))
-      {
-        // sensor is in the database
-        ALICEVISION_LOG_TRACE("Sensor width found in sensor database: " << std::endl
-                              << "\t- brand: " << make << std::endl
-                              << "\t- model: " << model << std::endl
-                              << "\t- sensor width: " << datasheet._sensorWidth << " mm");
-
-        if(datasheet._model != model) {
-          // the camera model in sensor database is slightly different
-          unsureSensors.emplace(std::make_pair(make, model), std::make_pair(view.getImagePath(), datasheet)); // will throw a warning message
-        }
-
-        sensorWidth = datasheet._sensorWidth;
-        sensorWidthSource = ESensorWidthSource::FROM_DB;
-
-        if(focalLengthmm > 0.0) {
-          intrinsicInitMode = camera::EInitMode::ESTIMATED;
-        }
-      }
+      sensorDB::getInfo(make, model, sensorDatabase, datasheet);
+      #pragma omp critical(unsureSensors)
+      unsureSensors.emplace(std::make_pair(make, model), std::make_pair(view.getImagePath(), datasheet));
     }
-
-    // try to find / compute with 'FocalLengthIn35mmFilm' metadata
-    if (hasFocalIn35mmMetadata)
+    else if (errCode == 4)
     {
-      if (sensorWidth == -1.0)
-      {
-        const double invRatio = 1.0 / imageRatio;
-
-        if (focalLengthmm > 0.0)
-        {
-          // no sensorWidth but valid focalLength and valid focalLengthIn35mm, so deduce sensorWith approximation
-          const double sensorDiag = (focalLengthmm * diag24x36) / focalIn35mm; // 43.3 is the diagonal of 35mm film
-          sensorWidth = sensorDiag * std::sqrt(1.0 / (1.0 + invRatio * invRatio));
-          sensorWidthSource = ESensorWidthSource::FROM_METADATA_ESTIMATION;
-        }
-        else
-        {
-          // no sensorWidth and no focalLength but valid focalLengthIn35mm, so consider sensorWith as 35mm
-          sensorWidth = diag24x36 * std::sqrt(1.0 / (1.0 + invRatio * invRatio));
-          focalLengthmm = sensorWidth * (focalIn35mm ) / 36.0;
-          sensorWidthSource = ESensorWidthSource::UNKNOWN;
-        }
-
-        intrinsicsSetFromFocal35mm.emplace(view.getImagePath(), std::make_pair(sensorWidth, focalLengthmm));
-        intrinsicInitMode = camera::EInitMode::ESTIMATED;
-      }
-      else if(sensorWidth > 0 && focalLengthmm <= 0)
-      {
-        // valid sensorWidth and valid focalLengthIn35mm but no focalLength, so convert focalLengthIn35mm to the actual width of the sensor
-        const double sensorDiag = std::sqrt(std::pow(sensorWidth, 2) +  std::pow(sensorWidth / imageRatio,2));
-        focalLengthmm = (sensorDiag * focalIn35mm) / diag24x36;
-
-        intrinsicsSetFromFocal35mm.emplace(view.getImagePath(), std::make_pair(sensorWidth, focalLengthmm));
-        intrinsicInitMode = camera::EInitMode::ESTIMATED;
-      }
+      #pragma omp critical(intrinsicsSetFromFocal35mm)
+      intrinsicsSetFromFocal35mm.emplace(view.getImagePath(), std::make_pair(sensorWidth, focalLengthmm));
     }
 
-    // error handling
-    if(sensorWidth == -1.0)
+    // try to find an appropriate Lens Correction Profile
+    LCPinfo* lcpData = nullptr;
+    if (lcpStore.size() == 1)
     {
-      if(hasCameraMetadata)
-      {
-        // sensor is not in the database
-  #pragma omp critical (unknownSensors)
-        unknownSensors.emplace(std::make_pair(make, model), view.getImagePath()); // will throw a warning at the end
-      }
-      else
-      {
-        // no metadata 'Make' and 'Model' can't find sensor width
-  #pragma omp critical (noMetadataImagePaths)
-        noMetadataImagePaths.emplace_back(view.getImagePath()); // will throw a warning message at the end
-      }
+      lcpData = lcpStore.retrieveLCP();
     }
-    else
+    else if (!lcpStore.empty())
     {
-      // we have a valid sensorWidth information, so we store it into the metadata (where it would have been nice to have it in the first place)
-      if(sensorWidthSource == ESensorWidthSource::FROM_DB) {
-        view.addMetadata("AliceVision:SensorWidth", std::to_string(sensorWidth));
-      }
-      else if(sensorWidthSource == ESensorWidthSource::FROM_METADATA_ESTIMATION) {
-        view.addMetadata("AliceVision:SensorWidthEstimation", std::to_string(sensorWidth));
+      // Find an LCP file that matches the camera model and the lens model.
+      const std::string& lensModel = view.getMetadataLensModel();
+      const int lensID = view.getMetadataLensID();
+
+      if (!make.empty() && !lensModel.empty())
+      {
+        #pragma omp critical(lcp)
+        lcpData = lcpStore.findLCP(make, model, lensModel, lensID, 1);
       }
     }
 
-    if (sensorWidth < 0)
-    {
-      ALICEVISION_LOG_WARNING("Sensor size is unknown");
-      ALICEVISION_LOG_WARNING("Use default sensor size (36 mm)");
-      sensorWidth = 36.0;
-    }
-
-    float apertureValue = 2.f * std::log(view.getMetadataFNumber()) / std::log(2.0);
-    float focusDistance = 0.f;
-
-    camera::EINTRINSIC lcpCameraModel = camera::EINTRINSIC::UNKNOWN;
+    // const  apertureValue = 2.f * std::log(view.getMetadataFNumber()) / std::log(2.0); // to be uncommented when adding lcp defringing model search
+    const float focusDistance = 0.f;
 
     LensParam lensParam;
     if ((lcpData != nullptr) && !(lcpData->isEmpty()))
     {
-        lcpData->getDistortionParams(focalLengthmm, focusDistance, lensParam);
-        lcpData->getVignettingParams(focalLengthmm, focusDistance, lensParam);
+      lcpData->getDistortionParams(focalLengthmm, focusDistance, lensParam);
+      lcpData->getVignettingParams(focalLengthmm, focusDistance, lensParam);
+    }
 
-        lcpCameraModel = lensParam.isFisheye() ? camera::EINTRINSIC::PINHOLE_CAMERA_FISHEYE : camera::EINTRINSIC::PINHOLE_CAMERA_RADIAL3;
+    if (lensParam.hasVignetteParams() && !lensParam.vignParams.isEmpty)
+    {
+      view.addVignettingMetadata(lensParam);
+      ++lcpVignettingViewCount;
     }
 
     // build intrinsic
-    std::shared_ptr<camera::IntrinsicBase> intrinsicBase = getViewIntrinsic(
-        view, focalLengthmm, sensorWidth, defaultFocalLength, defaultFieldOfView, 
-        defaultFocalRatio, defaultOffsetX, defaultOffsetY, 
-        lcpCameraModel, defaultCameraModel, allowedCameraModels);
+    std::shared_ptr<camera::IntrinsicBase> intrinsicBase = getViewIntrinsic(view, focalLengthmm, sensorWidth, defaultFocalLength, defaultFieldOfView, defaultFocalRatio,
+                                                                            defaultOffsetX, defaultOffsetY, &lensParam, defaultCameraModel, allowedCameraModels);
 
-    if (lcpData != nullptr)
-    {
-        std::shared_ptr<camera::IntrinsicsScaleOffsetDisto> intrinsicDisto = std::dynamic_pointer_cast<camera::IntrinsicsScaleOffsetDisto>(intrinsicBase);
-        if (intrinsicDisto)
-        {
-          std::shared_ptr<camera::Distortion> distortion = intrinsicDisto->getDistortion();
-
-          if (!lensParam.isFisheye())
-          {
-              std::shared_ptr<camera::DistortionRadialK3> distoRadialK3 = std::dynamic_pointer_cast<camera::DistortionRadialK3>(distortion);
-              if (distoRadialK3)
-              {
-                  const int Dmax = std::max<int>(lcpData->getImageWidth(), lcpData->getImageLength());
-
-                  const aliceVision::Vec2 offset((lensParam.perspParams.ImageXCenter - 0.5f) * Dmax, (lensParam.perspParams.ImageYCenter - 0.5f) * Dmax);
-                  intrinsicDisto->setOffset(offset);
-
-                  std::vector<double> p;
-                  p.push_back(lensParam.perspParams.RadialDistortParam1);
-                  p.push_back(lensParam.perspParams.RadialDistortParam2);
-                  p.push_back(lensParam.perspParams.RadialDistortParam3);
-                  intrinsicDisto->setDistortionParams(p);
-
-                  ++lcpGeometryViewCount;
-              }
-          }
-          else
-          {
-              std::shared_ptr<camera::DistortionFisheye> DistortionFisheye = std::dynamic_pointer_cast<camera::DistortionFisheye>(distortion);
-              if (DistortionFisheye)
-              {
-                  const int Dmax = std::max<int>(lcpData->getImageWidth(), lcpData->getImageLength());
-
-                  const aliceVision::Vec2 offset((lensParam.perspParams.ImageXCenter - 0.5f) * Dmax, (lensParam.perspParams.ImageYCenter - 0.5f) * Dmax);
-                  intrinsicDisto->setOffset(offset);
-
-                  std::vector<double> p;
-                  p.push_back(lensParam.fisheyeParams.RadialDistortParam1);
-                  p.push_back(lensParam.fisheyeParams.RadialDistortParam2);
-                  p.push_back(0.0);
-                  p.push_back(0.0);
-                  intrinsicDisto->setDistortionParams(p);
-
-                  ++lcpGeometryViewCount;
-              }
-          }
-          // set disto initialization mode
-          intrinsicDisto->setDistortionInitializationMode(camera::EInitMode::ESTIMATED);
-        }
-
-        if (lensParam.hasVignetteParams() && !lensParam.vignParams.isEmpty)
-        {
-            view.addMetadata("AliceVision:VignParamFocX", std::to_string(lensParam.vignParams.FocalLengthX));
-            view.addMetadata("AliceVision:VignParamFocY", std::to_string(lensParam.vignParams.FocalLengthY));
-            view.addMetadata("AliceVision:VignParamCenterX", std::to_string(lensParam.vignParams.ImageXCenter));
-            view.addMetadata("AliceVision:VignParamCenterY", std::to_string(lensParam.vignParams.ImageYCenter));
-            view.addMetadata("AliceVision:VignParam1", std::to_string(lensParam.vignParams.VignetteModelParam1));
-            view.addMetadata("AliceVision:VignParam2", std::to_string(lensParam.vignParams.VignetteModelParam2));
-            view.addMetadata("AliceVision:VignParam3", std::to_string(lensParam.vignParams.VignetteModelParam3));
-
-            ++lcpVignettingViewCount;
-        }
-    }
+    if (!lensParam.isEmpty())
+      ++lcpGeometryViewCount;
 
     std::shared_ptr<camera::IntrinsicsScaleOffset> intrinsic = std::dynamic_pointer_cast<camera::IntrinsicsScaleOffset>(intrinsicBase);
 
@@ -777,22 +643,8 @@ int aliceVision_main(int argc, char **argv)
     intrinsic->setInitializationMode(intrinsicInitMode);
 
     // Set sensor size
-    if (sensorHeight > 0.0) 
-    {
-      intrinsicBase->setSensorWidth(sensorWidth);
-      intrinsicBase->setSensorHeight(sensorHeight);
-    }
-    else 
-    {
-      if (imageRatio > 1.0) {
-        intrinsicBase->setSensorWidth(sensorWidth);
-        intrinsicBase->setSensorHeight(sensorWidth / imageRatio);
-      }
-      else {
-        intrinsicBase->setSensorWidth(sensorWidth);
-        intrinsicBase->setSensorHeight(sensorWidth * imageRatio);
-      }
-    }
+    intrinsicBase->setSensorWidth(sensorWidth);
+    intrinsicBase->setSensorHeight(sensorHeight);
 
     if(intrinsic && intrinsic->isValid())
     {
@@ -1036,7 +888,6 @@ int aliceVision_main(int argc, char **argv)
                           << "Check your input images metadata (brand, model, focal length, ...), more should be set and correct." << std::endl);
     return EXIT_FAILURE;
   }
-
 
   //Check unique frame id per rig element
   if (!rigHasUniqueFrameIds(sfmData))

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -537,7 +537,7 @@ int aliceVision_main(int argc, char **argv)
 
     if (imgFormat.compare("raw") == 0)
     {
-        // Store the color interpretation mode choosen for raw images in metadata,
+        // Store the color interpretation mode chosen for raw images in metadata,
         // so all future loads of this image will be interpreted in the same way.
         if (!dcpError)
         {

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -43,11 +43,13 @@ alicevision_add_software(aliceVision_imageProcessing
     FOLDER ${FOLDER_SOFTWARE_UTILS}
     LINKS aliceVision_system
         aliceVision_cmdline
+        aliceVision_sensorDB
         aliceVision_image
         aliceVision_feature
         aliceVision_sfm
         aliceVision_sfmData
         aliceVision_sfmDataIO
+		aliceVision_lensCorrectionProfile
         ${Boost_LIBRARIES}
 )
 

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -49,7 +49,7 @@ alicevision_add_software(aliceVision_imageProcessing
         aliceVision_sfm
         aliceVision_sfmData
         aliceVision_sfmDataIO
-		aliceVision_lensCorrectionProfile
+        aliceVision_lensCorrectionProfile
         ${Boost_LIBRARIES}
 )
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -406,7 +406,7 @@ void undistortVignetting(aliceVision::image::Image<aliceVision::image::RGBAfColo
     }
 }
 
-void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams& pParams, const std::map<std::string, std::string>& imageMetadata, std::shared_ptr<camera::IntrinsicBase> cam)
+void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams& pParams, std::map<std::string, std::string>& imageMetadata, std::shared_ptr<camera::IntrinsicBase> cam)
 {
     const unsigned int nchannels = 4;
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -412,7 +412,7 @@ void undistortVignetting(aliceVision::image::Image<aliceVision::image::RGBAfColo
     }
 }
 
-void undistordRectilinearGeometryLCP(const aliceVision::image::Image<aliceVision::image::RGBAfColor>& img,
+void undistortRectilinearGeometryLCP(const aliceVision::image::Image<aliceVision::image::RGBAfColor>& img,
                                      RectilinearModel& model,
                                      aliceVision::image::Image<aliceVision::image::RGBAfColor>& img_ud,
                                      const image::RGBAfColor fillcolor)
@@ -438,7 +438,7 @@ void undistordRectilinearGeometryLCP(const aliceVision::image::Image<aliceVision
 
                 // disto
                 float xd, yd;
-                model.distord(x, y, xd, yd);
+                model.distort(x, y, xd, yd);
 
                 // camera to image
                 const Vec2 distoPix(xd * scaleX + ppX, yd * scaleY + ppY);
@@ -452,11 +452,11 @@ void undistordRectilinearGeometryLCP(const aliceVision::image::Image<aliceVision
     }
 }
 
-void undistordChromaticAberrations(const aliceVision::image::Image<aliceVision::image::RGBAfColor>& img,
+void undistortChromaticAberrations(const aliceVision::image::Image<aliceVision::image::RGBAfColor>& img,
                                    RectilinearModel& greenModel, RectilinearModel& blueGreenModel,
                                    RectilinearModel& redGreenModel,
                                    aliceVision::image::Image<aliceVision::image::RGBAfColor>& img_ud,
-                                   const image::RGBAfColor fillcolor, bool undistordGeometry = false)
+                                   const image::RGBAfColor fillcolor, bool undistortGeometry = false)
 {
     if(!greenModel.isEmpty && greenModel.FocalLengthX != 0.0 && greenModel.FocalLengthY != 0.0)
     {
@@ -479,17 +479,17 @@ void undistordChromaticAberrations(const aliceVision::image::Image<aliceVision::
 
                 // disto
                 float xdRed,ydRed,xdGreen,ydGreen,xdBlue,ydBlue;
-                if(undistordGeometry)
+                if(undistortGeometry)
                 {
-                    greenModel.distord(x, y, xdGreen, ydGreen);
+                    greenModel.distort(x, y, xdGreen, ydGreen);
                 }
                 else
                 {
                     xdGreen = x;
                     ydGreen = y;
                 }
-                redGreenModel.distord(xdGreen, ydGreen, xdRed, ydRed);
-                blueGreenModel.distord(xdGreen, ydGreen, xdBlue, ydBlue);
+                redGreenModel.distort(xdGreen, ydGreen, xdRed, ydRed);
+                blueGreenModel.distort(xdGreen, ydGreen, xdBlue, ydBlue);
 
                 // camera to image
                 const Vec2 distoPixRed(xdRed * scaleX + ppX, ydRed * scaleY + ppY);
@@ -544,7 +544,7 @@ void processImage(image::Image<image::RGBAfColor>& image, ProcessingParams& pPar
         {
             const image::RGBAfColor FBLACK_A(.0f, .0f, .0f, 1.0f);
             image::Image<image::RGBAfColor> image_ud;
-            undistordChromaticAberrations(image, pParams.lensCorrection.caGModel, pParams.lensCorrection.caBGModel,
+            undistortChromaticAberrations(image, pParams.lensCorrection.caGModel, pParams.lensCorrection.caBGModel,
                                             pParams.lensCorrection.caRGModel, image_ud, FBLACK_A, false);
             image = image_ud;
         }

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -45,7 +45,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 2
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 3
 
 using namespace aliceVision;
 namespace po = boost::program_options;


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
In order to make the imageProcessing exec self sufficient for vignetting and geometry correction, the capability to manage Adobe LCP files has been duplicated from the cameraInit exec. As a consequence a code factorization between these two execs has been done. In addition, support of chromatic aberration correction using LCP model has been enabled.

In relation with Meshroom PR https://github.com/alicevision/Meshroom/pull/2042

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
- [X] Create a getSensorSize method in the View class.
- [X] Update the getViewIntrinsic function by adding a pointer on a LensParam parameter in the interface and by using this parameter to initialize the coefficients of the distortion model.
- [X] Create the addVignettingMetadata method in the View class for simplifying the cameraInit code.
- [X] Create the isEmpty method in the LensParam class.
- [X] Add chromatic aberrations correction (defringing) using LCP model.

## Implementation remarks

The getSensorSize method return a non null error code if the sensor size cannot be computed of if it is computed with some uncertainty. This is needed for statistics generation on the read image set by the cameraInit exec. Because this method is used in a parallelized loop within cameraInit, verbosity can be disabled.

A pointer instead of a reference is used in the interface of getViewIntrinsic for the LensParam parameter to make it optional.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

