### PR TITLE
Noise reduction in HDR merging

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -127,9 +127,9 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
     return true;
 }
 
-void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
-                       std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
-                       const std::string& lumaStatFilepath, const double meanTargetedLuma, const double minLuma)
+int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
+                      std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
+                      const std::string& lumaStatFilepath, const double meanTargetedLuma, const double minLuma)
 {
     // If targetIndexesFilename cannot be opened or is not valid an error is thrown
     // For odd number, there is no ambiguity on the middle image.
@@ -239,7 +239,7 @@ void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVi
 
         out_targetViews.push_back(group[targetIndex]);
     }
-    return;
+    return targetIndex;
 }
 
 }

--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -129,7 +129,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
 
 int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
                       std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
-                      const std::string& lumaStatFilepath, const double meanTargetedLuma, const double minLuma)
+                      const std::string& lumaStatFilepath, const double meanTargetedLuma)
 {
     // If targetIndexesFilename cannot be opened or is not valid an error is thrown
     // For odd number, there is no ambiguity on the middle image.
@@ -198,7 +198,6 @@ int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVie
 
         double minDiffWithLumaTarget = 1000.0;
         targetIndex = 0;
-        int firstValidIndex = 0; // A valid index corresponds to a mean luminance higher than minLuma
 
         for (int k = 0; k < lastIdx; ++k)
         {
@@ -208,25 +207,8 @@ int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVie
                 minDiffWithLumaTarget = diffWithLumaTarget;
                 targetIndex = k;
             }
-            if (v_lumaMeanMean[k] < minLuma)
-            {
-                ++firstValidIndex;
-            }
         }
         ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter automaticaly set to " << targetIndex - middleIndex);
-
-        firstValidIndex = std::min<int>(firstValidIndex, targetIndex - 1);
-
-        ALICEVISION_LOG_INFO("Index of first image to be considered for merging: " << firstValidIndex);
-
-        if (firstValidIndex > 0)
-        {
-            for (auto& group : groups)
-            {
-                group.erase(group.begin(), group.begin() + firstValidIndex);
-            }
-            targetIndex -= firstValidIndex;
-        }
     }
 
     for (auto& group : groups)

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -93,11 +93,12 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
  * @param[in] targetIndexesFilename: in case offsetRefBracketIndex is out of range the number of views in a group target indexes can be read from a text file
  *                                   if the file cannot be read or does not contain the expected number of values (same as view group number) and
  *                                   if offsetRefBracketIndex is out of range the number of views then a clamped values of offsetRefBracketIndex is considered
+ * @return Index of the targetView
  */
-void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
-                       std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
-                       const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4,
-                       const double minLuma = 0.25);
+int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
+                      std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
+                      const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4,
+                      const double minLuma = 0.25);
 
 }
 }

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -94,7 +94,10 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
  *                                   if the file cannot be read or does not contain the expected number of values (same as view group number) and
  *                                   if offsetRefBracketIndex is out of range the number of views then a clamped values of offsetRefBracketIndex is considered
  */
-void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>> & out_targetViews, const std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex, const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4);
+void selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
+                       std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
+                       const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4,
+                       const double minLuma = 0.25);
 
 }
 }

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -97,8 +97,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
  */
 int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
                       std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
-                      const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4,
-                      const double minLuma = 0.25);
+                      const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4);
 
 }
 }

--- a/src/aliceVision/hdr/hdrMerge.cpp
+++ b/src/aliceVision/hdr/hdrMerge.cpp
@@ -47,7 +47,8 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
                         const rgbCurve &weight,
                         const rgbCurve &response,
                         image::Image<image::RGBfColor> &radiance,
