### PR TITLE
[ci] Windows: Stop building modules that are not tested

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -143,6 +143,10 @@ jobs:
         run: |
           ${{ env.vcpkgDir }}\vcpkg list
 
+      - name: vcpkg - Remove zip file with prebuilt binaries
+        run: |
+          rm ${{ env.vcpkgArchive }}
+
       - name: Get CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.10
         id: cuda-toolkit
@@ -183,6 +187,9 @@ jobs:
                              -DALICEVISION_USE_POPSIFT=OFF
                              -DALICEVISION_USE_ALEMBIC=ON
                              -DALICEVISION_USE_OPENGV=OFF
+                             -DALICEVISION_BUILD_STEREOPHOTOMETRY=OFF
+                             -DALICEVISION_BUILD_SEGMENTATION=OFF
+                             -DBOOST_NO_CXX11=ON
           # This input tells run-cmake to consume the vcpkg.cmake toolchain file set by run-vcpkg.
           cmakeBuildType: Release
           buildWithCMake: true


### PR DESCRIPTION
## Description

This PR fixes the continuous integration build for Windows that currently fails because there is not enough space on the disk:
- The vcpkg zip file that contains the prebuilt binaries is removed as soon as it has been dezipped (which saves approximately 1 Go of disk space);
- The modules that are not needed for the functional tests (segmentation and photostereometry) are not built anymore, which saves both a bit of space and a bit of time.