### PR TITLE
Remove limits on outliers for brackets detection

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -110,12 +110,6 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         }
     }
 
-    //Make sure we only have a few spurious measures
-    if (groups.size() * maxSize < countImages - 2)
-    {
-        return false;
-    }
-
     std::vector< std::vector<sfmData::ExposureSetting>> v_exposuresSetting;
     for(auto & group : groups)
     {


### PR DESCRIPTION
This PR removes the limits on the number of supported outliers when detecting the number of brackets.

Corresponding Meshroom pull request: https://github.com/alicevision/Meshroom/pull/2118.