### PR TITLE
HDR default number of brackets should be 0

### DIFF
--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -73,7 +73,7 @@ int aliceVision_main(int argc, char** argv)
     std::string sfmInputDataFilename;
     std::string inputResponsePath;
     std::string sfmOutputDataFilepath;
-    int nbBrackets = 3;
+    int nbBrackets = 0;
     bool byPass = false;
     bool keepSourceImageName = false;
     int channelQuantizationPower = 10;


### PR DESCRIPTION
LdrToHDRMerging had the default nb of brackets set to 3 ? should be 0 to enable by default automatic bracketing estimation