### PR TITLE
[software] panoramaPostProcessing: export downscaled panorama levels

### DIFF
--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -402,7 +402,8 @@ int aliceVision_main(int argc, char** argv)
 
     for (int levelIdx = 1; levelIdx <= nbLevels; ++levelIdx)
     {
-        fs::path levelPath = fs::path(outputPanoramaPath).parent_path() / ("level_" + std::to_string(levelIdx) + ".exr");
+        const int levelWidth = width / (1 << levelIdx);
+        fs::path levelPath = fs::path(outputPanoramaPath).parent_path() / ("level_" + std::to_string(levelWidth) + ".exr");
         levelOutputs.push_back(std::move(oiio::ImageOutput::create(levelPath.string())));
 
         oiio::ImageSpec levelSpec(outputSpec);

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -201,6 +201,7 @@ int aliceVision_main(int argc, char** argv)
     image::EImageColorSpace outputColorSpace = image::EImageColorSpace::LINEAR;
     size_t previewSize = 1000;
     bool fillHoles = false;
+    bool exportLevels = false;
 
     // Description of mandatory parameters
     po::options_description requiredParams("Required parameters");
@@ -221,6 +222,7 @@ int aliceVision_main(int argc, char** argv)
          "Only dwaa, dwab, zip and zips compression methods are concerned.")
 
         ("fillHoles", po::value<bool>(&fillHoles)->default_value(fillHoles), "Execute fill holes algorithm")
+        ("exportLevels", po::value<bool>(&exportLevels)->default_value(exportLevels), "Export downscaled panorama levels")
         ("previewSize", po::value<size_t>(&previewSize)->default_value(previewSize), "Preview image width")
         ("outputColorSpace", po::value<image::EImageColorSpace>(&outputColorSpace)->default_value(outputColorSpace), "Color space for the output panorama.")
         ("outputPanoramaPreview,p", po::value<std::string>(&outputPanoramaPreviewPath)->default_value(outputPanoramaPreviewPath), "Path of the output panorama preview.");
@@ -338,7 +340,7 @@ int aliceVision_main(int argc, char** argv)
     int previewCurrentRow = 0;
 
     // Create image outputs for downscaled panorama levels
-    const int nbLevels = static_cast<int>(std::floor(std::log2(tileSize)));
+    const int nbLevels = exportLevels ? static_cast<int>(std::floor(std::log2(tileSize))) : 0;
     std::vector<std::unique_ptr<oiio::ImageOutput>> levelOutputs;
 
     ALICEVISION_LOG_INFO("Number of downscaled panorama levels to generate: " << nbLevels);

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -251,6 +251,7 @@ int aliceVision_main(int argc, char** argv)
     size_t previewSize = 1000;
     bool fillHoles = false;
     bool exportLevels = false;
+    int lastLevelMaxSize = 3840;
 
     // Description of mandatory parameters
     po::options_description requiredParams("Required parameters");
@@ -272,6 +273,7 @@ int aliceVision_main(int argc, char** argv)
 
         ("fillHoles", po::value<bool>(&fillHoles)->default_value(fillHoles), "Execute fill holes algorithm")
         ("exportLevels", po::value<bool>(&exportLevels)->default_value(exportLevels), "Export downscaled panorama levels")
+        ("lastLevelMaxSize", po::value<int>(&lastLevelMaxSize)->default_value(lastLevelMaxSize), "Maximum width of smallest downscaled panorama level.")
         ("previewSize", po::value<size_t>(&previewSize)->default_value(previewSize), "Preview image width")
         ("outputColorSpace", po::value<image::EImageColorSpace>(&outputColorSpace)->default_value(outputColorSpace), "Color space for the output panorama.")
         ("outputPanoramaPreview,p", po::value<std::string>(&outputPanoramaPreviewPath)->default_value(outputPanoramaPreviewPath), "Path of the output panorama preview.");
@@ -389,7 +391,11 @@ int aliceVision_main(int argc, char** argv)
     int previewCurrentRow = 0;
 
     // Create image outputs for downscaled panorama levels
-    const int nbLevels = exportLevels ? static_cast<int>(std::floor(std::log2(tileSize))) : 0;
+    const int nbLevels = exportLevels ?
+        static_cast<int>(std::min(
+            std::floor(std::log2(tileSize)),
+            std::ceil(std::log2(width) - std::log2(lastLevelMaxSize))))
+        : 0;
     std::vector<std::unique_ptr<oiio::ImageOutput>> levelOutputs;
 
     ALICEVISION_LOG_INFO("Number of downscaled panorama levels to generate: " << nbLevels);

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -34,7 +34,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;


### PR DESCRIPTION
## Description

Add an option to the `aliceVision_panoramaPostProcessing` software to export downscaled versions of the output panorama (50%, 25%, etc.).