### PR TITLE
[doc] INSTALL.md: Fix typo in "nonfree" module for OpenCV in vcpkg install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,7 +91,7 @@ vcpkg install ^
           eigen3 ^
           expat ^
           onnxruntime-gpu ^
-          opencv[eigen,ffmpeg,webp,contrib,nonFree,cuda] ^
+          opencv[eigen,ffmpeg,webp,contrib,nonfree,cuda] ^
           openimageio[libraw,ffmpeg,freetype,opencv,gif,openjpeg,webp] ^
           ceres[suitesparse,cxsparse] ^
           cuda ^


### PR DESCRIPTION
## Description

With vcpkg's latest versions, the module names should always be lowercased. Errors are generated otherwise.
