### PR TITLE
Add automatic method for HDR calibration

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -9,59 +9,66 @@
 namespace aliceVision {
 namespace hdr {
 
-bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, const sfmData::SfMData& sfmData, size_t countBrackets)
+bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups,
+                                 const sfmData::SfMData& sfmData,
+                                 size_t countBrackets)
 {
     groups.clear();
 
     size_t countImages = sfmData.getViews().size();
-    if(countImages == 0)
+    if (countImages == 0)
     {
         return false;
     }
-
 
     const sfmData::Views & views = sfmData.getViews();
 
     // Order views by their image names (without path and extension to make sure we handle rotated images)
     std::vector<std::shared_ptr<sfmData::View>> viewsOrderedByName;
-    for(auto& viewIt : sfmData.getViews())
+    for (auto& viewIt : sfmData.getViews())
     {
         viewsOrderedByName.push_back(viewIt.second);
     }
+
     std::sort(viewsOrderedByName.begin(), viewsOrderedByName.end(),
-        [](const std::shared_ptr<sfmData::View>& a, const std::shared_ptr<sfmData::View>& b) -> bool {
-            if(a == nullptr || b == nullptr)
+        [](const std::shared_ptr<sfmData::View>& a, const std::shared_ptr<sfmData::View>& b) -> bool
+        {
+            if (a == nullptr || b == nullptr)
                 return true;
 
             boost::filesystem::path path_a(a->getImagePath());
             boost::filesystem::path path_b(b->getImagePath());
 
             return (path_a.stem().string() < path_b.stem().string());
-        });
+        }
+    );
 
     // Print a warning if the aperture changes.
     std::set<float> fnumbers;
