### PR TITLE
[segmentation] fix crash when resized image is too small

### DIFF
--- a/src/aliceVision/segmentation/segmentation.cpp
+++ b/src/aliceVision/segmentation/segmentation.cpp
@@ -98,18 +98,36 @@ bool Segmentation::processImage(image::Image<IndexT> &labels, const image::Image
 {
     //Todo : handle orientation and small images smaller than model input
         
-    // Compute the optimal resized size such that at last one dimension fit the model
+    // Compute the optimal resized size such that:
+    // - at last one dimension fit the model
+    // - both dimensions are larger or equal than the model dimensions
     int resizedHeight = 0;
     int resizedWidth = 0;
     if (source.Height() < source.Width())
     {
-        resizedHeight = _parameters.modelHeight;
         resizedWidth = double(source.Width()) * double(_parameters.modelHeight) / double(source.Height());
+        if (resizedWidth < _parameters.modelWidth)
+        {
+            resizedWidth = _parameters.modelWidth;
+            resizedHeight = double(resizedWidth) * double(_parameters.modelHeight) / double(_parameters.modelWidth);
+        }
+        else
+        {
+            resizedHeight = _parameters.modelHeight;
+        }
     }
     else 
     {
-        resizedWidth = _parameters.modelWidth;
         resizedHeight = double(source.Height()) * double(_parameters.modelWidth) / double(source.Width());
+        if (resizedHeight < _parameters.modelHeight)
+        {
+            resizedHeight = _parameters.modelHeight;
+            resizedWidth = double(resizedHeight) * double(_parameters.modelWidth) / double(_parameters.modelHeight);
+        }
+        else
+        {
+            resizedWidth = _parameters.modelWidth;
+        }
     }
 
     //Resize image

--- a/src/aliceVision/segmentation/segmentation.cpp
+++ b/src/aliceVision/segmentation/segmentation.cpp
@@ -105,11 +105,15 @@ bool Segmentation::processImage(image::Image<IndexT> &labels, const image::Image
     int resizedWidth = 0;
     if (source.Height() < source.Width())
     {
-        resizedWidth = double(source.Width()) * double(_parameters.modelHeight) / double(source.Height());
+        resizedWidth = static_cast<int>(
+            static_cast<double>(source.Width()) * static_cast<double>(_parameters.modelHeight)
+            / static_cast<double>(source.Height()));
         if (resizedWidth < _parameters.modelWidth)
         {
             resizedWidth = _parameters.modelWidth;
-            resizedHeight = double(resizedWidth) * double(_parameters.modelHeight) / double(_parameters.modelWidth);
+            resizedHeight = static_cast<int>(
+                static_cast<double>(resizedWidth) * static_cast<double>(_parameters.modelHeight)
+                / static_cast<double>(_parameters.modelWidth));
         }
         else
         {
@@ -118,11 +122,15 @@ bool Segmentation::processImage(image::Image<IndexT> &labels, const image::Image
     }
     else 
     {
-        resizedHeight = double(source.Height()) * double(_parameters.modelWidth) / double(source.Width());
+        resizedHeight = static_cast<int>(
+            static_cast<double>(source.Height()) * static_cast<double>(_parameters.modelWidth)
+            / static_cast<double>(source.Width()));
         if (resizedHeight < _parameters.modelHeight)
         {
             resizedHeight = _parameters.modelHeight;
-            resizedWidth = double(resizedHeight) * double(_parameters.modelWidth) / double(_parameters.modelHeight);
+            resizedWidth = static_cast<int>(
+                static_cast<double>(resizedHeight) * static_cast<double>(_parameters.modelWidth)
+                / static_cast<double>(_parameters.modelHeight));
         }
         else
         {


### PR DESCRIPTION
## Description

At the beginning of the segmentation process, the input image is resized so that one dimensions matches the model dimensions (1280x720).

Here we make sure that both dimensions are at least as big as the model dimensions, otherwise the segmentation process will try to access unavailable parts of the resized image.