### PR TITLE
add memory use constraint in texturing

### DIFF
--- a/src/aliceVision/cmdline/cmdline.cpp
+++ b/src/aliceVision/cmdline/cmdline.cpp
@@ -1,7 +1,6 @@
 #include "cmdline.hpp"
 
 #include <aliceVision/system/cpu.hpp>
-#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/alicevision_omp.hpp>
 
 namespace aliceVision {

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -9,7 +9,6 @@
 #include "UVAtlas.hpp"
 
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/pixelTypes.hpp>
 #include <aliceVision/numeric/numeric.hpp>
@@ -285,6 +284,7 @@ void Texturing::updateAtlases()
 
 void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
                                  const boost::filesystem::path& outPath,
+                                 size_t memoryAvailable,
                                  image::EImageFileType textureFileType)
 {
     // Ensure that contribution levels do not contain 0 and are sorted (as each frequency band contributes to lower bands).
@@ -312,7 +312,6 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
     ALICEVISION_LOG_INFO("Images loaded from cache with: " + ECorrectEV_enumToString(texParams.correctEV));
 
     //calculate the maximum number of atlases in memory in MB
-    system::MemoryInfo memInfo = system::getMemoryInfo();
     const std::size_t imageMaxMemSize =
             mp.getMaxImageWidth() * mp.getMaxImageHeight() * sizeof(image::RGBfColor) / std::pow(2,20); //MB
     const std::size_t imagePyramidMaxMemSize = texParams.nbBand * imageMaxMemSize;
@@ -320,7 +319,7 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
             texParams.textureSide * texParams.textureSide * (sizeof(image::RGBfColor)+sizeof(float)) / std::pow(2,20); //MB
     const std::size_t atlasPyramidMaxMemSize = texParams.nbBand * atlasContribMemSize;
 
-    const int availableRam = int(memInfo.availableRam / std::pow(2,20));
+    const int availableRam = int(memoryAvailable / std::pow(2,20));
     const int availableMem = availableRam - 2 * (imagePyramidMaxMemSize + imageMaxMemSize); // keep some memory for the 2 input images in cache and one laplacian pyramid
 
     const int nbAtlas = _atlases.size();

--- a/src/aliceVision/mesh/Texturing.hpp
+++ b/src/aliceVision/mesh/Texturing.hpp
@@ -200,6 +200,7 @@ public:
     /// Generate texture files for all texture atlases
     void generateTextures(const mvsUtils::MultiViewParams& mp,
                           const bfs::path &outPath,
+                          size_t memoryAvailable,
                           image::EImageFileType textureFileType = image::EImageFileType::PNG);
 
     /// Generate texture files for the given sub-set of texture atlases

--- a/src/aliceVision/system/hardwareContext.cpp
+++ b/src/aliceVision/system/hardwareContext.cpp
@@ -52,4 +52,14 @@ unsigned int HardwareContext::getMaxThreads() const
     return count;
 }
 
+size_t HardwareContext::getMaxMemory() const 
+{
+    auto meminfo = system::getMemoryInfo();
+
+    size_t ret = meminfo.availableRam;
+    ret = std::min(ret, _maxUserMemoryAvailable);
+
+    return ret;
+}
+
 }

--- a/src/aliceVision/system/hardwareContext.hpp
+++ b/src/aliceVision/system/hardwareContext.hpp
@@ -24,7 +24,7 @@ public:
 
     void setUserMaxMemoryAvailable(size_t val)
     {
-        _maxUserCoresAvailable = val;
+        _maxUserMemoryAvailable = val;
     }
 
     unsigned int getUserMaxCoresAvailable() const

--- a/src/aliceVision/system/hardwareContext.hpp
+++ b/src/aliceVision/system/hardwareContext.hpp
@@ -44,6 +44,12 @@ public:
 
     unsigned int getMaxThreads() const;
 
+    /**
+     * @brief compute the maximum memory available 
+     * @return the size in bytes
+     */
+    size_t getMaxMemory() const;
+
 private:
     /**
      * @brief This is the maximum memory available 

--- a/src/software/pipeline/main_imageSegmentation.cpp
+++ b/src/software/pipeline/main_imageSegmentation.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/image/imageAlgo.hpp>
 
 // System
-#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 // Reading command line options

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -18,7 +18,6 @@
 #include <aliceVision/image/imageAlgo.hpp>
 
 // System
-#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 // Reading command line options

--- a/src/software/pipeline/main_panoramaMerging.cpp
+++ b/src/software/pipeline/main_panoramaMerging.cpp
@@ -13,7 +13,6 @@
 #include <aliceVision/image/imageAlgo.hpp>
 
 // System
-#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 // Reading command line options

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -9,7 +9,6 @@
 #include <aliceVision/image/all.hpp>
 
 // System
-#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 // Reading command line options

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -17,7 +17,6 @@
 #include <aliceVision/image/imageAlgo.hpp>
 
 // System
-#include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 // Reading command line options

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -227,7 +227,7 @@ int aliceVision_main(int argc, char* argv[])
     if(!inputMeshFilepath.empty() && !sfmDataFilename.empty() && texParams.textureFileType != image::EImageFileType::NONE)
     {
         ALICEVISION_LOG_INFO("Generate textures.");
-        mesh.generateTextures(mp, outputFolder, texParams.textureFileType);
+        mesh.generateTextures(mp, outputFolder, hwc.getMaxMemory(), texParams.textureFileType);
     }
 
 


### PR DESCRIPTION
Texturing module was probing the available memory directly from the system functions. Bypassing the user specified limits on memory usage. Now using hardwarecontext class instead of system function.