### PR TITLE
bundle adjustment improvement

### DIFF
--- a/src/aliceVision/camera/DistortionRadial.cpp
+++ b/src/aliceVision/camera/DistortionRadial.cpp
@@ -151,52 +151,47 @@ Eigen::Matrix2d DistortionRadialK3::getDerivativeAddDistoWrtPt(const Vec2 & p) c
     const double& k2 = _distortionParams[1];
     const double& k3 = _distortionParams[2];
 
-    const double r = sqrt(p(0)*p(0) + p(1)*p(1));
-    const double eps = 1e-8;
-    if (r < eps)
+    const double r2 = p(0) * p(0) + p(1) * p(1);
+    const double eps = 1e-21;
+    if (r2 < eps)
     {
         return Eigen::Matrix2d::Identity();
     }
 
-    Eigen::Matrix<double, 1, 2> d_r_d_p;
-    d_r_d_p(0) = p(0) / r;
-    d_r_d_p(1) = p(1) / r;
-
-    const double r2 = r * r;
-    const double r3 = r2 * r;
     const double r4 = r2 * r2;
-    const double r5 = r4 * r;
     const double r6 = r4 * r2;
 
     const double r_coeff = 1.0 + k1 * r2 + k2 * r4 + k3 * r6;
+    const double d_coeff = 2.0 * k1 + 4.0 * k2 * r2 + 6.0 * k3 * r4;
 
-    double d_r_coeff_d_r = 2.0 * k1 * r + 4.0 * k2 * r3 + 6.0 * k3 * r5;
-    Eigen::Matrix<double, 1, 2> d_r_coeff_d_p = d_r_coeff_d_r * d_r_d_p;
+    Eigen::Matrix2d ret;
+    ret(0, 0) = r_coeff + p(0) * d_coeff * p(0);
+    ret(0, 1) = p(0) * d_coeff * p(1);
+    ret(1, 0) = p(1) * d_coeff * p(0);
+    ret(1, 1) = r_coeff + p(1) * d_coeff * p(1);
 
-    return Eigen::Matrix2d::Identity() * r_coeff + p * d_r_coeff_d_p;
+    return ret;
 }
 
 Eigen::MatrixXd DistortionRadialK3::getDerivativeAddDistoWrtDisto(const Vec2 & p) const
 {
-    const double r = sqrt(p(0)*p(0) + p(1)*p(1));
-    const double eps = 1e-8;
-    if (r < eps)
+    const double r2 = p(0)*p(0) + p(1)*p(1);
+    const double eps = 1e-21;
+    if (r2 < eps)
     {
         return Eigen::Matrix<double, 2, 3>::Zero();
     }
 
-    const double r2 = r * r;
     const double r4 = r2 * r2;
     const double r6 = r4 * r2;
 
-    /*const double r_coeff = 1.0 + k1 * r2 + k2 * r4 + k3 * r6;*/
-
-    Eigen::Matrix<double, 1, 3> d_r_coeff_d_params;
-    d_r_coeff_d_params(0, 0) = r2;
-    d_r_coeff_d_params(0, 1) = r4;
-    d_r_coeff_d_params(0, 2) = r6;
-
-    Eigen::MatrixXd ret = p * d_r_coeff_d_params;
+    Eigen::Matrix<double, 2, 3> ret;
+    ret(0, 0) = p(0) * r2;
+    ret(0, 1) = p(0) * r4;
+    ret(0, 2) = p(0) * r6;
+    ret(1, 0) = p(1) * r2;
+    ret(1, 1) = p(1) * r4;
+    ret(1, 2) = p(1) * r6;
 
     return ret;
 }

--- a/src/aliceVision/camera/Equidistant.cpp
+++ b/src/aliceVision/camera/Equidistant.cpp
@@ -38,12 +38,12 @@ Vec2 Equidistant::project(const Eigen::Matrix4d& pose, const Vec4& pt, bool appl
     return pt_ima;
 }
 
