### PR TITLE
[docker] Dependencies: Remove duplicated `gcc` install 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     container:
-      image: alicevision/alicevision-deps:2023.09.20-centos7-cuda11.3.1
+      image: alicevision/alicevision-deps:2023.10.02-centos7-cuda11.3.1
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release

--- a/docker/Dockerfile_centos_deps
+++ b/docker/Dockerfile_centos_deps
@@ -36,7 +36,7 @@ ENV AV_DEV=/opt/AliceVisionDeps_git \
 RUN $YUM_INSTALL centos-release-scl-rh && \
     $YUM_INSTALL yum-utils && \
     $YUM_INSTALL python3 && \
-    $YUM_INSTALL gcc python3-devel && \
+    $YUM_INSTALL python3-devel && \
     yum clean all && \
     $YUM_INSTALL devtoolset-10-toolchain devtoolset-10-libatomic-devel --nogpgcheck && \
     $YUM_INSTALL --enablerepo=extras epel-release && \

--- a/docker/build-centos.sh
+++ b/docker/build-centos.sh
@@ -7,7 +7,7 @@ test -e docker/fetch.sh || {
     exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.09.20
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.10.02
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$CENTOS_VERSION" && CENTOS_VERSION=7

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.09.20
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.10.02
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=20.04


### PR DESCRIPTION
## Description

Following #1540 and https://github.com/alicevision/AliceVision/pull/1540#discussion_r1336106955,  `gcc` can be removed from the dependencies Dockerfile. A new Docker image has been pushed, and all the tags are updated accordingly.

This PR relates to #1535 and should ideally be merged before it.