### PR TITLE
Pose3 internal representation

### DIFF
--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -26,6 +26,7 @@ alicevision_add_library(aliceVision_geometry
 # Unit tests
 alicevision_add_test(rigidTransformation3D_test.cpp NAME "geometry_rigidTransformation3D" LINKS aliceVision_geometry)
 alicevision_add_test(halfSpaceIntersection_test.cpp NAME "geometry_halfSpaceIntersection" LINKS aliceVision_geometry)
+alicevision_add_test(Pose3d_test.cpp NAME "geometry_pose3D" LINKS aliceVision_geometry)
 alicevision_add_test(frustumIntersection_test.cpp
   NAME "geometry_frustumIntersection"
   LINKS aliceVision_geometry

--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -5,6 +5,7 @@ set(geometry_files_headers
     Pose3.hpp
     rigidTransformation3D.hpp
     Similarity3.hpp
+    lie.hpp
 )
 
 # Sources

--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -2,10 +2,10 @@
 set(geometry_files_headers
     Frustum.hpp
     HalfPlane.hpp
+    lie.hpp
     Pose3.hpp
     rigidTransformation3D.hpp
     Similarity3.hpp
-    lie.hpp
 )
 
 # Sources

--- a/src/aliceVision/geometry/Pose3.hpp
+++ b/src/aliceVision/geometry/Pose3.hpp
@@ -22,8 +22,9 @@ class Pose3
     Vec3 _center;
 
   public:
-    // Constructors
+    
     Pose3() : _rotation(Mat3::Identity()), _center(Vec3::Zero()) {}
+
     Pose3(const Mat3& r, const Vec3& c) : _rotation(r), _center(c) {}
     Pose3(const Mat34& Rt)
     : _rotation(Rt.block<3,3>(0,0))
@@ -113,12 +114,9 @@ inline Pose3 poseFromRT(const Mat3& R, const Vec3& t)
 
 inline Pose3 randomPose()
 {
-    using namespace Eigen;
-    Vec3 rAngles = Vec3::Random() * boost::math::constants::pi<double>();
-    Mat3 R(AngleAxisd(rAngles(0), Vec3::UnitZ())
-          * AngleAxisd(rAngles(1), Vec3::UnitY())
-          * AngleAxisd(rAngles(2), Vec3::UnitZ()));
-    return geometry::Pose3(R, Vec3::Random());
+    Vec3 vecR = Vec3::Random().normalized() * boost::math::constants::pi<double>();
+    
+    return geometry::Pose3(SO3::expm(vecR), Vec3::Random());
 }
 
 } // namespace geometry

--- a/src/aliceVision/geometry/Pose3.hpp
+++ b/src/aliceVision/geometry/Pose3.hpp
@@ -1,5 +1,5 @@
 // This file is part of the AliceVision project.
-// Copyright (c) 2016 AliceVision contributors.
+// Copyright (c) 2023 AliceVision contributors.
 // Copyright (c) 2012 openMVG contributors.
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -9,6 +9,7 @@
 
 #include <aliceVision/numeric/numeric.hpp>
 #include <boost/math/constants/constants.hpp>
+
 
 namespace aliceVision {
 namespace geometry {
@@ -33,10 +34,15 @@ class Pose3
 
     // Accessors
     const Mat3& rotation() const { return _rotation; }
-    Mat3& rotation() { return _rotation; }
+    void setRotation(const Mat3 & rotation) 
+    {
+        _rotation = rotation;
+    }
     const Vec3& center() const { return _center; }
-    Vec3& center() { return _center; }
-
+    void setCenter(const Vec3 & center) 
+    {
+        _center = center;
+    }
     // Translation vector t = -RC
     inline Vec3 translation() const { return -(_rotation * _center); }
 

--- a/src/aliceVision/geometry/Pose3.hpp
+++ b/src/aliceVision/geometry/Pose3.hpp
@@ -1,5 +1,5 @@
 // This file is part of the AliceVision project.
-// Copyright (c) 2023 AliceVision contributors.
+// Copyright (c) 2016 AliceVision contributors.
 // Copyright (c) 2012 openMVG contributors.
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -18,25 +18,20 @@ namespace geometry {
 // Define a 3D Pose as a SE3 matrix
 class Pose3
 {
-  protected:
-    SE3::Matrix _homogeneous;
+protected:
+    SE3::Matrix _homogeneous{SE3::Matrix::Identity()};
 
-  public:
+public:
+    Pose3() = default;
 
-    Pose3() : _homogeneous(SE3::Matrix::Identity())
-    {
-
-    }
-
-    Pose3(const Mat3& c_R_w, const Vec3& w_c) 
+    Pose3(const Mat3& c_R_w, const Vec3& w_c)
     {
         _homogeneous.setIdentity();
         _homogeneous.block<3, 3>(0, 0) = c_R_w;
         _homogeneous.block<3, 1>(0, 3) = - c_R_w * w_c;
     }
 
-    Pose3(const Mat4 & T)
-    : _homogeneous(T)
+    Pose3(const Mat4& T) : _homogeneous(T)
     {
     }
 
@@ -46,22 +41,22 @@ class Pose3
         return _homogeneous.block<3, 3>(0, 0); 
     }
 
-    void setRotation(const Mat3 & rotation) 
+    void setRotation(const Mat3& rotation)
     {
         _homogeneous.block<3, 3>(0, 0) = rotation;
     }
 
-    Vec3 translation() const 
+    Vec3 translation() const
     { 
         return _homogeneous.block<3, 1>(0, 3); 
     }
 
-    Vec3 center() const 
+    Vec3 center() const
     { 
         return - rotation().transpose() * translation(); 
     }
 
-    void setCenter(const Vec3 & center) 
+    void setCenter(const Vec3& center)
     {
         _homogeneous.block<3, 1>(0, 3) = - rotation() * center;
     }
@@ -69,48 +64,48 @@ class Pose3
     // Apply pose
     inline Mat3X operator () (const Mat3X& p) const
     {
-      return rotation() * (p.colwise() - center());
+        return rotation() * (p.colwise() - center());
     }
 
     // Composition
     Pose3 operator * (const Pose3& P) const
     {
-      return Pose3(_homogeneous * P._homogeneous);
+        return Pose3(_homogeneous * P._homogeneous);
     }
 
     // Operator ==
     bool operator==(const Pose3& other) const
     {
-      return AreMatNearEqual(rotation(), other.rotation(), 1e-6) &&
-              AreVecNearEqual(center(), other.center(), 1e-6);
+        return AreMatNearEqual(rotation(), other.rotation(), 1e-6) &&
+               AreVecNearEqual(center(), other.center(), 1e-6);
     }
 
     // Inverse
     Pose3 inverse() const
     {
-      // parameter is center ... which will inverse
-      return Pose3(rotation().transpose(),  translation() );
+        // parameter is center ... which will inverse
+        return Pose3(rotation().transpose(),  translation() );
     }
 
     /// Return the depth (distance) of a point respect to the camera center
-    double depth(const Vec3 &X) const
+    double depth(const Vec3& X) const
     {
-      return (rotation() * (X - center()))[2];
+        return (rotation() * (X - center()))[2];
     }
 
     /// Return the pose with the Scale, Rotation and translation applied.
-    Pose3 transformSRt(const double S, const Mat3 & R, const Vec3 & t) const
+    Pose3 transformSRt(const double S, const Mat3& R, const Vec3& t) const
     {
-      Pose3 pose;
-      pose.setCenter(S * R * center() + t);
-      pose.setRotation(rotation() * R.transpose());
+        Pose3 pose;
+        pose.setCenter(S * R * center() + t);
+        pose.setRotation(rotation() * R.transpose());
 
-      return pose;
+        return pose;
     }
 
     const SE3::Matrix & getHomogeneous() const 
     {
-      return _homogeneous;
+        return _homogeneous;
     }
 
 public:
@@ -125,7 +120,7 @@ public:
  */
 inline Pose3 poseFromRT(const Mat3& R, const Vec3& t) 
 {
-  return Pose3(R, -R.transpose()*t);
+    return Pose3(R, -R.transpose() * t);
 }
 
 inline Pose3 randomPose()

--- a/src/aliceVision/geometry/Pose3d_test.cpp
+++ b/src/aliceVision/geometry/Pose3d_test.cpp
@@ -1,0 +1,205 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE Pose3d
+
+#include <aliceVision/geometry/Pose3.hpp>
+#include <aliceVision/unitTest.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+using namespace aliceVision;
+
+BOOST_AUTO_TEST_CASE(DefaultConstructorTest)
+{
+    geometry::Pose3 pose;
+    const double precision{1e-5};
+    EXPECT_MATRIX_NEAR(pose.rotation(), Mat3::Identity(), precision);
+    EXPECT_MATRIX_NEAR(pose.center(), Vec3::Zero(), precision);
+    EXPECT_MATRIX_NEAR(pose.translation(), Vec3::Zero(), precision);
+}
+
+BOOST_AUTO_TEST_CASE(ConstructorTest)
+{
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    //  rotation << 1, 0, 0,
+    //              0, 1, 0,
+    //              0, 0, 1;
+    const Vec3 center(-1.34, 2.432, 3.396);
+    const double precision{1e-5};
+
+    geometry::Pose3 pose(rotation, center);
+
+    EXPECT_MATRIX_NEAR(pose.rotation(), rotation, precision);
+    EXPECT_MATRIX_NEAR(pose.center(), center, precision);
+    EXPECT_MATRIX_NEAR(pose.translation(), Vec3(-rotation*center), precision);
+}
+
+BOOST_AUTO_TEST_CASE(RotationAccessorsTest)
+{
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const double precision{1e-5};
+    geometry::Pose3 pose;
+    pose.setRotation(rotation);
+
+    EXPECT_MATRIX_NEAR(pose.rotation(), rotation, precision);
+}
+
+BOOST_AUTO_TEST_CASE(CenterAccessorsTest)
+{
+    const double precision{1e-5};
+    const Vec3 center(-1.34, 2.432, 3.396);
+
+    geometry::Pose3 pose;
+    pose.setCenter(center);
+
+    EXPECT_MATRIX_NEAR(pose.center(), center, precision);
+}
+
+BOOST_AUTO_TEST_CASE(TranslationTest)
+{
+    const double precision{1e-5};
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const Vec3 center(-1.34, 2.432, 3.396);
+    const Vec3 translation = -rotation * center;
+
+    geometry::Pose3 pose(rotation, center);
+
+    EXPECT_MATRIX_NEAR(pose.translation(), translation, precision);
+}
+
+BOOST_AUTO_TEST_CASE(ApplyPoseTest)
+{
+    const double precision{1e-5};
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const Vec3 center(-1.34, 2.432, 3.396);
+    const Vec3 translation = -rotation * center;
+
+    const Mat4 transform = Eigen::Affine3d(Eigen::Translation3d(translation) * rotation).matrix();
+
+    const geometry::Pose3 pose(rotation, center);
+
+    const Mat3X points = Mat3X::Random(3, 10);
+
+    const Mat3X result = pose(points);
+
+    const Mat3X expected = (transform * points.colwise().homogeneous()).colwise().hnormalized();
+
+    EXPECT_MATRIX_NEAR(result, expected, precision);
+}
+
+BOOST_AUTO_TEST_CASE(CompositionTest)
+{
+    const double precision{1e-5};
+    const Mat3 rotation1 = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const Vec3 center1(-1.34, 2.432, 3.396);
+    const Vec3 translation1 = -rotation1 * center1;
+    const Mat4 homogeneous1 = Eigen::Affine3d(Eigen::Translation3d(translation1) * rotation1).matrix();
+
+    const Mat3 rotation2 = Eigen::AngleAxisd(-0.965, Vec3(-0.034, 1, 0.2).normalized()).toRotationMatrix();
+    const Vec3 center2(10.4, -25.2, 9.5);
+    const Vec3 translation2 = -rotation2 * center2;
+    const Mat4 homogeneous2 = Eigen::Affine3d(Eigen::Translation3d(translation2) * rotation2).matrix();
+
+    const geometry::Pose3 pose1(rotation1, center1);
+    const geometry::Pose3 pose2(rotation2, center2);
+
+    const geometry::Pose3 result = pose1 * pose2;
+    const Mat4 expected = homogeneous1 * homogeneous2;
+
+    EXPECT_MATRIX_NEAR(result.getHomogeneous(), expected, precision);
+}
+
+BOOST_AUTO_TEST_CASE(EqualityTest)
+{
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const Vec3 center(-1.34, 2.432, 3.396);
+
+    const geometry::Pose3 pose(rotation, center);
+
+    BOOST_CHECK(pose == pose);
+}
+
+BOOST_AUTO_TEST_CASE(InverseTest)
+{
+    const double precision{1e-5};
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const Vec3 center(-1.34, 2.432, 3.396);
+
+    const geometry::Pose3 pose(rotation, center);
+    const geometry::Pose3 inverse = pose.inverse();
+
+    const Mat3 expectedRotation = rotation.transpose();
+    const Vec3 expectedCenter = pose.translation();
+
+    EXPECT_MATRIX_NEAR(inverse.rotation(), expectedRotation, precision);
+    EXPECT_MATRIX_NEAR(inverse.center(), expectedCenter, precision);
+    EXPECT_MATRIX_NEAR((inverse * pose).getHomogeneous(), Mat4::Identity(), precision);
+
+}
+
+BOOST_AUTO_TEST_CASE(DepthTest)
+{
+    const double precision{1e-5};
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const Vec3 center(-1.34, 2.432, 3.396);
+    const Vec3 translation = -rotation * center;
+    const Mat4 homogeneous = Eigen::Affine3d(Eigen::Translation3d(translation) * rotation).matrix();
+
+    geometry::Pose3 pose(rotation, center);
+
+    const Mat3X points = Mat3X::Random(3, 10);
+
+    for(Eigen::Index i{0}; i < points.cols(); ++i)
+    {
+        const auto& point = points.col(i);
+        const auto& transformedPoint = (homogeneous * point.homogeneous()).hnormalized();
+        const double expectedDepth = transformedPoint(2);
+        const double depth = pose.depth(point);
+
+        BOOST_CHECK_CLOSE(depth, expectedDepth, precision);
+    }
+}
+
+//BOOST_AUTO_TEST_CASE(TransformSRtTest)
+//{
+//    const double precision{1e-5};
+//    Mat3 rotation;
+//    rotation << 1, 0, 0, 0, 1, 0, 0, 0, 1;
+//    const Vec3 center(1, 2, 3);
+//
+//    const geometry::Pose3 pose(rotation, center);
+//
+//    double scale{2.0};
+//    Mat3 newRotation;
+//    newRotation << 0, -1, 0, 1, 0, 0, 0, 0, 1;
+//    const Vec3 translation(4, 5, 6);
+//
+//    const geometry::Pose3 transformedPose = pose.transformSRt(scale, newRotation, translation);
+//
+//    const Vec3 expectedCenter = scale * newRotation * center + translation;
+//    const Mat3 expectedRotation = rotation * newRotation.transpose();
+//
+//    EXPECT_MATRIX_NEAR(transformedPose.center(), expectedCenter, precision);
+//    EXPECT_MATRIX_NEAR(transformedPose.rotation(), expectedRotation, precision);
+//}
+
+BOOST_AUTO_TEST_CASE(GetHomogeneousTest)
+{
+    const double precision{1e-5};
+    const Mat3 rotation = Eigen::AngleAxisd(-0.324, Vec3(-0.236, 1, 0.874).normalized()).toRotationMatrix();
+    const Vec3 center(-1.34, 2.432, 3.396);
+    const Vec3 translation = -rotation * center;
+
+    const geometry::Pose3 pose(rotation, center);
+
+    const Mat4 expectedHomogeneous = Eigen::Affine3d(Eigen::Translation3d(translation) * rotation).matrix();
+
+    const Mat4 homogeneous = pose.getHomogeneous();
+
+    EXPECT_MATRIX_NEAR(homogeneous, expectedHomogeneous, precision);
+}
+

--- a/src/aliceVision/geometry/lie.hpp
+++ b/src/aliceVision/geometry/lie.hpp
@@ -1,0 +1,154 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <Eigen/Dense>
+
+namespace aliceVision {
+
+namespace SO2 {
+
+using Matrix = Eigen::Matrix<double, 2, 2, Eigen::RowMajor>;
+
+/**
+Compute the exponential map of the given algebra on the group
+@param algebra the 1d vector
+@return a 2*2 S0(2) matrix
+*/
+inline Eigen::Matrix2d expm(double algebra){
+
+  Eigen::Matrix2d ret;
+  
+  ret(0, 0) = cos(algebra);
+  ret(0, 1) = -sin(algebra);
+  ret(1, 0) = sin(algebra);
+  ret(1, 1) = cos(algebra);
+
+  return ret;
+}
+} //namespace SO2
+
+namespace SO3 {
+
+using Matrix = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
+
+/**
+Compute the skew symmetric matrix of the given vector 3d
+@param int the 3d vector
+@return a skew symmetric matrix
+*/
+inline Eigen::Matrix3d skew(const Eigen::Vector3d & in) {
+    Eigen::Matrix3d ret;
+
+    ret.fill(0);
+
+    ret(0, 1) = -in(2);
+    ret(1, 0) = in(2);
+    ret(0, 2) = in(1);
+    ret(2, 0) = -in(1);
+    ret(1, 2) = -in(0);
+    ret(2, 1) = in(0);
+
+    return ret;
+}
+
+/**
+Compute the exponential map of the given algebra on the group
+@param algebra the 3d vector
+@return a 3*3 SO(3) matrix
+*/
+inline Eigen::Matrix3d expm(const Eigen::Vector3d & algebra) {
+    double angle = algebra.norm();
+
+    if (angle < std::numeric_limits<double>::epsilon()) {
+        return Eigen::Matrix3d::Identity();
+    }
+
+    Eigen::Matrix3d omega = skew(algebra);
+
+    Eigen::Matrix3d ret;
+    ret = Eigen::Matrix3d::Identity() + (sin(angle) / angle) * omega + ((1.0 - cos(angle)) / (angle * angle)) * omega * omega;
+
+    return ret;
+}
+
+/**
+Compute the algebra related to a given rotation matrix
+@param R the input rotation matrix
+@return the algebra
+*/
+inline Eigen::Vector3d logm(const Eigen::Matrix3d & R) {
+
+    Eigen::Vector3d ret;
+
+    double p1 = R(2, 1) - R(1, 2);
+    double p2 = R(0, 2) - R(2, 0);
+    double p3 = R(1, 0) - R(0, 1);
+
+    double costheta = (R.trace() - 1.0) / 2.0;
+    if (costheta < -1.0) {
+        costheta = -1.0;
+    }
+
+    if (costheta > 1.0) {
+        costheta = 1.0;
+    }
+
+    if (1.0 - costheta < 1e-24) {
+        ret.fill(0);
+        return ret;
+    }
+
+    double theta = acos(costheta);
+    double scale = theta / (2.0 * sin(theta));
+
+    ret(0) = scale * p1;
+    ret(1) = scale * p2;
+    ret(2) = scale * p3;
+
+    return ret;
+}
+} //namespace SO3
+
+
+namespace SE3 {
+
+using Matrix = Eigen::Matrix<double, 4, 4, Eigen::RowMajor>;
+
+/**
+Compute the exponential map of the given algebra on the group
+@param algebra the 6d vector
+@return a 4*4 SE(3) matrix
+*/
+inline Eigen::Matrix4d expm(const Eigen::Matrix<double, 6, 1> & algebra){
+
+  Eigen::Matrix4d ret;
+  ret.setIdentity();
+
+  Eigen::Vector3d vecR = algebra.block<3, 1>(0, 0);
+  Eigen::Vector3d vecT = algebra.block<3, 1>(3, 0);
+
+
+  double angle = vecR.norm();
+  if (angle < std::numeric_limits<double>::epsilon()) {
+    ret.setIdentity();
+    ret.block<3, 1>(0, 3) = vecT;
+    return ret;
+  }
+
+  Eigen::Matrix3d omega = SO3::skew(vecR);
+  Eigen::Matrix3d V = Eigen::Matrix3d::Identity() + ((1.0 - cos(angle)) / (angle*angle)) * omega + ((angle - sin(angle)) / (angle*angle*angle)) * omega * omega;
+
+  ret.block<3, 3>(0, 0) = SO3::expm(vecR);
+  ret.block<3, 1>(0, 3) = V * vecT;
+
+  return ret;
+}
+
+}
+
+} //namespace aliceVision

--- a/src/aliceVision/geometry/lie.hpp
+++ b/src/aliceVision/geometry/lie.hpp
@@ -15,20 +15,19 @@ namespace SO2 {
 using Matrix = Eigen::Matrix<double, 2, 2, Eigen::RowMajor>;
 
 /**
-Compute the exponential map of the given algebra on the group
-@param algebra the 1d vector
-@return a 2*2 S0(2) matrix
-*/
-inline Eigen::Matrix2d expm(double algebra){
+ * @brief Compute the exponential map of the given algebra on the group.
+ * @param algebra the 1D vector
+ * @return a 2*2 S0(2) matrix
+ */
+inline Eigen::Matrix2d expm(double algebra) {
+    Eigen::Matrix2d ret;
 
-  Eigen::Matrix2d ret;
-  
-  ret(0, 0) = cos(algebra);
-  ret(0, 1) = -sin(algebra);
-  ret(1, 0) = sin(algebra);
-  ret(1, 1) = cos(algebra);
+    ret(0, 0) = cos(algebra);
+    ret(0, 1) = -sin(algebra);
+    ret(1, 0) = sin(algebra);
+    ret(1, 1) = cos(algebra);
 
-  return ret;
+    return ret;
 }
 } //namespace SO2
 
@@ -37,11 +36,11 @@ namespace SO3 {
 using Matrix = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
 
 /**
-Compute the skew symmetric matrix of the given vector 3d
-@param int the 3d vector
-@return a skew symmetric matrix
-*/
-inline Eigen::Matrix3d skew(const Eigen::Vector3d & in) {
+ * @brief Compute the skew symmetric matrix of the given vector 3D.
+ * @param in the 3D vector
+ * @return a skew symmetric matrix
+ */
+inline Eigen::Matrix3d skew(const Eigen::Vector3d& in) {
     Eigen::Matrix3d ret;
 
     ret.fill(0);
@@ -57,11 +56,11 @@ inline Eigen::Matrix3d skew(const Eigen::Vector3d & in) {
 }
 
 /**
-Compute the exponential map of the given algebra on the group
-@param algebra the 3d vector
-@return a 3*3 SO(3) matrix
-*/
-inline Eigen::Matrix3d expm(const Eigen::Vector3d & algebra) {
+ * @brief Compute the exponential map of the given algebra on the group.
+ * @param algebra the 3D vector
+ * @return a 3*3 SO(3) matrix
+ */
+inline Eigen::Matrix3d expm(const Eigen::Vector3d& algebra) {
     double angle = algebra.norm();
 
     if (angle < std::numeric_limits<double>::epsilon()) {
@@ -77,12 +76,11 @@ inline Eigen::Matrix3d expm(const Eigen::Vector3d & algebra) {
 }
 
 /**
-Compute the algebra related to a given rotation matrix
-@param R the input rotation matrix
-@return the algebra
-*/
-inline Eigen::Vector3d logm(const Eigen::Matrix3d & R) {
-
+ * @brief Compute the algebra related to a given rotation matrix.
+ * @param R the input rotation matrix
+ * @return the algebra
+ */
+inline Eigen::Vector3d logm(const Eigen::Matrix3d& R) {
     Eigen::Vector3d ret;
 
     double p1 = R(2, 1) - R(1, 2);
@@ -120,35 +118,34 @@ namespace SE3 {
 using Matrix = Eigen::Matrix<double, 4, 4, Eigen::RowMajor>;
 
 /**
-Compute the exponential map of the given algebra on the group
-@param algebra the 6d vector
-@return a 4*4 SE(3) matrix
-*/
-inline Eigen::Matrix4d expm(const Eigen::Matrix<double, 6, 1> & algebra){
-
-  Eigen::Matrix4d ret;
-  ret.setIdentity();
-
-  Eigen::Vector3d vecR = algebra.block<3, 1>(0, 0);
-  Eigen::Vector3d vecT = algebra.block<3, 1>(3, 0);
-
-
-  double angle = vecR.norm();
-  if (angle < std::numeric_limits<double>::epsilon()) {
+ * @brief Compute the exponential map of the given algebra on the group.
+ * @param algebra the 6D vector
+ * @return a 4*4 SE(3) matrix
+ */
+inline Eigen::Matrix4d expm(const Eigen::Matrix<double, 6, 1>& algebra) {
+    Eigen::Matrix4d ret;
     ret.setIdentity();
-    ret.block<3, 1>(0, 3) = vecT;
+
+    Eigen::Vector3d vecR = algebra.block<3, 1>(0, 0);
+    Eigen::Vector3d vecT = algebra.block<3, 1>(3, 0);
+
+    double angle = vecR.norm();
+    if (angle < std::numeric_limits<double>::epsilon()) {
+        ret.setIdentity();
+        ret.block<3, 1>(0, 3) = vecT;
+        return ret;
+    }
+
+    Eigen::Matrix3d omega = SO3::skew(vecR);
+    Eigen::Matrix3d V = Eigen::Matrix3d::Identity() + ((1.0 - cos(angle)) / (angle * angle))
+        * omega + ((angle - sin(angle)) / (angle * angle * angle)) * omega * omega;
+
+    ret.block<3, 3>(0, 0) = SO3::expm(vecR);
+    ret.block<3, 1>(0, 3) = V * vecT;
+
     return ret;
-  }
-
-  Eigen::Matrix3d omega = SO3::skew(vecR);
-  Eigen::Matrix3d V = Eigen::Matrix3d::Identity() + ((1.0 - cos(angle)) / (angle*angle)) * omega + ((angle - sin(angle)) / (angle*angle*angle)) * omega * omega;
-
-  ret.block<3, 3>(0, 0) = SO3::expm(vecR);
-  ret.block<3, 1>(0, 3) = V * vecT;
-
-  return ret;
 }
 
-}
+} //namespace SE3
 
 } //namespace aliceVision

--- a/src/aliceVision/geometry/lie.hpp
+++ b/src/aliceVision/geometry/lie.hpp
@@ -61,13 +61,13 @@ inline Eigen::Matrix3d skew(const Eigen::Vector3d& in) {
  * @return a 3*3 SO(3) matrix
  */
 inline Eigen::Matrix3d expm(const Eigen::Vector3d& algebra) {
-    double angle = algebra.norm();
+    const double angle = algebra.norm();
 
     if (angle < std::numeric_limits<double>::epsilon()) {
         return Eigen::Matrix3d::Identity();
     }
 
-    Eigen::Matrix3d omega = skew(algebra);
+    const Eigen::Matrix3d omega = skew(algebra);
 
     Eigen::Matrix3d ret;
     ret = Eigen::Matrix3d::Identity() + (sin(angle) / angle) * omega + ((1.0 - cos(angle)) / (angle * angle)) * omega * omega;
@@ -83,9 +83,9 @@ inline Eigen::Matrix3d expm(const Eigen::Vector3d& algebra) {
 inline Eigen::Vector3d logm(const Eigen::Matrix3d& R) {
     Eigen::Vector3d ret;
 
-    double p1 = R(2, 1) - R(1, 2);
-    double p2 = R(0, 2) - R(2, 0);
-    double p3 = R(1, 0) - R(0, 1);
+    const double p1 = R(2, 1) - R(1, 2);
+    const double p2 = R(0, 2) - R(2, 0);
+    const double p3 = R(1, 0) - R(0, 1);
 
     double costheta = (R.trace() - 1.0) / 2.0;
     if (costheta < -1.0) {
@@ -101,8 +101,8 @@ inline Eigen::Vector3d logm(const Eigen::Matrix3d& R) {
         return ret;
     }
 
-    double theta = acos(costheta);
-    double scale = theta / (2.0 * sin(theta));
+    const double theta = acos(costheta);
+    const double scale = theta / (2.0 * sin(theta));
 
     ret(0) = scale * p1;
     ret(1) = scale * p2;
@@ -126,8 +126,8 @@ inline Eigen::Matrix4d expm(const Eigen::Matrix<double, 6, 1>& algebra) {
     Eigen::Matrix4d ret;
     ret.setIdentity();
 
-    Eigen::Vector3d vecR = algebra.block<3, 1>(0, 0);
-    Eigen::Vector3d vecT = algebra.block<3, 1>(3, 0);
+    const Eigen::Vector3d vecR = algebra.block<3, 1>(0, 0);
+    const Eigen::Vector3d vecT = algebra.block<3, 1>(3, 0);
 
     double angle = vecR.norm();
     if (angle < std::numeric_limits<double>::epsilon()) {
@@ -136,8 +136,8 @@ inline Eigen::Matrix4d expm(const Eigen::Matrix<double, 6, 1>& algebra) {
         return ret;
     }
 
-    Eigen::Matrix3d omega = SO3::skew(vecR);
-    Eigen::Matrix3d V = Eigen::Matrix3d::Identity() + ((1.0 - cos(angle)) / (angle * angle))
+    const Eigen::Matrix3d omega = SO3::skew(vecR);
+    const Eigen::Matrix3d V = Eigen::Matrix3d::Identity() + ((1.0 - cos(angle)) / (angle * angle))
         * omega + ((angle - sin(angle)) / (angle * angle * angle)) * omega * omega;
 
     ret.block<3, 3>(0, 0) = SO3::expm(vecR);

--- a/src/aliceVision/localization/LocalizationResult_test.cpp
+++ b/src/aliceVision/localization/LocalizationResult_test.cpp
@@ -52,7 +52,7 @@ localization::LocalizationResult generateRandomResult(std::size_t numPts)
   }
   
   // random pose
-  geometry::Pose3 pose = geometry::Pose3(Mat3::Random(), Vec3::Random());
+  geometry::Pose3 pose = geometry::randomPose();
   
   // random intrinsics
   camera::Pinhole intrinsics = camera::Pinhole(
@@ -93,6 +93,7 @@ BOOST_AUTO_TEST_CASE(LocalizationResult_LoadSaveVector)
     resGT.push_back(generateRandomResult(numpts(gen)));
   }
 
+ 
   BOOST_CHECK_NO_THROW(localization::LocalizationResult::save(resGT, filename));
   BOOST_CHECK_NO_THROW(localization::LocalizationResult::load(resCheck, filename));
   BOOST_CHECK(resCheck.size() == resGT.size());

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -306,7 +306,7 @@ public:
       return true;
     }
 
-     const geometry::Pose3 T_pose3(T.block<3, 4>(0, 0));
+    const geometry::Pose3 T_pose3(T);
     size_t params_size = _intrinsics->getParams().size();
 
     double d_res_d_pt_est = 1.0 / scale;

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -221,7 +221,7 @@ public:
     _intrinsics->updateFromParams(params);
 
     const SE3::Matrix T = cTr * rTo;
-    const geometry::Pose3 T_pose3(T.block<3, 4>(0, 0));
+    const geometry::Pose3 T_pose3(T);
 
     const Vec4 pth = pt.homogeneous();
 
@@ -343,6 +343,7 @@ void BundleAdjustmentSymbolicCeres::addPose(const sfmData::CameraPose& cameraPos
 {
   const Mat3& R = cameraPose.getTransform().rotation();
   const Vec3& t = cameraPose.getTransform().translation();
+  
 
   poseBlock = SE3::Matrix::Identity();
   poseBlock.block<3,3>(0, 0) = R;

--- a/src/aliceVision/sfm/liealgebra.hpp
+++ b/src/aliceVision/sfm/liealgebra.hpp
@@ -1,5 +1,12 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #pragma once
 
+#include <aliceVision/geometry/lie.hpp>
 #include <Eigen/Dense>
 #include <unsupported/Eigen/KroneckerProduct>
 #include <aliceVision/utils/CeresUtils.hpp>
@@ -7,85 +14,6 @@
 
 namespace aliceVision {
 namespace SO3 {
-
-using Matrix = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
-
-/**
-Compute the skew symmetric matrix of the given vector 3d
-@param int the 3d vector
-@return a skew symmetric matrix
-*/
-inline Eigen::Matrix3d skew(const Eigen::Vector3d & in) {
-    Eigen::Matrix3d ret;
-
-    ret.fill(0);
-
-    ret(0, 1) = -in(2);
-    ret(1, 0) = in(2);
-    ret(0, 2) = in(1);
-    ret(2, 0) = -in(1);
-    ret(1, 2) = -in(0);
-    ret(2, 1) = in(0);
-
-    return ret;
-}
-
-/**
-Compute the exponential map of the given algebra on the group
-@param algebra the 3d vector
-@return a 3*3 SO(3) matrix
-*/
-inline Eigen::Matrix3d expm(const Eigen::Vector3d & algebra) {
-    double angle = algebra.norm();
-
-    if (angle < std::numeric_limits<double>::epsilon()) {
-        return Eigen::Matrix3d::Identity();
-    }
-
-    Eigen::Matrix3d omega = skew(algebra);
-
-    Eigen::Matrix3d ret;
-    ret = Eigen::Matrix3d::Identity() + (sin(angle) / angle) * omega + ((1.0 - cos(angle)) / (angle * angle)) * omega * omega;
-
-    return ret;
-}
-
-/**
-Compute the algebra related to a given rotation matrix
-@param R the input rotation matrix
-@return the algebra
-*/
-inline Eigen::Vector3d logm(const Eigen::Matrix3d & R) {
-
-    Eigen::Vector3d ret;
-
-    double p1 = R(2, 1) - R(1, 2);
-    double p2 = R(0, 2) - R(2, 0);
-    double p3 = R(1, 0) - R(0, 1);
-
-    double costheta = (R.trace() - 1.0) / 2.0;
-    if (costheta < -1.0) {
-        costheta = -1.0;
-    }
-
-    if (costheta > 1.0) {
-        costheta = 1.0;
-    }
-
-    if (1.0 - costheta < 1e-24) {
-        ret.fill(0);
-        return ret;
-    }
-
-    double theta = acos(costheta);
-    double scale = theta / (2.0 * sin(theta));
-
-    ret(0) = scale * p1;
-    ret(1) = scale * p2;
-    ret(2) = scale * p3;
-
-    return ret;
-}
 
 /**
 Compute the jacobian of the logarithm wrt changes in the rotation matrix values
@@ -201,41 +129,9 @@ class Manifold : public utils::CeresManifold {
   int TangentSize() const override { return 3; }
 };
 
-}
+}//namespace SO3 
 
 namespace SE3 {
-
-using Matrix = Eigen::Matrix<double, 4, 4, Eigen::RowMajor>;
-
-/**
-Compute the exponential map of the given algebra on the group
-@param algebra the 6d vector
-@return a 4*4 SE(3) matrix
-*/
-inline Eigen::Matrix4d expm(const Eigen::Matrix<double, 6, 1> & algebra){
-
-  Eigen::Matrix4d ret;
-  ret.setIdentity();
-
-  Eigen::Vector3d vecR = algebra.block<3, 1>(0, 0);
-  Eigen::Vector3d vecT = algebra.block<3, 1>(3, 0);
-
-
-  double angle = vecR.norm();
-  if (angle < std::numeric_limits<double>::epsilon()) {
-    ret.setIdentity();
-    ret.block<3, 1>(0, 3) = vecT;
-    return ret;
-  }
-
-  Eigen::Matrix3d omega = SO3::skew(vecR);
-  Eigen::Matrix3d V = Eigen::Matrix3d::Identity() + ((1.0 - cos(angle)) / (angle*angle)) * omega + ((angle - sin(angle)) / (angle*angle*angle)) * omega * omega;
-
-  ret.block<3, 3>(0, 0) = SO3::expm(vecR);
-  ret.block<3, 1>(0, 3) = V * vecT;
-
-  return ret;
-}
 
 
 class ManifoldLeft : public utils::CeresManifold {
@@ -379,30 +275,11 @@ private:
   bool _refineRotation;
   bool _refineTranslation;
 };
-}
+
+} //namespace SE3 
 
 
 namespace SO2 {
-
-using Matrix = Eigen::Matrix<double, 2, 2, Eigen::RowMajor>;
-
-/**
-Compute the exponential map of the given algebra on the group
-@param algebra the 1d vector
-@return a 2*2 S0(2) matrix
-*/
-inline Eigen::Matrix2d expm(double algebra){
-
-  Eigen::Matrix2d ret;
-  
-  ret(0, 0) = cos(algebra);
-  ret(0, 1) = -sin(algebra);
-  ret(1, 0) = sin(algebra);
-  ret(1, 1) = cos(algebra);
-
-  return ret;
-}
-
 
 class Manifold : public utils::CeresManifold {
 public:
@@ -447,6 +324,6 @@ public:
   }
 };
 
-}
+} //namespace SO2 
 
-}
+} //namespace aliceVision 

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -164,7 +164,7 @@ inline void applyTransform(sfmData::SfMData& sfmData,
     {
         for (auto& subPose : rigIt.second.getSubPoses())
         {
-            subPose.pose.center() *= S;
+            subPose.pose.setCenter(subPose.pose.center() * S);
         }
     }
 

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -693,7 +693,7 @@ bool readCamera(const Version & abcVersion, const ICamera& camera, const M44d& m
       T2 = (M * T * M).inverse();
     }
 
-    Pose3 pose(T2.block<3, 4>(0, 0));
+    Pose3 pose(T2);
 
     if(view->isPartOfRig() && !view->isPoseIndependant())
     {
@@ -825,7 +825,7 @@ bool readXform(const Version & abcVersion, IXform& xform, M44d& mat, sfmData::Sf
           T2 = (M * T * M).inverse();
       }
 
-      Pose3 pose(T2.block<3, 4>(0, 0));
+      Pose3 pose(T2);
 
       if (sfmData.getPoses().find(poseId) == sfmData.getPoses().end())
       {

--- a/src/aliceVision/sfmDataIO/gtIO.cpp
+++ b/src/aliceVision/sfmDataIO/gtIO.cpp
@@ -75,7 +75,9 @@ bool read_aliceVision_Camera(const std::string& camName, camera::Pinhole& cam, g
   KRt_from_P(P, &K, &R, &t);
   cam = camera::Pinhole(0,0,K);
   // K.transpose() is applied to give [R t] to the constructor instead of P = K [R t]
-  pose = geometry::Pose3(K.transpose() * P);
+  Mat4 T = Mat4::Identity();
+  T.block<3, 4>(0, 0) = K.transpose() * P;
+  pose = geometry::Pose3(T);
   return true;
 }
 

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -280,7 +280,7 @@ int aliceVision_main(int argc, char** argv)
 
             Eigen::Matrix3d c_R_oprior = p.rotation() * ocur_R_oprior;
 
-            p.rotation() = c_R_oprior;
+            p.setRotation(c_R_oprior);
             pose.second.setTransform(p);
         }
     }
@@ -299,7 +299,7 @@ int aliceVision_main(int argc, char** argv)
         Eigen::Matrix3d matLatitude =
             Eigen::AngleAxisd(degreeToRadian(offsetLatitude), Vec3(1, 0, 0)).toRotationMatrix();
         Eigen::Matrix3d newR = p.rotation() * matLongitude * matLatitude;
-        p.rotation() = newR;
+        p.setRotation(newR);
         pose.second.setTransform(p);
     }
 


### PR DESCRIPTION
Current pose3 is internally represented by a rotation matrix and a center (the inverse of the translation).

I propose to change its internal representation with an homogeneous transformation.

The objective is to be able to directly use a sfmData as the internal storage of the bundle adjustment. The next version (WIP) should work on matrices using Lie Algebra. This is an intermediate step toward this goal.

Note that this has no effect on the other part of aliceVision (except some part which directly used the internal components).