-Eigen::Matrix<double, 2, 9> Equidistant::getDerivativeProjectWrtRotation(const geometry::Pose3& pose, const Vec4 & pt)
+Eigen::Matrix<double, 2, 9> Equidistant::getDerivativeProjectWrtRotation(const Eigen::Matrix4d & pose, const Vec4 & pt)
 {
-    Eigen::Matrix4d T = pose.getHomogeneous();
+    Eigen::Matrix4d T = pose;
     const Vec4 X = T * pt; // apply pose
 
-    const Eigen::Matrix<double, 3, 9> d_X_d_R = getJacobian_AB_wrt_A<3, 3, 1>(pose.rotation(), pt.head(3));
+    const Eigen::Matrix<double, 3, 9> d_X_d_R = getJacobian_AB_wrt_A<3, 3, 1>(pose.block<3, 3>(0, 0), pt.head(3));
 
     /* Compute angle with optical center */
     double len2d = sqrt(X(0) * X(0) + X(1) * X(1));
@@ -87,9 +87,9 @@ Eigen::Matrix<double, 2, 9> Equidistant::getDerivativeProjectWrtRotation(const g
     return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtPt(P) * d_P_d_angles * d_angles_d_X * d_X_d_R;
 }
 
-Eigen::Matrix<double, 2, 16> Equidistant::getDerivativeProjectWrtPoseLeft(const geometry::Pose3& pose, const Vec4 & pt) const
+Eigen::Matrix<double, 2, 16> Equidistant::getDerivativeProjectWrtPose(const Eigen::Matrix4d & pose, const Vec4 & pt) const
 {
-    Eigen::Matrix4d T = pose.getHomogeneous();
+    Eigen::Matrix4d T = pose;
     const Vec4 X = T * pt; // apply pose
 
     const Eigen::Matrix<double, 4, 16> d_X_d_T = getJacobian_AB_wrt_A<4, 4, 1>(T, pt);
@@ -136,9 +136,58 @@ Eigen::Matrix<double, 2, 16> Equidistant::getDerivativeProjectWrtPoseLeft(const 
     return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtPt(P) * d_P_d_angles * d_angles_d_X * d_X_d_T.block<3, 16>(0, 0);
 }
 
-Eigen::Matrix<double, 2, 4> Equidistant::getDerivativeProjectWrtPoint(const geometry::Pose3& pose, const Vec4 & pt) const
+Eigen::Matrix<double, 2, 16> Equidistant::getDerivativeProjectWrtPoseLeft(const Eigen::Matrix4d & pose, const Vec4 & pt) const
 {
-    Eigen::Matrix4d T = pose.getHomogeneous();
+    Eigen::Matrix4d T = pose;
+    const Vec4 X = T * pt; // apply pose
+
+    const Eigen::Matrix<double, 4, 16> d_X_d_T = getJacobian_AB_wrt_A<4, 4, 1>(T, pt);
+
+    /* Compute angle with optical center */
+    double len2d = sqrt(X(0) * X(0) + X(1) * X(1));
+    Eigen::Matrix<double, 2, 2> d_len2d_d_X;
+    d_len2d_d_X(0) = X(0) / len2d;
+    d_len2d_d_X(1) = X(1) / len2d;
+
+    const double angle_Z = std::atan2(len2d, X(2));
+    const double d_angle_Z_d_len2d = X(2) / (len2d*len2d + X(2) * X(2));
+
+    /* Ignore depth component and compute radial angle */
+    const double angle_radial = std::atan2(X(1), X(0));
+
+    Eigen::Matrix<double, 2, 3> d_angles_d_X;
+    d_angles_d_X(0, 0) = - X(1) / (X(0) * X(0) + X(1) * X(1));
+    d_angles_d_X(0, 1) = X(0) / (X(0) * X(0) + X(1) * X(1));
+    d_angles_d_X(0, 2) = 0.0;
+
+    d_angles_d_X(1, 0) = d_angle_Z_d_len2d * d_len2d_d_X(0);
+    d_angles_d_X(1, 1) = d_angle_Z_d_len2d * d_len2d_d_X(1);
+    d_angles_d_X(1, 2) = - len2d / (len2d * len2d + X(2) * X(2));
+
+    const double rsensor = std::min(sensorWidth(), sensorHeight());
+    const double rscale = sensorWidth() / std::max(w(), h());
+    const double fmm = _scale(0) * rscale;
+    const double fov = rsensor / fmm;
+
+    const double radius = angle_Z / (0.5 * fov);
+
+    const double d_radius_d_angle_Z = 1.0 / (0.5 * fov);
+
+    /* radius = focal * angle_Z */
+    const Vec2 P{cos(angle_radial) * radius, sin(angle_radial) * radius};
+
+    Eigen::Matrix<double, 2, 2> d_P_d_angles;
+    d_P_d_angles(0, 0) = - sin(angle_radial) * radius;
+    d_P_d_angles(0, 1) = cos(angle_radial) * d_radius_d_angle_Z;
+    d_P_d_angles(1, 0) = cos(angle_radial) * radius;
+    d_P_d_angles(1, 1) = sin(angle_radial) * d_radius_d_angle_Z;
+
+    return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtPt(P) * d_P_d_angles * d_angles_d_X * d_X_d_T.block<3, 16>(0, 0);
+}
+
+Eigen::Matrix<double, 2, 4> Equidistant::getDerivativeProjectWrtPoint(const Eigen::Matrix4d & pose, const Vec4 & pt) const
+{
+    Eigen::Matrix4d T = pose;
     const Vec4 X = T * pt; // apply pose
 
     const Eigen::Matrix4d& d_X_d_pt = T;
@@ -235,9 +284,9 @@ Eigen::Matrix<double, 2, 3> Equidistant::getDerivativeProjectWrtPoint3(const Eig
     return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtPt(P) * d_P_d_angles * d_angles_d_X * d_X_d_pt;
 }
 
-Eigen::Matrix<double, 2, 3> Equidistant::getDerivativeProjectWrtDisto(const geometry::Pose3& pose, const Vec4 & pt)
+Eigen::Matrix<double, 2, 3> Equidistant::getDerivativeProjectWrtDisto(const Eigen::Matrix4d & pose, const Vec4 & pt)
 {
-    Eigen::Matrix4d T = pose.getHomogeneous();
+    Eigen::Matrix4d T = pose;
     const Vec4 X = T * pt; // apply pose
 
     /* Compute angle with optical center */
@@ -259,9 +308,9 @@ Eigen::Matrix<double, 2, 3> Equidistant::getDerivativeProjectWrtDisto(const geom
     return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtDisto(P);
 }
 
-Eigen::Matrix<double, 2, 2> Equidistant::getDerivativeProjectWrtScale(const geometry::Pose3& pose, const Vec4 & pt)
+Eigen::Matrix<double, 2, 2> Equidistant::getDerivativeProjectWrtScale(const Eigen::Matrix4d & pose, const Vec4 & pt)
 {
-    Eigen::Matrix4d T = pose.getHomogeneous();
+    Eigen::Matrix4d T = pose;
     const Vec4 X = T * pt; // apply pose
 
     /* Compute angle with optical center */
@@ -294,12 +343,12 @@ Eigen::Matrix<double, 2, 2> Equidistant::getDerivativeProjectWrtScale(const geom
     return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtPt(P) * d_P_d_radius * d_radius_d_fov * d_fov_d_scale;
 }
 
-Eigen::Matrix<double, 2, 2> Equidistant::getDerivativeProjectWrtPrincipalPoint(const geometry::Pose3& pose, const Vec4 & pt)
+Eigen::Matrix<double, 2, 2> Equidistant::getDerivativeProjectWrtPrincipalPoint(const Eigen::Matrix4d & pose, const Vec4 & pt)
 {
     return getDerivativeCam2ImaWrtPrincipalPoint();
 }
 
-Eigen::Matrix<double, 2, Eigen::Dynamic> Equidistant::getDerivativeProjectWrtParams(const geometry::Pose3& pose, const Vec4& pt3D) const
+Eigen::Matrix<double, 2, Eigen::Dynamic> Equidistant::getDerivativeProjectWrtParams(const Eigen::Matrix4d & pose, const Vec4& pt3D) const
 {
     return Eigen::Matrix<double, 2, Eigen::Dynamic>(2, 6);
 }

--- a/src/aliceVision/camera/Equidistant.hpp
+++ b/src/aliceVision/camera/Equidistant.hpp
@@ -78,21 +78,23 @@ public:
         return project(pose.getHomogeneous(), pt3D, applyDistortion);
     }
 
-    Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const geometry::Pose3& pose, const Vec4 & pt);
+    Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const Eigen::Matrix4d & pose, const Vec4 & pt);
 
-    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const geometry::Pose3& pose, const Vec4 & pt) const override;
+    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPose(const Eigen::Matrix4d & pose, const Vec4 & pt) const override;
 
-    Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const geometry::Pose3& pose, const Vec4 & pt) const override;
+    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const Eigen::Matrix4d & pose, const Vec4 & pt) const override;
 
