### PR TITLE
Make sure openexr does not use too many threads

### DIFF
--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -679,7 +679,11 @@ int aliceVision_main(int argc, char** argv)
     // set maxThreads
     HardwareContext hwc = cmdline.getHardwareContext();
     hwc.setUserCoresLimit(maxThreads);
+    
     omp_set_num_threads(hwc.getMaxThreads());
+    oiio::attribute("threads", static_cast<int>(hwc.getMaxThreads()));
+    oiio::attribute("exr_threads", static_cast<int>(hwc.getMaxThreads()));
+
 
     if(overlayType == "borders" || overlayType == "all")
     {

--- a/src/software/pipeline/main_panoramaMerging.cpp
+++ b/src/software/pipeline/main_panoramaMerging.cpp
@@ -71,6 +71,10 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    HardwareContext hwc = cmdline.getHardwareContext();
+    oiio::attribute("threads", static_cast<int>(hwc.getMaxThreads()));
+    oiio::attribute("exr_threads", static_cast<int>(hwc.getMaxThreads()));
+
     // load input scene
     sfmData::SfMData sfmData;
     if(!sfmDataIO::Load(sfmData, sfmDataFilepath, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::EXTRINSICS | sfmDataIO::INTRINSICS)))


### PR DESCRIPTION
OpenImageIO sets by default OpenEXR to use all the available CPU cores.

This may be not wanted for two reasons : 
- Each thread will use some local memory, which may create huge memory usage on machine with hundred of cores and large images.
- Cores may be shared amongst multiple tasks (See CGroups)