### PR TITLE
Correctly count the best brackets count

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -86,21 +86,37 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
     }
 
 
-    //Check maximal size
-    int maxSize = 0;
-    for (auto & group : groups)
+    //Vote for the best bracket count
+    std::map<size_t, int> counters;
+    for (const auto & group : groups)
     {
-        if (group.size() > maxSize)
+        size_t bracketCount = group.size();
+        if (counters.find(bracketCount) != counters.end())
         {
-            maxSize = group.size();
+            counters[bracketCount]++;
+        }
+        else
+        {
+            counters[bracketCount] = 1;
         }
     }
 
-    //Only keep groups with majority group size
+    int maxSize = 0;
+    int bestBracketCount = 0;
+    for (const auto & item : counters)
+    {
+        if (item.second > maxSize)
+        {
+            maxSize = item.second;
+            bestBracketCount = item.first;
+        }
+    }
+
+    //Only keep groups with majority bracket size
     auto groupIt = groups.begin();
     while (groupIt != groups.end())
     {
-        if (groupIt->size() != maxSize)
+        if (groupIt->size() != bestBracketCount)
         {
             groupIt = groups.erase(groupIt);
         }


### PR DESCRIPTION
Previously introduced heuristics assumed that outliers were only smallest groups. It is not always the case so instead vote for the bracket size which has the more groups with this number.