-    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4 & pt) const override;
+    Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const Eigen::Matrix4d & pose, const Vec4 & pt) const override;
 
-    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtDisto(const geometry::Pose3& pose, const Vec4 & pt);
+    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d & pose, const Vec4 & pt) const override;
 
-    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtScale(const geometry::Pose3& pose, const Vec4 & pt);
+    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtDisto(const Eigen::Matrix4d & pose, const Vec4 & pt);
 
-    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtPrincipalPoint(const geometry::Pose3& pose, const Vec4 & pt);
+    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtScale(const Eigen::Matrix4d & pose, const Vec4 & pt);
 
-    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtParams(const geometry::Pose3& pose, const Vec4& pt3D) const override;
+    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtPrincipalPoint(const Eigen::Matrix4d & pose, const Vec4 & pt);
+
+    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtParams(const Eigen::Matrix4d & pose, const Vec4& pt3D) const override;
 
     Vec3 toUnitSphere(const Vec2 & pt) const override;
 

--- a/src/aliceVision/camera/Equidistant.hpp
+++ b/src/aliceVision/camera/Equidistant.hpp
@@ -71,13 +71,20 @@ public:
 
     EINTRINSIC getType() const override;
 
-    Vec2 project(const geometry::Pose3& pose, const Vec4& pt, bool applyDistortion = true) const override;
+    Vec2 project(const Eigen::Matrix4d & pose, const Vec4& pt, bool applyDistortion = true) const override;
+
+    Vec2 project(const geometry::Pose3& pose, const Vec4& pt3D, bool applyDistortion = true) const
+    {
+        return project(pose.getHomogeneous(), pt3D, applyDistortion);
+    }
 
     Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const geometry::Pose3& pose, const Vec4 & pt);
 
-    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPose(const geometry::Pose3& pose, const Vec4 & pt) const override;
+    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const geometry::Pose3& pose, const Vec4 & pt) const override;
 
     Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const geometry::Pose3& pose, const Vec4 & pt) const override;
+
+    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4 & pt) const override;
 
     Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtDisto(const geometry::Pose3& pose, const Vec4 & pt);
 

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -126,7 +126,16 @@ public:
      * @param[in] applyDistortion If true apply distrortion if any
      * @return The projection jacobian  wrt pose
      */
-    virtual Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const geometry::Pose3& pose, const Vec4& pt3D) const = 0;
+    virtual Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPose(const Eigen::Matrix4d & pose, const Vec4& pt3D) const = 0;
+
+    /**
+     * @brief get derivative of a projection of a 3D point into the camera plane
+     * @param[in] pose The pose
+     * @param[in] pt3D The 3d point
+     * @param[in] applyDistortion If true apply distrortion if any
+     * @return The projection jacobian  wrt pose
+     */
+    virtual Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const Eigen::Matrix4d & pose, const Vec4& pt3D) const = 0;
 
     /**
      * @brief get derivative of a projection of a 3D point into the camera plane
@@ -135,7 +144,7 @@ public:
      * @param[in] applyDistortion If true apply distrortion if any
      * @return The projection jacobian  wrt point
      */
-    virtual Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const geometry::Pose3 & pose, const Vec4& pt3D) const = 0;
+    virtual Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const Eigen::Matrix4d & pose, const Vec4& pt3D) const = 0;
 
     /**
      * @brief get derivative of a projection of a 3D point into the camera plane
@@ -153,7 +162,7 @@ public:
      * @param[in] applyDistortion If true apply distrortion if any
      * @return The projection jacobian wrt params
      */
-    virtual Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtParams(const geometry::Pose3& pose, const Vec4& pt3D) const = 0;
+    virtual Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtParams(const Eigen::Matrix4d & pos, const Vec4& pt3D) const = 0;
 
     /**
      * @brief Compute the residual between the 3D projected point X and an image observation x

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -91,7 +91,19 @@ public:
      * @param[in] applyDistortion If true apply distrortion if any
      * @return The 2d projection in the camera plane
      */
