### PR TITLE
Enable multiple calibrations on hdr

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -57,7 +57,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
     }
     
     std::vector<std::shared_ptr<sfmData::View>> group;
-    std::vector<double> exposures;
+    double lastExposure = std::numeric_limits<double>::max();
     for(auto& view : viewsOrderedByName)
     {
         if (countBrackets > 0)
@@ -73,13 +73,12 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         {
             // Automatically determines the number of brackets
             double exp = view->getCameraExposureSetting().getExposure();
-            if(!exposures.empty() && exp != exposures.back() && exp == exposures.front())
+            if(exp < lastExposure)
             {
                 groups.push_back(group);
                 group.clear();
-                exposures.clear();
             }
-            exposures.push_back(exp);
+
             group.push_back(view);
         }
     }

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -217,127 +217,117 @@ int aliceVision_main(int argc, char** argv)
     const size_t channelQuantization = std::pow(2, channelQuantizationPower);
 
     // Make groups
-    std::vector<std::vector<std::shared_ptr<sfmData::View>>> groupedViews;
-    if (!hdr::estimateBracketsFromSfmData(groupedViews, sfmData, nbBrackets))
+    std::vector<std::vector<std::shared_ptr<sfmData::View>>> globalGroupedViews;
+    if (!hdr::estimateBracketsFromSfmData(globalGroupedViews, sfmData, nbBrackets))
     {
         ALICEVISION_LOG_ERROR("Error on brackets information");
         return EXIT_FAILURE;
     }
 
+    std::set<std::size_t> sizeOfGroups;
+    for(auto& group : globalGroupedViews)
     {
-        std::set<std::size_t> sizeOfGroups;
-        for(auto& group : groupedViews)
-        {
-            sizeOfGroups.insert(group.size());
-        }
-        if(sizeOfGroups.size() == 1)
-        {
-            std::size_t usedNbBrackets = *sizeOfGroups.begin();
-            if(usedNbBrackets == 1)
-            {
-                ALICEVISION_LOG_INFO("No multi-bracketing.");
-                // Nothing to calibrate, export a linear CRF.
-                calibrationMethod = ECalibrationMethod::LINEAR;
-            }
-            ALICEVISION_LOG_INFO("Number of brackets automatically detected: "
-                                 << usedNbBrackets << ". It will generate " << groupedViews.size()
-                                 << " hdr images.");
-        }
-        else
-        {
-            ALICEVISION_LOG_ERROR("Exposure groups do not have a consistent number of brackets.");
-            return EXIT_FAILURE;
-        }
+        sizeOfGroups.insert(group.size());
     }
-
-    std::vector<std::map<int, luminanceInfo>> v_luminanceInfos;
-    std::vector<std::vector<hdr::ImageSample>> calibrationSamples;
-    hdr::rgbCurve calibrationWeight(channelQuantization);
-    std::vector<std::vector<double>> groupedExposures;
-
-    if (samplesFolder.empty())
+    if(sizeOfGroups.size() == 1)
     {
-        ALICEVISION_LOG_ERROR("A folder with selected samples is required to calibrate the Camera Response Function (CRF) and/or estimate the hdr output exposure level.");
-        return EXIT_FAILURE;
+        std::size_t usedNbBrackets = *sizeOfGroups.begin();
+        if(usedNbBrackets == 1)
+        {
+            ALICEVISION_LOG_INFO("No multi-bracketing.");
+            // Nothing to calibrate, export a linear CRF.
+            calibrationMethod = ECalibrationMethod::LINEAR;
+        }
+        ALICEVISION_LOG_INFO("Number of brackets automatically detected: "
+                                << usedNbBrackets << ". It will generate " << globalGroupedViews.size()
+                                << " hdr images.");
     }
     else
     {
-        // Build camera exposure table
-        for (int i = 0; i < groupedViews.size(); ++i)
+        ALICEVISION_LOG_ERROR("Exposure groups do not have a consistent number of brackets.");
+        return EXIT_FAILURE;
+    }
+
+    std::map<IndexT, std::vector<std::vector<std::shared_ptr<sfmData::View>>>> groupedViewsPerIntrinsics;
+    for (const auto & group : globalGroupedViews)
+    {
+        IndexT intrinsicId = UndefinedIndexT;
+
+        for (const auto & v : group)
         {
-            const std::vector<std::shared_ptr<sfmData::View>>& group = groupedViews[i];
-            std::vector<sfmData::ExposureSetting> exposuresSetting;
-
-            for (int j = 0; j < group.size(); ++j)
+            IndexT lid = v->getIntrinsicId();
+            if (intrinsicId == UndefinedIndexT)
             {
-                const sfmData::ExposureSetting exp = group[j]->getCameraExposureSetting();
-                exposuresSetting.push_back(exp);
+                intrinsicId = lid;
             }
-            if (!sfmData::hasComparableExposures(exposuresSetting))
-            {
-                ALICEVISION_THROW_ERROR("Camera exposure settings are inconsistent.");
-            }
-            groupedExposures.push_back(getExposures(exposuresSetting));
-        }
 
-        size_t group_pos = 0;
-        hdr::Sampling sampling;
-
-        ALICEVISION_LOG_INFO("Analyzing samples for each group");
-        for (auto& group : groupedViews)
-        {
-            // Read from file
-            const std::string samplesFilepath = (fs::path(samplesFolder) / (std::to_string(group_pos) + "_samples.dat")).string();
-            std::ifstream fileSamples(samplesFilepath, std::ios::binary);
-            if (!fileSamples.is_open())
+            if (lid != intrinsicId)
             {
-                ALICEVISION_LOG_ERROR("Impossible to read samples from file " << samplesFilepath);
+                ALICEVISION_LOG_INFO("One group shall not have multiple intrinsics");
                 return EXIT_FAILURE;
             }
-
-            std::size_t size;
-            fileSamples.read((char*)&size, sizeof(size));
-
-            std::vector<hdr::ImageSample> samples(size);
-            for (std::size_t i = 0; i < size; ++i)
-            {
-                fileSamples >> samples[i];
-            }
-
-            sampling.analyzeSource(samples, channelQuantization, group_pos);
-
-            std::map<int, luminanceInfo> luminanceInfos;
-            computeLuminanceStatFromSamples(samples, luminanceInfos);
-
-            // Check that all views in the group have an associated luminance stat info
-            for (const auto& v : group)
-            {
-                if (luminanceInfos.find(v->getViewId()) == luminanceInfos.end())
-                {
-                    luminanceInfo lumaInfo;
-                    lumaInfo.exposure = -1.0; // Dummy exposure used later indicating a dummy info
-                    luminanceInfos[v->getViewId()] = lumaInfo;
-                }
-            }
-
-            v_luminanceInfos.push_back(luminanceInfos);
-
-            ++group_pos;
         }
 
-        if (!byPass)
+        if (intrinsicId == UndefinedIndexT)
         {
-            // We need to trim samples list
-            sampling.filter(maxTotalPoints);
+            ALICEVISION_LOG_INFO("One group has no intrinsics");
+            return EXIT_FAILURE;
+        }
 
-            ALICEVISION_LOG_INFO("Extracting samples for each group");
-            group_pos = 0;
+        groupedViewsPerIntrinsics[intrinsicId].push_back(group);
+    }
 
