### PR TITLE
Bugfix on dng reading

### DIFF
--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1331,7 +1331,7 @@ int aliceVision_main(int argc, char * argv[])
                         (rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata)))
                 {
                     // Fallback case of missing profile but no error requested
-                    readOptions.rawColorInterpretation = image::ERawColorInterpretation::LibRawNoWhiteBalancing;
+                    readOptions.rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
                 }
                 else
                 {

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -320,7 +320,7 @@ struct ProcessingParams
     bool fixNonFinite = false;
     bool applyDcpMetadata = false;
     bool useDCPColorMatrixOnly = false;
-    bool sourceIsRaw = false;
+    bool enableColorTempProcessing = false;
     double correlatedColorTemperature = -1.0;
 
     LensCorrectionParams lensCorrection =
@@ -600,7 +600,7 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 #endif
     }
 
-    if (pParams.applyDcpMetadata || (pParams.sourceIsRaw && pParams.correlatedColorTemperature <= 0.0))
+    if (pParams.applyDcpMetadata || (pParams.enableColorTempProcessing && pParams.correlatedColorTemperature <= 0.0))
     {
         bool dcpMetadataOK = map_has_non_empty_value(imageMetadata, "AliceVision:DCP:Temp1") &&
                              map_has_non_empty_value(imageMetadata, "AliceVision:DCP:Temp2") &&
@@ -678,7 +678,7 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
         double cct = pParams.correlatedColorTemperature;
         double tint;
 
-        if (pParams.sourceIsRaw)
+        if (pParams.enableColorTempProcessing)
         {
             dcpProf.getColorTemperatureAndTintFromNeutral(neutral, cct, tint);
         }
@@ -690,7 +690,7 @@ void processImage(image::Image<image::RGBAfColor>& image, const ProcessingParams
 
         imageMetadata["AliceVision:ColorTemperature"] = std::to_string(cct);
     }
-    else if (pParams.sourceIsRaw && pParams.correlatedColorTemperature > 0.0)
+    else if (pParams.enableColorTempProcessing && pParams.correlatedColorTemperature > 0.0)
     {
         imageMetadata["AliceVision:ColorTemperature"] = std::to_string(pParams.correlatedColorTemperature);
     }
@@ -1108,7 +1108,7 @@ int aliceVision_main(int argc, char * argv[])
                 options.rawAutoBright = pParams.rawAutoBright;
                 options.correlatedColorTemperature = correlatedColorTemperature;
                 pParams.correlatedColorTemperature = correlatedColorTemperature;
-                pParams.sourceIsRaw = true;
+                pParams.enableColorTempProcessing = options.rawColorInterpretation == image::ERawColorInterpretation::DcpLinearProcessing;
             }
 
             if (pParams.lensCorrection.enabled && pParams.lensCorrection.vignetting)
@@ -1351,7 +1351,7 @@ int aliceVision_main(int argc, char * argv[])
                 readOptions.rawAutoBright = pParams.rawAutoBright;
                 readOptions.correlatedColorTemperature = correlatedColorTemperature;
                 pParams.correlatedColorTemperature = correlatedColorTemperature;
-                pParams.sourceIsRaw = true;
+                pParams.enableColorTempProcessing = readOptions.rawColorInterpretation == image::ERawColorInterpretation::DcpLinearProcessing;
 
                 pParams.useDCPColorMatrixOnly = useDCPColorMatrixOnly;
                 if (pParams.applyDcpMetadata)


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Enable color temperature processing only if a dcp color profile is available. If an image is read without any corresponding dcp profile (libRaw modes) the color temperature will not be adjusted. In this case, camera white balancing is enabled in the fallback color processing based on libRaw.



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