-    virtual Vec2 project(const geometry::Pose3& pose, const Vec4& pt3D, bool applyDistortion = true) const = 0;
+    Vec2 project(const geometry::Pose3& pose, const Vec4& pt3D, bool applyDistortion = true) const
+    {
+        return project(pose.getHomogeneous(), pt3D, applyDistortion);
+    }
+
+    /**
+     * @brief Projection of a 3D point into the camera plane (Apply pose, disto (if any) and Intrinsics)
+     * @param[in] pose The pose
+     * @param[in] pt3D The 3d point
+     * @param[in] applyDistortion If true apply distrortion if any
+     * @return The 2d projection in the camera plane
+     */
+    virtual Vec2 project(const Eigen::Matrix4d & pose, const Vec4& pt3D, bool applyDistortion = true) const = 0;
 
     /**
      * @brief Back-projection of a 2D point at a specific depth into a 3D point
@@ -114,7 +126,7 @@ public:
      * @param[in] applyDistortion If true apply distrortion if any
      * @return The projection jacobian  wrt pose
      */
-    virtual Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPose(const geometry::Pose3& pose, const Vec4& pt3D) const = 0;
+    virtual Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const geometry::Pose3& pose, const Vec4& pt3D) const = 0;
 
     /**
      * @brief get derivative of a projection of a 3D point into the camera plane
@@ -123,7 +135,16 @@ public:
      * @param[in] applyDistortion If true apply distrortion if any
      * @return The projection jacobian  wrt point
      */
-    virtual Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const geometry::Pose3& pose, const Vec4& pt3D) const = 0;
+    virtual Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const geometry::Pose3 & pose, const Vec4& pt3D) const = 0;
+
+    /**
+     * @brief get derivative of a projection of a 3D point into the camera plane
+     * @param[in] pose The pose
+     * @param[in] pt3D The 3d point
+     * @param[in] applyDistortion If true apply distrortion if any
+     * @return The projection jacobian  wrt point
+     */
+    virtual Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4& pt3D) const = 0;
 
     /**
      * @brief get derivative of a projection of a 3D point into the camera plane

--- a/src/aliceVision/camera/Pinhole.hpp
+++ b/src/aliceVision/camera/Pinhole.hpp
@@ -79,13 +79,20 @@ public:
 
     void setK(const Mat3 & K);
 
-    Vec2 project(const geometry::Pose3& pose, const Vec4& pt, bool applyDistortion = true) const override;
+    Vec2 project(const geometry::Pose3& pose, const Vec4& pt3D, bool applyDistortion = true) const
+    {
+        return project(pose.getHomogeneous(), pt3D, applyDistortion);
+    }
+
+    Vec2 project(const Eigen::Matrix4d & pose, const Vec4& pt, bool applyDistortion = true) const override;
 
     Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const geometry::Pose3& pose, const Vec4 & pt);
 
-    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPose(const geometry::Pose3& pose, const Vec4& pt) const override;
+    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const geometry::Pose3& pose, const Vec4& pt) const override;
 
     Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const geometry::Pose3& pose, const Vec4 & pt) const override;
+
+    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4 & pt) const override;
 
     Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtDisto(const geometry::Pose3& pose, const Vec4 & pt) const;
 

--- a/src/aliceVision/camera/Pinhole.hpp
+++ b/src/aliceVision/camera/Pinhole.hpp
@@ -86,21 +86,23 @@ public:
 
     Vec2 project(const Eigen::Matrix4d & pose, const Vec4& pt, bool applyDistortion = true) const override;
 
-    Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const geometry::Pose3& pose, const Vec4 & pt);
+    Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const Eigen::Matrix4d & pose, const Vec4 & pt);
 
-    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const geometry::Pose3& pose, const Vec4& pt) const override;
+    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPose(const Eigen::Matrix4d & pose, const Vec4& pt) const override;
 
-    Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const geometry::Pose3& pose, const Vec4 & pt) const override;
+    Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPoseLeft(const Eigen::Matrix4d & pose, const Vec4& pt) const override;
 
-    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4 & pt) const override;
+    Eigen::Matrix<double, 2, 4> getDerivativeProjectWrtPoint(const Eigen::Matrix4d & pose, const Vec4 & pt) const override;
 
-    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtDisto(const geometry::Pose3& pose, const Vec4 & pt) const;
+    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d & pose, const Vec4 & pt) const override;
 
-    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtPrincipalPoint(const geometry::Pose3& pose, const Vec4 & pt) const;
+    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtDisto(const Eigen::Matrix4d & pose, const Vec4 & pt) const;
 
-    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtScale(const geometry::Pose3& pose, const Vec4 & pt) const;
+    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtPrincipalPoint(const Eigen::Matrix4d & pose, const Vec4 & pt) const;
 
-    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtParams(const geometry::Pose3& pose, const Vec4& pt3D) const override;
+    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtScale(const Eigen::Matrix4d & pose, const Vec4 & pt) const;
+
+    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtParams(const Eigen::Matrix4d & pose, const Vec4& pt3D) const override;
 
     Vec3 toUnitSphere(const Vec2 & pt) const override;
 

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.cpp
@@ -512,7 +512,11 @@ void BundleAdjustmentCeres::setSolverOptions(ceres::Solver::Options& solverOptio
   solverOptions.minimizer_progress_to_stdout = _ceresOptions.verbose;
   solverOptions.logging_type = ceres::SILENT;
   solverOptions.num_threads = _ceresOptions.nbThreads;
-
+  solverOptions.max_num_iterations = _ceresOptions.maxNumIterations;
+  /*solverOptions.function_tolerance = 1e-12;
+  solverOptions.gradient_tolerance = 1e-12;
+  solverOptions.parameter_tolerance = 1e-12;*/
+  
 #if CERES_VERSION_MAJOR < 2
   solverOptions.num_linear_solver_threads = _ceresOptions.nbThreads;
 #endif