-            std::size_t total = 0;
+    for (const auto & intrinsicGroups: groupedViewsPerIntrinsics)
+    {        
+        IndexT intrinsicId = intrinsicGroups.first;
+        const auto & groupedViews = intrinsicGroups.second;
+
+        std::vector<std::map<int, luminanceInfo>> v_luminanceInfos;
+        std::vector<std::vector<hdr::ImageSample>> calibrationSamples;
+        hdr::rgbCurve calibrationWeight(channelQuantization);
+        std::vector<std::vector<double>> groupedExposures;
+
+        if (samplesFolder.empty())
+        {
+            ALICEVISION_LOG_ERROR("A folder with selected samples is required to calibrate the Camera Response Function (CRF) and/or estimate the hdr output exposure level.");
+            return EXIT_FAILURE;
+        }
+        else
+        {
+            // Build camera exposure table
+            for (int i = 0; i < groupedViews.size(); ++i)
+            {
+                const std::vector<std::shared_ptr<sfmData::View>>& group = groupedViews[i];
+                std::vector<sfmData::ExposureSetting> exposuresSetting;
+
+                for (int j = 0; j < group.size(); ++j)
+                {
+                    const sfmData::ExposureSetting exp = group[j]->getCameraExposureSetting();
+                    exposuresSetting.push_back(exp);
+                }
+                if (!sfmData::hasComparableExposures(exposuresSetting))
+                {
+                    ALICEVISION_THROW_ERROR("Camera exposure settings are inconsistent.");
+                }
+                groupedExposures.push_back(getExposures(exposuresSetting));
+            }
+
+            size_t group_pos = 0;
+            hdr::Sampling sampling;
+
+            ALICEVISION_LOG_INFO("Analyzing samples for each group");
             for (auto& group : groupedViews)
             {
+                if (group.size() == 0)
+                {
+                    continue;
+                }
+
+                bool first = true;
+                IndexT firstViewId = group.begin()->get()->getViewId();
+
                 // Read from file
-                const std::string samplesFilepath = (fs::path(samplesFolder) / (std::to_string(group_pos) + "_samples.dat")).string();
+                const std::string samplesFilepath = (fs::path(samplesFolder) / (std::to_string(firstViewId) + "_samples.dat")).string();
                 std::ifstream fileSamples(samplesFilepath, std::ios::binary);
                 if (!fileSamples.is_open())
                 {
@@ -345,135 +335,199 @@ int aliceVision_main(int argc, char** argv)
                     return EXIT_FAILURE;
                 }
 
-                std::size_t size = 0;
+                std::size_t size;
                 fileSamples.read((char*)&size, sizeof(size));
 
                 std::vector<hdr::ImageSample> samples(size);
-                for (int i = 0; i < size; ++i)
+                for (std::size_t i = 0; i < size; ++i)
                 {
                     fileSamples >> samples[i];
                 }
 
-                std::vector<hdr::ImageSample> out_samples;
-                sampling.extractUsefulSamples(out_samples, samples, group_pos);
+                sampling.analyzeSource(samples, channelQuantization, group_pos);
 
-                calibrationSamples.push_back(out_samples);
+                std::map<int, luminanceInfo> luminanceInfos;
+                computeLuminanceStatFromSamples(samples, luminanceInfos);
+
+                // Check that all views in the group have an associated luminance stat info
+                for (const auto& v : group)
+                {
+                    if (luminanceInfos.find(v->getViewId()) == luminanceInfos.end())
+                    {
+                        luminanceInfo lumaInfo;
+                        lumaInfo.exposure = -1.0; // Dummy exposure used later indicating a dummy info
+                        luminanceInfos[v->getViewId()] = lumaInfo;
+                    }
+                }
+
+                v_luminanceInfos.push_back(luminanceInfos);
 
                 ++group_pos;
             }
 
-            // Define calibration weighting curve from name
-            boost::algorithm::to_lower(calibrationWeightFunction);
-            if (calibrationWeightFunction == "default")
+            if (!byPass)
             {
-                switch (calibrationMethod)
+                // We need to trim samples list
+                sampling.filter(maxTotalPoints);
+
+                ALICEVISION_LOG_INFO("Extracting samples for each group");
+                group_pos = 0;
+
+                std::size_t total = 0;
+                for (auto& group : groupedViews)
                 {
-                case ECalibrationMethod::DEBEVEC:
-                    calibrationWeightFunction = hdr::EFunctionType_enumToString(hdr::EFunctionType::TRIANGLE);
-                    break;
-                case ECalibrationMethod::LINEAR:
-                case ECalibrationMethod::GROSSBERG:
-                case ECalibrationMethod::LAGUERRE:
-                default:
-                    calibrationWeightFunction = hdr::EFunctionType_enumToString(hdr::EFunctionType::GAUSSIAN);
-                    break;
-                }
-            }
-            calibrationWeight.setFunction(hdr::EFunctionType_stringToEnum(calibrationWeightFunction));
-        }
-    }
-
-    if (!byPass)
-    {
-        ALICEVISION_LOG_INFO("Start calibration");
-        hdr::rgbCurve response(channelQuantization);
-
-        switch (calibrationMethod)
-        {
-        case ECalibrationMethod::LINEAR:
-        {
-            // set the response function to linear
-            response.setLinear();
-            break;
-        }
-        case ECalibrationMethod::DEBEVEC:
-        {
-            hdr::DebevecCalibrate debevec;
-            const float lambda = channelQuantization;
-            bool res = debevec.process(calibrationSamples, groupedExposures, channelQuantization, calibrationWeight, lambda, response);
-            if (!res) {
-                ALICEVISION_LOG_ERROR("Calibration failed");
-                return EXIT_FAILURE;
-            }
-
-            response.exponential();
-            response.scale();
-            break;
-        }
-        case ECalibrationMethod::GROSSBERG:
-        {
-            hdr::GrossbergCalibrate calibration(5);
-            calibration.process(calibrationSamples, groupedExposures, channelQuantization, response);
-            break;
-        }
-        case ECalibrationMethod::LAGUERRE:
-        {
-            hdr::LaguerreBACalibration calibration;
-            calibration.process(calibrationSamples, groupedExposures, channelQuantization, false, response);
-            break;
-        }
-        }
-
-        const std::string methodName = ECalibrationMethod_enumToString(calibrationMethod);
-        const std::string htmlOutput = (fs::path(outputResponsePath).parent_path() / (std::string("response_") + methodName + std::string(".html"))).string();
-
-        response.write(outputResponsePath);
-        response.writeHtml(htmlOutput, "response");
-    }
-
-    const std::string lumastatFilename = (fs::path(outputResponsePath).parent_path() / "luminanceStatistics.txt").string();
-    std::ofstream file(lumastatFilename);
-    if (!file)
-    {
-        ALICEVISION_LOG_ERROR("Unable to create file " << lumastatFilename << " for storing luminance statistics");
-        return EXIT_FAILURE;
-    }
-
-    file << v_luminanceInfos.size() << std::endl;
-    if (!v_luminanceInfos.empty())
-    {
-        file << v_luminanceInfos[0].size() << std::endl;
-        file << "# viewId ; exposure ; sampleNumber ; meanLuminance ; minLuminance ; maxLuminance" << std::endl;
-
-        for (int i = 0; i < v_luminanceInfos.size(); ++i)
-        {
-            while (!v_luminanceInfos[i].empty())
-            {
-                // search min exposure
-                IndexT srcIdWithMinimalExposure = UndefinedIndexT;
-                double exposureMin = 1e9;
-                for (auto it = v_luminanceInfos[i].begin(); it != v_luminanceInfos[i].end(); it++)
-                {
-                    if ((it->second).exposure < exposureMin)
+                    if (group.size() == 0)
                     {
-                        exposureMin = (it->second).exposure;
-                        srcIdWithMinimalExposure = it->first;
+                        continue;
+                    }
+
+                    bool first = true;
+                    IndexT firstViewId = group.begin()->get()->getViewId();
+
+
+                    // Read from file
+                    const std::string samplesFilepath = (fs::path(samplesFolder) / (std::to_string(firstViewId) + "_samples.dat")).string();
+                    std::ifstream fileSamples(samplesFilepath, std::ios::binary);
+                    if (!fileSamples.is_open())
+                    {
+                        ALICEVISION_LOG_ERROR("Impossible to read samples from file " << samplesFilepath);
+                        return EXIT_FAILURE;
+                    }
+
+                    std::size_t size = 0;
+                    fileSamples.read((char*)&size, sizeof(size));
+
+                    std::vector<hdr::ImageSample> samples(size);
+                    for (int i = 0; i < size; ++i)
+                    {
+                        fileSamples >> samples[i];
+                    }
+
+                    std::vector<hdr::ImageSample> out_samples;
+                    sampling.extractUsefulSamples(out_samples, samples, group_pos);
+
+                    calibrationSamples.push_back(out_samples);
+
+                    ++group_pos;
+                }
+
+                // Define calibration weighting curve from name
+                boost::algorithm::to_lower(calibrationWeightFunction);
+                if (calibrationWeightFunction == "default")
+                {
+                    switch (calibrationMethod)
+                    {
+                    case ECalibrationMethod::DEBEVEC:
+                        calibrationWeightFunction = hdr::EFunctionType_enumToString(hdr::EFunctionType::TRIANGLE);
+                        break;
+                    case ECalibrationMethod::LINEAR:
+                    case ECalibrationMethod::GROSSBERG:
+                    case ECalibrationMethod::LAGUERRE:
+                    default:
+                        calibrationWeightFunction = hdr::EFunctionType_enumToString(hdr::EFunctionType::GAUSSIAN);
+                        break;
                     }
                 }
-                // write in file
-                file << srcIdWithMinimalExposure << " ";
-                file << v_luminanceInfos[i][srcIdWithMinimalExposure].exposure << " " << v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb << " ";
-                if (v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb > 0)
-                {
-                    file << v_luminanceInfos[i][srcIdWithMinimalExposure].meanLum / v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb << " ";
+                calibrationWeight.setFunction(hdr::EFunctionType_stringToEnum(calibrationWeightFunction));
+            }
+        }
+
+        if (!byPass)
+        {
+            ALICEVISION_LOG_INFO("Start calibration");
+            hdr::rgbCurve response(channelQuantization);
+
+            switch (calibrationMethod)
+            {
+            case ECalibrationMethod::LINEAR:
+            {
+                // set the response function to linear
+                response.setLinear();
+                break;
+            }
+            case ECalibrationMethod::DEBEVEC:
+            {
+                hdr::DebevecCalibrate debevec;
+                const float lambda = channelQuantization;
+                bool res = debevec.process(calibrationSamples, groupedExposures, channelQuantization, calibrationWeight, lambda, response);
+                if (!res) {
+                    ALICEVISION_LOG_ERROR("Calibration failed");
+                    return EXIT_FAILURE;
                 }
-                else
+
+                response.exponential();
+                response.scale();
+                break;
+            }
+            case ECalibrationMethod::GROSSBERG:
+            {
+                hdr::GrossbergCalibrate calibration(5);
+                calibration.process(calibrationSamples, groupedExposures, channelQuantization, response);
+                break;
+            }
+            case ECalibrationMethod::LAGUERRE:
+            {
+                hdr::LaguerreBACalibration calibration;
+                calibration.process(calibrationSamples, groupedExposures, channelQuantization, false, response);
+                break;
+            }
+            }
+
+            const std::string methodName = ECalibrationMethod_enumToString(calibrationMethod);
+            
+            const std::string baseName = (fs::path(outputResponsePath).parent_path() / std::string("response_")).string();
+            const std::string intrinsicName = baseName + std::to_string(intrinsicId);
+            const std::string htmlName = intrinsicName + "_" + methodName + std::string(".html");
+
+            response.write(intrinsicName + ".csv");
+            response.writeHtml(htmlName, "response");
+        }
+
+        const std::string lumastatBasename = "luminanceStatistics";
+        const std::string lumastatFilename = (fs::path(outputResponsePath).parent_path() / (lumastatBasename + "_" + std::to_string(intrinsicId) + ".txt")).string();
+        std::ofstream file(lumastatFilename);
+        if (!file)
+        {
+            ALICEVISION_LOG_ERROR("Unable to create file " << lumastatFilename << " for storing luminance statistics");
+            return EXIT_FAILURE;
+        }
+
+        file << v_luminanceInfos.size() << std::endl;
+        if (!v_luminanceInfos.empty())
+        {
+            file << v_luminanceInfos[0].size() << std::endl;
+            file << "# viewId ; exposure ; sampleNumber ; meanLuminance ; minLuminance ; maxLuminance" << std::endl;
+
+            for (int i = 0; i < v_luminanceInfos.size(); ++i)
+            {
+                while (!v_luminanceInfos[i].empty())
                 {
-                    file << "0.0 ";
+                    // search min exposure
+                    IndexT srcIdWithMinimalExposure = UndefinedIndexT;
+                    double exposureMin = 1e9;
+                    for (auto it = v_luminanceInfos[i].begin(); it != v_luminanceInfos[i].end(); it++)
+                    {
+                        if ((it->second).exposure < exposureMin)
+                        {
+                            exposureMin = (it->second).exposure;
+                            srcIdWithMinimalExposure = it->first;
+                        }
+                    }
+                    // write in file
+                    file << srcIdWithMinimalExposure << " ";
+                    file << v_luminanceInfos[i][srcIdWithMinimalExposure].exposure << " " << v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb << " ";
+                    if (v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb > 0)
+                    {
+                        file << v_luminanceInfos[i][srcIdWithMinimalExposure].meanLum / v_luminanceInfos[i][srcIdWithMinimalExposure].itemNb << " ";
+                    }
+                    else
+                    {
+                        file << "0.0 ";
+                    }
+                    file << v_luminanceInfos[i][srcIdWithMinimalExposure].minLum << " " << v_luminanceInfos[i][srcIdWithMinimalExposure].maxLum << std::endl;
+                    // erase from map
+                    v_luminanceInfos[i].erase(srcIdWithMinimalExposure);
                 }
-                file << v_luminanceInfos[i][srcIdWithMinimalExposure].minLum << " " << v_luminanceInfos[i][srcIdWithMinimalExposure].maxLum << std::endl;
-                // erase from map
-                v_luminanceInfos[i].erase(srcIdWithMinimalExposure);
             }
         }
     }

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -194,6 +194,7 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // Check groups
     std::size_t usedNbBrackets;
     {
         std::set<std::size_t> sizeOfGroups;
@@ -218,34 +219,75 @@ int aliceVision_main(int argc, char** argv)
             return EXIT_FAILURE;
         }
     }