-                        float targetCameraExposure)
+                        float targetCameraExposure,
+                        int refImageIndex)
 {
   //checks
   assert(!response.isEmpty());
@@ -72,6 +73,28 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
   rgbCurve weightLongestExposure = weight;
   weightLongestExposure.freezeFirstPartValues();
 
+  const std::string mergeInfoFilename = "C:/Temp/mergeInfo.csv";
+  std::ofstream file(mergeInfoFilename);
+
+  std::vector<double> v_minRatio;
+  std::vector<double> v_maxRatio;
+
+  // For each exposure except the longuest,
+  //   Compute a ratio between the next and the current exposure values.
+  //   Deduce a range of ratii that will be used for enabling input data.
+  // Duplicate the last range limits to associate it with the longuest exposure
+  for (std::size_t i = 0; i < times.size() - 1; i++)
+  {
+    const double refRatio = times[i + 1] / times[i];
+    v_minRatio.push_back(0.25 * refRatio);
+    v_maxRatio.push_back(1.75 * refRatio);
+  }
+  v_minRatio.push_back(v_minRatio.back());
+  v_maxRatio.push_back(v_maxRatio.back());
+
+  const double minValue = 0.05;
+  const double maxValue = 0.999;
+
   #pragma omp parallel for
   for(int y = 0; y < height; ++y)
   {
@@ -80,64 +103,164 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
       //for each pixels
       image::RGBfColor &radianceColor = radiance(y, x);
 
-      for(std::size_t channel = 0; channel < 3; ++channel)
+      //if ((x%1000 == 780) && (y%1000 == 446))
+      //{
+      //    if(!file)
+      //    {
+      //        ALICEVISION_LOG_WARNING("Unable to create file " << mergeInfoFilename << " for storing merging info.");
+      //    }
+      //    else
+      //    {
+      //        file << x << "," << y << std::endl;
+      //        file << "time,R,resp(R),coeff,resp(R)/time,G,resp(G),coeff,resp(G)/time,B,resp(B),coeff,resp(B)/time," << std::endl;
+      //        for(std::size_t i = 0; i < images.size(); i++)
+      //        {
+      //            const double time = times[i];
+      //            file << time << ",";
+      //            for(std::size_t channel = 0; channel < 3; ++channel)
+      //            {
+      //                const double value = images[i](y, x)(channel);
+      //                const double r = response(value, channel);
+      //                double w = std::max(0.001f, (i == 0) ? weightShortestExposure(value, channel)
+      //                                                     : (i == (images.size() - 1) ? weightLongestExposure(value, channel)
+      //                                                                                 : weight(value, channel)));
+
+      //                file << value << ",";
+      //                file << r << ",";
+      //                file << w << ",";
+      //                file << r/time << ",";
+      //            }
+      //            file << std::endl;
+      //        }
+
+      //    }
+      //}
+
+      const double meanValueHighExp = (images[images.size() - 1](y, x)(0) + images[images.size() - 1](y, x)(1) +
+                                       images[images.size() - 1](y, x)(2)) /
+                                      3.0;
+
+      const double noiseThreshold = 0.1;
+
+      if(meanValueHighExp < noiseThreshold) // Noise case
       {
-        double wsum = 0.0;
-        double wdiv = 0.0;
+          for(std::size_t channel = 0; channel < 3; ++channel)
+          {
+              radianceColor(channel) = targetCameraExposure * response(meanValueHighExp, channel) / times[images.size() - 1];
+          }
+      }
+      else
+      {
+          std::vector<std::vector<double>> vv_ratio;
+          std::vector<std::vector<double>> vv_coeff;
+          std::vector<std::vector<double>> vv_coeff_filt;
+          std::vector<double> v_sumCoeff;
+          std::vector<std::vector<double>> vv_normalizedValue;
 
-        // Merge shortest exposure
-        {
-            int exposureIndex = 0;
+          // Per channel, and per exposition compute a mixing coefficient and the ratio between linearized values at the next and the current exposure. 
+          // Keep the coeffcient if the computed ratio is in the predefined range and if the linearized input value is significant enough (higher than a threshold).
+          // To deal with highlights, keep the shortest exposure if the second one is saturated.
 
-            // for each image
-            const double value = images[exposureIndex](y, x)(channel);
-            const double time = times[exposureIndex];
-            //
-            // weightShortestExposure:          _______
-            //                          _______/
-            //                                0      1
-            double w = std::max(0.001f, weightShortestExposure(value, channel));
+          for(std::size_t channel = 0; channel < 3; ++channel)
+          {
+              std::vector<double> v_ratio;
+              std::vector<double> v_coeff;
+              std::vector<double> v_coeff_filt;
+              std::vector<double> v_normalizedValue;
 
-            const double r = response(value, channel);
+              {
+                  const double value = response(images[0](y, x)(channel), channel);
+                  const double ratio = (value > 0.0) ? response(images[1](y, x)(channel), channel) / value : 0.0;
+                  const double normalizedValue = value / times[0];
+                  double coeff = std::max(0.001f, weightShortestExposure(images[0](y, x)(channel), channel));
 
-            wsum += w * r / time;
-            wdiv += w;
-        }
-        // Merge intermediate exposures
-        for(std::size_t i = 1; i < images.size() - 1; ++i)
-        {
-          // for each image
-          const double value = images[i](y, x)(channel);
-          const double time = times[i];
-          //
-          // weight:          ____
-          //          _______/    \________
-          //                0      1
-          double w = std::max(0.001f, weight(value, channel));
+                  const bool coeffOK = (value > minValue && ratio > v_minRatio[0] && ratio < v_maxRatio[0]) ||
+                                       response(images[1](y, x)(channel), channel) > maxValue;
 
-          const double r = response(value, channel);
-          wsum += w * r / time;
-          wdiv += w;
-        }
-        // Merge longest exposure
-        {
-            int exposureIndex = images.size() - 1;
+                  v_normalizedValue.push_back(normalizedValue);
+                  v_ratio.push_back(ratio);
+                  v_coeff.push_back(coeff);
+                  v_coeff_filt.push_back(coeffOK ? coeff : 0.0);
+              }
 
-            // for each image
-            const double value = images[exposureIndex](y, x)(channel);
-            const double time = times[exposureIndex];
-            //
-            // weightLongestExposure:  ____________
-            //                                      \_______
-            //                                0      1
-            double w = std::max(0.001f, weightLongestExposure(value, channel));
+              for(std::size_t e = 1; e < images.size() - 1; e++)
+              {
+                  const double value = response(images[e](y, x)(channel), channel);
+                  const double normalizedValue = value / times[e];
+                  const double ratio = (value > 0.0) ? response(images[e + 1](y, x)(channel), channel) / value : 0.0;
+                  double coeff = std::max(0.001f, weight(value, channel));
 
-            const double r = response(value, channel);
+                  const bool coeffOK = (value > minValue && ratio > v_minRatio[e] && ratio < v_maxRatio[e]);
 
-            wsum += w * r / time;
-            wdiv += w;
-        }
-        radianceColor(channel) = wsum / std::max(0.001, wdiv) * targetCameraExposure;
+                  v_normalizedValue.push_back(normalizedValue);
+                  v_ratio.push_back(ratio);
+                  v_coeff.push_back(coeff);
+                  v_coeff_filt.push_back(coeffOK ? coeff : 0.0);
+              }
+
+              {
+                  const double value = response(images[images.size() - 1](y, x)(channel), channel);
+                  const double ratio = v_ratio.back();
+                  const double normalizedValue = value / times[images.size() - 1];
+                  double coeff = std::max(
+                      0.001f,
+                      weightLongestExposure(response(images[images.size() - 1](y, x)(channel), channel), channel));
+
+                  const bool coeffOK = (value < maxValue && ratio > v_minRatio[images.size() - 1] &&
+                                        ratio < v_maxRatio[images.size() - 1]);
+
+                  v_normalizedValue.push_back(normalizedValue);
+                  //v_ratio.push_back(ratio);
+                  v_coeff.push_back(coeff);
+                  v_coeff_filt.push_back(coeffOK ? coeff : 0.0);
+              }
+
+              //vv_ratio.push_back(v_ratio);
+              vv_coeff.push_back(v_coeff);
+              vv_coeff_filt.push_back(v_coeff_filt);
+              vv_normalizedValue.push_back(v_normalizedValue);
+          }
+
+          std::vector<std::vector<double>> vv_coeff_final = vv_coeff_filt;
+          v_sumCoeff = {0.0, 0.0, 0.0};
+
+          // Per exposure and per channel,
+          //   If the coeff has been discarded for the current channel but is valid for at least one of the two other channels, restore it's original value.
+          // Per channel, sum the valid coefficients.
+          for(std::size_t e = 0; e < images.size(); e++)
+          {
+              for(std::size_t channel = 0; channel < 3; ++channel)
+              {
+                  if(vv_coeff_final[channel][e] == 0.0 &&
+                     (vv_coeff_filt[(channel + 1) % 3][e] != 0.0 || vv_coeff_filt[(channel + 2) % 3][e] != 0.0))
+                  {
+                      vv_coeff_final[channel][e] = vv_coeff[channel][e];
+                  }
+                  v_sumCoeff[channel] += vv_coeff_final[channel][e];
+              }
+          }
+
+          // Per channel, if the sum of the coefficients is null, restore the coefficient corresponding to the reference image.
+          // Due to the previous step, if the sum of the coefficients is null for a given channel it should be also null for the two other channels.
+          if(v_sumCoeff[0] == 0.0)
+          {
+              for(std::size_t channel = 0; channel < 3; ++channel)
+              {
+                  vv_coeff_final[channel][refImageIndex] = 1.0;
+                  v_sumCoeff[channel] = 1.0;
+              }
+          }
+
+          // Compute the final result and adjust the exposure to the reference one.
+          for(std::size_t channel = 0; channel < 3; ++channel)
+          {
+                double v = 0.0;
+                for(std::size_t i = 0; i < images.size(); ++i)
+                {
+                    v += vv_coeff_final[channel][i] * vv_normalizedValue[channel][i];
+                }
+                radianceColor(channel) = targetCameraExposure * (v != 0.0 ? v : vv_normalizedValue[channel][refImageIndex]) / v_sumCoeff[channel];
+          }
       }
     }
   }
