### PR TITLE
[software] sfmTransform: Increase precision of coefficients in the log

### DIFF
--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/program_options.hpp>
 
+#include <iomanip>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -512,7 +513,8 @@ int aliceVision_main(int argc, char **argv)
   }
 
   {
-      ALICEVISION_LOG_INFO("Transformation:" << std::endl
+      ALICEVISION_LOG_INFO(std::setprecision(17)
+          << "Transformation:" << std::endl
           << "\t- Scale: " << S << std::endl
           << "\t- Rotation:\n" << R << std::endl
           << "\t- Translate: " << t.transpose());


### PR DESCRIPTION
## Description

This PR increases the output precision of transformation coefficients logged by sfmTransform so that the exact coefficients can be read from the log. Note that 17 digits are sufficient to reconstruct a double precision number.

Please see https://github.com/alicevision/Meshroom/issues/2103 for more context.