-    std::vector<std::shared_ptr<sfmData::View>> targetViews;
-    int estimatedTargetIndex;
 
+    // Group all groups sharing the same intrinsic
+    std::map<IndexT, std::vector<std::vector<std::shared_ptr<sfmData::View>>>> groupedViewsPerIntrinsics;
+    for (const auto & group : groupedViews)
+    {
+        IndexT intrinsicId = UndefinedIndexT;
+
+        for (const auto & v : group)
+        {
+            IndexT lid = v->getIntrinsicId();
+            if (intrinsicId == UndefinedIndexT)
+            {
+                intrinsicId = lid;
+            }
+
+            if (lid != intrinsicId)
+            {
+                ALICEVISION_LOG_INFO("One group shall not have multiple intrinsics");
+                return EXIT_FAILURE;
+            }
+        }
+
+        if (intrinsicId == UndefinedIndexT)
+        {
+            ALICEVISION_LOG_INFO("One group has no intrinsics");
+            return EXIT_FAILURE;
+        }
+
+        groupedViewsPerIntrinsics[intrinsicId].push_back(group);
+    }
+
+
+    //Estimate target views for each group
+    std::map<IndexT, std::vector<std::shared_ptr<sfmData::View>>> targetViewsPerIntrinsics;
+    std::map<IndexT, int> targetIndexPerIntrinsics;
     if (!byPass)
     {
-        const int middleIndex = usedNbBrackets / 2;
-        const int targetIndex = middleIndex + offsetRefBracketIndex;
-        const bool isOffsetRefBracketIndexValid = (targetIndex >= 0) && (targetIndex < usedNbBrackets);
-
-        const fs::path lumaStatFilepath(fs::path(inputResponsePath).parent_path() / (std::string("luminanceStatistics.txt")));
-
-        if (!fs::is_regular_file(lumaStatFilepath) && !isOffsetRefBracketIndexValid)
+        for (const auto& intrinsicGroup : groupedViewsPerIntrinsics)
         {
-            ALICEVISION_LOG_ERROR("Unable to open the file " << lumaStatFilepath.string() << " with luminance statistics. This file is needed to select the optimal exposure for the creation of HDR images.");
-            return EXIT_FAILURE;
-        }
+            IndexT intrinsicId = intrinsicGroup.first;
+            std::vector<std::vector<std::shared_ptr<sfmData::View>>> groups = intrinsicGroup.second;
+            std::vector<std::shared_ptr<sfmData::View>> targetViews;
 
-        // Adjust the targeted luminance level by removing the corresponding gamma if the working color space is not sRGB.
-        if (workingColorSpace != image::EImageColorSpace::SRGB)
-        {
-            meanTargetedLumaForMerging = std::pow((meanTargetedLumaForMerging + 0.055) / 1.055, 2.2);
-        }
-        estimatedTargetIndex = hdr::selectTargetViews(targetViews, groupedViews, offsetRefBracketIndex, lumaStatFilepath.string(), meanTargetedLumaForMerging);
+            const int middleIndex = usedNbBrackets / 2;
+            const int targetIndex = middleIndex + offsetRefBracketIndex;
+            const bool isOffsetRefBracketIndexValid = (targetIndex >= 0) && (targetIndex < usedNbBrackets);
 
-        if ((targetViews.empty() || targetViews.size() != groupedViews.size()) && !isOffsetRefBracketIndexValid)
-        {
-            ALICEVISION_LOG_ERROR("File " << lumaStatFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
-            return EXIT_FAILURE;
+            const fs::path lumaStatFilepath(fs::path(inputResponsePath).parent_path() / (std::string("luminanceStatistics") + "_" + std::to_string(intrinsicId) + ".txt"));
+
+            if (!fs::is_regular_file(lumaStatFilepath) && !isOffsetRefBracketIndexValid)
+            {
+                ALICEVISION_LOG_ERROR("Unable to open the file " << lumaStatFilepath.string() << " with luminance statistics. This file is needed to select the optimal exposure for the creation of HDR images.");
+                return EXIT_FAILURE;
+            }
+
+            // Adjust the targeted luminance level by removing the corresponding gamma if the working color space is not sRGB.
+            if (workingColorSpace != image::EImageColorSpace::SRGB)
+            {
+                meanTargetedLumaForMerging = std::pow((meanTargetedLumaForMerging + 0.055) / 1.055, 2.2);
+            }
+            targetIndexPerIntrinsics[intrinsicId] = hdr::selectTargetViews(targetViews, groups, offsetRefBracketIndex, lumaStatFilepath.string(), meanTargetedLumaForMerging);
+
+            if ((targetViews.empty() || targetViews.size() != groups.size()) && !isOffsetRefBracketIndexValid)
+            {
+                ALICEVISION_LOG_ERROR("File " << lumaStatFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
+                return EXIT_FAILURE;
+            }
+
+            targetViewsPerIntrinsics[intrinsicId] = targetViews;
         }
     }
 
@@ -277,30 +319,41 @@ int aliceVision_main(int argc, char** argv)
 
         // If we are on the first chunk, or we are computing all the dataset
         // Export a new sfmData with HDR images as new Views.
-        for(std::size_t g = 0; g < groupedViews.size(); ++g)
+        for (const auto & groupedViews : groupedViewsPerIntrinsics)
         {
-            std::shared_ptr<sfmData::View> hdrView;
-            if (groupedViews[g].size() == 1)
+            IndexT intrinsicId = groupedViews.first;
+            
+            const auto & groups = groupedViews.second;
+            const auto & targetViews = targetViewsPerIntrinsics[intrinsicId];
+
+            for (int g = 0; g < groups.size(); g++)
             {
-                hdrView = std::make_shared<sfmData::View>(*groupedViews[g][0]);
+                std::shared_ptr<sfmData::View> hdrView;
+
+                const auto & group = groups[g];
+                
+                if (group.size() == 1)
+                {
+                    hdrView = std::make_shared<sfmData::View>(*group.at(0));
+                }
+                else if (targetViews.empty())
+                {
+                    ALICEVISION_LOG_ERROR("Target view for HDR merging has not been computed");
+                    return EXIT_FAILURE;
+                }
+                else
+                {
+                    hdrView = std::make_shared<sfmData::View>(*targetViews.at(g));
+                }
+                if(!byPass)
+                {
+                    boost::filesystem::path p(targetViews[g]->getImagePath());
+                    const std::string hdrImagePath = getHdrImagePath(outputPath, g, keepSourceImageName ? p.stem().string() : "");
+                    hdrView->setImagePath(hdrImagePath);
+                }
+                hdrView->addMetadata("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(mergedColorSpace));
+                outputSfm.getViews()[hdrView->getViewId()] = hdrView;
             }
-            else if (targetViews.empty())
-            {
-                ALICEVISION_LOG_ERROR("Target view for HDR merging has not been computed");
-                return EXIT_FAILURE;
-            }
-            else
-            {
-                hdrView = std::make_shared<sfmData::View>(*targetViews[g]);
-            }
-            if(!byPass)
-            {
-                boost::filesystem::path p(targetViews[g]->getImagePath());
-                const std::string hdrImagePath = getHdrImagePath(outputPath, g, keepSourceImageName ? p.stem().string() : "");
-                hdrView->setImagePath(hdrImagePath);
-            }
-            hdrView->addMetadata("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(mergedColorSpace));
-            outputSfm.getViews()[hdrView->getViewId()] = hdrView;
         }
 
         // Export output sfmData
@@ -310,129 +363,152 @@ int aliceVision_main(int argc, char** argv)
             return EXIT_FAILURE;
         }
     }
+
+    
     if(byPass)
     {
         ALICEVISION_LOG_INFO("Bypass enabled, nothing to compute.");
         return EXIT_SUCCESS;
     }
 
-    hdr::rgbCurve fusionWeight(channelQuantization);
-    fusionWeight.setFunction(fusionWeightFunction);
+    int rangeEnd = rangeStart + rangeSize;
 
-    ALICEVISION_LOG_DEBUG("inputResponsePath: " << inputResponsePath);
-
-    hdr::rgbCurve response(channelQuantization);
-    response.read(inputResponsePath);
-
-    for(std::size_t g = rangeStart; g < rangeStart + rangeSize; ++g)
+    int pos = 0;
+    for (const auto & pGroupedViews : groupedViewsPerIntrinsics)
     {
-        const std::vector<std::shared_ptr<sfmData::View>>& group = groupedViews[g];
+        IndexT intrinsicId = pGroupedViews.first;
 
-        std::vector<image::Image<image::RGBfColor>> images(group.size());
-        std::shared_ptr<sfmData::View> targetView = targetViews[g];
-        std::vector<sfmData::ExposureSetting> exposuresSetting(group.size());
+        const auto & groupedViews = pGroupedViews.second;
+        const auto & targetViews = targetViewsPerIntrinsics.at(intrinsicId);
 
-        // Load all images of the group
-        for(std::size_t i = 0; i < group.size(); ++i)
+        hdr::rgbCurve fusionWeight(channelQuantization);
+        fusionWeight.setFunction(fusionWeightFunction);
+        hdr::rgbCurve response(channelQuantization);
+
+        const std::string baseName = (fs::path(inputResponsePath).parent_path() / std::string("response_")).string();
+        const std::string intrinsicName = baseName + std::to_string(intrinsicId);
+        const std::string intrinsicInputResponsePath = intrinsicName + ".csv";
+
+        ALICEVISION_LOG_DEBUG("inputResponsePath: " << intrinsicInputResponsePath);
+        response.read(intrinsicInputResponsePath);
+
+        for (std::size_t g = 0; g < groupedViews.size(); ++g, ++pos)
         {
-            const std::string filepath = group[i]->getImagePath();
-            ALICEVISION_LOG_INFO("Load " << filepath);
-
-            image::ImageReadOptions options;
-            options.workingColorSpace = workingColorSpace;
-            options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
-            options.colorProfileFileName = group[i]->getColorProfileFileName();
-            // Whatever the raw color interpretation mode, the default read processing for raw images is to apply white balancing in libRaw, before demosaicing.
-            // The DcpMetadata mode allows to not apply color management after demosaicing.
-            // Because if requested after demosaicing, white balancing is done at color management stage, we can set this option to true to get real raw data,
-            // without any white balancing, when the DcpMetadata mode is selected.
-            if (options.rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata)
+            if (pos < rangeStart || pos >= rangeEnd)
             {
-                options.doWBAfterDemosaicing = true;
+                continue;
             }
-            image::readImage(filepath, images[i], options);
 
-            exposuresSetting[i] = group[i]->getCameraExposureSetting(/*targetView->getMetadataISO(), targetView->getMetadataFNumber()*/);
-        }
-        if(!sfmData::hasComparableExposures(exposuresSetting))
-        {
-            ALICEVISION_THROW_ERROR("Camera exposure settings are inconsistent.");
-        }
-        std::vector<double> exposures = getExposures(exposuresSetting);
+            const std::vector<std::shared_ptr<sfmData::View>> & group = groupedViews[g];
 
-        // Merge HDR images
-        image::Image<image::RGBfColor> HDRimage;
-        image::Image<image::RGBfColor> lowLightMask;
-        image::Image<image::RGBfColor> highLightMask;
-        image::Image<image::RGBfColor> noMidLightMask;
-        if(images.size() > 1)
-        {
-            hdr::hdrMerge merge;
-            sfmData::ExposureSetting targetCameraSetting = targetView->getCameraExposureSetting();
-            ALICEVISION_LOG_INFO("[" << g - rangeStart << "/" << rangeSize << "] Merge " << group.size() << " LDR images " << g << "/" << groupedViews.size());
+            std::vector<image::Image<image::RGBfColor>> images(group.size());
+            std::shared_ptr<sfmData::View> targetView = targetViews[g];
+            std::vector<sfmData::ExposureSetting> exposuresSetting(group.size());
 
-            hdr::MergingParams mergingParams;
-            mergingParams.targetCameraExposure = targetCameraSetting.getExposure();
-            mergingParams.refImageIndex = estimatedTargetIndex;
-            mergingParams.minSignificantValue = minSignificantValue;
-            mergingParams.maxSignificantValue = maxSignificantValue;
-            mergingParams.computeLightMasks = computeLightMasks;
-
-            merge.process(images, exposures, fusionWeight, response, HDRimage, lowLightMask, highLightMask, noMidLightMask, mergingParams);//, targetCameraSetting.getExposure(), estimatedTargetIndex);
-            if(highlightCorrectionFactor > 0.0f)
+            // Load all images of the group
+            for(std::size_t i = 0; i < group.size(); ++i)
             {
-                merge.postProcessHighlight(images, exposures, fusionWeight, response, HDRimage, targetCameraSetting.getExposure(), highlightCorrectionFactor, highlightTargetLux);
+                const std::string filepath = group[i]->getImagePath();
+                ALICEVISION_LOG_INFO("Load " << filepath);
+
+                image::ImageReadOptions options;
+                options.workingColorSpace = workingColorSpace;
+                options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
+                options.colorProfileFileName = group[i]->getColorProfileFileName();
+
+                // Whatever the raw color interpretation mode, the default read processing for raw images is to apply white balancing in libRaw, before demosaicing.
+                // The DcpMetadata mode allows to not apply color management after demosaicing.
+                // Because if requested after demosaicing, white balancing is done at color management stage, we can set this option to true to get real raw data,
+                // without any white balancing, when the DcpMetadata mode is selected.
+                if (options.rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata)
+                {
+                    options.doWBAfterDemosaicing = true;
+                }
+                
+                image::readImage(filepath, images[i], options);
+
+                exposuresSetting[i] = group[i]->getCameraExposureSetting();
             }
-        }
-        else if(images.size() == 1)
-        {
-            // Nothing to do
-            HDRimage = images[0];
-        }
 
-        boost::filesystem::path p(targetView->getImagePath());
-        const std::string hdrImagePath = getHdrImagePath(outputPath, g, keepSourceImageName ? p.stem().string() : "");
-
-        // Write an image with parameters from the target view
-        std::map<std::string, std::string> viewMetadata = targetView->getMetadata();
-
-        oiio::ParamValueList targetMetadata;
-        for (const auto& meta : viewMetadata)
-        {
-            if (meta.first.compare(0, 3, "raw") == 0)
+            if(!sfmData::hasComparableExposures(exposuresSetting))
             {
-                targetMetadata.add_or_replace(oiio::ParamValue("AliceVision:" + meta.first, meta.second));
+                ALICEVISION_THROW_ERROR("Camera exposure settings are inconsistent.");
             }
-            else
+
+            std::vector<double> exposures = getExposures(exposuresSetting);
+
+            // Merge HDR images
+            image::Image<image::RGBfColor> HDRimage;
+            image::Image<image::RGBfColor> lowLightMask;
+            image::Image<image::RGBfColor> highLightMask;
+            image::Image<image::RGBfColor> noMidLightMask;
+            if(images.size() > 1)
             {
-                targetMetadata.add_or_replace(oiio::ParamValue(meta.first, meta.second));
+                hdr::hdrMerge merge;
+                sfmData::ExposureSetting targetCameraSetting = targetView->getCameraExposureSetting();
+                hdr::MergingParams mergingParams;
+                mergingParams.targetCameraExposure = targetCameraSetting.getExposure();
+                mergingParams.refImageIndex = targetIndexPerIntrinsics[intrinsicId];
+                mergingParams.minSignificantValue = minSignificantValue;
+                mergingParams.maxSignificantValue = maxSignificantValue;
+                mergingParams.computeLightMasks = computeLightMasks;
+               
+                merge.process(images, exposures, fusionWeight, response, HDRimage, lowLightMask, highLightMask, noMidLightMask, mergingParams);
+                if(highlightCorrectionFactor > 0.0f)
+                {
+                    merge.postProcessHighlight(images, exposures, fusionWeight, response, HDRimage, targetCameraSetting.getExposure(), highlightCorrectionFactor, highlightTargetLux);
+                }
             }
-        }
+            else if(images.size() == 1)
+            {
+                // Nothing to do
+                HDRimage = images[0];
+            }
 
-        targetMetadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(mergedColorSpace)));
+            boost::filesystem::path p(targetView->getImagePath());
+            const std::string hdrImagePath = getHdrImagePath(outputPath, pos, keepSourceImageName ? p.stem().string() : "");
 
-        image::ImageWriteOptions writeOptions;
-        writeOptions.fromColorSpace(mergedColorSpace);
-        writeOptions.toColorSpace(mergedColorSpace);
-        writeOptions.storageDataType(storageDataType);
+            // Write an image with parameters from the target view
+            std::map<std::string, std::string> viewMetadata = targetView->getMetadata();
 
-        image::writeImage(hdrImagePath, HDRimage, writeOptions, targetMetadata);
+            oiio::ParamValueList targetMetadata;
+            for (const auto& meta : viewMetadata)
+            {
+                if (meta.first.compare(0, 3, "raw") == 0)
+                {
+                    targetMetadata.add_or_replace(oiio::ParamValue("AliceVision:" + meta.first, meta.second));
+                }
+                else
+                {
+                    targetMetadata.add_or_replace(oiio::ParamValue(meta.first, meta.second));
+                }
+            }
 
-        if(computeLightMasks)
-        {
-            const std::string hdrMaskLowLightPath =
-                getHdrMaskPath(outputPath, g, "lowLight", keepSourceImageName ? p.stem().string() : "");
-            const std::string hdrMaskHighLightPath =
-                getHdrMaskPath(outputPath, g, "highLight", keepSourceImageName ? p.stem().string() : "");
-            const std::string hdrMaskNoMidLightPath =
-                getHdrMaskPath(outputPath, g, "noMidLight", keepSourceImageName ? p.stem().string() : "");
+            targetMetadata.add_or_replace(oiio::ParamValue("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(mergedColorSpace)));
 
-            image::ImageWriteOptions maskWriteOptions;
-            maskWriteOptions.exrCompressionMethod(image::EImageExrCompression::None);
+            image::ImageWriteOptions writeOptions;
+            writeOptions.fromColorSpace(mergedColorSpace);
+            writeOptions.toColorSpace(mergedColorSpace);
+            writeOptions.storageDataType(storageDataType);
 
-            image::writeImage(hdrMaskLowLightPath, lowLightMask, maskWriteOptions);
-            image::writeImage(hdrMaskHighLightPath, highLightMask, maskWriteOptions);
-            image::writeImage(hdrMaskNoMidLightPath, noMidLightMask, maskWriteOptions);
+            image::writeImage(hdrImagePath, HDRimage, writeOptions, targetMetadata);
+
+            if(computeLightMasks)
+            {
+                const std::string hdrMaskLowLightPath =
+                    getHdrMaskPath(outputPath, pos, "lowLight", keepSourceImageName ? p.stem().string() : "");
+                const std::string hdrMaskHighLightPath =
+                    getHdrMaskPath(outputPath, pos, "highLight", keepSourceImageName ? p.stem().string() : "");
+                const std::string hdrMaskNoMidLightPath =
+                    getHdrMaskPath(outputPath, pos, "noMidLight", keepSourceImageName ? p.stem().string() : "");
+
+                image::ImageWriteOptions maskWriteOptions;
+                maskWriteOptions.exrCompressionMethod(image::EImageExrCompression::None);
+
+                image::writeImage(hdrMaskLowLightPath, lowLightMask, maskWriteOptions);
+                image::writeImage(hdrMaskHighLightPath, highLightMask, maskWriteOptions);
+                image::writeImage(hdrMaskNoMidLightPath, noMidLightMask, maskWriteOptions);
+            }
         }
     }
 

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -314,6 +314,7 @@ int aliceVision_main(int argc, char** argv)
 
     if(rangeStart == 0)
     {
+        int pos = 0;
         sfmData::SfMData outputSfm;
         outputSfm.getIntrinsics() = sfmData.getIntrinsics();
 
@@ -326,7 +327,7 @@ int aliceVision_main(int argc, char** argv)
             const auto & groups = groupedViews.second;
             const auto & targetViews = targetViewsPerIntrinsics[intrinsicId];
 
-            for (int g = 0; g < groups.size(); g++)
+            for (int g = 0; g < groups.size(); g++, pos++)
             {
                 std::shared_ptr<sfmData::View> hdrView;
 
@@ -348,7 +349,7 @@ int aliceVision_main(int argc, char** argv)
                 if(!byPass)
                 {
                     boost::filesystem::path p(targetViews[g]->getImagePath());
-                    const std::string hdrImagePath = getHdrImagePath(outputPath, g, keepSourceImageName ? p.stem().string() : "");
+                    const std::string hdrImagePath = getHdrImagePath(outputPath, pos, keepSourceImageName ? p.stem().string() : "");
                     hdrView->setImagePath(hdrImagePath);
                 }
                 hdrView->addMetadata("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(mergedColorSpace));

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -122,16 +122,6 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    // Make sure there is only one kind of image in dataset
-    if(sfmData.getIntrinsics().size() > 1)
-    {
-        ALICEVISION_LOG_ERROR("Only one intrinsic allowed (" << sfmData.getIntrinsics().size() << " found)");
-        return EXIT_FAILURE;
-    }
-
-    const std::size_t width = sfmData.getIntrinsics().begin()->second->w();
-    const std::size_t height = sfmData.getIntrinsics().begin()->second->h();
-
     // Make groups
     std::vector<std::vector<std::shared_ptr<sfmData::View>>> groupedViews;
     if (!hdr::estimateBracketsFromSfmData(groupedViews, sfmData, nbBrackets))
@@ -188,105 +178,155 @@ int aliceVision_main(int argc, char** argv)
         rangeSize = groupedViews.size();
     }
     ALICEVISION_LOG_DEBUG("Range to compute: rangeStart=" << rangeStart << ", rangeSize=" << rangeSize);
+    
 
+    std::map<IndexT, std::vector<std::vector<std::shared_ptr<sfmData::View>>>> groupedViewsPerIntrinsics;
     for(std::size_t groupIdx = rangeStart; groupIdx < rangeStart + rangeSize; ++groupIdx)
     {
         auto & group = groupedViews[groupIdx];
-        ALICEVISION_LOG_INFO("Extracting samples from group " << groupIdx);
 
-        std::vector<std::string> paths;
-        std::vector<sfmData::ExposureSetting> exposuresSetting;
-        std::vector<IndexT> viewIds;
+        IndexT intrinsicId = UndefinedIndexT;
 
-        image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
-        std::string colorProfileFileName = "";
-
-        for (auto & v : group)
+        for (const auto & v : group)
         {
-            paths.push_back(v->getImagePath());
-            exposuresSetting.push_back(v->getCameraExposureSetting());
-            viewIds.push_back(v->getViewId());
-
-            const std::string rawColorInterpretation_str = v->getRawColorInterpretation();
-            rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(rawColorInterpretation_str);
-            colorProfileFileName = v->getColorProfileFileName();
-
-            ALICEVISION_LOG_INFO("Image: " << paths.back() << ", exposure: " << exposuresSetting.back() << ", raw color interpretation: " << ERawColorInterpretation_enumToString(rawColorInterpretation));
-        }
-        if(!sfmData::hasComparableExposures(exposuresSetting))
-        {
-            ALICEVISION_THROW_ERROR("Camera exposure settings are inconsistent.");
-        }
-        std::vector<double> exposures = getExposures(exposuresSetting);
-
-        image::ImageReadOptions imgReadOptions;
-        imgReadOptions.workingColorSpace = workingColorSpace;
-        imgReadOptions.rawColorInterpretation = rawColorInterpretation;
-        imgReadOptions.colorProfileFileName = colorProfileFileName;
-
-        const bool simplifiedSampling = byPass || (calibrationMethod == ECalibrationMethod::LINEAR);
-
-        std::vector<hdr::ImageSample> out_samples;
-        const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, viewIds, exposures, width, height, channelQuantization, imgReadOptions, params, simplifiedSampling);
-        if (!res)
-        {
-            ALICEVISION_LOG_ERROR("Error while extracting samples from group " << groupIdx);
-        }
-
-        using namespace boost::accumulators;
-        using Accumulator = accumulator_set<float, stats<tag::min, tag::max, tag::median, tag::mean>>;
-        Accumulator acc_nbUsedBrackets;
-        {
-            utils::Histogram<int> histogram(1, usedNbBrackets, usedNbBrackets-1);
-            for(const hdr::ImageSample& sample : out_samples)
+            IndexT lid = v->getIntrinsicId();
+            if (intrinsicId == UndefinedIndexT)
             {
-                acc_nbUsedBrackets(sample.descriptions.size());
-                histogram.Add(sample.descriptions.size());
+                intrinsicId = lid;
             }
-            ALICEVISION_LOG_INFO("Number of used brackets in selected samples: "
-                                 << " min: " << extract::min(acc_nbUsedBrackets) << " max: "
-                                 << extract::max(acc_nbUsedBrackets) << " mean: " << extract::mean(acc_nbUsedBrackets)
-                                 << " median: " << extract::median(acc_nbUsedBrackets));
 
-            ALICEVISION_LOG_INFO("Histogram of the number of brackets per sample: " << histogram.ToString("", 2));
-        }
-        if(debug)
-        {
-            image::Image<image::RGBfColor> selectedPixels(width, height, true);
-
-            for(const hdr::ImageSample& sample: out_samples)
+            if (lid != intrinsicId)
             {
-                const float score = float(sample.descriptions.size()) / float(usedNbBrackets);
-                const image::RGBfColor color = getColorFromJetColorMap(score);
-                selectedPixels(sample.y, sample.x) = image::RGBfColor(color.r(), color.g(), color.b());
+                ALICEVISION_LOG_INFO("One group shall not have multiple intrinsics");
+                return EXIT_FAILURE;
             }
-            oiio::ParamValueList metadata;
-            metadata.push_back(oiio::ParamValue("AliceVision:nbSelectedPixels", int(selectedPixels.size())));
-            metadata.push_back(oiio::ParamValue("AliceVision:minNbUsedBrackets", extract::min(acc_nbUsedBrackets)));
-            metadata.push_back(oiio::ParamValue("AliceVision:maxNbUsedBrackets", extract::max(acc_nbUsedBrackets)));
-            metadata.push_back(oiio::ParamValue("AliceVision:meanNbUsedBrackets", extract::mean(acc_nbUsedBrackets)));
-            metadata.push_back(oiio::ParamValue("AliceVision:medianNbUsedBrackets", extract::median(acc_nbUsedBrackets)));
-
-            image::writeImage((fs::path(outputFolder) / (std::to_string(groupIdx) + "_selectedPixels.png")).string(),
-                              selectedPixels, image::ImageWriteOptions(), metadata);
-
         }
 
-        // Store to file
-        const std::string samplesFilepath = (fs::path(outputFolder) / (std::to_string(groupIdx) + "_samples.dat")).string();
-        std::ofstream fileSamples(samplesFilepath, std::ios::binary);
-        if (!fileSamples.is_open())
+        if (intrinsicId == UndefinedIndexT)
         {
-            ALICEVISION_LOG_ERROR("Impossible to write samples");
+            ALICEVISION_LOG_INFO("One group has no intrinsics");
             return EXIT_FAILURE;
         }
 
-        const std::size_t size = out_samples.size();
-        fileSamples.write((const char *)&size, sizeof(size));
+        groupedViewsPerIntrinsics[intrinsicId].push_back(group);
+    }
 
-        for(std::size_t i = 0; i < out_samples.size(); ++i)
+    for (const auto  & pGroups : groupedViewsPerIntrinsics)
+    {
+        IndexT intrinsicId = pGroups.first;
+
+        const auto & intrinsic = sfmData.getIntrinsics().at(intrinsicId);
+        const std::size_t width = intrinsic->w();
+        const std::size_t height = intrinsic->h();
+
+        for (const auto & group : pGroups.second)
         {
-            fileSamples << out_samples[i];
+            std::vector<std::string> paths;
+            std::vector<sfmData::ExposureSetting> exposuresSetting;
+            std::vector<IndexT> viewIds;
+
+            image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
+            std::string colorProfileFileName = "";
+
+            bool first = true;
+            IndexT firstViewId = UndefinedIndexT;
+
+
+            for (auto & v : group)
+            {
+                //Retrieve first view Id to get a unique name for files
+                //As one view is only in one group
+                if (first)
+                {
+                    firstViewId = v->getViewId();
+                    first = false;
+                }
+
+                paths.push_back(v->getImagePath());
+                exposuresSetting.push_back(v->getCameraExposureSetting());
+                viewIds.push_back(v->getViewId());
+
+                const std::string rawColorInterpretation_str = v->getRawColorInterpretation();
+                rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(rawColorInterpretation_str);
+                colorProfileFileName = v->getColorProfileFileName();
+
+                ALICEVISION_LOG_INFO("Image: " << paths.back() << ", exposure: " << exposuresSetting.back() << ", raw color interpretation: " << ERawColorInterpretation_enumToString(rawColorInterpretation));
+            }
+            if(!sfmData::hasComparableExposures(exposuresSetting))
+            {
+                ALICEVISION_THROW_ERROR("Camera exposure settings are inconsistent.");
+            }
+            std::vector<double> exposures = getExposures(exposuresSetting);
+
+            image::ImageReadOptions imgReadOptions;
+            imgReadOptions.workingColorSpace = workingColorSpace;
+            imgReadOptions.rawColorInterpretation = rawColorInterpretation;
+            imgReadOptions.colorProfileFileName = colorProfileFileName;
+
+            const bool simplifiedSampling = byPass || (calibrationMethod == ECalibrationMethod::LINEAR);
+
+            std::vector<hdr::ImageSample> out_samples;
+            const bool res = hdr::Sampling::extractSamplesFromImages(out_samples, paths, viewIds, exposures, width, height, channelQuantization, imgReadOptions, params, simplifiedSampling);
+            if (!res)
+            {
+                ALICEVISION_LOG_ERROR("Error while extracting samples from group");
+            }
+
+            using namespace boost::accumulators;
+            using Accumulator = accumulator_set<float, stats<tag::min, tag::max, tag::median, tag::mean>>;
+            Accumulator acc_nbUsedBrackets;
+            {
+                utils::Histogram<int> histogram(1, usedNbBrackets, usedNbBrackets-1);
+                for(const hdr::ImageSample& sample : out_samples)
+                {
+                    acc_nbUsedBrackets(sample.descriptions.size());
+                    histogram.Add(sample.descriptions.size());
+                }
+                ALICEVISION_LOG_INFO("Number of used brackets in selected samples: "
+                                    << " min: " << extract::min(acc_nbUsedBrackets) << " max: "
+                                    << extract::max(acc_nbUsedBrackets) << " mean: " << extract::mean(acc_nbUsedBrackets)
+                                    << " median: " << extract::median(acc_nbUsedBrackets));
+
+                ALICEVISION_LOG_INFO("Histogram of the number of brackets per sample: " << histogram.ToString("", 2));
+            }
+            if(debug)
+            {
+                image::Image<image::RGBfColor> selectedPixels(width, height, true);
+
+                for(const hdr::ImageSample& sample: out_samples)
+                {
+                    const float score = float(sample.descriptions.size()) / float(usedNbBrackets);
+                    const image::RGBfColor color = getColorFromJetColorMap(score);
+                    selectedPixels(sample.y, sample.x) = image::RGBfColor(color.r(), color.g(), color.b());
+                }
+                oiio::ParamValueList metadata;
+                metadata.push_back(oiio::ParamValue("AliceVision:nbSelectedPixels", int(selectedPixels.size())));
+                metadata.push_back(oiio::ParamValue("AliceVision:minNbUsedBrackets", extract::min(acc_nbUsedBrackets)));
+                metadata.push_back(oiio::ParamValue("AliceVision:maxNbUsedBrackets", extract::max(acc_nbUsedBrackets)));
+                metadata.push_back(oiio::ParamValue("AliceVision:meanNbUsedBrackets", extract::mean(acc_nbUsedBrackets)));
+                metadata.push_back(oiio::ParamValue("AliceVision:medianNbUsedBrackets", extract::median(acc_nbUsedBrackets)));
+
+                image::writeImage((fs::path(outputFolder) / (std::to_string(firstViewId) + "_selectedPixels.png")).string(),
+                                selectedPixels, image::ImageWriteOptions(), metadata);
+
+            }
+
+            // Store to file
+            const std::string samplesFilepath = (fs::path(outputFolder) / (std::to_string(firstViewId) + "_samples.dat")).string();
+            std::ofstream fileSamples(samplesFilepath, std::ios::binary);
+            if (!fileSamples.is_open())
+            {
+                ALICEVISION_LOG_ERROR("Impossible to write samples");
+                return EXIT_FAILURE;
+            }
+
+            const std::size_t size = out_samples.size();
+            fileSamples.write((const char *)&size, sizeof(size));
+
+            for(std::size_t i = 0; i < out_samples.size(); ++i)
+            {
+                fileSamples << out_samples[i];
+            }
         }
     }
 


### PR DESCRIPTION
Previously, when launching the HDR pipeline, all the input images were using the same camera / intrinsicID.

Here we want to enable multiple intrinsics to process heterogeneous inputs. One calibration will be done separately per intrinsic.