### PR TITLE
Keyframe Selection: Add multi-threading and improve overall performances

### DIFF
--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -509,8 +509,7 @@ bool KeyframeSelector::writeSelection(const std::vector<std::string>& brands,
                 metadata.push_back(oiio::ParamValue("Exif:FocalLength", mmFocals[id]));
                 metadata.push_back(oiio::ParamValue("Exif:ImageUniqueID", std::to_string(getRandomInt())));
                 metadata.push_back(oiio::ParamValue("Orientation", orientation));  // Will not propagate for PNG outputs
-                if (outputExtension != "jpg")  // TODO: propagate pixelAspectRatio properly for JPG
-                    metadata.push_back(oiio::ParamValue("PixelAspectRatio", pixelAspectRatio));
+                metadata.push_back(oiio::ParamValue("PixelAspectRatio", pixelAspectRatio));
 
                 fs::path folder = _outputFolder;
                 std::ostringstream filenameSS;

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -397,14 +397,15 @@ bool KeyframeSelector::computeScores(const std::size_t rescaledWidthSharpness, c
                         // currentFrame + 2 = next frame to evaluate with indexing starting at 1, for display reasons
                         ALICEVISION_LOG_WARNING("Invalid or missing frame " << currentFrame + 1
                                                 << ", attempting to read frame " << currentFrame + 2 << ".");
+
+                        // Push dummy scores for the frame that was skipped
+                        _sharpnessScores[currentFrame] = -1.f;
+                        _flowScores[currentFrame] = -1.f;
+
                         success = feed.goToFrame(++currentFrame);
                         if (success) {
                             currentMatSharpness = readImage(feed, rescaledWidthSharpness);
                         }
-
-                        // Push dummy scores for the frame that was skipped
-                        _sharpnessScores.push_back(-1.f);
-                        _flowScores.push_back(-1.f);
                     }
                 }
             }
@@ -436,8 +437,8 @@ bool KeyframeSelector::computeScores(const std::size_t rescaledWidthSharpness, c
         }
 
         // Save scores for the current frame
-        _sharpnessScores.push_back(minimalSharpness);
-        _flowScores.push_back(currentFrame > 0 ? minimalFlow : -1.f);
+        _sharpnessScores[currentFrame] = minimalSharpness;
+        _flowScores[currentFrame] = currentFrame > 0 ? minimalFlow : -1.f;
         ++currentFrame;
     }
 

--- a/src/aliceVision/keyframe/KeyframeSelector.hpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.hpp
@@ -17,7 +17,6 @@
 #include <opencv2/imgcodecs.hpp>
 
 #include <string>
-#include <deque>
 #include <map>
 #include <vector>
 #include <memory>
@@ -334,9 +333,9 @@ private:
     unsigned int _minOutFrames = 10;
 
     /// Sharpness scores for each frame
-    std::vector<double> _sharpnessScores;
+    std::map<std::size_t, double> _sharpnessScores;
     /// Optical flow scores for each frame
-    std::vector<double> _flowScores;
+    std::map<std::size_t, double> _flowScores;
     /// Vector containing 1s for frames that have been selected, 0 for those which have not
     std::vector<char> _selectedFrames;
 
@@ -357,7 +356,7 @@ private:
     std::map<std::size_t, std::vector<std::string>> _keyframesPaths;
 
     /// Map score vectors with names for export
-    std::map<const std::string, const std::vector<double>*> scoresMap;
+    std::map<const std::string, const std::map<std::size_t, double>*> scoresMap;
 };
 
 } // namespace keyframe 

--- a/src/aliceVision/keyframe/KeyframeSelector.hpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.hpp
@@ -235,6 +235,17 @@ private:
     double computeSharpness(const cv::Mat& grayscaleImage, const std::size_t windowSize);
 
     /**
+     * @brief Compute the standard deviation of the local averaged Laplacian in an image.
+     * @param sum The integral image of the Laplacian of a given image
+     * @param squaredSum The squared integral image of the Laplacian of a given image
+     * @param x The x-coordinate of the top-left corner of the window for the local standard deviation computation
+     * @param y The y-coordinate of the top-left corner of the window for the local standard deviation computation
+     * @param windowSize The size of the window along the x- and y-axis for the local standard deviation computation
+     * @return a const double value representating the local standard deviation of the Laplacian
+     */
+    const double computeSharpnessStd(const cv::Mat& sum, const cv::Mat& squaredSum, const int x, const int y, const int windowSize);
+
+    /**
      * @brief Estimate the optical flow score for an input grayscale frame based on its previous frame cell by cell
      * @param[in] ptrFlow the OpenCV's DenseOpticalFlow object
      * @param[in] grayscaleImage the grayscale matrix of the current frame

--- a/src/aliceVision/keyframe/KeyframeSelector.hpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <map>
+#include <mutex>
 #include <vector>
 #include <memory>
 #include <limits>
@@ -181,6 +182,15 @@ public:
     }
 
     /**
+     * @brief Set the minimum size of the blocks of frames for the multi-threading
+     * @param[in] blockSize minimum number of frames in a block for a thread to be spawned
+     */
+    void setMinBlockSize(std::size_t blockSize)
+    {
+        _minBlockSize = blockSize;
+    }
+
+    /**
      * @brief Get the minimum frame step parameter for the processing algorithm
      * @return minimum number of frames between two keyframes
      */
