### PR TITLE
[fuseCut] Fix adding helper points

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -3064,11 +3064,16 @@ void DelaunayGraphCut::createDensePointCloud(const Point3d hexah[8], const Stati
 
   ALICEVISION_LOG_INFO("Creating dense point cloud.");
 
-  const float minDist = hexah ? (hexah[0] - hexah[1]).size() / 1000.0f : 0.00001f;
   const int helperPointsGridSize = _mp.userParams.get<int>("LargeScale.helperPointsGridSize", 10);
   const int densifyNbFront = _mp.userParams.get<int>("LargeScale.densifyNbFront", 0);
   const int densifyNbBack = _mp.userParams.get<int>("LargeScale.densifyNbBack", 0);
   const double densifyScale = _mp.userParams.get<double>("LargeScale.densifyScale", 1.0);
+
+  const float minDist =
+      hexah && (helperPointsGridSize >= 0)
+          ? ((hexah[0] - hexah[1]).size() + (hexah[0] - hexah[3]).size() + (hexah[0] - hexah[4]).size()) /
+                (3. * helperPointsGridSize)
+          : 0.00001f;
 
   // add points from depth maps
   if(depthMapsFuseParams != nullptr)

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -938,7 +938,7 @@ void DelaunayGraphCut::addGridHelperPoints(int helperPointsGridSize, const Point
     auto rand = std::bind(std::uniform_real_distribution<float>{0.0, 1.0}, generator);
 
     int addedPoints = 0;
-    float minDist2 = minDist * minDist;
+    const float minDist2 = minDist * minDist;
     Tree kdTree(_verticesCoords);
     for(int x = 0; x <= ns; ++x)
     {

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -3070,7 +3070,7 @@ void DelaunayGraphCut::createDensePointCloud(const Point3d hexah[8], const Stati
   const double densifyScale = _mp.userParams.get<double>("LargeScale.densifyScale", 1.0);
 
   const float minDist =
-      hexah && (helperPointsGridSize >= 0)
+      hexah && (helperPointsGridSize > 0)
           ? ((hexah[0] - hexah[1]).size() + (hexah[0] - hexah[3]).size() + (hexah[0] - hexah[4]).size()) /
                 (3. * helperPointsGridSize)
           : 0.00001f;

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -795,7 +795,7 @@ void DelaunayGraphCut::addPointsFromSfM(const Point3d hexah[8], const StaticVect
 void DelaunayGraphCut::addPointsFromCameraCenters(const StaticVector<int>& cams, float minDist)
 {
     int addedPoints = 0;
-    float minDist2 = minDist * minDist;
+    const float minDist2 = minDist * minDist;
     Tree kdTree(_verticesCoords);
     for(int camid = 0; camid < cams.size(); camid++)
     {
@@ -846,7 +846,7 @@ void DelaunayGraphCut::addPointsToPreventSingularities(const Point3d voxel[8], f
     fcg = (voxel[3] + voxel[2] + voxel[6] + voxel[7]) / 4.0f;
     extrPts[5] = fcg + (fcg - vcg) / 10.0f;
     int addedPoints = 0;
-    float minDist2 = minDist * minDist;
+    const float minDist2 = minDist * minDist;
     Tree kdTree(_verticesCoords);
     for(int i = 0; i < 6; i++)
     {

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.hpp
@@ -280,21 +280,7 @@ public:
         }
         return result;
     }
-
-    inline GEO::index_t locateNearestVertex(const Point3d& p) const
-    {
-        if(_tetrahedralization->nb_vertices() == 0)
-            return GEO::NO_VERTEX;
-        /*
-        GEO::index_t cellIndex = ((const GEO::Delaunay3d*)_tetrahedralization.get())->locate(p.m); // TODO GEOGRAM: how to??
-        if(cellIndex == NO_TETRAHEDRON)
-            return GEO::NO_VERTEX;
-
-        return nearestVertexInCell(cellIndex, p);
-        */
-        return _tetrahedralization->nearest_vertex(p.m); // TODO GEOGRAM: this is a brute force approach!
-    }
-
+    
     /**
      * @brief A cell is infinite if one of its vertices is infinite.
      */


### PR DESCRIPTION
- The computation of neighborhood when adding helper points was not functional since the tetrahedralization was not initialized with the vertices prior to this computation.
- KdTree is now used instead for computing the neighborhood (better performance)
- minDist (used in validating the helper points to add) now takes into consideration the helper points grid size and the three dimensions of the bounding box (instead of only one)