-    for(auto& view : viewsOrderedByName) {
+    for (auto& view : viewsOrderedByName)
+    {
         fnumbers.insert(view->getMetadataFNumber());
     }
     
-    if(fnumbers.size() != 1) {
+    if (fnumbers.size() != 1)
+    {
         ALICEVISION_LOG_WARNING("Different apertures amongst the dataset. For correct HDR, you should only change "
                                 "the shutter speed (and eventually the ISO).");
         ALICEVISION_LOG_WARNING("Used f-numbers:");
-        for(auto f : fnumbers) {
+        for (auto f : fnumbers)
+        {
             ALICEVISION_LOG_WARNING(" * " << f);
         }
     }
     
     std::vector<std::shared_ptr<sfmData::View>> group;
     double lastExposure = std::numeric_limits<double>::min();
-    for(auto& view : viewsOrderedByName)
+    for (auto& view : viewsOrderedByName)
     {
         if (countBrackets > 0)
         {
             group.push_back(view);
-            if(group.size() == countBrackets)
+            if (group.size() == countBrackets)
             {
                 groups.push_back(group);
                 group.clear();
@@ -71,7 +78,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         {
             // Automatically determines the number of brackets
             double exp = view->getCameraExposureSetting().getExposure();
-            if(exp < lastExposure)
+            if (exp < lastExposure)
             {
                 groups.push_back(group);
                 group.clear();
@@ -88,7 +95,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
     }
 
 
-    //Vote for the best bracket count
+    // Vote for the best bracket count
     std::map<size_t, int> counters;
     for (const auto & group : groups)
     {
@@ -114,13 +121,13 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         }
         else if (item.second == maxSize && item.first > bestBracketCount)
         {
-            //If two brackets size have the same vote number, 
-            //Keep the larger one (Just to avoid keeping only the outlier)
+            // If two brackets size have the same vote number,
+            // keep the larger one (this avoids keeping only the outlier)
             bestBracketCount = item.first;
         }
     }
 
-    //Only keep groups with majority bracket size
+    // Only keep groups with the majority bracket size
     auto groupIt = groups.begin();
     while (groupIt != groups.end())
     {
@@ -135,15 +142,18 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
     }
 
     std::vector< std::vector<sfmData::ExposureSetting>> v_exposuresSetting;
-    for(auto & group : groups)
+    for (auto & group : groups)
     {
         // Sort all images by exposure time
         std::sort(group.begin(), group.end(),
-                  [](const std::shared_ptr<sfmData::View>& a, const std::shared_ptr<sfmData::View>& b) -> bool {
-                      if(a == nullptr || b == nullptr)
-                          return true;
-                      return (a->getCameraExposureSetting().getExposure() < b->getCameraExposureSetting().getExposure());
-                  });
+            [](const std::shared_ptr<sfmData::View>& a, const std::shared_ptr<sfmData::View>& b) -> bool
+            {
+                if (a == nullptr || b == nullptr)
+                    return true;
+                return (a->getCameraExposureSetting().getExposure() < b->getCameraExposureSetting().getExposure());
+            }
+        );
+
         std::vector<sfmData::ExposureSetting> exposuresSetting;
         for (auto& v : group)
         {
@@ -173,10 +183,12 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
 }
 
 int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
-                      std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
-                      const std::string& lumaStatFilepath, const double meanTargetedLuma)
+                      std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups,
+                      int offsetRefBracketIndex,
+                      const std::string& lumaStatFilepath,
+                      const double meanTargetedLuma)
 {
-    // If targetIndexesFilename cannot be opened or is not valid an error is thrown
+    // If targetIndexesFilename cannot be opened or is not valid, an error is thrown.
     // For odd number, there is no ambiguity on the middle image.
     // For even number, we arbitrarily choose the more exposed view (as we usually have more under-exposed images than over-exposed).
     const int viewNumberPerGroup = groups[0].size();
@@ -191,10 +203,13 @@ int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVie
     }
     else // try to use the luminance statistics of the LDR images stored in the file
     {
-        ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter out of range, read file containing luminance statistics to compute an estimation");
+        ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter out of range, " <<
+                             "read file containing luminance statistics to compute an estimation");
         std::ifstream file(lumaStatFilepath);
         if (!file)
+        {
             ALICEVISION_THROW_ERROR("Failed to open file: " << lumaStatFilepath);
+        }
         std::vector<std::string> lines;
         std::string line;
         while (std::getline(file, line))
@@ -204,7 +219,7 @@ int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVie
         if ((lines.size() < 3) || (std::stoi(lines[0]) != groups.size()) || (std::stoi(lines[1]) < groups[0].size()) ||
             (lines.size() < 3 + std::stoi(lines[0]) * std::stoi(lines[1])))
         {
-            ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
+            ALICEVISION_THROW_ERROR("File '" << lumaStatFilepath << "' is not a valid file");
         }
         int nbGroup = std::stoi(lines[0]);
         int nbExp = std::stoi(lines[1]);
@@ -223,9 +238,12 @@ int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVie
                 double exposure, lumaMean, lumaMin, lumaMax;
                 if (!(iss >> srcId >> exposure >> nbItem >> lumaMean >> lumaMin >> lumaMax))
                 {
-                    ALICEVISION_THROW_ERROR("File: " << lumaStatFilepath << " is not a valid file");
+                    ALICEVISION_THROW_ERROR("File '" << lumaStatFilepath << "' is not a valid file");
                 }
-                if (exposure > 0.0) // discard dummy luminance info (with exposure set to -1.0) added at calibration stage if samples are missing for a view
+
+                // Discard dummy luminance info (with exposure set to -1.0) added at calibration stage if samples are
+                // missing for a view
+                if (exposure > 0.0)
                 {
                     lumaMeanMean += lumaMean;
                     ++nbValidViews;
@@ -234,9 +252,10 @@ int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVie
             v_lumaMeanMean.push_back(lumaMeanMean / nbValidViews);
         }
 
-        // adjust last index to avoid non increasing luminance curve due to saturation in highlights
+        // Adjust last index to avoid non increasing luminance curve due to saturation in highlights
         int lastIdx = v_lumaMeanMean.size() - 1;
-        while ((lastIdx > 1) && ((v_lumaMeanMean[lastIdx] < v_lumaMeanMean[lastIdx - 1]) || (v_lumaMeanMean[lastIdx] < v_lumaMeanMean[lastIdx - 2])))
+        while ((lastIdx > 1) && ((v_lumaMeanMean[lastIdx] < v_lumaMeanMean[lastIdx - 1]) ||
+                                 (v_lumaMeanMean[lastIdx] < v_lumaMeanMean[lastIdx - 2])))
         {
             lastIdx--;
         }
@@ -246,14 +265,16 @@ int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetVie
 
         for (int k = 0; k < lastIdx; ++k)
         {
-            const double diffWithLumaTarget = (v_lumaMeanMean[k] > meanTargetedLuma) ? (v_lumaMeanMean[k] - meanTargetedLuma) : (meanTargetedLuma - v_lumaMeanMean[k]);
+            const double diffWithLumaTarget = (v_lumaMeanMean[k] > meanTargetedLuma) ?
+                                              (v_lumaMeanMean[k] - meanTargetedLuma) :
+                                              (meanTargetedLuma - v_lumaMeanMean[k]);
             if (diffWithLumaTarget < minDiffWithLumaTarget)
             {
                 minDiffWithLumaTarget = diffWithLumaTarget;
                 targetIndex = k;
             }
         }
-        ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter automaticaly set to " << targetIndex - middleIndex);
+        ALICEVISION_LOG_INFO("offsetRefBracketIndex parameter automatically set to " << targetIndex - middleIndex);
     }
 
     for (auto& group : groups)

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -21,9 +21,9 @@ enum class ECalibrationMethod
 };
 
 /**
- * @brief convert an enum ECalibrationMethod to its corresponding string
- * @param ECalibrationMethod
- * @return String
+ * @brief Convert a calibration method from an ECalibrationMethod enum to its corresponding string
+ * @param[in] calibrationMethod the ECalibrationMethod enum to convert to a string
+ * @return the string containing the calibration method corresponding to the input ECalibration enum
  */
 inline std::string ECalibrationMethod_enumToString(const ECalibrationMethod calibrationMethod)
 {
@@ -44,9 +44,9 @@ inline std::string ECalibrationMethod_enumToString(const ECalibrationMethod cali
 }
 
 /**
- * @brief convert a string calibration method name to its corresponding enum ECalibrationMethod
- * @param ECalibrationMethod
- * @return String
+ * @brief Convert a string containing the calibration method name to its corresponding ECalibrationMethod enum
+ * @param[in] calibrationMethodName the string containing the calibration method name to convert to an ECalibrationMethod enum
+ * @return the ECalibrationMethod enum corresponding to the input calibration method
  */
 inline ECalibrationMethod ECalibrationMethod_stringToEnum(const std::string& calibrationMethodName)
 {
@@ -64,7 +64,7 @@ inline ECalibrationMethod ECalibrationMethod_stringToEnum(const std::string& cal
     if (methodName == "laguerre")
         return ECalibrationMethod::LAGUERRE;
 
-    throw std::out_of_range("Invalid method name : '" + calibrationMethodName + "'");
+    throw std::out_of_range("Invalid method name: '" + calibrationMethodName + "'");
 }
 
 inline std::ostream& operator<<(std::ostream& os, ECalibrationMethod calibrationMethodName)
@@ -82,27 +82,33 @@ inline std::istream& operator>>(std::istream& in, ECalibrationMethod& calibratio
 }
 
 /**
- * @brief Estimate brackets information from sfm data
- * @param[out] groups: estimated groups
- * @param[in] sfmData
- * @param[in] countBrackets: number of brackets
- * @return false if an error occur, like an invalid sfm data
+ * @brief Estimate the brackets information from the SfM data
+ * @param[out] groups the estimated groups
+ * @param[in] sfmData SfM data to estimate the brackets from
+ * @param[in] countBrackets the number of brackets
+ * @return false if an error occurs (e.g. an invalid SfMData file has been provided), true otherwise
  */
-bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData::View>>> & groups, const sfmData::SfMData& sfmData, size_t countBrackets);
+bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData::View>>> & groups,
+                                 const sfmData::SfMData& sfmData,
+                                 size_t countBrackets);
 
 /**
  * @brief Select the target views (used for instance to define the expoure)
- * @param[out] targetViews: estimated target views
- * @param[in] groups: groups of Views corresponding to multi-bracketing. Warning: Needs be sorted by exposure time.
- * @param[in] offsetRefBracketIndex: 0 mean center bracket and you can choose +N/-N to select the reference bracket
- * @param[in] targetIndexesFilename: in case offsetRefBracketIndex is out of range the number of views in a group target indexes can be read from a text file
- *                                   if the file cannot be read or does not contain the expected number of values (same as view group number) and
- *                                   if offsetRefBracketIndex is out of range the number of views then a clamped values of offsetRefBracketIndex is considered
- * @return Index of the targetView
+ * @param[out] targetViews the estimated target views
+ * @param[in] groups the groups of Views corresponding to multi-bracketing. Warning: Needs be sorted by exposure time.
+ * @param[in] offsetRefBracketIndex 0 means center bracket and you can choose +N/-N to select the reference bracket
+ * @param[in] targetIndexesFilename in case offsetRefBracketIndex is out of range, the number of views in a group target
+ *                                  indexes can be read from a text file. If the file cannot be read or does not contain
+ *                                  the expected number of values (same as view group number) and if
+ *                                  offsetRefBracketIndex is out of range, the number of views then a clamped value of
+ *                                  offsetRefBracketIndex is considered
+ * @return the index of the target view
  */
 int selectTargetViews(std::vector<std::shared_ptr<sfmData::View>>& out_targetViews,
-                      std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups, int offsetRefBracketIndex,
-                      const std::string& targetIndexesFilename = "", const double meanTargetedLuma = 0.4);
+                      std::vector<std::vector<std::shared_ptr<sfmData::View>>>& groups,
+                      int offsetRefBracketIndex,
+                      const std::string& targetIndexesFilename = "",
+                      const double meanTargetedLuma = 0.4);
 
 }
 }

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -17,6 +17,7 @@ enum class ECalibrationMethod
     DEBEVEC,
     GROSSBERG,
     LAGUERRE,