@@ -166,8 +289,8 @@ void hdrMerge::postProcessHighlight(const std::vector< image::Image<image::RGBfC
 
     // get images width, height
     const std::size_t width = inputImage.Width();
-    const std::size_t height = inputImage.Height();
 
+    const std::size_t height = inputImage.Height();
     image::Image<float> isPixelClamped(width, height);
 
 #pragma omp parallel for

--- a/src/aliceVision/hdr/hdrMerge.cpp
+++ b/src/aliceVision/hdr/hdrMerge.cpp
@@ -75,15 +75,12 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
   rgbCurve weightLongestExposure = weight;
   weightLongestExposure.freezeFirstPartValues();
 
-  //const std::string mergeInfoFilename = "C:/Temp/mergeInfo.csv";
-  //std::ofstream file(mergeInfoFilename);
-
-  const std::vector<double> v_minValue = {mergingParams.minSignificantValue * response(1.0, 0),
-                                          mergingParams.minSignificantValue * response(1.0, 1),
-                                          mergingParams.minSignificantValue * response(1.0, 2)};
-  const std::vector<double> v_maxValue = {mergingParams.maxSignificantValue * response(1.0, 0),
-                                          mergingParams.maxSignificantValue * response(1.0, 1),
-                                          mergingParams.maxSignificantValue * response(1.0, 2)};
+  const std::vector<double> v_minValue = {response(mergingParams.minSignificantValue, 0),
+                                          response(mergingParams.minSignificantValue, 1),
+                                          response(mergingParams.minSignificantValue, 2)};
+  const std::vector<double> v_maxValue = {response(mergingParams.maxSignificantValue, 0),
+                                          response(mergingParams.maxSignificantValue, 1),
+                                          response(mergingParams.maxSignificantValue, 2)};
 
   highLight.resize(width, height, true, image::RGBfColor(0.f, 0.f, 0.f));
   lowLight.resize(width, height, true, image::RGBfColor(0.f, 0.f, 0.f));
@@ -94,174 +91,107 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
   {
     for(int x = 0; x < width; ++x)
     {
-      //for each pixels
-      image::RGBfColor& radianceColor = radiance(y, x);
-      image::RGBfColor& highLightColor = highLight(y, x);
-      image::RGBfColor& lowLightColor = lowLight(y, x);
-      image::RGBfColor& noMidLightColor = noMidLight(y, x);
+        //for each pixels
+        image::RGBfColor& radianceColor = radiance(y, x);
+        image::RGBfColor& highLightColor = highLight(y, x);
+        image::RGBfColor& lowLightColor = lowLight(y, x);
+        image::RGBfColor& noMidLightColor = noMidLight(y, x);
 
-      //if ((x%1000 == 650) && (y%1000 == 850))
-      //{
-      //    if(!file)
-      //    {
-      //        ALICEVISION_LOG_WARNING("Unable to create file " << mergeInfoFilename << " for storing merging info.");
-      //    }
-      //    else
-      //    {
-      //        file << x << "," << y << std::endl;
-      //        file << "time,R,resp(R),coeff,resp(R)/time,G,resp(G),coeff,resp(G)/time,B,resp(B),coeff,resp(B)/time," << std::endl;
-      //        for(std::size_t i = 0; i < images.size(); i++)
-      //        {
-      //            const double time = times[i];
-      //            file << time << ",";
-      //            for(std::size_t channel = 0; channel < 3; ++channel)
-      //            {
-      //                const double value = images[i](y, x)(channel);
-      //                const double r = response(value, channel);
-      //                double w = std::max(0.001f, (i == 0) ? weightShortestExposure(value, channel)
-      //                                                     : (i == (images.size() - 1) ? weightLongestExposure(value, channel)
-      //                                                                                 : weight(value, channel)));
+        std::vector<std::vector<double>> vv_coeff;
+        std::vector<std::vector<double>> vv_value;
+        std::vector<std::vector<double>> vv_normalizedValue;
 
-      //                file << value << ",";
-      //                file << r << ",";
-      //                file << w << ",";
-      //                file << r/time << ",";
-      //            }
-      //            file << std::endl;
-      //        }
+        // Compute merging range
+        std::vector<int> v_firstIndex;
+        std::vector<int> v_lastIndex;
+        for(std::size_t channel = 0; channel < 3; ++channel)
+        {
+            int firstIndex = mergingParams.refImageIndex;
+            while(firstIndex > 0 && (response(images[firstIndex](y, x)(channel), channel) > v_minValue[channel] ||
+                                    firstIndex == images.size() - 1))
+            {
+                firstIndex--;
+            }
+            v_firstIndex.push_back(firstIndex);
 
-      //    }
-      //}
+            int lastIndex = v_firstIndex[channel] + 1;
+            while(lastIndex < images.size() - 1 && response(images[lastIndex](y, x)(channel), channel) < v_maxValue[channel])
+            {
+                lastIndex++;
+            }
+            v_lastIndex.push_back(lastIndex);
+        }
 
-      const double meanValueHighExp = (images[images.size() - 1](y, x)(0) + images[images.size() - 1](y, x)(1) +
-                                       images[images.size() - 1](y, x)(2)) /
-                                      3.0;
+        // Compute merging coeffs and values to be merged
+        for(std::size_t channel = 0; channel < 3; ++channel)
+        {
+            std::vector<double> v_coeff;
+            std::vector<double> v_normalizedValue;
+            std::vector<double> v_value;
 
-      if(meanValueHighExp < mergingParams.noiseThreshold) // Noise case
-      {
-          for(std::size_t channel = 0; channel < 3; ++channel)
-          {
-              radianceColor(channel) = mergingParams.targetCameraExposure * response(meanValueHighExp, channel) / times[images.size() - 1];
-              highLightColor(channel) = 0.0;
-              lowLightColor(channel) = 1.0;
-              noMidLightColor(channel) = 0.0;
-          }
-      }
-      else
-      {
-          std::vector<std::vector<double>> vv_coeff;
-          std::vector<std::vector<double>> vv_value;
-          std::vector<std::vector<double>> vv_normalizedValue;
+            for(std::size_t e = 0; e < images.size(); ++e)
+            {
+                const double value = images[e](y, x)(channel);
+                const double resp = response(value, channel);
+                const double normalizedValue = resp / times[e];
+                double coeff = std::max(0.001f, e == 0 ? weightShortestExposure(value, channel) :
+                                                        (e == images.size() - 1 ? weightLongestExposure(value, channel) :
+                                                                                  weight(value, channel)));
 
-          // Compute merging range
-          std::vector<int> v_firstIndex;
-          std::vector<int> v_lastIndex;
-          for(std::size_t channel = 0; channel < 3; ++channel)
-          {
-              int firstIndex = mergingParams.refImageIndex;
-              while(firstIndex > 0 && (response(images[firstIndex](y, x)(channel), channel) > v_minValue[channel] ||
-                                       firstIndex == images.size() - 1))
-              {
-                  firstIndex--;
-              }
-              v_firstIndex.push_back(firstIndex);
+                v_value.push_back(value);
+                v_normalizedValue.push_back(normalizedValue);
+                v_coeff.push_back(coeff);
+            }
 
-              int lastIndex = v_firstIndex[channel] + 1;
-              while(lastIndex < images.size() - 1 && response(images[lastIndex](y, x)(channel), channel) < v_maxValue[channel])
-              {
-                  lastIndex++;
-              }
-              v_lastIndex.push_back(lastIndex);
-          }
+            vv_coeff.push_back(v_coeff);
+            vv_normalizedValue.push_back(v_normalizedValue);
+            vv_value.push_back(v_value);
+        }
 
-          // Compute merging coeffs and values to be merged
-          for(std::size_t channel = 0; channel < 3; ++channel)
-          {
-              std::vector<double> v_coeff;
-              std::vector<double> v_normalizedValue;
-              std::vector<double> v_value;
+        // Compute light masks if required (monitoring and debug purposes)
+        if(mergingParams.computeLightMasks)
+        {
+            for(std::size_t channel = 0; channel < 3; ++channel)
+            {
+                int idxMaxValue = 0;
+                int idxMinValue = 0;
+                double maxValue = 0.0;
+                double minValue = 10000.0;
+                bool jump = true;
+                for(std::size_t e = 0; e < images.size(); ++e)
+                {
+                    if(vv_value[channel][e] > maxValue)
+                    {
+                        maxValue = vv_value[channel][e];
+                        idxMaxValue = e;
+                    }
+                    if(vv_value[channel][e] < minValue)
+                    {
+                        minValue = vv_value[channel][e];
+                        idxMinValue = e;
+                    }
+                    jump = jump && ((vv_value[channel][e] < mergingParams.minSignificantValue && e < images.size() - 1) ||
+                                    (vv_value[channel][e] > mergingParams.maxSignificantValue && e > 0));
+                }
+                highLightColor(channel) = minValue > mergingParams.maxSignificantValue ? 1.0 : 0.0;
+                lowLightColor(channel) = maxValue < mergingParams.minSignificantValue ? 1.0 : 0.0;
+                noMidLightColor(channel) = jump ? 1.0 : 0.0;
+            }
+        }
 
-              {
-                  const double value = response(images[0](y, x)(channel), channel);
-                  const double normalizedValue = value / times[0];
-                  double coeff = std::max(0.001f, weightShortestExposure(value, channel));
-
-                  v_value.push_back(value);
-                  v_normalizedValue.push_back(normalizedValue);
-                  v_coeff.push_back(coeff);
-              }
-
-              for(std::size_t e = 1; e < images.size() - 1; e++)
-              {
-                  const double value = response(images[e](y, x)(channel), channel);
-                  const double normalizedValue = value / times[e];
-                  double coeff = std::max(0.001f, weight(value, channel));
-
-                  v_value.push_back(value);
-                  v_normalizedValue.push_back(normalizedValue);
-                  v_coeff.push_back(coeff);
-              }
-
-              {
-                  const double value = response(images[images.size() - 1](y, x)(channel), channel);
-                  const double normalizedValue = value / times[images.size() - 1];
-                  double coeff = std::max(0.001f, weightLongestExposure(value, channel));
-
-                  v_value.push_back(value);
-                  v_normalizedValue.push_back(normalizedValue);
-                  v_coeff.push_back(coeff);
-              }
-
-              vv_coeff.push_back(v_coeff);
-              vv_normalizedValue.push_back(v_normalizedValue);
-              vv_value.push_back(v_value);
-          }
-
-          // Compute light masks if required (monitoring and debug purposes)
-          if(mergingParams.computeLightMasks)
-          {
-              for(std::size_t channel = 0; channel < 3; ++channel)
-              {
-                  int idxMaxValue = 0;
-                  int idxMinValue = 0;
-                  double maxValue = 0.0;
-                  double minValue = 10000.0;
-                  bool jump = true;
-                  for(std::size_t e = 0; e < images.size(); ++e)
-                  {
-                      if(vv_value[channel][e] > maxValue)
-                      {
-                          maxValue = vv_value[channel][e];
-                          idxMaxValue = e;
-                      }
-                      if(vv_value[channel][e] < minValue)
-                      {
-                          minValue = vv_value[channel][e];
-                          idxMinValue = e;
-                      }
-                      jump = jump && ((vv_value[channel][e] < 0.1 && e < images.size() - 1) ||
-                                      (vv_value[channel][e] > 0.9 && e > 0));
-                  }
-                  highLightColor(channel) = minValue > 0.9 ? 1.0 : 0.0;
-                  lowLightColor(channel) = maxValue < 0.1 ? 1.0 : 0.0;
-                  noMidLightColor(channel) = jump ? 1.0 : 0.0;
-              }
-          }
-
-          // Compute the final result and adjust the exposure to the reference one.
-          for(std::size_t channel = 0; channel < 3; ++channel)
-          {
-              double v = 0.0;
-              double sumCoeff = 0.0;
-              for(std::size_t i = v_firstIndex[channel]; i <= v_lastIndex[channel]; ++i)
-              {
-                  v += vv_coeff[channel][i] * vv_normalizedValue[channel][i];
-                  sumCoeff += vv_coeff[channel][i];
-              }
-              radianceColor(channel) = mergingParams.targetCameraExposure *
-                                       (sumCoeff != 0.0 ? v / sumCoeff : vv_normalizedValue[channel][mergingParams.refImageIndex]);
-          }
-      }
+        // Compute the final result and adjust the exposure to the reference one.
+        for(std::size_t channel = 0; channel < 3; ++channel)
+        {
+            double v = 0.0;
+            double sumCoeff = 0.0;
+            for(std::size_t i = v_firstIndex[channel]; i <= v_lastIndex[channel]; ++i)
+            {
+                v += vv_coeff[channel][i] * vv_normalizedValue[channel][i];
+                sumCoeff += vv_coeff[channel][i];
+            }
+            radianceColor(channel) = mergingParams.targetCameraExposure *
+                                    (sumCoeff != 0.0 ? v / sumCoeff : vv_normalizedValue[channel][mergingParams.refImageIndex]);
+        }
     }
   }
 }

