### PR TITLE
[ci] Update the vcpkg archive link for the Windows build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,7 +131,7 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.3.0
         id: vcpkgDownload
         with:
-          url: "https://gdirect.cc/d/mrmIK&type=1"
+          url: "https://gdirect.cc/d/Y7J7p&type=1"
           target: "${{ env.vcpkgDir }}"
           filename: installed.zip
 


### PR DESCRIPTION
## Description

This PR updates the link to download the vcpkg archive that is used by the CI for the Windows build, as the previous link had expired.