--- a/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/BundleAdjustmentCeres.hpp
@@ -35,9 +35,10 @@ public:
    */
   struct CeresOptions
   {
-    CeresOptions(bool verbose = true, bool multithreaded = true)
+    CeresOptions(bool verbose = true, bool multithreaded = true, unsigned int maxIterations = 50)
       : verbose(verbose)
       , nbThreads(multithreaded ? omp_get_max_threads() : 1) // set number of threads, 1 if OpenMP is not enabled
+      , maxNumIterations(maxIterations)
     {
       setDenseBA(); // use dense BA by default
       lossFunction.reset(new ceres::HuberLoss(Square(4.0)));
@@ -51,6 +52,7 @@ public:
     ceres::SparseLinearAlgebraLibraryType sparseLinearAlgebraLibraryType;
     std::shared_ptr<ceres::LossFunction> lossFunction;
     unsigned int nbThreads;
+    unsigned int maxNumIterations;
     bool useParametersOrdering = true;
     bool summary = false;
     bool verbose = true;

--- a/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentPanoramaCeres.cpp
@@ -91,13 +91,16 @@ public:
     _intrinsic->setDistortionParamsFn(3, [&](auto index) { return parameter_intrinsics[4 + index]; });
 
     Eigen::Matrix3d R = jRo * iRo.transpose();
-    geometry::Pose3 T(R, Vec3({0,0,0}));
+
+
+    geometry::Pose3 T_pose3(R, Vec3({0,0,0}));
+    Eigen::Matrix4d T = T_pose3.getHomogeneous();
 
     Vec2 pt_i_cam = _intrinsic->ima2cam(pt_i);
     Vec2 pt_i_undist = _intrinsic->removeDistortion(pt_i_cam);
     Vec4 pt_i_sphere = _intrinsic->toUnitSphere(pt_i_undist).homogeneous();
 
-    Vec2 pt_j_est = _intrinsic->project(T, pt_i_sphere, true);
+    Vec2 pt_j_est = _intrinsic->project(T_pose3, pt_i_sphere, true);
 
     residuals[0] = pt_j_est(0) - pt_j(0);
     residuals[1] = pt_j_est(1) - pt_j(1);
@@ -177,13 +180,14 @@ public:
     });
 
     Eigen::Matrix3d R = jRo * iRo.transpose();
-    geometry::Pose3 T(R, Vec3({0,0,0}));
+    geometry::Pose3 T_pose3(R, Vec3({0,0,0}));
+    Eigen::Matrix4d T = T_pose3.getHomogeneous();
 
     Vec2 pt_i_cam = _intrinsic->ima2cam(pt_i);
     Vec2 pt_i_undist = _intrinsic->removeDistortion(pt_i_cam);
     Vec4 pt_i_sphere = _intrinsic->toUnitSphere(pt_i_undist).homogeneous();
 
-    Vec2 pt_j_est = _intrinsic->project(T, pt_i_sphere, true);
+    Vec2 pt_j_est = _intrinsic->project(T_pose3, pt_i_sphere, true);
 
     residuals[0] = pt_j_est(0) - pt_j(0);
     residuals[1] = pt_j_est(1) - pt_j(1);

--- a/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/BundleAdjustmentSymbolicCeres.cpp
@@ -241,26 +241,26 @@ public:
     if (jacobians[0] != nullptr) {
       Eigen::Map<Eigen::Matrix<double, 2, 16, Eigen::RowMajor>> J(jacobians[0]);
 
-      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPoseLeft(T_pose3, pth) * getJacobian_AB_wrt_B<4, 4, 4>(cTr, rTo) * getJacobian_AB_wrt_A<4, 4, 4>(Eigen::Matrix4d::Identity(), rTo);
+      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPose(T, pth) * getJacobian_AB_wrt_B<4, 4, 4>(cTr, rTo) * getJacobian_AB_wrt_A<4, 4, 4>(Eigen::Matrix4d::Identity(), rTo);
     }
 
     if (jacobians[1] != nullptr) {
       Eigen::Map<Eigen::Matrix<double, 2, 16, Eigen::RowMajor>> J(jacobians[1]);
       
-      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPoseLeft(T_pose3, pth) * getJacobian_AB_wrt_A<4, 4, 4>(cTr, rTo) * getJacobian_AB_wrt_A<4, 4, 4>(Eigen::Matrix4d::Identity(), cTr);
+      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPose(T, pth) * getJacobian_AB_wrt_A<4, 4, 4>(cTr, rTo) * getJacobian_AB_wrt_A<4, 4, 4>(Eigen::Matrix4d::Identity(), cTr);
     }
 
     if (jacobians[2] != nullptr) {
       Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobians[2], 2, params_size);
       
-      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtParams(T_pose3, pth);
+      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtParams(T, pth);
     }
 
     if (jacobians[3] != nullptr) {
       Eigen::Map<Eigen::Matrix<double, 2, 3, Eigen::RowMajor>> J(jacobians[3]);
 
 
-      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPoint(T_pose3, pth) * Eigen::Matrix<double, 4, 3>::Identity();
+      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPoint(T, pth) * Eigen::Matrix<double, 4, 3>::Identity();
     }
 
     return true;
