### PR TITLE
[Fix] transformsRt function

### DIFF
--- a/src/aliceVision/geometry/Pose3.hpp
+++ b/src/aliceVision/geometry/Pose3.hpp
@@ -97,8 +97,8 @@ public:
     Pose3 transformSRt(const double S, const Mat3& R, const Vec3& t) const
     {
         Pose3 pose;
-        pose.setCenter(S * R * center() + t);
         pose.setRotation(rotation() * R.transpose());
+        pose.setCenter(S * R * center() + t);
 
         return pose;
     }


### PR DESCRIPTION
Bad order of functions caused erroneous transformation of cameras