--- a/src/aliceVision/hdr/hdrMerge.cpp
+++ b/src/aliceVision/hdr/hdrMerge.cpp
@@ -78,8 +78,12 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
   //const std::string mergeInfoFilename = "C:/Temp/mergeInfo.csv";
   //std::ofstream file(mergeInfoFilename);
 
-  const double minValue = mergingParams.minSignificantValue;
-  const double maxValue = mergingParams.maxSignificantValue;
+  const std::vector<double> v_minValue = {mergingParams.minSignificantValue * response(1.0, 0),
+                                          mergingParams.minSignificantValue * response(1.0, 1),
+                                          mergingParams.minSignificantValue * response(1.0, 2)};
+  const std::vector<double> v_maxValue = {mergingParams.maxSignificantValue * response(1.0, 0),
+                                          mergingParams.maxSignificantValue * response(1.0, 1),
+                                          mergingParams.maxSignificantValue * response(1.0, 2)};
 
   highLight.resize(width, height, true, image::RGBfColor(0.f, 0.f, 0.f));
   lowLight.resize(width, height, true, image::RGBfColor(0.f, 0.f, 0.f));
@@ -155,15 +159,15 @@ void hdrMerge::process(const std::vector< image::Image<image::RGBfColor> > &imag
           for(std::size_t channel = 0; channel < 3; ++channel)
           {
               int firstIndex = mergingParams.refImageIndex;
-              while(firstIndex > 0 &&
-                    (response(images[firstIndex](y, x)(channel), channel) > 0.05 || firstIndex == images.size() - 1))
+              while(firstIndex > 0 && (response(images[firstIndex](y, x)(channel), channel) > v_minValue[channel] ||
+                                       firstIndex == images.size() - 1))
               {
                   firstIndex--;
               }
               v_firstIndex.push_back(firstIndex);
 
               int lastIndex = v_firstIndex[channel] + 1;
-              while(lastIndex < images.size() - 1 && response(images[lastIndex](y, x)(channel), channel) < 0.995)
+              while(lastIndex < images.size() - 1 && response(images[lastIndex](y, x)(channel), channel) < v_maxValue[channel])
               {
                   lastIndex++;
               }

--- a/src/aliceVision/hdr/hdrMerge.hpp
+++ b/src/aliceVision/hdr/hdrMerge.hpp
@@ -29,7 +29,8 @@ public:
                 const rgbCurve &weight,
                 const rgbCurve &response,
                 image::Image<image::RGBfColor> &radiance,
-                float targetCameraExposure);
+                float targetCameraExposure,
+                int refImageIndex);
 
   void postProcessHighlight(const std::vector< image::Image<image::RGBfColor> > &images,
       const std::vector<double> &times,

--- a/src/aliceVision/hdr/hdrMerge.hpp
+++ b/src/aliceVision/hdr/hdrMerge.hpp
@@ -12,6 +12,16 @@
 
 namespace aliceVision {
 namespace hdr {
+
+struct MergingParams
+{
+    double minSignificantValue = 0.05;
+    double maxSignificantValue = 0.999;
+    double dataRatioTolerance = 0.75; // +/- 75%
+    double noiseThreshold = 0.1;
+    float targetCameraExposure;
+    int refImageIndex;
+};
  
 class hdrMerge {
 public:
@@ -24,13 +34,9 @@ public:
    * @param targetCameraExposure
    * @param response
    */
-  void process(const std::vector< image::Image<image::RGBfColor> > &images,
-                const std::vector<double> &times,
-                const rgbCurve &weight,
-                const rgbCurve &response,
-                image::Image<image::RGBfColor> &radiance,
-                float targetCameraExposure,
-                int refImageIndex);
+    void process(const std::vector<image::Image<image::RGBfColor>>& images, const std::vector<double>& times,
+                 const rgbCurve& weight, const rgbCurve& response, image::Image<image::RGBfColor>& radiance,
+                 MergingParams& mergingParams);
 
   void postProcessHighlight(const std::vector< image::Image<image::RGBfColor> > &images,
       const std::vector<double> &times,

--- a/src/aliceVision/hdr/hdrMerge.hpp
+++ b/src/aliceVision/hdr/hdrMerge.hpp
@@ -17,7 +17,6 @@ struct MergingParams
 {
     double minSignificantValue = 0.05;
     double maxSignificantValue = 0.995;
-    double noiseThreshold = 0.1;
     float targetCameraExposure;
     int refImageIndex;
     bool computeLightMasks = false;

--- a/src/aliceVision/hdr/hdrMerge.hpp
+++ b/src/aliceVision/hdr/hdrMerge.hpp
@@ -16,11 +16,11 @@ namespace hdr {
 struct MergingParams
 {
     double minSignificantValue = 0.05;
-    double maxSignificantValue = 0.999;
-    double dataRatioTolerance = 0.75; // +/- 75%
+    double maxSignificantValue = 0.995;
     double noiseThreshold = 0.1;
     float targetCameraExposure;
     int refImageIndex;
+    bool computeLightMasks = false;
 };
  
 class hdrMerge {
@@ -36,6 +36,7 @@ public:
    */
     void process(const std::vector<image::Image<image::RGBfColor>>& images, const std::vector<double>& times,
                  const rgbCurve& weight, const rgbCurve& response, image::Image<image::RGBfColor>& radiance,
+                 image::Image<image::RGBfColor>& lowLight, image::Image<image::RGBfColor>& highLight, image::Image<image::RGBfColor>& noMidLight,
                  MergingParams& mergingParams);
 
   void postProcessHighlight(const std::vector< image::Image<image::RGBfColor> > &images,

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -79,7 +79,6 @@ int aliceVision_main(int argc, char** argv)
     int channelQuantizationPower = 10;
     int offsetRefBracketIndex = 1000; // By default, use the automatic selection
     double meanTargetedLumaForMerging = 0.4;
-    double noiseThreshold = 0.1;
     double minSignificantValue = 0.05;
     double maxSignificantValue = 0.995;
     bool computeLightMasks = false;
@@ -122,8 +121,6 @@ int aliceVision_main(int argc, char** argv)
          "Zero to use the center bracket. +N to use a more exposed bracket or -N to use a less exposed backet.")
         ("meanTargetedLumaForMerging", po::value<double>(&meanTargetedLumaForMerging)->default_value(meanTargetedLumaForMerging),
          "Mean expected luminance after merging step when input LDR images are decoded in sRGB color space. Must be in the range [0, 1].")
-        ("noiseThreshold", po::value<double>(&noiseThreshold)->default_value(noiseThreshold),
-         "Value under which input channel value is considered as noise. Used in advanced pixelwise merging.")
         ("minSignificantValue", po::value<double>(&minSignificantValue)->default_value(minSignificantValue),
          "Minimum channel input value to be considered in advanced pixelwise merging. Used in advanced pixelwise merging.")
         ("maxSignificantValue", po::value<double>(&maxSignificantValue)->default_value(maxSignificantValue),
@@ -377,7 +374,6 @@ int aliceVision_main(int argc, char** argv)
             hdr::MergingParams mergingParams;
             mergingParams.targetCameraExposure = targetCameraSetting.getExposure();
             mergingParams.refImageIndex = estimatedTargetIndex;
-            mergingParams.noiseThreshold = noiseThreshold;
             mergingParams.minSignificantValue = minSignificantValue;
             mergingParams.maxSignificantValue = maxSignificantValue;
             mergingParams.computeLightMasks = computeLightMasks;
@@ -393,35 +389,6 @@ int aliceVision_main(int argc, char** argv)
             // Nothing to do
             HDRimage = images[0];
         }
-
-        //for (int x = 252; x < 7000; x += 1000)
-        //{
-        //    for (int y = 750; y < 4000; y += 1000)
-        //    {
-        //        for(int l = x - 10; l <= x + 11; l++)
-        //        {
-        //            image::RGBfColor& pix1 = HDRimage(y - 10, l);
-        //            pix1[0] = 1.f;
-        //            pix1[1] = 0.f;
-        //            pix1[2] = 0.f;
-        //            image::RGBfColor& pix2 = HDRimage(y + 11, l);
-        //            pix2[0] = 1.f;
-        //            pix2[1] = 0.f;
-        //            pix2[2] = 0.f;
-        //        }
-        //        for(int c = y - 10; c <= y + 11; c++)
-        //        {
-        //            image::RGBfColor& pix1 = HDRimage(c, x - 10);
-        //            pix1[0] = 1.f;
-        //            pix1[1] = 0.f;
-        //            pix1[2] = 0.f;
-        //            image::RGBfColor& pix2 = HDRimage(c, x + 11);
-        //            pix2[0] = 1.f;
-        //            pix2[1] = 0.f;
-        //            pix2[2] = 0.f;
-        //        }
-        //    }
-        //}
 
         boost::filesystem::path p(targetView->getImagePath());
         const std::string hdrImagePath = getHdrImagePath(outputPath, g, keepSourceImageName ? p.stem().string() : "");

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -64,6 +64,7 @@ int aliceVision_main(int argc, char** argv)
     int channelQuantizationPower = 10;
     int offsetRefBracketIndex = 1000; // By default, use the automatic selection
     double meanTargetedLumaForMerging = 0.4;
+    double minLumaForMerging = 0.25;
     image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB;
 
     hdr::EFunctionType fusionWeightFunction = hdr::EFunctionType::GAUSSIAN;
@@ -103,6 +104,8 @@ int aliceVision_main(int argc, char** argv)
          "Zero to use the center bracket. +N to use a more exposed bracket or -N to use a less exposed backet.")
         ("meanTargetedLumaForMerging", po::value<double>(&meanTargetedLumaForMerging)->default_value(meanTargetedLumaForMerging),
          "Mean expected luminance after merging step when input LDR images are decoded in sRGB color space. Must be in the range [0, 1].")
+        ("minLumaForMerging", po::value<double>(&minLumaForMerging)->default_value(minLumaForMerging),
+         "Minimum mean luminance of LDR images for merging. Must be in the range [0, 1].")
         ("highlightTargetLux", po::value<float>(&highlightTargetLux)->default_value(highlightTargetLux),
          "Highlights maximum luminance.")
         ("highlightCorrectionFactor", po::value<float>(&highlightCorrectionFactor)->default_value(highlightCorrectionFactor),
@@ -214,8 +217,9 @@ int aliceVision_main(int argc, char** argv)
         if (workingColorSpace != image::EImageColorSpace::SRGB)
         {
             meanTargetedLumaForMerging = std::pow((meanTargetedLumaForMerging + 0.055) / 1.055, 2.2);
+            minLumaForMerging = std::pow((minLumaForMerging + 0.055) / 1.055, 2.2);
         }
-        hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, lumaStatFilepath.string(), meanTargetedLumaForMerging);
+        hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, lumaStatFilepath.string(), meanTargetedLumaForMerging, minLumaForMerging);
 
         if ((targetViews.empty() || targetViews.size() != groupedViews.size()) && !isOffsetRefBracketIndexValid)
         {


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Update the HDR merging algorithm to reduce the resulting noise when the majority of the original LDR images are under exposed and very dark.
Optionally compute and output 3 light mask (darklights, highlights, no midlights) for the purpose of the LDR stack of views analysis.

linked to https://github.com/alicevision/Meshroom/pull/2072

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
- [X] Update the interface of the selectTargetView function by returning the index of the selected reference view.
- [X] Add 2 new parameters (min and max significant values) in the main LDR_to_HDR_merge executable.
- [X] Update hdr process method with the new algorithm.
- [X] Output 3 light masks (darklights, highlights, no midlights).

## Implementation remarks

The main idea of the algorithm update is to determine for each channel of each pixel an optimal set of views to be merged. Assuming that the views are sorted from the shortest to the longest exposure (from the darkest to the brightest views) and a reference view has been selected, starting from the index of the reference view the index to start is decremented while the channel value is higher than the minimum significant value. Starting from the computed first index incremented by 1, the last index is incremented while the channel value is lower than the maximum significant value.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

