### PR TITLE
[build] Update OIIO to 2.4.13.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: alicevision/alicevision-deps:2023.07.31-centos7-cuda11.3.1
+      image: alicevision/alicevision-deps:2023.09.07-centos7-cuda11.3.1
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release
@@ -131,7 +131,7 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.3.0
         id: vcpkgDownload
         with:
-          url: "https://gdirect.cc/d/mrmIK&type=1"
+          url: "https://gdirect.cc/d/Dv7x7&type=1"
           target: "${{ env.vcpkgDir }}"
           filename: installed.zip
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,8 +722,8 @@ endif()
 # Add OpenImageIO
 set(OPENIMAGEIO_TARGET openimageio)
 ExternalProject_Add(${OPENIMAGEIO_TARGET}
-      URL https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.4.9.0.tar.gz
-      URL_HASH MD5=7da92a7d6029921a8599a977ff1efa2a
+      URL https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.4.13.0.tar.gz
+      URL_HASH MD5=c7df7aaf576e3dbbea7dd89fd2b71871
       DOWNLOAD_DIR ${BUILD_DIR}/download/oiio
       PREFIX ${BUILD_DIR}
       BUILD_IN_SOURCE 0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,7 @@ AliceVision depends on external libraries:
 * Flann >= 1.8.4, use [our fork](https://github.com/alicevision/flann) with a CMake build system
 * [Geogram >= 1.7.5](https://github.com/BrunoLevy/geogram)
 * [OpenEXR >= 2.5](https://github.com/AcademySoftwareFoundation/openexr)
-* [OpenImageIO >= 2.1.0 (recommended >= 2.4.12)](https://github.com/OpenImageIO/oiio)
+* [OpenImageIO >= 2.1.0 (recommended >= 2.4.13)](https://github.com/OpenImageIO/oiio)
 * Open Solver Interface (Osi) >= 0.106.10 use [our fork](https://github.com/alicevision/Osi)) with a CMake build system
 * [zlib](https://www.zlib.net)
 

--- a/docker/build-centos.sh
+++ b/docker/build-centos.sh
@@ -7,7 +7,7 @@ test -e docker/fetch.sh || {
     exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.07.31
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.09.07
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$CENTOS_VERSION" && CENTOS_VERSION=7

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.07.31
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.09.07
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=20.04


### PR DESCRIPTION
## Description

This PR updates the version of OIIO to 2.4.13.0. The Docker image for AliceVision's dependencies has been rebuilt and pushed, and the Dockerfiles have been updated to use the latest version. The GitHub CI has also been updated to use it.