### PR TITLE
Fallback when camera motion is not distinctive enough

### DIFF
--- a/src/aliceVision/sfm/utils/alignment.cpp
+++ b/src/aliceVision/sfm/utils/alignment.cpp
@@ -608,7 +608,7 @@ void computeNewCoordinateSystemFromCamerasXAxis(const sfmData::SfMData& sfmData,
     Eigen::Vector3d nullestSpace = solver.eigenvectors().col(minCol).real();
     Eigen::Vector3d referenceAxis = Eigen::Vector3d::UnitY();    
 
-    if (unicity < 10.0)
+    if (std::abs(unicity) < 10.0)
     {
         ALICEVISION_LOG_DEBUG("Algorithm did not find a clear axis. Align with raw Y.");
         nullestSpace = meanRy;


### PR DESCRIPTION
If set of cameras' x axis does not span correctly a plane, then we fallback to align their Y axis to the scene Y axis.

**It's assuming the cameras are standing vertically.**