### PR TITLE
[image] readImageSpec: perform safety check before anything else

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -427,10 +427,11 @@ oiio::ImageSpec readImageSpec(const std::string& path)
 #endif 
 
   std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path, &configSpec));
-  oiio::ImageSpec spec = in->spec();
 
   if(!in)
     throw std::runtime_error("Can't find/open image file '" + path + "'.");
+
+  oiio::ImageSpec spec = in->spec();
 
   in->close();
 


### PR DESCRIPTION
## Description

`ImageInput` pointer was being used before safety check was performed, leading to segmentation faults when the input image could not be read.