### PR TITLE
Masking: Handle different file extensions for masks and allow mask inversion in `ImageSegmentation`

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -1288,15 +1288,15 @@ void writeImageWithFloat(const std::string& path, const Image<IndexT>& image,
 
 
 bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& masksFolders,
-                 const IndexT viewId, const std::string & srcImage)
+                 const IndexT viewId, const std::string& srcImage, const std::string& fileExtension)
 {
     for (const auto & masksFolder_str : masksFolders)
     {
         if (!masksFolder_str.empty() && fs::exists(masksFolder_str))
         {
             const auto masksFolder = fs::path(masksFolder_str);
-            const auto idMaskPath = masksFolder / fs::path(std::to_string(viewId)).replace_extension("png");
-            const auto nameMaskPath = masksFolder / fs::path(srcImage).filename().replace_extension("png");
+            const auto idMaskPath = masksFolder / fs::path(std::to_string(viewId)).replace_extension(fileExtension);
+            const auto nameMaskPath = masksFolder / fs::path(srcImage).filename().replace_extension(fileExtension);
 
             if (fs::exists(idMaskPath))
             {

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -506,7 +506,7 @@ struct ColorTypeInfo<RGBAfColor>
 };
 
 bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& masksFolders,
-                 const IndexT viewId, const std::string & srcImage);
+                 const IndexT viewId, const std::string& srcImage, const std::string& fileExtension);
 
 /**
  * Returns the value of ALICEVISION_ROOT environmental variable, or empty string if it is not

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -24,7 +24,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
@@ -38,10 +38,12 @@ namespace fs = boost::filesystem;
  */
 struct MaskCache
 {
-    MaskCache(const mvsUtils::MultiViewParams& mp, const std::vector<std::string>& masksFolders, bool undistortMasks, int maxSize = 16)
+    MaskCache(const mvsUtils::MultiViewParams& mp, const std::vector<std::string>& masksFolders, bool undistortMasks,
+              const std::string maskExtension, int maxSize = 16)
         : _mp(mp)
         , _masksFolders(masksFolders)
         , _undistortMasks(undistortMasks)
+        , _maskExtension(maskExtension)
         , _maxSize(maxSize)
     {
     }
@@ -68,7 +70,7 @@ struct MaskCache
             item = &_cache.back();
             const IndexT viewId = _mp.getViewId(camId);
             auto * const mask = item->mask.get();
-            const bool loaded = tryLoadMask(mask, _masksFolders, viewId, _mp.getImagePath(camId));
+            const bool loaded = tryLoadMask(mask, _masksFolders, viewId, _mp.getImagePath(camId), _maskExtension);
             if (loaded)
             {
                 if (_undistortMasks)
@@ -147,6 +149,7 @@ private:
     mvsUtils::MultiViewParams _mp;
     std::vector<std::string> _masksFolders;
     bool _undistortMasks;
+    std::string _maskExtension;
     int _maxSize;
     std::vector<Item> _cache;
 };
@@ -347,6 +350,7 @@ void meshMasking(
     const mvsUtils::MultiViewParams & mp,
     mesh::Mesh & inputMesh,
     const std::vector<std::string> & masksFolders,
+    const std::string & maskExtension,
     const std::string & outputMeshPath,
     const int threshold,
     const bool invert,
@@ -355,7 +359,7 @@ void meshMasking(
     const bool usePointsVisibilities
     )
 {
-    MaskCache maskCache(mp, masksFolders, undistortMasks);
+    MaskCache maskCache(mp, masksFolders, undistortMasks, maskExtension);
 
     // compute visibility for every vertex
     // also update inputMesh.pointsVisibilities according to the masks
@@ -513,6 +517,7 @@ int main(int argc, char **argv)
     bool smoothBoundary = false;
     bool undistortMasks = false;
     bool usePointsVisibilities = false;
+    std::string maskExtension = "png";
 
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
@@ -539,6 +544,8 @@ int main(int argc, char **argv)
             "Undistort the masks with the same parameters as the matching image. Use it if the masks are drawn on the original images.")
         ("usePointsVisibilities", po::value<bool>(&usePointsVisibilities)->default_value(usePointsVisibilities),
             "Use the points visibilities from the meshing to filter triangles. Example: when they are occluded, back-face, etc.")
+        ("maskExtension", po::value<std::string>(&maskExtension)->default_value(maskExtension),
+            "File extension for the masks to use.")
         ;
 
     CmdLine cmdline("AliceVision meshMasking");
@@ -613,7 +620,7 @@ int main(int argc, char **argv)
     }
 
     ALICEVISION_LOG_INFO("Mask mesh");
-    meshMasking(mp, inputMesh, masksFolders, outputMeshPath, threshold, invert, smoothBoundary, undistortMasks, usePointsVisibilities);
+    meshMasking(mp, inputMesh, masksFolders, maskExtension, outputMeshPath, threshold, invert, smoothBoundary, undistortMasks, usePointsVisibilities);
     ALICEVISION_LOG_INFO("Task done in (s): " + std::to_string(timer.elapsed()));
     return EXIT_SUCCESS;
 }

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -29,7 +29,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 using namespace aliceVision::camera;
@@ -79,6 +79,7 @@ void process(const std::string &dstColorImage, const IntrinsicBase* cam, const o
 bool prepareDenseScene(const SfMData& sfmData,
                        const std::vector<std::string>& imagesFolders,
                        const std::vector<std::string>& masksFolders,
+                       const std::string& maskExtension,
                        int beginIndex,
                        int endIndex,
                        const std::string& outFolder,
@@ -246,7 +247,7 @@ bool prepareDenseScene(const SfMData& sfmData,
             }
 
             image::Image<unsigned char> mask;
-            if(tryLoadMask(&mask, masksFolders, viewId, srcImage))
+            if(tryLoadMask(&mask, masksFolders, viewId, srcImage, maskExtension))
             {
                 process<Image<RGBAfColor>>(dstColorImage, cam, metadata, srcImage, evCorrection, exposureCompensation, [&mask] (Image<RGBAfColor> & image)
                 {
@@ -286,6 +287,7 @@ int aliceVision_main(int argc, char *argv[])
     std::string outImageFileTypeName = image::EImageFileType_enumToString(image::EImageFileType::EXR);
     std::vector<std::string> imagesFolders;
     std::vector<std::string> masksFolders;
+    std::string maskExtension = "png";
     int rangeStart = -1;
     int rangeSize = 1;
     bool saveMetadata = true;
@@ -307,6 +309,8 @@ int aliceVision_main(int argc, char *argv[])
         ("masksFolders", po::value<std::vector<std::string>>(&masksFolders)->multitoken(),
          "Use masks from specific folder(s).\n"
          "Filename should be the same or the image uid.")
+        ("maskExtension", po::value<std::string>(&maskExtension)->default_value(maskExtension),
+         "File extension of the masks to use.")
         ("outputFileType", po::value<std::string>(&outImageFileTypeName)->default_value(outImageFileTypeName),
          image::EImageFileType_informations().c_str())
         ("saveMetadata", po::value<bool>(&saveMetadata)->default_value(saveMetadata),
@@ -371,7 +375,7 @@ int aliceVision_main(int argc, char *argv[])
     }
 
     // export
-    if(prepareDenseScene(sfmData, imagesFolders, masksFolders, rangeStart, rangeEnd,
+    if(prepareDenseScene(sfmData, imagesFolders, masksFolders, maskExtension, rangeStart, rangeEnd,
                          outFolder, outputFileType, saveMetadata, saveMatricesTxtFiles, evCorrection))
         return EXIT_SUCCESS;
 


### PR DESCRIPTION
## Description

The goal of this PR is to handle masks better:
- In the `image` module, the `tryLoadMask` method was trying to load masks that needed to have the `.png` extension, and the extension was hard-coded. The extension of the masks is now provided as a parameter.
- As a consequence, all the executables using `tryLoadMask` (`main_meshMasking` and `main_PrepareDenseScene`) now have a new command-line argument to specify the extension of the masks, when they are provided. By default, it is set to "png".
- When performing image segmentation in `main_ImageSegmentation`, pixels associated to a label are by default set to 255, while pixels that do not correspond to any label are set to 0. For some use cases, having the pixels associated to labels set to 0 might be better, so a new command-line argument has been added to invert the masks' values. If enabled, pixels that are not associated with any labels will be set to 255, and those which are will be set to 0. 


## Features list

- [x] Add a new `maskExtension` parameter to the `tryLoadMask` method in the `image` module;
- [x] Add new `maskExtension` parameters to the command-lines of the `MeshMasking` and `PrepareDenseScene` executables;
- [x] Add a new `maskInvert` command-line argument for the `ImageSegmentation` executable.