@@ -314,13 +314,13 @@ public:
     if (jacobians[0] != nullptr) {
       Eigen::Map<Eigen::Matrix<double, 2, 16, Eigen::RowMajor>> J(jacobians[0]);
 
-      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPoseLeft(T_pose3, pth);
+      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPoseLeft(T, pth);
     }
 
     if (jacobians[1] != nullptr) {
       Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobians[1], 2, params_size);
       
-      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtParams(T_pose3, pth);
+      J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtParams(T, pth);
     }
 
     if (jacobians[2] != nullptr) {

--- a/src/aliceVision/sfm/liealgebra.hpp
+++ b/src/aliceVision/sfm/liealgebra.hpp
@@ -262,7 +262,6 @@ public:
   bool PlusJacobian(const double * x, double* jacobian) const override {
 
     Eigen::Map<Eigen::Matrix<double, 16, 6, Eigen::RowMajor>> J(jacobian);
-    Eigen::Map<const Eigen::Matrix<double, 4, 4, Eigen::RowMajor>> T(x);
 
     J.fill(0);
 

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -196,6 +196,19 @@ alicevision_add_software(aliceVision_sfmTransform
         Boost::program_options
 )
 
+# SfM Regression
+alicevision_add_software(aliceVision_sfmRegression
+  SOURCE main_sfmRegression.cpp
+  FOLDER ${FOLDER_SOFTWARE_UTILS}
+  LINKS aliceVision_system
+        aliceVision_cmdline
+        aliceVision_feature
+        aliceVision_sfm
+        aliceVision_sfmData
+        aliceVision_sfmDataIO
+        Boost::program_options
+)
+
 # SfM split reconstructed
 alicevision_add_software(aliceVision_sfmSplitReconstructed
   SOURCE main_sfmSplitReconstructed.cpp

--- a/src/software/utils/main_sfmRegression.cpp
+++ b/src/software/utils/main_sfmRegression.cpp
@@ -42,7 +42,7 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
 
     auto phIntrinsicEst = camera::createIntrinsic(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 950, 950, 0, 0);
     auto phPinholeEst = std::dynamic_pointer_cast<camera::PinholeRadialK3>(phIntrinsicEst);
-    std::vector<double> paramsEst = {0.1, 0.002, -0.01};
+    std::vector<double> paramsEst = {0.0, 0.0, -0.0};
     phPinholeEst->setDistortionParams(paramsEst);
     sfmDataEst.getIntrinsics()[0] = phPinholeEst;
 
@@ -51,17 +51,17 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
     Vec3 axis = {1.0, 1.0, 0.0};
     axis = axis.normalized();
 
-    for (int i = 0; i < 40; i++)
+    for (int i = 0; i < 120; i++)
     {
-        Vec3 pos = direction * double(i) / 40.0;
-        Eigen::Matrix3d R = SO3::expm(axis * double(0) * M_PI / (8*40.0));
+        Vec3 pos = direction * double(i) / 120.0;
+        Eigen::Matrix3d R = SO3::expm(axis * double(i) * M_PI / (8*120.0));
         geometry::Pose3 poseGT(R, pos);
         sfmData::CameraPose cposeGT(poseGT);
         sfmDataGT.getPoses()[i] = cposeGT;
         sfmDataGT.getViews()[i] = std::make_shared<sfmData::View>("", i, 0, i, 1920, 1080);
 
-        Eigen::Matrix3d Rup = SO3::expm(Vec3::Random() * ((i < 1)?0.0:0.05));
-        Eigen::Vector3d tup = Vec3::Random() * ((i < 1)?0.0:0.1);
+        Eigen::Matrix3d Rup = SO3::expm(Vec3::Random() * (0.1));
+        Eigen::Vector3d tup = Vec3::Random() * (0.5);
 
         geometry::Pose3 poseEst(Rup * R, pos + tup);
         sfmData::CameraPose cposeEst(poseEst, (i==0));
@@ -71,7 +71,7 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
     }
 
     int tid = 0;
-    for (double y = -2.0; y < 2.0; y+=0.1)
+    /*for (double y = -2.0; y < 2.0; y+=0.1)
     {
         for (double x = -2.0; x < 2.0; x+=0.1)
         {
@@ -86,7 +86,7 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
 
             tid++;
         }
-    }
+    }*/
 
     for (double y = -2.0; y < 2.0; y+=0.1)
     {
@@ -98,7 +98,7 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
             sfmDataGT.getLandmarks()[tid] = lGT;
 
             sfmData::Landmark lEst = lGT;
-            lEst.X += Vec3::Random() * 0.9;
+            lEst.X += Vec3::Random() * 2.9;
             sfmDataEst.getLandmarks()[tid] = lEst;
 
             tid++;
@@ -115,7 +115,7 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
             sfmDataGT.getLandmarks()[tid] = lGT;
 
             sfmData::Landmark lEst = lGT;
-            lEst.X += Vec3::Random() * 0.9;
+            lEst.X += Vec3::Random() * 1.9;
             sfmDataEst.getLandmarks()[tid] = lEst;
 
             tid++;
@@ -166,7 +166,7 @@ int aliceVision_main(int argc, char **argv)
     generateSampleSceneOnePlane(sfmDataGT, sfmDataEst);
 
     BundleAdjustmentSymbolicCeres::CeresOptions options;
-    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION |BundleAdjustment::REFINE_STRUCTURE | BundleAdjustment::REFINE_INTRINSICS_FOCAL | BundleAdjustment::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS;
+    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION |BundleAdjustment::REFINE_STRUCTURE | BundleAdjustment::REFINE_INTRINSICS_FOCAL | BundleAdjustment::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS | BundleAdjustment::REFINE_INTRINSICS_DISTORTION;
     options.summary = true;
     //options.nbThreads = 1;
 
@@ -181,7 +181,7 @@ int aliceVision_main(int argc, char **argv)
     generateSampleSceneOnePlane(sfmDataGT, sfmDataEst);
 
     BundleAdjustmentCeres::CeresOptions options;
-    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION |BundleAdjustment::REFINE_STRUCTURE | BundleAdjustment::REFINE_INTRINSICS_FOCAL | BundleAdjustment::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS;
+    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION |BundleAdjustment::REFINE_STRUCTURE | BundleAdjustment::REFINE_INTRINSICS_FOCAL | BundleAdjustment::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS | BundleAdjustment::REFINE_INTRINSICS_DISTORTION;
     options.summary = true;
     //options.nbThreads = 1;
 

--- a/src/software/utils/main_sfmRegression.cpp
+++ b/src/software/utils/main_sfmRegression.cpp
@@ -1,0 +1,193 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/config.hpp>
+#include <boost/program_options.hpp>
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfm/BundleAdjustmentCeres.hpp>
+#include <aliceVision/sfm/BundleAdjustmentSymbolicCeres.hpp>
+
+#include <string>
+#include <sstream>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+using namespace aliceVision::sfm;
+
+namespace po = boost::program_options;
+
+
+void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::SfMData & returnSfmDataToEstimate)
+{
+    sfmData::SfMData sfmDataGT;
+    sfmData::SfMData sfmDataEst;
+
+    auto phIntrinsicGT = camera::createIntrinsic(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 980, 980, 10, 20);
+    auto phPinholeGT = std::dynamic_pointer_cast<camera::PinholeRadialK3>(phIntrinsicGT);
+    std::vector<double> paramsGT = {0.1, 0.002, -0.01};
+    phPinholeGT->setDistortionParams(paramsGT);
+    sfmDataGT.getIntrinsics()[0] = phPinholeGT;
+
+    auto phIntrinsicEst = camera::createIntrinsic(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 950, 950, 0, 0);
+    auto phPinholeEst = std::dynamic_pointer_cast<camera::PinholeRadialK3>(phIntrinsicEst);
+    std::vector<double> paramsEst = {0.1, 0.002, -0.01};
+    phPinholeEst->setDistortionParams(paramsEst);
+    sfmDataEst.getIntrinsics()[0] = phPinholeEst;
+
+    Vec3 direction = {1.0, 1.0, 1.0};
+    direction = direction.normalized();
+    Vec3 axis = {1.0, 1.0, 0.0};
+    axis = axis.normalized();
+
+    for (int i = 0; i < 40; i++)
+    {
+        Vec3 pos = direction * double(i) / 40.0;
+        Eigen::Matrix3d R = SO3::expm(axis * double(0) * M_PI / (8*40.0));
+        geometry::Pose3 poseGT(R, pos);
+        sfmData::CameraPose cposeGT(poseGT);
+        sfmDataGT.getPoses()[i] = cposeGT;
+        sfmDataGT.getViews()[i] = std::make_shared<sfmData::View>("", i, 0, i, 1920, 1080);
+
+        Eigen::Matrix3d Rup = SO3::expm(Vec3::Random() * ((i < 1)?0.0:0.05));
+        Eigen::Vector3d tup = Vec3::Random() * ((i < 1)?0.0:0.1);
+
+        geometry::Pose3 poseEst(Rup * R, pos + tup);
+        sfmData::CameraPose cposeEst(poseEst, (i==0));
+        sfmDataEst.getPoses()[i] = cposeEst;
+        sfmDataEst.getViews()[i] = std::make_shared<sfmData::View>("", i, 0, i, 1920, 1080);
+
+    }
+
+    int tid = 0;
+    for (double y = -2.0; y < 2.0; y+=0.1)
+    {
+        for (double x = -2.0; x < 2.0; x+=0.1)
+        {
+            sfmData::Landmark lGT;
+            lGT.X = Vec3(x, y, 2.0);
+            lGT.descType = feature::EImageDescriberType::SIFT;
+            sfmDataGT.getLandmarks()[tid] = lGT;
+
+            sfmData::Landmark lEst = lGT;
+            lEst.X += Vec3::Random() * 0.9;
+            sfmDataEst.getLandmarks()[tid] = lEst;
+
+            tid++;
+        }
+    }
+
+    for (double y = -2.0; y < 2.0; y+=0.1)
+    {
+        for (double x = -2.0; x < 2.0; x+=0.1)
+        {
+            sfmData::Landmark lGT;
+            lGT.X = Vec3(x, y, 4.0);
+            lGT.descType = feature::EImageDescriberType::SIFT;
+            sfmDataGT.getLandmarks()[tid] = lGT;
+
+            sfmData::Landmark lEst = lGT;
+            lEst.X += Vec3::Random() * 0.9;
+            sfmDataEst.getLandmarks()[tid] = lEst;
+
+            tid++;
+        }
+    }
+
+    for (double y = -2.0; y < 2.0; y+=0.1)
+    {
+        for (double x = -2.0; x < 2.0; x+=0.1)
+        {
+            sfmData::Landmark lGT;
+            lGT.X = Vec3(x, y, 3.0 + sqrt(x*x + y*y));
+            lGT.descType = feature::EImageDescriberType::SIFT;
+            sfmDataGT.getLandmarks()[tid] = lGT;
+
+            sfmData::Landmark lEst = lGT;
+            lEst.X += Vec3::Random() * 0.9;
+            sfmDataEst.getLandmarks()[tid] = lEst;
+
+            tid++;
+        }
+    }
+    
+    //Compute observations
+    for (auto & pl : sfmDataGT.getLandmarks())
+    {
+        sfmData::Landmark & lEst = sfmDataEst.getLandmarks()[pl.first];
+        
+        for (auto & pp : sfmDataGT.getPoses())
+        {
+            sfmData::Observation obs;
+            obs.x = phIntrinsicGT->project(pp.second.getTransform(), pl.second.X.homogeneous(), true);
+            obs.scale = 1.0;
+            obs.id_feat = pl.first;
+
+            
+            if (pp.second.getTransform()(pl.second.X)(2) < 0.1)
+            {
+                continue;
+            }
+
+            pl.second.observations[pp.first] = obs;
+            lEst.observations[pp.first] = obs;
+        }
+    }
+
+    returnSfmDataGT = sfmDataGT;
+    returnSfmDataToEstimate = sfmDataEst;
+}
+
+int aliceVision_main(int argc, char **argv)
+{
+  po::options_description allParams("AliceVision sfmRegression");
+
+  CmdLine cmdline("AliceVision sfmRegression");
+  if (!cmdline.execute(argc, argv))
+  {
+      return EXIT_FAILURE;
+  }
+
+  {
+    srand(0);
+    sfmData::SfMData sfmDataGT;
+    sfmData::SfMData sfmDataEst;
+    generateSampleSceneOnePlane(sfmDataGT, sfmDataEst);
+
+    BundleAdjustmentSymbolicCeres::CeresOptions options;
+    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION |BundleAdjustment::REFINE_STRUCTURE | BundleAdjustment::REFINE_INTRINSICS_FOCAL | BundleAdjustment::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS;
+    options.summary = true;
+    //options.nbThreads = 1;
+
+    BundleAdjustmentSymbolicCeres BA(options, 3);
+    const bool success = BA.adjust(sfmDataEst, refineOptions);
+  }
+
+  {
+    srand(0);
+    sfmData::SfMData sfmDataGT;
+    sfmData::SfMData sfmDataEst;
+    generateSampleSceneOnePlane(sfmDataGT, sfmDataEst);
+
+    BundleAdjustmentCeres::CeresOptions options;
+    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION |BundleAdjustment::REFINE_STRUCTURE | BundleAdjustment::REFINE_INTRINSICS_FOCAL | BundleAdjustment::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS;
+    options.summary = true;
+    //options.nbThreads = 1;
+
+    BundleAdjustmentCeres BA(options, 3);
+    const bool success = BA.adjust(sfmDataEst, refineOptions);
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_sfmRegression.cpp
+++ b/src/software/utils/main_sfmRegression.cpp
@@ -34,16 +34,10 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
     sfmData::SfMData sfmDataGT;
     sfmData::SfMData sfmDataEst;
 
-    auto phIntrinsicGT = camera::createIntrinsic(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 980, 980, 10, 20);
-    auto phPinholeGT = std::dynamic_pointer_cast<camera::PinholeRadialK3>(phIntrinsicGT);
-    std::vector<double> paramsGT = {0.1, 0.002, -0.01};
-    phPinholeGT->setDistortionParams(paramsGT);
+    auto phPinholeGT = camera::createPinhole(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 980, 980, 10, 20, {0.1, 0.002, -0.01});
     sfmDataGT.getIntrinsics()[0] = phPinholeGT;
 
-    auto phIntrinsicEst = camera::createIntrinsic(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 950, 950, 0, 0);
-    auto phPinholeEst = std::dynamic_pointer_cast<camera::PinholeRadialK3>(phIntrinsicEst);
-    std::vector<double> paramsEst = {0.0, 0.0, -0.0};
-    phPinholeEst->setDistortionParams(paramsEst);
+    auto phPinholeEst = camera::createPinhole(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 950, 950, 0, 0, {0.0, 0.0, 0.0});
     sfmDataEst.getIntrinsics()[0] = phPinholeEst;
 
     Vec3 direction = {1.0, 1.0, 1.0};
@@ -71,23 +65,6 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
     }
 
     int tid = 0;
-    /*for (double y = -2.0; y < 2.0; y+=0.1)
-    {
-        for (double x = -2.0; x < 2.0; x+=0.1)
-        {
-            sfmData::Landmark lGT;
-            lGT.X = Vec3(x, y, 2.0);
-            lGT.descType = feature::EImageDescriberType::SIFT;
-            sfmDataGT.getLandmarks()[tid] = lGT;
-
-            sfmData::Landmark lEst = lGT;
-            lEst.X += Vec3::Random() * 0.9;
-            sfmDataEst.getLandmarks()[tid] = lEst;
-
-            tid++;
-        }
-    }*/
-
     for (double y = -2.0; y < 2.0; y+=0.1)
     {
         for (double x = -2.0; x < 2.0; x+=0.1)
@@ -130,7 +107,7 @@ void generateSampleSceneOnePlane(sfmData::SfMData & returnSfmDataGT, sfmData::Sf
         for (auto & pp : sfmDataGT.getPoses())
         {
             sfmData::Observation obs;
-            obs.x = phIntrinsicGT->project(pp.second.getTransform(), pl.second.X.homogeneous(), true);
+            obs.x = phPinholeGT->project(pp.second.getTransform(), pl.second.X.homogeneous(), true);
             obs.scale = 1.0;
             obs.id_feat = pl.first;
 


### PR DESCRIPTION
Bundle adjustment is currently performed

- for the reconstruction using ceres automatic differenciation and using some rotation representation for the poses.
- for the panorama using analytical differenciation (jacobians) ans using another rotation representation for the poses.

It would be nice to merge both by using analytical differentiation in reconstruction/tracking and panorama.

This PR tries to optimize the jacobians and provides an application to check if there is no discrepancy.