### PR TITLE
[docker] Update version of the AV dependencies image

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: alicevision/alicevision-deps:2023.06.07-centos7-cuda11.3.1
+      image: alicevision/alicevision-deps:2023.06.21-centos7-cuda11.3.1
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release

--- a/docker/build-centos.sh
+++ b/docker/build-centos.sh
@@ -7,7 +7,7 @@ test -e docker/fetch.sh || {
     exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.06.07
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.06.21
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$CENTOS_VERSION" && CENTOS_VERSION=7

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.03.20
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.06.21
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=20.04


### PR DESCRIPTION
## Description

This PR updates the version of the dependencies image used in the script to build the docker with the latest available version ([2023.06.21](https://hub.docker.com/layers/alicevision/alicevision-deps/2023.06.21-centos7-cuda11.3.1/images/sha256-0f869ff1b4b00331eabd58a303e476a7d3b63d0061b2a6cb5e43e9c617ae994b?context=explore)).

The dependencies image that is used in the CI has also been updated accordingly. 