### PR TITLE
[software] LdrToHdrMerge: fix bug introduced in PR 1536

### DIFF
--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -366,7 +366,7 @@ int aliceVision_main(int argc, char** argv)
                 }
                 else
                 {
-                    hdrView.reset(group.at(g)->clone());
+                    hdrView.reset(targetViews.at(g)->clone());
                 }
                 if (!byPass)
                 {


### PR DESCRIPTION
## Description

Fix a crash in the first chunk of `aliceVision_ldrToHdrMerge` which was introduced by a typo in this commit: https://github.com/alicevision/AliceVision/commit/1188433d9ff321b29e74093e3dd7e8b4ddb9ae7a