### PR TITLE
[mvsUtils] fix writing metadata for filtered depthmaps

### DIFF
--- a/src/aliceVision/mvsUtils/mapIO.cpp
+++ b/src/aliceVision/mvsUtils/mapIO.cpp
@@ -477,7 +477,7 @@ void writeMapToFileOrTile(int rc,
     }
 
     // min/max/nb depth metadata (for depth map only)
-    if(fileType == EFileType::depthMap)
+    if((fileType == EFileType::depthMap) || (fileType == EFileType::depthMapFiltered))
     {
         const int nbDepthValues = std::count_if(in_map.data(), in_map.data() + in_map.size(), [](float v) { return v > 0.0f; });
         float maxDepth = -1.0f;


### PR DESCRIPTION
minDepth and maxDepth were not being written for filtered depthmaps (see issue https://github.com/alicevision/AliceVision/issues/1466).

This PR should fix the issue (proposed by @gregoire-dl ).

closes https://github.com/alicevision/AliceVision/issues/1466