### PR TITLE
Camera exposure update

### DIFF
--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -413,8 +413,12 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
         {
             ALICEVISION_LOG_INFO("  exposure compensation for image " << camId + 1 << ": " << exposureCompensation);
 
-            for (std::size_t i = 0; i < img.size(); ++i)
-                img(i) = img(i) * exposureCompensation;
+            for(std::size_t i = 0; i < img.size(); ++i)
+            {
+                img(i)[0] *= exposureCompensation;
+                img(i)[1] *= exposureCompensation;
+                img(i)[2] *= exposureCompensation;
+            }
 
             imageAlgo::colorconvert(img, image::EImageColorSpace::LINEAR, colorspace);
         }

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -130,7 +130,7 @@ public:
         area2 = (aperture1 / aperture2)^2
         */
         double new_fnumber = fnumber * iso_2_aperture;
-        double exp_increase = (new_fnumber / lReferenceFNumber) * (new_fnumber / lReferenceFNumber);
+        double exp_increase = (lReferenceFNumber / new_fnumber) * (lReferenceFNumber / new_fnumber);
 
         // If the aperture was more important for this image, this means that it received less light than with a default aperture
         // This means also that if we want to simulate that all the image have the same aperture, we have to increase virtually th

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -52,7 +52,9 @@ void process(const std::string &dstColorImage, const IntrinsicBase* cam, const o
     {
         for(int pix = 0; pix < image.Width() * image.Height(); ++pix)
         {
-            image(pix) = image(pix) * exposureCompensation;
+            image(pix)[0] *= exposureCompensation;
+            image(pix)[1] *= exposureCompensation;
+            image(pix)[2] *= exposureCompensation;
         }
     }
 

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -55,7 +55,7 @@ int aliceVision_main(int argc, char* argv[])
     image::EImageColorSpace workingColorSpace = image::EImageColorSpace::SRGB;
     image::EImageColorSpace outputColorSpace = image::EImageColorSpace::AUTO;
     bool flipNormals = false;
-    bool correctEV = false;
+    bool correctEV = true;
 
     mesh::TexturingParams texParams;
     std::string unwrapMethod = mesh::EUnwrapMethod_enumToString(mesh::EUnwrapMethod::Basic);


### PR DESCRIPTION


<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR update the camera exposure computation to match the standard exposure value formula.
In addition, the PR fix the inappropriate application of the exposure correction on the alpha channel when computing undistorted images and textures.
The exposure correction is now enabled by default at the texturing stage.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

