### PR TITLE
tolerant bracket size estimation

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -17,10 +17,6 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         return false;
     }
 
-    if ((countBrackets > 0) && ((countImages % countBrackets) != 0))
-    {
-        return false;
-    }
 
     const sfmData::Views & views = sfmData.getViews();
 
@@ -79,6 +75,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
                 group.clear();
             }
 
+            lastExposure = exp;
             group.push_back(view);
         }
     }
@@ -86,6 +83,37 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
     if (!group.empty())
     {
         groups.push_back(group);
+    }
+
+
+    //Check maximal size
+    int maxSize = 0;
+    for (auto & group : groups)
+    {
+        if (group.size() > maxSize)
+        {
+            maxSize = group.size();
+        }
+    }
+
+    //Only keep groups with majority group size
+    auto groupIt = groups.begin();
+    while (groupIt != groups.end())
+    {
+        if (groupIt->size() != maxSize)
+        {
+            groupIt = groups.erase(groupIt);
+        }
+        else
+        {
+            groupIt++;
+        }
+    }
+
+    //Make sure we only have a few spurious measures
+    if (groups.size() * maxSize < countImages - 2)
+    {
+        return false;
     }
 
     std::vector< std::vector<sfmData::ExposureSetting>> v_exposuresSetting;

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -171,11 +171,6 @@ int aliceVision_main(int argc, char** argv)
         ALICEVISION_LOG_ERROR("The input SfMData contains no image.");
         return EXIT_FAILURE;
     }
-    if(nbBrackets > 0 && (countImages % nbBrackets) != 0)
-    {
-        ALICEVISION_LOG_ERROR("The input SfMData file (" << countImages << " images) is not compatible with the number of brackets (" << nbBrackets << " brackets).");
-        return EXIT_FAILURE;
-    }
     if(nbBrackets == 1 && !byPass)
     {
         ALICEVISION_LOG_WARNING("Enable bypass as there is only one input bracket.");
@@ -191,6 +186,7 @@ int aliceVision_main(int argc, char** argv)
     std::vector<std::vector<std::shared_ptr<sfmData::View>>> groupedViews;
     if (!hdr::estimateBracketsFromSfmData(groupedViews, sfmData, nbBrackets))
     {
+        ALICEVISION_LOG_ERROR("Failure to estimate brackets.");
         return EXIT_FAILURE;
     }
 

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -126,6 +126,7 @@ int aliceVision_main(int argc, char** argv)
     std::vector<std::vector<std::shared_ptr<sfmData::View>>> groupedViews;
     if (!hdr::estimateBracketsFromSfmData(groupedViews, sfmData, nbBrackets))
     {
+        ALICEVISION_LOG_ERROR("Failure to estimate brackets.");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
Bracket size selection is now tolerant to at most two spurious image in the images list.

rule : (Bracket size * countGroupsWithThisSize) >= totalImages - 2

see https://github.com/alicevision/Meshroom/pull/2113