### PR TITLE
Update cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -214,6 +214,7 @@ Archos;Archos Sense 50DC;4.69;devicespecifications
 Archos;Archos Sense 55DC;4.69;devicespecifications
 Archos;Archos Sense 55s;3.67;devicespecifications
 ARRI;Alexa65 65 SXT;54.12;usercontribution
+ARRI;ARRI ALEXA 35;27.99;usercontribution
 ARRI;ARRI ALEXA LF;36.70;ARRI
 ARRI;ARRI Alexa Mini;28.25;ARRI
 ARRI;ARRI ALEXA Mini LF;36.70;ARRI


### PR DESCRIPTION
Add ARRI ALEXA 35 to sensor database.

Source:
https://www.arri.com/en/camera-systems/cameras/alexa-35#273064