@@ -218,13 +228,35 @@ public:
     
 private:
     /**
-     * @brief Read an image from a feed provider into a grayscale OpenCV matrix, and rescale it if a size is provided.
+     * @brief Read an image from a feed provider into a grayscale OpenCV matrix, and rescale it if a size is provided
      * @param[in] feed The feed provider
      * @param[in] width The width to resize the input image to. The height will be adjusted with respect to the size ratio.
      *                  There will be no resizing if this parameter is set to 0
      * @return An OpenCV Mat object containing the image
      */
     cv::Mat readImage(dataio::FeedProvider &feed, std::size_t width = 0);
+
+
+    /**
+     * @brief Compute the sharpness and optical flow scores for the input media paths for a given range of frames
+     * @param[in] startFrame the index of the first frame to compute the scores for
+     * @param[in] endFrame the index of the last frame to compute the scores for
+     * @param[in] nbFrames the total number of frames in the sequence
+     * @param[in] rescaledWidthSharpness the width to resize the input frames to before using them to compute the
+     *            sharpness scores (if equal to 0, no rescale will be performed)
+     * @param[in] rescaledWidthFlow the width to resize the input frames to before using them to compute the
+     *            motion scores (if equal to 0, no rescale will be performed)
+     * @param[in] sharpnessWindowSize the size of the sliding window used to compute sharpness scores, in pixels
+     * @param[in] flowCellSize the size of the cells within a frame that are used to compute the optical flow scores,
+     *            in pixels
+     * @param[in] skipSharpnessComputation if true, the sharpness score computations will not be performed and a fixed
+     *            sharpness score will be given to all the input frames
+     * @return true if the scores have been successfully computed for all frames, false otherwise
+     */
+    bool computeScoresProc(const std::size_t startFrame, const std::size_t endFrame, const std::size_t nbFrames,
+                           const std::size_t rescaledWidthSharpness, const std::size_t rescaledWidthFlow,
+                           const std::size_t sharpnessWindowSize, const std::size_t flowCellSize,
+                           const bool skipSharpnessComputation);
 
     /**
      * @brief Compute the sharpness scores for an input grayscale frame with a sliding window
@@ -235,7 +267,7 @@ private:
     double computeSharpness(const cv::Mat& grayscaleImage, const std::size_t windowSize);
 
     /**
-     * @brief Compute the standard deviation of the local averaged Laplacian in an image.
+     * @brief Compute the standard deviation of the local averaged Laplacian in an image
      * @param sum The integral image of the Laplacian of a given image
      * @param squaredSum The squared integral image of the Laplacian of a given image
      * @param x The x-coordinate of the top-left corner of the window for the local standard deviation computation
@@ -343,6 +375,9 @@ private:
     /// Minimum number of output frames
     unsigned int _minOutFrames = 10;
 
+    /// Minimum block size for multi-threading
+    std::size_t _minBlockSize = 10;
+
     /// Sharpness scores for each frame
     std::map<std::size_t, double> _sharpnessScores;
     /// Optical flow scores for each frame
@@ -368,6 +403,9 @@ private:
 
     /// Map score vectors with names for export
     std::map<const std::string, const std::map<std::size_t, double>*> scoresMap;
+
+    /// Mutex to ensure thread-safe operations
+    mutable std::mutex _mutex;
 };
 
 } // namespace keyframe 


### PR DESCRIPTION
## Description

This PR speeds up the selection of keyframes on two different accounts:
- During the computation of the sharpness scores, the sliding window used to be moved pixel by pixel, which resulted in very accurate sharpness scores but also expensive computations. As the sharpness score can afford losing a bit of accuracy, the sliding window is now moved across the image by steps of `windowSize / 4`, with `windowSize` the size of the sliding window. 
- For the computation of all the scores, blocks of frames whose size depends on the number of available threads are computed and then processed in dedicated threads. Blocks are overlapping, since the optical flow requires the current frame N as well as the previous frame N-1. 

It relates to alicevision/Meshroom#2161 and should only be merged once #1510 has been integrated into develop.

## Features list

- [x] Use a larger step for the sliding window of the sharpness score computation, effectively reducing the computation time for the sharpness score;
- [x] Add multi-threading for the computation of all scores.


## Implementation remarks

The parallelization system using chunks that is used in Meshroom cannot be used to speed the keyframe selection up, because only the step of the score computation can be parallelized: once all the scores have been computed, they need to be put back all together sequentially for the keyframes to actually be selected and this process cannot be split.