+    AUTO,
 };
 
 /**
@@ -28,6 +29,8 @@ inline std::string ECalibrationMethod_enumToString(const ECalibrationMethod cali
 {
     switch (calibrationMethod)
     {
+    case ECalibrationMethod::AUTO:
+        return "auto";
     case ECalibrationMethod::LINEAR:
         return "linear";
     case ECalibrationMethod::DEBEVEC:
@@ -50,6 +53,8 @@ inline ECalibrationMethod ECalibrationMethod_stringToEnum(const std::string& cal
     std::string methodName = calibrationMethodName;
     std::transform(methodName.begin(), methodName.end(), methodName.begin(), ::tolower);
 
+    if (methodName == "auto")
+        return ECalibrationMethod::AUTO;
     if (methodName == "linear")
         return ECalibrationMethod::LINEAR;
     if (methodName == "debevec")

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -166,7 +166,9 @@ int aliceVision_main(int argc, char** argv)
         ("samplesFolders,f", po::value<std::string>(&samplesFolder)->default_value(samplesFolder),
          "Path to folder containing the extracted samples (Required if the calibration is not linear).")
         ("calibrationMethod,m", po::value<ECalibrationMethod>(&calibrationMethod)->default_value(calibrationMethod),
-         "Name of method used for camera calibration: linear, debevec, grossberg, laguerre.")
+         "Name of the method used for the camera calibration: auto, linear, debevec, grossberg, laguerre."
+         "If 'auto' is selected, the linear method will be used if there are RAW images; otherwise, the Debevec method "
+         "will be used.")
         ("calibrationWeight,w", po::value<std::string>(&calibrationWeightFunction)->default_value(calibrationWeightFunction),
          "Weight function used to calibrate camera response (default depends on the calibration method, gaussian, "
          "triangle, plateau).")

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -392,7 +392,7 @@ int aliceVision_main(int argc, char** argv)
                         const bool isRAW = imgFormat.compare("raw") == 0;
 
                         calibrationMethod = isRAW ? ECalibrationMethod::LINEAR : ECalibrationMethod::DEBEVEC;
-                        ALICEVISION_LOG_INFO("Calibration method automaticaly set to " << calibrationMethod);
+                        ALICEVISION_LOG_INFO("Calibration method automatically set to " << calibrationMethod);
                     }
 
                     // Read from file
@@ -483,7 +483,7 @@ int aliceVision_main(int argc, char** argv)
             }
             case ECalibrationMethod::AUTO:
             {
-                ALICEVISION_LOG_ERROR("Calibration method cannot be automaticaly selected");
+                ALICEVISION_LOG_ERROR("Calibration method cannot be automatically selected");
                 return EXIT_FAILURE;
             }
             }

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -481,6 +481,11 @@ int aliceVision_main(int argc, char** argv)
                 calibration.process(calibrationSamples, groupedExposures, channelQuantization, false, response);
                 break;
             }
+            case ECalibrationMethod::AUTO:
+            {
+                ALICEVISION_LOG_ERROR("Calibration method cannot be automaticaly selected");
+                return EXIT_FAILURE;
+            }
             }
 
             const std::string methodName = ECalibrationMethod_enumToString(calibrationMethod);

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -41,7 +41,7 @@ std::string getHdrImagePath(const std::string& outputPath, std::size_t g, const 
 {
     // Output image file path
     std::stringstream sstream;
-    if(rootname == "")
+    if (rootname == "")
     {
         sstream << "hdr_" << std::setfill('0') << std::setw(4) << g << ".exr";
     }
@@ -53,11 +53,14 @@ std::string getHdrImagePath(const std::string& outputPath, std::size_t g, const 
     return hdrImagePath;
 }
 
-std::string getHdrMaskPath(const std::string& outputPath, std::size_t g, const std::string& maskname, const std::string& rootname = "")
+std::string getHdrMaskPath(const std::string& outputPath,
+                           std::size_t g,
+                           const std::string& maskname,
+                           const std::string& rootname = "")
 {
     // Output image file path
     std::stringstream sstream;
-    if(rootname == "")
+    if (rootname == "")
     {
         sstream << "hdrMask_" << maskname << "_" << std::setfill('0') << std::setw(4) << g << ".exr";
     }
@@ -100,38 +103,41 @@ int aliceVision_main(int argc, char** argv)
         ("input,i", po::value<std::string>(&sfmInputDataFilename)->required(),
          "SfMData file input.")
         ("response,o", po::value<std::string>(&inputResponsePath)->required(),
-        "Input path for the response file.")
+         "Input path for the response file.")
         ("outSfMData,o", po::value<std::string>(&sfmOutputDataFilepath)->required(),
          "SfMData file output.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
         ("nbBrackets,b", po::value<int>(&nbBrackets)->default_value(nbBrackets),
-         "bracket count per HDR image (0 means automatic).")
+         "Bracket count per HDR image (0 means automatic).")
         ("byPass", po::value<bool>(&byPass)->default_value(byPass),
-         "bypass HDR creation and use medium bracket as input for next steps")
+         "Bypass HDR creation and use a single bracket as the input for the next steps.")
         ("keepSourceImageName", po::value<bool>(&keepSourceImageName)->default_value(keepSourceImageName),
-         "Keep the filename of the input image selected as central image for the output image filename")
+         "Use the filename of the input image selected as the central image for the output image filename.")
         ("channelQuantizationPower", po::value<int>(&channelQuantizationPower)->default_value(channelQuantizationPower),
          "Quantization level like 8 bits or 10 bits.")
         ("workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
          ("Working color space: " + image::EImageColorSpace_informations()).c_str())
         ("fusionWeight,W", po::value<hdr::EFunctionType>(&fusionWeightFunction)->default_value(fusionWeightFunction),
-         "Weight function used to fuse all LDR images together (gaussian, triangle, plateau).")
+         "Weight function used to fuse all the LDR images together (gaussian, triangle, plateau).")
         ("offsetRefBracketIndex", po::value<int>(&offsetRefBracketIndex)->default_value(offsetRefBracketIndex),
-         "Zero to use the center bracket. +N to use a more exposed bracket or -N to use a less exposed backet.")
+         "Zero to use the center bracket. +N to use a more exposed bracket or -N to use a less exposed bracket.")
         ("meanTargetedLumaForMerging", po::value<double>(&meanTargetedLumaForMerging)->default_value(meanTargetedLumaForMerging),
-         "Mean expected luminance after merging step when input LDR images are decoded in sRGB color space. Must be in the range [0, 1].")
+         "Mean expected luminance after merging step when the input LDR images are decoded in the sRGB color space. "
+         "Must be in the range [0, 1].")
         ("minSignificantValue", po::value<double>(&minSignificantValue)->default_value(minSignificantValue),
-         "Minimum channel input value to be considered in advanced pixelwise merging. Used in advanced pixelwise merging.")
+         "Minimum channel input value to be considered in advanced pixelwise merging. "
+         "Used in advanced pixelwise merging.")
         ("maxSignificantValue", po::value<double>(&maxSignificantValue)->default_value(maxSignificantValue),
-         "Maximum channel input value to be considered in advanced pixelwise merging. Used in advanced pixelwise merging.")
+         "Maximum channel input value to be considered in advanced pixelwise merging. "
+         "Used in advanced pixelwise merging.")
         ("computeLightMasks", po::value<bool>(&computeLightMasks)->default_value(computeLightMasks),
          "Compute masks of dark and high lights and missing mid lights info.")
         ("highlightTargetLux", po::value<float>(&highlightTargetLux)->default_value(highlightTargetLux),
          "Highlights maximum luminance.")
         ("highlightCorrectionFactor", po::value<float>(&highlightCorrectionFactor)->default_value(highlightCorrectionFactor),
-         "float value between 0 and 1 to correct clamped highlights in dynamic range: use 0 for no correction, 1 for "
+         "Float value between 0 and 1 to correct clamped highlights in dynamic range: use 0 for no correction, 1 for "
          "full correction to maxLuminance.")
         ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
          ("Storage data type: " + image::EStorageDataType_informations()).c_str())
@@ -150,7 +156,7 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    // set maxThreads
+    // Set maxThreads
     HardwareContext hwc = cmdline.getHardwareContext();
     omp_set_num_threads(hwc.getMaxThreads());
 
@@ -158,21 +164,21 @@ int aliceVision_main(int argc, char** argv)
     boost::filesystem::path path(sfmOutputDataFilepath);
     std::string outputPath = path.parent_path().string();
 
-    // Read sfm data
+    // Read SfMData
     sfmData::SfMData sfmData;
-    if(!sfmDataIO::Load(sfmData, sfmInputDataFilename, sfmDataIO::ESfMData::ALL))
+    if (!sfmDataIO::Load(sfmData, sfmInputDataFilename, sfmDataIO::ESfMData::ALL))
     {
         ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmInputDataFilename << "' cannot be read.");
         return EXIT_FAILURE;
     }
     // Check input compatibility with brackets
     const int countImages = sfmData.getViews().size();
-    if(countImages == 0)
+    if (countImages == 0)
     {
         ALICEVISION_LOG_ERROR("The input SfMData contains no image.");
         return EXIT_FAILURE;
     }
-    if(nbBrackets == 1 && !byPass)
+    if (nbBrackets == 1 && !byPass)
     {
         ALICEVISION_LOG_WARNING("Enable bypass as there is only one input bracket.");
         byPass = true;
@@ -180,7 +186,7 @@ int aliceVision_main(int argc, char** argv)
 
     const std::size_t channelQuantization = std::pow(2, channelQuantizationPower);
 
-    // Make groups
+    // Estimate groups
     std::vector<std::vector<std::shared_ptr<sfmData::View>>> groupedViews;
     if (!hdr::estimateBracketsFromSfmData(groupedViews, sfmData, nbBrackets))
     {
@@ -192,20 +198,20 @@ int aliceVision_main(int argc, char** argv)
     std::size_t usedNbBrackets;
     {
         std::set<std::size_t> sizeOfGroups;
-        for(auto& group : groupedViews)
+        for (auto& group : groupedViews)
         {
             sizeOfGroups.insert(group.size());
         }
-        if(sizeOfGroups.size() == 1)
+        if (sizeOfGroups.size() == 1)
         {
             usedNbBrackets = *sizeOfGroups.begin();
-            if(usedNbBrackets == 1)
+            if (usedNbBrackets == 1)
             {
                 ALICEVISION_LOG_INFO("No multi-bracketing.");
             }
             ALICEVISION_LOG_INFO("Number of brackets automatically detected: "
                                  << usedNbBrackets << ". It will generate " << groupedViews.size()
-                                 << " hdr images.");
+                                 << " HDR images.");
         }
         else
         {
@@ -230,14 +236,14 @@ int aliceVision_main(int argc, char** argv)
 
             if (lid != intrinsicId)
             {
-                ALICEVISION_LOG_INFO("One group shall not have multiple intrinsics");
+                ALICEVISION_LOG_INFO("One group shall not have multiple intrinsics.");
                 return EXIT_FAILURE;
             }
         }
 
         if (intrinsicId == UndefinedIndexT)
         {
-            ALICEVISION_LOG_INFO("One group has no intrinsics");
+            ALICEVISION_LOG_INFO("One group has no intrinsics.");
             return EXIT_FAILURE;
         }
 
@@ -252,12 +258,13 @@ int aliceVision_main(int argc, char** argv)
         const bool isRAW = imgFormat.compare("raw") == 0;
 
         workingColorSpace = isRAW ? image::EImageColorSpace::LINEAR : image::EImageColorSpace::SRGB;
-        ALICEVISION_LOG_INFO("Working color space automatically set to " << workingColorSpace);
+        ALICEVISION_LOG_INFO("Working color space automatically set to " << workingColorSpace << ".");
     }
 
     // Fusion always produces linear image. sRGB is the only non linear color space that must be changed to linear (sRGB
     // linear).
-    image::EImageColorSpace mergedColorSpace = (workingColorSpace == image::EImageColorSpace::SRGB) ? image::EImageColorSpace::LINEAR : workingColorSpace;
+    image::EImageColorSpace mergedColorSpace = (workingColorSpace == image::EImageColorSpace::SRGB) ?
+                                               image::EImageColorSpace::LINEAR : workingColorSpace;
 
     // Estimate target views for each group
     std::map<IndexT, std::vector<std::shared_ptr<sfmData::View>>> targetViewsPerIntrinsics;
@@ -278,7 +285,9 @@ int aliceVision_main(int argc, char** argv)
 
             if (!fs::is_regular_file(lumaStatFilepath) && !isOffsetRefBracketIndexValid)
             {
-                ALICEVISION_LOG_ERROR("Unable to open the file " << lumaStatFilepath.string() << " with luminance statistics. This file is needed to select the optimal exposure for the creation of HDR images.");
+                ALICEVISION_LOG_ERROR("Unable to open the file '" << lumaStatFilepath.string() << "' with luminance "
+                                      "statistics. This file is needed to select the optimal exposure for the creation "
+                                      "of HDR images.");
                 return EXIT_FAILURE;
             }
 
@@ -287,11 +296,16 @@ int aliceVision_main(int argc, char** argv)
             {
                 meanTargetedLumaForMerging = std::pow((meanTargetedLumaForMerging + 0.055) / 1.055, 2.2);
             }
-            targetIndexPerIntrinsics[intrinsicId] = hdr::selectTargetViews(targetViews, groups, offsetRefBracketIndex, lumaStatFilepath.string(), meanTargetedLumaForMerging);
+            targetIndexPerIntrinsics[intrinsicId] = hdr::selectTargetViews(targetViews,
+                                                                           groups,
+                                                                           offsetRefBracketIndex,
+                                                                           lumaStatFilepath.string(),
+                                                                           meanTargetedLumaForMerging);
 
             if ((targetViews.empty() || targetViews.size() != groups.size()) && !isOffsetRefBracketIndexValid)
             {
-                ALICEVISION_LOG_ERROR("File " << lumaStatFilepath.string() << " is not valid. This file is required to select the optimal exposure for the creation of HDR images.");
+                ALICEVISION_LOG_ERROR("File '" << lumaStatFilepath.string() << "' is not valid. This file is required "
+                                      "to select the optimal exposure for the creation of HDR images.");
                 return EXIT_FAILURE;
             }
 
@@ -300,15 +314,15 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // Define range to compute
-    if(rangeStart != -1)
+    if (rangeStart != -1)
     {
-        if(rangeStart < 0 || rangeSize < 0 || rangeStart > groupedViews.size())
+        if (rangeStart < 0 || rangeSize < 0 || rangeStart > groupedViews.size())
         {
-            ALICEVISION_LOG_ERROR("Range is incorrect");
+            ALICEVISION_LOG_ERROR("Range is incorrect.");
             return EXIT_FAILURE;
         }
 
-        if(rangeStart + rangeSize > groupedViews.size())
+        if (rangeStart + rangeSize > groupedViews.size())
         {
             rangeSize = groupedViews.size() - rangeStart;
         }
@@ -318,9 +332,9 @@ int aliceVision_main(int argc, char** argv)
         rangeStart = 0;
         rangeSize = groupedViews.size();
     }
-    ALICEVISION_LOG_DEBUG("Range to compute: rangeStart=" << rangeStart << ", rangeSize=" << rangeSize);
+    ALICEVISION_LOG_DEBUG("Range to compute: rangeStart = " << rangeStart << ", rangeSize = " << rangeSize);
 
-    if(rangeStart == 0)
+    if (rangeStart == 0)
     {
         int pos = 0;
         sfmData::SfMData outputSfm;
@@ -347,14 +361,14 @@ int aliceVision_main(int argc, char** argv)
                 }
                 else if (targetViews.empty())
                 {
-                    ALICEVISION_LOG_ERROR("Target view for HDR merging has not been computed");
+                    ALICEVISION_LOG_ERROR("Target view for HDR merging has not been computed.");
                     return EXIT_FAILURE;
                 }
                 else
                 {
                     hdrView = std::make_shared<sfmData::View>(*targetViews.at(g));
                 }
-                if(!byPass)
+                if (!byPass)
                 {
                     boost::filesystem::path p(targetViews[g]->getImagePath());
                     const std::string hdrImagePath = getHdrImagePath(outputPath, pos, keepSourceImageName ? p.stem().string() : "");
@@ -365,15 +379,15 @@ int aliceVision_main(int argc, char** argv)
             }
         }
 
-        // Export output sfmData
-        if(!sfmDataIO::Save(outputSfm, sfmOutputDataFilepath, sfmDataIO::ESfMData::ALL))
+        // Export output SfMData
+        if (!sfmDataIO::Save(outputSfm, sfmOutputDataFilepath, sfmDataIO::ESfMData::ALL))
         {
-            ALICEVISION_LOG_ERROR("Can not save output sfm file at " << sfmOutputDataFilepath);
+            ALICEVISION_LOG_ERROR("Cannot save output SfMData file at '" << sfmOutputDataFilepath << "'.");
             return EXIT_FAILURE;
         }
     }
     
-    if(byPass)
+    if (byPass)
     {
         ALICEVISION_LOG_INFO("Bypass enabled, nothing to compute.");
         return EXIT_SUCCESS;
@@ -424,10 +438,12 @@ int aliceVision_main(int argc, char** argv)
                 options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(group[i]->getRawColorInterpretation());
                 options.colorProfileFileName = group[i]->getColorProfileFileName();
 
-                // Whatever the raw color interpretation mode, the default read processing for raw images is to apply white balancing in libRaw, before demosaicing.
+                // Whatever the raw color interpretation mode, the default read processing for raw images is to apply
+                // white balancing in libRaw, before demosaicing.
                 // The DcpMetadata mode allows to not apply color management after demosaicing.
-                // Because if requested after demosaicing, white balancing is done at color management stage, we can set this option to true to get real raw data,
-                // without any white balancing, when the DcpMetadata mode is selected.
+                // Because if requested after demosaicing, white balancing is done at color management stage, we can
+                // set this option to true to get real raw data, without any white balancing, when the DcpMetadata mode
+                // is selected.
                 if (options.rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata)
                 {
                     options.doWBAfterDemosaicing = true;
@@ -438,7 +454,7 @@ int aliceVision_main(int argc, char** argv)
                 exposuresSetting[i] = group[i]->getCameraExposureSetting();
             }
 
-            if(!sfmData::hasComparableExposures(exposuresSetting))
+            if (!sfmData::hasComparableExposures(exposuresSetting))
             {
                 ALICEVISION_THROW_ERROR("Camera exposure settings are inconsistent.");
             }
@@ -450,7 +466,7 @@ int aliceVision_main(int argc, char** argv)
             image::Image<image::RGBfColor> lowLightMask;
             image::Image<image::RGBfColor> highLightMask;
             image::Image<image::RGBfColor> noMidLightMask;
-            if(images.size() > 1)
+            if (images.size() > 1)
             {
                 hdr::hdrMerge merge;
                 sfmData::ExposureSetting targetCameraSetting = targetView->getCameraExposureSetting();
@@ -461,13 +477,16 @@ int aliceVision_main(int argc, char** argv)
                 mergingParams.maxSignificantValue = maxSignificantValue;
                 mergingParams.computeLightMasks = computeLightMasks;
                
-                merge.process(images, exposures, fusionWeight, response, HDRimage, lowLightMask, highLightMask, noMidLightMask, mergingParams);
-                if(highlightCorrectionFactor > 0.0f)
+                merge.process(images, exposures, fusionWeight, response, HDRimage, lowLightMask, highLightMask,
+                              noMidLightMask, mergingParams);
+                if (highlightCorrectionFactor > 0.0f)
                 {
-                    merge.postProcessHighlight(images, exposures, fusionWeight, response, HDRimage, targetCameraSetting.getExposure(), highlightCorrectionFactor, highlightTargetLux);
+                    merge.postProcessHighlight(images, exposures, fusionWeight, response, HDRimage,
+                                               targetCameraSetting.getExposure(), highlightCorrectionFactor,
+                                               highlightTargetLux);
                 }
             }
-            else if(images.size() == 1)
+            else if (images.size() == 1)
             {
                 // Nothing to do
                 HDRimage = images[0];
@@ -501,7 +520,7 @@ int aliceVision_main(int argc, char** argv)
 
             image::writeImage(hdrImagePath, HDRimage, writeOptions, targetMetadata);
 
-            if(computeLightMasks)
+            if (computeLightMasks)
             {
                 const std::string hdrMaskLowLightPath =
                     getHdrMaskPath(outputPath, pos, "lowLight", keepSourceImageName ? p.stem().string() : "");

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -244,7 +244,7 @@ int aliceVision_main(int argc, char** argv)
         groupedViewsPerIntrinsics[intrinsicId].push_back(group);
     }
 
-    //Estimate working color space if set to AUTO
+    // Estimate working color space if set to AUTO
     if (workingColorSpace == image::EImageColorSpace::AUTO)
     {
         const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(groupedViews[0][0]->getImagePath()));
@@ -252,14 +252,14 @@ int aliceVision_main(int argc, char** argv)
         const bool isRAW = imgFormat.compare("raw") == 0;
 
         workingColorSpace = isRAW ? image::EImageColorSpace::LINEAR : image::EImageColorSpace::SRGB;
-        ALICEVISION_LOG_INFO("Working color space automaticaly set to " << workingColorSpace);
+        ALICEVISION_LOG_INFO("Working color space automatically set to " << workingColorSpace);
     }
 
     // Fusion always produces linear image. sRGB is the only non linear color space that must be changed to linear (sRGB
     // linear).
     image::EImageColorSpace mergedColorSpace = (workingColorSpace == image::EImageColorSpace::SRGB) ? image::EImageColorSpace::LINEAR : workingColorSpace;
 
-    //Estimate target views for each group
+    // Estimate target views for each group
     std::map<IndexT, std::vector<std::shared_ptr<sfmData::View>>> targetViewsPerIntrinsics;
     std::map<IndexT, int> targetIndexPerIntrinsics;
     if (!byPass)

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -85,7 +85,9 @@ int aliceVision_main(int argc, char** argv)
         ("workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
          ("Working color space: " + image::EImageColorSpace_informations()).c_str())
         ("calibrationMethod,m", po::value<ECalibrationMethod>(&calibrationMethod)->default_value(calibrationMethod),
-         "Name of method used for camera calibration: linear, debevec, grossberg, laguerre.")
+         "Name of the method used for the camera calibration: auto, linear, debevec, grossberg, laguerre."
+         "If 'auto' is selected, the linear method will be used if there are RAW images; otherwise, the Debevec method "
+         "will be used.")
         ("blockSize", po::value<int>(&params.blockSize)->default_value(params.blockSize),
          "Size of the image tile to extract a sample.")
         ("radius", po::value<int>(&params.radius)->default_value(params.radius),

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -249,12 +249,12 @@ int aliceVision_main(int argc, char** argv)
                     if (calibrationMethod == ECalibrationMethod::AUTO)
                     {
                         calibrationMethod = isRAW ? ECalibrationMethod::LINEAR : ECalibrationMethod::DEBEVEC;
-                        ALICEVISION_LOG_INFO("Calibration method automaticaly set to " << calibrationMethod);
+                        ALICEVISION_LOG_INFO("Calibration method automatically set to " << calibrationMethod);
                     }
                     if (workingColorSpace == image::EImageColorSpace::AUTO)
                     {
                         workingColorSpace = isRAW ? image::EImageColorSpace::LINEAR : image::EImageColorSpace::SRGB;
-                        ALICEVISION_LOG_INFO("Working color space automaticaly set to " << workingColorSpace);
+                        ALICEVISION_LOG_INFO("Working color space automatically set to " << workingColorSpace);
                     }
                 }
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
The HDR calibration method used to generate the camera response curve needed for HDR fusion can now be automatically selected based on image type. If raw images are detected then "Linear" (no calibration) is selected else "Debevec" method is enabled. The working color space, linked with the calibration method, is also automatically selected. "Linear" is selected for raw images, sRGB for any other images. For both, calibration method and working color space, automatic detection is set as the default behavior.

linked to https://github.com/alicevision/Meshroom/pull/2169

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

