### PR TITLE
Compositing does not fail on range error

### DIFF
--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -747,8 +747,8 @@ int aliceVision_main(int argc, char** argv)
 
         if(rangeIteration >= countIterations)
         {
-            ALICEVISION_LOG_ERROR("Range is incorrect");
-            return EXIT_FAILURE;
+            // nothing to compute for this chunk
+            return EXIT_SUCCESS;
         }
 
         rangeSize = rangeSize * divideRoundUp(viewsCount, oldViewsCount);


### PR DESCRIPTION
Due to limitations on current meshroom, meshroom compute statically chunks. For performance reasons, alicevision compute dynamically chunks. In some case, meshroom may ask for too many chunks.

As a temporary workaround, make sure av does not returns an error when the chunk id is too large.