### PR TITLE
Meshing: fix in graphcut weighting and minor sampling improvements

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -795,18 +795,19 @@ void DelaunayGraphCut::addPointsFromSfM(const Point3d hexah[8], const StaticVect
 void DelaunayGraphCut::addPointsFromCameraCenters(const StaticVector<int>& cams, float minDist)
 {
     int addedPoints = 0;
-    const float minDist2 = minDist * minDist;
-    Tree kdTree(_verticesCoords);
+    // Note: For now, we skip the check of collision between cameras and data points to avoid useless computation.
+    // const float minDist2 = minDist * minDist;
+    // Tree kdTree(_verticesCoords);
     for(int camid = 0; camid < cams.size(); camid++)
     {
         int rc = cams[camid];
         {
             const Point3d p(_mp.CArr[rc].x, _mp.CArr[rc].y, _mp.CArr[rc].z);
-            std::size_t vi;
-            double sq_dist;
+            // std::size_t vi;
+            // double sq_dist;
 
             // if there is no nearest vertex or the nearest vertex is not too close
-            if(!kdTree.locateNearestVertex(p, vi, sq_dist) || (sq_dist > minDist2))
+            // if(!kdTree.locateNearestVertex(p, vi, sq_dist) || (sq_dist > minDist2))
             {
                 const GEO::index_t nvi = _verticesCoords.size();
                 _verticesCoords.push_back(p);
@@ -819,10 +820,10 @@ void DelaunayGraphCut::addPointsFromCameraCenters(const StaticVector<int>& cams,
                 _verticesAttr.push_back(newv);
                 ++addedPoints;
             }
-            else
-            {
-                _camsVertexes[rc] = vi;
-            }
+            // else
+            // {
+            //     _camsVertexes[rc] = vi;
+            // }
         }
     }
     ALICEVISION_LOG_WARNING("Add " << addedPoints << " new points for the " << cams.size() << " cameras centers.");
@@ -846,17 +847,13 @@ void DelaunayGraphCut::addPointsToPreventSingularities(const Point3d voxel[8], f
     extrPts[4] = fcg + (fcg - vcg) * s;
     fcg = (voxel[3] + voxel[2] + voxel[6] + voxel[7]) * 0.25;
     extrPts[5] = fcg + (fcg - vcg) * s;
+
     int addedPoints = 0;
-    const float minDist2 = minDist * minDist;
-    Tree kdTree(_verticesCoords);
-    for(int i = 0; i < 6; i++)
+    for(int i = 0; i < 6; ++i)
     {
         const Point3d p(extrPts[i].x, extrPts[i].y, extrPts[i].z);
-        std::size_t vi;
-        double sq_dist;
 
-        // if there is no nearest vertex or the nearest vertex is not too close
-        if(!kdTree.locateNearestVertex(p, vi, sq_dist) || (sq_dist > minDist2))
+        // Note: As we create points outside of the bbox, we do not check collisions with data points.
         {
             _verticesCoords.push_back(p);
             GC_vertexInfo newv;

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -830,21 +830,22 @@ void DelaunayGraphCut::addPointsFromCameraCenters(const StaticVector<int>& cams,
 
 void DelaunayGraphCut::addPointsToPreventSingularities(const Point3d voxel[8], float minDist)
 {
-    Point3d vcg = (voxel[0] + voxel[1] + voxel[2] + voxel[3] + voxel[4] + voxel[5] + voxel[6] + voxel[7]) / 8.0f;
+    Point3d vcg = (voxel[0] + voxel[1] + voxel[2] + voxel[3] + voxel[4] + voxel[5] + voxel[6] + voxel[7]) / 8.0;
     Point3d extrPts[6];
     Point3d fcg;
-    fcg = (voxel[0] + voxel[1] + voxel[2] + voxel[3]) / 4.0f;
-    extrPts[0] = fcg + (fcg - vcg) / 10.0f;
-    fcg = (voxel[0] + voxel[4] + voxel[7] + voxel[3]) / 4.0f;
-    extrPts[1] = fcg + (fcg - vcg) / 10.0f;
-    fcg = (voxel[0] + voxel[1] + voxel[5] + voxel[4]) / 4.0f;
-    extrPts[2] = fcg + (fcg - vcg) / 10.0f;
-    fcg = (voxel[4] + voxel[5] + voxel[6] + voxel[7]) / 4.0f;
-    extrPts[3] = fcg + (fcg - vcg) / 10.0f;
-    fcg = (voxel[1] + voxel[5] + voxel[6] + voxel[2]) / 4.0f;
-    extrPts[4] = fcg + (fcg - vcg) / 10.0f;
-    fcg = (voxel[3] + voxel[2] + voxel[6] + voxel[7]) / 4.0f;
-    extrPts[5] = fcg + (fcg - vcg) / 10.0f;
+    const double s = 0.1;
+    fcg = (voxel[0] + voxel[1] + voxel[2] + voxel[3]) * 0.25;
+    extrPts[0] = fcg + (fcg - vcg) * s;
+    fcg = (voxel[0] + voxel[4] + voxel[7] + voxel[3]) * 0.25;
+    extrPts[1] = fcg + (fcg - vcg) * s;
+    fcg = (voxel[0] + voxel[1] + voxel[5] + voxel[4]) * 0.25;
+    extrPts[2] = fcg + (fcg - vcg) * s;
+    fcg = (voxel[4] + voxel[5] + voxel[6] + voxel[7]) * 0.25;
+    extrPts[3] = fcg + (fcg - vcg) * s;
+    fcg = (voxel[1] + voxel[5] + voxel[6] + voxel[2]) * 0.25;
+    extrPts[4] = fcg + (fcg - vcg) * s;
+    fcg = (voxel[3] + voxel[2] + voxel[6] + voxel[7]) * 0.25;
+    extrPts[5] = fcg + (fcg - vcg) * s;
     int addedPoints = 0;
     const float minDist2 = minDist * minDist;
     Tree kdTree(_verticesCoords);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -3110,16 +3110,16 @@ void DelaunayGraphCut::createDensePointCloud(const Point3d hexah[8], const Stati
   // add points for cam centers
   addPointsFromCameraCenters(cams, minDist);
 
-  // add 6 points to prevent singularities
-  addPointsToPreventSingularities(hexah, minDist);
-
   densifyWithHelperPoints(densifyNbFront, densifyNbBack, densifyScale);
 
   // add volume points to prevent singularities
   {
     Point3d hexahExt[8];
-    mvsUtils::inflateHexahedron(hexah, hexahExt, 1.1);
+    mvsUtils::inflateHexahedron(hexah, hexahExt, 1.3);
     addGridHelperPoints(helperPointsGridSize, hexahExt, minDist);
+
+    // add 6 points to prevent singularities (one point beyond each bbox facet)
+    addPointsToPreventSingularities(hexahExt, minDist);
 
     // add point for shape from silhouette
     if(depthMapsFuseParams != nullptr)

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -834,9 +834,9 @@ void DelaunayGraphCut::addPointsToPreventSingularities(const Point3d voxel[8], f
     Point3d vcg = (voxel[0] + voxel[1] + voxel[2] + voxel[3] + voxel[4] + voxel[5] + voxel[6] + voxel[7]) / 8.0;
     Point3d extrPts[6];
     Point3d fcg;
-    const double s = 0.1;
-    fcg = (voxel[0] + voxel[1] + voxel[2] + voxel[3]) * 0.25;
-    extrPts[0] = fcg + (fcg - vcg) * s;
+    const double s = 0.25;
+    fcg = (voxel[0] + voxel[1] + voxel[2] + voxel[3]) * 0.25; // facet center
+    extrPts[0] = fcg + (fcg - vcg) * s; // extra point beyond the bbox facet
     fcg = (voxel[0] + voxel[4] + voxel[7] + voxel[3]) * 0.25;
     extrPts[1] = fcg + (fcg - vcg) * s;
     fcg = (voxel[0] + voxel[1] + voxel[5] + voxel[4]) * 0.25;

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1118,13 +1118,14 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
     // If too much points at the end, increment a coefficient factor on the pixel size
     // and iterate to fuse points until we get the right amount of points.
 
-    // unsigned long nbValidDepths = computeNumberOfAllPoints(mp, 0);
-    // int stepPts = divideRoundUp(nbValidDepths, maxPoints);
+    const unsigned long nbValidDepths = computeNumberOfAllPoints(_mp, _mp.getProcessDownscale());
+    ALICEVISION_LOG_INFO("Number of all valid depths in input depth maps: " << nbValidDepths);
     std::size_t nbPixels = 0;
     for(const auto& imgParams: _mp.getImagesParams())
     {
         nbPixels += imgParams.size;
     }
+    ALICEVISION_LOG_INFO("Number of pixels from all input images: " << nbPixels);
     int step = std::floor(std::sqrt(double(nbPixels) / double(params.maxInputPoints)));
     step = std::max(step, params.minStep);
     std::size_t realMaxVertices = 0;
@@ -1145,7 +1146,6 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
     int minAngleCounter = 0;
 
     ALICEVISION_LOG_INFO("simFactor: " << params.simFactor);
-    ALICEVISION_LOG_INFO("nbPixels: " << nbPixels);
     ALICEVISION_LOG_INFO("maxVertices: " << params.maxPoints);
     ALICEVISION_LOG_INFO("step: " << step << " (minStep: " << params.minStep << ")");
     ALICEVISION_LOG_INFO("realMaxVertices: " << realMaxVertices);

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -1117,8 +1117,9 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
     std::vector<double> pixSizePrepare(realMaxVertices);
     std::vector<float> simScorePrepare(realMaxVertices);
 
-    // counter for points filtered based on the number of observations (minVis)
+    // counter for filtered points
     int minVisCounter = 0;
+    int minAngleCounter = 0;
 
     ALICEVISION_LOG_INFO("simFactor: " << params.simFactor);
     ALICEVISION_LOG_INFO("nbPixels: " << nbPixels);
@@ -1326,6 +1327,7 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
         if(maxAngle < params.minAngleThreshold)
         {
             pixSizePrepare[vIndex] = -1;
+            minAngleCounter += 1;
             continue;
         }
         // Filter points based on their number of observations
@@ -1352,7 +1354,8 @@ void DelaunayGraphCut::fuseFromDepthMaps(const StaticVector<int>& cams, const Po
     ALICEVISION_LOG_INFO("Angle min: " << stat_minAngle << ", max: " << stat_maxAngle << ".");
     ALICEVISION_LOG_INFO("Angle score min: " << stat_minAngleScore << ", max: " << stat_maxAngleScore << ".");
 #endif
-    ALICEVISION_LOG_INFO((minVisCounter) << " points filtered based on the number of observations (minVis). ");
+    ALICEVISION_LOG_INFO(minAngleCounter << " filtered points due to low angle of observations (minAngleThreshold=" << params.minAngleThreshold << "). ");
+    ALICEVISION_LOG_INFO(minVisCounter << " filtered points due to low number of observations (minVis=" << params.minVis << "). ");
     removeInvalidPoints(verticesCoordsPrepare, pixSizePrepare, simScorePrepare, verticesAttrPrepare);
 
     ALICEVISION_LOG_INFO("Filter by angle score and sim score");

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -184,7 +184,7 @@ public:
 #else
         nanoflann::KNNResultSet<double, std::size_t> resultSet(1);
         resultSet.init(&index, &sq_dist);
-        if(!_tree->findNeighbors(resultSet, p.m, nanoflann::SearchParams()))
+        if(!_tree->findNeighbors(resultSet, p.m, nanoflann::SearchParameters()))
         {
             return false;
         }
@@ -251,8 +251,8 @@ void filterByPixSize(const std::vector<Point3d>& verticesCoordsPrepare, std::vec
             // }
         }
 #else
-
-        static const nanoflann::SearchParams searchParams(32, 0, false); // false: dont need to sort
+        
+        static const nanoflann::SearchParameters searchParams(0.f, false); // false: dont need to sort
         SmallerPixSizeInRadius<double, std::size_t> resultSet(pixSizeScore, pixSizePrepare, simScorePrepare, vIndex);
         kdTree.findNeighbors(resultSet, verticesCoordsPrepare[vIndex].m, searchParams);
         if(resultSet.found)
@@ -391,7 +391,7 @@ void createVerticesWithVisibilities(const StaticVector<int>& cams, std::vector<P
                 std::size_t nearestVertexIndex = std::numeric_limits<std::size_t>::max();
                 double dist = std::numeric_limits<double>::max();
                 resultSet.init(&nearestVertexIndex, &dist);
-                if(!kdTree.findNeighbors(resultSet, p.m, nanoflann::SearchParams()))
+                if(!kdTree.findNeighbors(resultSet, p.m, nanoflann::SearchParameters()))
                 {
                     ALICEVISION_LOG_TRACE("Failed to find Neighbors.");
                     continue;

--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -2013,7 +2013,7 @@ void DelaunayGraphCut::fillGraphPartPtRc(
     int vertexIndex, int cam, float weight, float fullWeight, double nPixelSizeBehind,
                                        bool fillOut, float distFcnHeight)  // nPixelSizeBehind=2*spaceSteps allPoints=1 behind=0 fillOut=1 distFcnHeight=0
 {
-    const int maxint = 1000000; // std::numeric_limits<int>::std::max()
+    const int maxint = std::numeric_limits<int>::max();
     const double marginEpsilonFactor = 1.0e-4;
 
     const Point3d& originPt = _verticesCoords[vertexIndex];
@@ -3247,7 +3247,7 @@ void DelaunayGraphCut::maxflow()
 void DelaunayGraphCut::voteFullEmptyScore(const StaticVector<int>& cams, const std::string& folderName)
 {
     ALICEVISION_LOG_INFO("DelaunayGraphCut::voteFullEmptyScore");
-    const int maxint = 1000000.0f;
+    const int maxint = std::numeric_limits<int>::max();
 
     long t1;
 

--- a/src/aliceVision/mvsUtils/mapIO.cpp
+++ b/src/aliceVision/mvsUtils/mapIO.cpp
@@ -314,10 +314,12 @@ void readMapFromFileOrTiles(int rc,
     // check single file fullsize map exists
     if(fs::exists(mapPath))
     {
+        ALICEVISION_LOG_TRACE("Load depth map (full image): " << mapPath << ", scale: " << scale << ", step: " << step);
         // read single file fullsize map
         image::readImage(mapPath, out_map, image::EImageColorSpace::NO_CONVERSION);
         return;
     }
+    ALICEVISION_LOG_TRACE("No full image depth map: " << mapPath << ", scale: " << scale << ", step: " << step << ". Looking for tiles.");
 
     // read map from tiles
     const ROI imageRoi(Range(0, mp.getWidth(rc)), Range(0, mp.getHeight(rc)));
@@ -338,6 +340,10 @@ void readMapFromFileOrTiles(int rc,
         // map can be empty
         ALICEVISION_LOG_INFO("Cannot find any " << getMapNameFromFileType(fileType) << " tile file (rc: " << rc << ").");
         return; // nothing to do, already initialized
+    }
+    else
+    {
+        ALICEVISION_LOG_TRACE("Load depth map from " << mapTilePathList.size() << " tiles. First tile: " << mapTilePathList[0] << ", scale: " << scale << ", step: " << step);
     }
 
     // get tileParams from first tile file metadata


### PR DESCRIPTION
## Features list

2 bug fixes:
- [x]  [mvsUtils] bug fix getNbDepthValuesFromDepthMap: load the correct depth map files
- [x]  [fuseCut] bug fix: need higher score of emptiness

1 library update:
- [x]  Update nanoflann

Update the way we create helper points to improve performances and to improve distribution and noise level:
- [x]  [fuseCut] helper points: inflate bbox 1.3
- [x]  [fuseCut] helper points: add omp and make noise proportional to each axis size
- [x]  [fuseCut] add 6 points around bbox: update from 10% to 25%
- [x]  [fuseCut] uniform noise on helper points with 1/4 margin around the vertex
- [x]  [fuseCut] skip some collision checks to avoid useless computation


