### PR TITLE
Debug in camera object

### DIFF
--- a/src/aliceVision/camera/Equidistant.hpp
+++ b/src/aliceVision/camera/Equidistant.hpp
@@ -28,7 +28,10 @@ namespace camera {
 class EquiDistant : public IntrinsicsScaleOffsetDisto
 {
 public:
-    EquiDistant() = default;
+    EquiDistant() :
+    EquiDistant(1, 1, 1.0, 0.0, 0.0)
+    {
+    }
 
     EquiDistant(unsigned int w, unsigned int h,
                 double focalLengthPix,

--- a/src/aliceVision/camera/EquidistantRadial.hpp
+++ b/src/aliceVision/camera/EquidistantRadial.hpp
@@ -26,8 +26,6 @@ namespace camera {
 class EquiDistantRadialK3 : public EquiDistant
 {
 public:
-    EquiDistantRadialK3() = default;
-
     explicit EquiDistantRadialK3(int w, int h,
                                  double focalLengthPix,
                                  double offsetX, double offsetY,

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -26,8 +26,6 @@ namespace camera {
 class IntrinsicBase
 {
 public:
-    IntrinsicBase() = default;
-
     explicit IntrinsicBase(unsigned int width, unsigned int height, const std::string& serialNumber = "") :
         _w(width), _h(height), _serialNumber(serialNumber)
     {

--- a/src/aliceVision/camera/IntrinsicsScaleOffset.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffset.hpp
@@ -18,8 +18,6 @@ namespace camera {
 class IntrinsicsScaleOffset: public IntrinsicBase
 {
 public:
-    IntrinsicsScaleOffset() = default;
-
     IntrinsicsScaleOffset(unsigned int w, unsigned int h,
                           double scaleX, double scaleY,
                           double offsetX, double offsetY) :

--- a/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
@@ -23,7 +23,6 @@ namespace camera {
 class IntrinsicsScaleOffsetDisto : public IntrinsicsScaleOffset
 {
 public:
-    IntrinsicsScaleOffsetDisto() = default;
 
     IntrinsicsScaleOffsetDisto(unsigned int w, unsigned int h,
                                 double scaleX, double scaleY,

--- a/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicsScaleOffsetDisto.hpp
@@ -35,6 +35,30 @@ public:
     {
     }
 
+    IntrinsicsScaleOffsetDisto(const IntrinsicsScaleOffsetDisto &other) 
+    : 
+        IntrinsicsScaleOffset(other),
+        _distortionInitializationMode(other._distortionInitializationMode)
+    {
+        if (other._pDistortion)
+        {
+            _pDistortion = std::shared_ptr<Distortion>(other._pDistortion->clone());
+        }
+        else 
+        {
+            _pDistortion = nullptr;
+        }
+
+        if (other._pUndistortion)
+        {
+            _pUndistortion = std::shared_ptr<Undistortion>(other._pUndistortion->clone());
+        }
+        else 
+        {
+            _pUndistortion = nullptr;
+        }
+    }
+
     void assign(const IntrinsicBase& other) override
     {
         *this = dynamic_cast<const IntrinsicsScaleOffsetDisto&>(other);

--- a/src/aliceVision/camera/Pinhole.hpp
+++ b/src/aliceVision/camera/Pinhole.hpp
@@ -25,7 +25,10 @@ namespace camera {
 class Pinhole : public IntrinsicsScaleOffsetDisto
 {
 public:
-    Pinhole() = default;
+    Pinhole() :
+    Pinhole(1, 1, 1.0, 1.0, 0.0, 0.0)
+    {
+    }
 
     Pinhole(unsigned int w, unsigned int h, const Mat3& K) :
     IntrinsicsScaleOffsetDisto(w, h, K(0, 0), K(1, 1), K(0, 2), K(1, 2))

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -1181,7 +1181,9 @@ int main(int argc, char* argv[])
                                                           << intrinsic->getTypeStr()
                                                           << " to an EquiDistant camera model.");
                 // convert non-EquiDistant intrinsics to EquiDistant
-                std::shared_ptr<camera::EquiDistantRadialK3> newEquidistant(new camera::EquiDistantRadialK3());
+                std::shared_ptr<camera::EquiDistantRadialK3> newEquidistant =
+                    std::dynamic_pointer_cast<camera::EquiDistantRadialK3>(
+                        camera::createIntrinsic(camera::EINTRINSIC::EQUIDISTANT_CAMERA_RADIAL3));
 
                 newEquidistant->copyFrom(*intrinsicSO);
                 // "radius" and "center" will be set later from the input parameters in another loop


### PR DESCRIPTION
- PanoramaInit was using a default constructor to create fisheye. This default constructor was not creating the distortion object. Fisheye did not have distortion parameters.

- Make sure the cameras clone function is a deep copy and not a shallow copy (Distortion is now cloned instead of copied)