### PR TITLE
[clean] Ransac containers

### DIFF
--- a/src/aliceVision/geometry/rigidTransformation3D.hpp
+++ b/src/aliceVision/geometry/rigidTransformation3D.hpp
@@ -12,48 +12,50 @@
 #include <aliceVision/robustEstimation/ISolver.hpp>
 #include <random>
 
-namespace aliceVision {
-namespace geometry {
+namespace aliceVision
+{
+namespace geometry
+{
 
 /**
- * @brief Compose a similarity matrix given a scale factor, a rotation matrix and 
+ * @brief Compose a similarity matrix given a scale factor, a rotation matrix and
  * a translation vector.
- * 
+ *
  * @param[in] S The scale factor.
  * @param[in] t The translation vector.
  * @param[in] R The rotation matrix.
  * @param[out] RTS The 4x4 similarity matrix [R*S | t; 0 0 0 1].
  */
-inline void composeRTS(double &S, const Vec3 &t, const Mat3 &R, Mat4 &RTS)
+inline void composeRTS(double& S, const Vec3& t, const Mat3& R, Mat4& RTS)
 {
-  RTS.topLeftCorner(3, 3) = R*S;
-  RTS.topRightCorner(3, 1) = t;
+    RTS.topLeftCorner(3, 3) = R * S;
+    RTS.topRightCorner(3, 1) = t;
 }
 
 /**
  * @brief Decompose a similarity matrix into its scale, rotation and translation parts
- * 
+ *
  * @param[in] RTS The similarity matrix to decompose.
  * @param[out] S The scale factor.
  * @param[out] t The translation part.
  * @param[out] R The rotation part.
  * @return true if the input matrix is a similarity matrix.
  */
-inline bool decomposeRTS(const Mat4 &RTS, double &S, Vec3 &t, Mat3 &R)
+inline bool decomposeRTS(const Mat4& RTS, double& S, Vec3& t, Mat3& R)
 {
-  // Check critical cases
-  R = RTS.topLeftCorner<3, 3>();
-  if (R.determinant() < 0)
-    return false;
-  S = pow(R.determinant(), 1.0 / 3.0);
-  // Check for degenerate case (if all points have the same value...)
-  if (S < std::numeric_limits<double>::epsilon())
-    return false;
+    // Check critical cases
+    R = RTS.topLeftCorner<3, 3>();
+    if(R.determinant() < 0)
+        return false;
+    S = pow(R.determinant(), 1.0 / 3.0);
+    // Check for degenerate case (if all points have the same value...)
+    if(S < std::numeric_limits<double>::epsilon())
+        return false;
 
-  // Extract transformation parameters
-  R /= S;
-  t = RTS.topRightCorner<3, 1>();
-  return true;
+    // Extract transformation parameters
+    R /= S;
+    t = RTS.topRightCorner<3, 1>();
+    return true;
 }
 
 /** 3D rigid transformation estimation (7 dof)
@@ -74,60 +76,68 @@ inline bool decomposeRTS(const Mat4 &RTS, double &S, Vec3 &t, Mat3 &R)
  * \note Need at least 3 points
  */
 
-inline bool FindRTS(const Mat &x1,
-  const Mat &x2,
-  double &S,
-  Vec3 &t,
-  Mat3 &R)
+inline bool FindRTS(const Mat& x1, const Mat& x2, double& S, Vec3& t, Mat3& R)
 {
-  if (x1.cols() < 3 || x2.cols() < 3)
-    return false;
+    if(x1.cols() < 3 || x2.cols() < 3)
+        return false;
 
-  assert(3 == x1.rows());
-  assert(3 <= x1.cols());
-  assert(x1.rows() == x2.rows());
-  assert(x1.cols() == x2.cols());
+    assert(3 == x1.rows());
+    assert(3 <= x1.cols());
+    assert(x1.rows() == x2.rows());
+    assert(x1.cols() == x2.cols());
 
-  // Get the transformation via Umeyama's least squares algorithm. This returns
-  // a matrix of the form:
-  // [ s * R t]
-  // [ 0 1]
-  // from which we can extract the scale, rotation, and translation.
-  const Eigen::Matrix4d transform = Eigen::umeyama(x1, x2, true);
+    // Get the transformation via Umeyama's least squares algorithm. This returns
+    // a matrix of the form:
+    // [ s * R t]
+    // [ 0 1]
+    // from which we can extract the scale, rotation, and translation.
+    const Eigen::Matrix4d transform = Eigen::umeyama(x1, x2, true);
 
-  return decomposeRTS(transform, S, t, R);
+    return decomposeRTS(transform, S, t, R);
 }
 
 // Eigen LM functor to refine translation, Rotation and Scale parameter.
 struct lm_SRTRefine_functor : LMFunctor<double>
 {
-  lm_SRTRefine_functor(int inputs, int values,
-    const Mat &x1, const Mat &x2,
-    const double &S, const Mat3 & R, const Vec &t): LMFunctor<double>(inputs,values),
-    _x1(x1), _x2(x2), _t(t), _R(R), _S(S) { }
+    lm_SRTRefine_functor(int inputs, int values, const Mat& x1, const Mat& x2, const double& S, const Mat3& R,
+                         const Vec& t)
+        : LMFunctor<double>(inputs, values)
+        , _x1(x1)
+        , _x2(x2)
+        , _t(t)
+        , _R(R)
+        , _S(S)
+    {
+    }
 
-  int operator()(const Vec &x, Vec &fvec) const;
+    int operator()(const Vec& x, Vec& fvec) const;
 
-  Mat _x1, _x2;
-  Vec3 _t;
-  Mat3 _R;
-  double _S;
+    Mat _x1, _x2;
+    Vec3 _t;
+    Mat3 _R;
+    double _S;
 };
 
 // Eigen LM functor to refine Rotation.
 struct lm_RRefine_functor : LMFunctor<double>
 {
-  lm_RRefine_functor(int inputs, int values,
-    const Mat &x1, const Mat &x2,
-    const double &S, const Mat3 & R, const Vec &t): LMFunctor<double>(inputs,values),
-    _x1(x1), _x2(x2), _t(t), _R(R), _S(S) { }
+    lm_RRefine_functor(int inputs, int values, const Mat& x1, const Mat& x2, const double& S, const Mat3& R,
+                       const Vec& t)
+        : LMFunctor<double>(inputs, values)
+        , _x1(x1)
+        , _x2(x2)
+        , _t(t)
+        , _R(R)
+        , _S(S)
+    {
+    }
 
-  int operator()(const Vec &x, Vec &fvec) const;
+    int operator()(const Vec& x, Vec& fvec) const;
 
-  Mat _x1, _x2;
-  Vec3 _t;
-  Mat3 _R;
-  double _S;
+    Mat _x1, _x2;
+    Vec3 _t;
+    Mat3 _R;
+    double _S;
 };
 
 /** 3D rigid transformation refinement using LM
@@ -142,11 +152,7 @@ struct lm_RRefine_functor : LMFunctor<double>
  *
  * \return none
  */
-void Refine_RTS(const Mat &x1,
-                const Mat &x2,
-                double &S,
-                Vec3 &t,
-                Mat3 &R);
+void Refine_RTS(const Mat& x1, const Mat& x2, double& S, Vec3& t, Mat3& R);
 
 /**
  * @brief the Solver to use for ACRansac
@@ -154,60 +160,54 @@ void Refine_RTS(const Mat &x1,
 class RTSSolver : public robustEstimation::ISolver<robustEstimation::MatrixModel<Mat4>>
 {
 public:
+    /**
+     * @brief Return the minimum number of required samples
+     * @return minimum number of required samples
+     */
+    inline std::size_t getMinimumNbRequiredSamples() const override { return 3; }
 
-  /**
-   * @brief Return the minimum number of required samples
-   * @return minimum number of required samples
-   */
-  inline std::size_t getMinimumNbRequiredSamples() const override
-  {
-    return 3;
-  }
+    /**
+     * @brief Return the maximum number of models
+     * @return maximum number of models
+     */
+    inline std::size_t getMaximumNbModels() const override { return 1; }
 
-  /**
-   * @brief Return the maximum number of models
-   * @return maximum number of models
-   */
-  inline std::size_t getMaximumNbModels() const override
-  {
-    return 1;
-  }
+    // solve the RTS problem
+    inline void solve(const Mat& pts1, const Mat& pts2, std::vector<robustEstimation::MatrixModel<Mat4>>& models) const
+    {
+        models.push_back(robustEstimation::MatrixModel<Mat4>(Eigen::umeyama(pts1, pts2, true)));
+    }
 
-  // solve the RTS problem
-  inline void solve(const Mat& pts1, const Mat& pts2, std::vector<robustEstimation::MatrixModel<Mat4>>& models) const
-  {
-    models.push_back( robustEstimation::MatrixModel<Mat4>(Eigen::umeyama(pts1, pts2, true)) );
-  }
+    void solve(const Mat& x1, const Mat& x2, std::vector<robustEstimation::MatrixModel<Mat4>>& models,
+               const std::vector<double>& weights) const override
+    {
+        throw std::logic_error("RTSSolver does not support problem solving with weights.");
+    }
 
-  void solve(const Mat& x1, const Mat& x2, std::vector<robustEstimation::MatrixModel<Mat4>>& models, const std::vector<double>& weights) const override
-  {
-     throw std::logic_error("RTSSolver does not support problem solving with weights.");
-  }
-
-  // compute the residual of the transformation
-  inline double error(const robustEstimation::MatrixModel<Mat4>& RTS, const Vec3& pt1, const Vec3& pt2)
-  {
-    const Mat4& matrixRTS = RTS.getMatrix();
-    const Mat3& RS = matrixRTS.topLeftCorner<3, 3>();
-    const Vec3& t = matrixRTS.topRightCorner<3, 1>();
-    return(pt2 - (RS*pt1 + t)).norm();
-  }
+    // compute the residual of the transformation
+    inline double error(const robustEstimation::MatrixModel<Mat4>& RTS, const Vec3& pt1, const Vec3& pt2)
+    {
+        const Mat4& matrixRTS = RTS.getMatrix();
+        const Mat3& RS = matrixRTS.topLeftCorner<3, 3>();
+        const Vec3& t = matrixRTS.topRightCorner<3, 1>();
+        return (pt2 - (RS * pt1 + t)).norm();
+    }
 };
 
 /**
  * @brief A functor that computes the squared error between points transformed by
  * a similarity
  */
-struct RTSSquaredResidualError 
+struct RTSSquaredResidualError
 {
-  // return the squared error
-  inline double error(const robustEstimation::MatrixModel<Mat4>& RTS, const Vec3& pt1, const Vec3& pt2) const
-  {
-    const Mat4& matrixRTS = RTS.getMatrix();
-    const Mat3& RS = matrixRTS.topLeftCorner<3, 3>();
-    const Vec3& t = matrixRTS.topRightCorner<3, 1>();
-    return (pt2 - (RS*pt1 + t)).squaredNorm();
-  }
+    // return the squared error
+    inline double error(const robustEstimation::MatrixModel<Mat4>& RTS, const Vec3& pt1, const Vec3& pt2) const
+    {
+        const Mat4& matrixRTS = RTS.getMatrix();
+        const Mat3& RS = matrixRTS.topLeftCorner<3, 3>();
+        const Vec3& t = matrixRTS.topRightCorner<3, 1>();
+        return (pt2 - (RS * pt1 + t)).squaredNorm();
+    }
 };
 
 /**
@@ -217,87 +217,78 @@ template <typename SolverT_, typename ErrorT_, typename ModelT_ = robustEstimati
 class ACKernelAdaptor_PointsRegistrationSRT
 {
 public:
-  using SolverT = SolverT_;
-  using ModelT = ModelT_;
-  using ErrorT = ErrorT_;
+    using SolverT = SolverT_;
+    using ModelT = ModelT_;
+    using ErrorT = ErrorT_;
 
-  ACKernelAdaptor_PointsRegistrationSRT(const Mat& xA, const Mat& xB)
-    : x1_(xA)
-    , x2_(xB)
-    , _logalpha0(log10(M_PI)) //@todo  WTF?
-  {
-    assert(3 == x1_.rows());
-    assert(x1_.rows() == x2_.rows());
-    assert(x1_.cols() == x2_.cols());
-    
-    // @todo normalize points?
-  }
+    ACKernelAdaptor_PointsRegistrationSRT(const Mat& xA, const Mat& xB)
+        : x1_(xA)
+        , x2_(xB)
+        , _logalpha0(log10(M_PI)) //@todo  WTF?
+    {
+        assert(3 == x1_.rows());
+        assert(x1_.rows() == x2_.rows());
+        assert(x1_.cols() == x2_.cols());
 
-  /**
-   * @brief Return the minimum number of required samples
-   * @return minimum number of required samples
-   */
-  inline std::size_t getMinimumNbRequiredSamples() const
-  {
-    return _kernelSolver.getMinimumNbRequiredSamples();
-  }
+        // @todo normalize points?
+    }
 
-  /**
-   * @brief Return the maximum number of models
-   * @return maximum number of models
-   */
-  inline std::size_t getMaximumNbModels() const
-  {
-    return _kernelSolver.getMaximumNbModels();
-  }
+    /**
+     * @brief Return the minimum number of required samples
+     * @return minimum number of required samples
+     */
+    inline std::size_t getMinimumNbRequiredSamples() const { return _kernelSolver.getMinimumNbRequiredSamples(); }
 
-  void fit(const std::vector<std::size_t>& samples, std::vector<ModelT>& models) const
-  {
-    const Mat x1 = ExtractColumns(x1_, samples);
-    const Mat x2 = ExtractColumns(x2_, samples);
-    _kernelSolver.solve(x1, x2, models);
-  }
+    /**
+     * @brief Return the maximum number of models
+     * @return maximum number of models
+     */
+    inline std::size_t getMaximumNbModels() const { return _kernelSolver.getMaximumNbModels(); }
 
-  double error(std::size_t sample, const ModelT& model) const
-  {
-    return Square(_errorEstimator.error(model, x1_.col(sample), x2_.col(sample)));
-  }
+    void fit(const std::vector<std::size_t>& samples, std::vector<ModelT>& models) const
+    {
+        const Mat x1 = buildSubsetMatrix(x1_, samples);
+        const Mat x2 = buildSubsetMatrix(x2_, samples);
+        _kernelSolver.solve(x1, x2, models);
+    }
 
-  void errors(const ModelT& model, std::vector<double> & vec_errors) const
-  {
-    vec_errors.resize(x1_.cols());
-    for(std::size_t sample = 0; sample < x1_.cols(); ++sample)
-      vec_errors[sample] = error(sample,model);
-  }
+    double error(std::size_t sample, const ModelT& model) const
+    {
+        return Square(_errorEstimator.error(model, x1_.col(sample), x2_.col(sample)));
+    }
 
-  std::size_t nbSamples() const
-  {
-    return static_cast<std::size_t> (x1_.cols());
-  }
+    void errors(const ModelT& model, std::vector<double>& vec_errors) const
+    {
+        vec_errors.resize(x1_.cols());
+        for(std::size_t sample = 0; sample < x1_.cols(); ++sample)
+            vec_errors[sample] = error(sample, model);
+    }
 
-  void unnormalize(ModelT& model) const { } //-- Do nothing, no normalization
+    std::size_t nbSamples() const { return static_cast<std::size_t>(x1_.cols()); }
 
-  double logalpha0() const { return _logalpha0; }
+    void unnormalize(ModelT& model) const {} //-- Do nothing, no normalization
 
-  double multError() const { return 1.;}
+    double logalpha0() const { return _logalpha0; }
 
-  Mat3 normalizer1() const { return Mat3::Identity(); }
+    double multError() const { return 1.; }
 
-  Mat3 normalizer2() const { return Mat3::Identity(); }
+    Mat3 normalizer1() const { return Mat3::Identity(); }
 
-  double unormalizeError(double val) const { return sqrt(val); }
+    Mat3 normalizer2() const { return Mat3::Identity(); }
+
+    double unormalizeError(double val) const { return sqrt(val); }
 
 private:
-  Mat x1_, x2_;       // normalized input data
-  double _logalpha0;  // alpha0 is used to make the error scale invariant
+    Mat x1_, x2_;      // normalized input data
+    double _logalpha0; // alpha0 is used to make the error scale invariant
 
-  SolverT _kernelSolver;
-  ErrorT _errorEstimator;
+    SolverT _kernelSolver;
+    ErrorT _errorEstimator;
 };
 
 /**
  * @brief Uses AC ransac to robustly estimate the similarity between two sets of points.
- * 
+ *
  * @param[in] x1 The first 3xN matrix of euclidean points.
  * @param[in] x2 The second 3xN matrix of euclidean points.
  * @param[in] randomNumberGenerator random number generator
@@ -309,43 +300,33 @@ private:
  * @return true if the found transformation is a similarity
  * @see FindRTS()
  */
-bool ACRansac_FindRTS(const Mat &x1,
-                      const Mat &x2,
-                      std::mt19937 &randomNumberGenerator,
-                      double &S,
-                      Vec3 &t,
-                      Mat3 &R,
-                      std::vector<std::size_t> &vec_inliers,
-                      bool refine = false);
+bool ACRansac_FindRTS(const Mat& x1, const Mat& x2, std::mt19937& randomNumberGenerator, double& S, Vec3& t, Mat3& R,
+                      std::vector<std::size_t>& vec_inliers, bool refine = false);
 
 /**
- * @brief Uses AC ransac to robustly estimate the similarity between two sets of 
+ * @brief Uses AC ransac to robustly estimate the similarity between two sets of
  * points. Just a wrapper that output the similarity in matrix form
  * @param[in] x1 The first 3xN matrix of euclidean points.
  * @param[in] x2 The second 3xN matrix of euclidean points.
  * @param[in] randomNumberGenerator random number generator
- * @param[out] RTS The 4x4 similarity matrix. 
+ * @param[out] RTS The 4x4 similarity matrix.
  * @param[out] vec_inliers The inliers used to estimate the similarity.
  * @param  refine Enable/Disable refining of the found transformation.
  * @return true if the found transformation is a similarity
  * @see geometry::FindRTS()
  * @see geometry::ACRansac_FindRTS()
  */
-inline bool ACRansac_FindRTS(const Mat &x1,
-                             const Mat &x2, 
-                             std::mt19937 &randomNumberGenerator,
-                             Mat4 &RTS, 
-                             std::vector<std::size_t> &vec_inliers,
-                             bool refine = false)
+inline bool ACRansac_FindRTS(const Mat& x1, const Mat& x2, std::mt19937& randomNumberGenerator, Mat4& RTS,
+                             std::vector<std::size_t>& vec_inliers, bool refine = false)
 {
-  double S;
-  Vec3 t; 
-  Mat3 R; 
-  const bool good = ACRansac_FindRTS(x1, x2, randomNumberGenerator ,S, t, R, vec_inliers, refine);
-  if(good)
-    composeRTS(S, t, R, RTS);
-  
-  return good;
+    double S;
+    Vec3 t;
+    Mat3 R;
+    const bool good = ACRansac_FindRTS(x1, x2, randomNumberGenerator, S, t, R, vec_inliers, refine);
+    if(good)
+        composeRTS(S, t, R, RTS);
+
+    return good;
 }
 
 } // namespace geometry

--- a/src/aliceVision/multiview/RelativePoseKernel.hpp
+++ b/src/aliceVision/multiview/RelativePoseKernel.hpp
@@ -140,8 +140,8 @@ public:
 
   void fit(const std::vector<std::size_t>& samples, std::vector<ModelT_>& models) const override
   {
-    const Mat x1 = ExtractColumns(_x1k, samples);
-    const Mat x2 = ExtractColumns(_x2k, samples);
+    const Mat x1 = buildSubsetMatrix(_x1k, samples);
+    const Mat x2 = buildSubsetMatrix(_x2k, samples);
 
     PFRansacKernel::PFKernel::_kernelSolver.solve(x1, x2, models);
   }

--- a/src/aliceVision/multiview/knownRotationTranslationKernel.hpp
+++ b/src/aliceVision/multiview/knownRotationTranslationKernel.hpp
@@ -126,8 +126,8 @@ public:
     assert(2 == _x1.rows());
     assert(2 == _x2.rows());
 
-    const Mat x1 = ExtractColumns(_x1, samples);
-    const Mat x2 = ExtractColumns(_x2, samples);
+    const Mat x1 = buildSubsetMatrix(_x1, samples);
+    const Mat x2 = buildSubsetMatrix(_x2, samples);
 
     _kernelSolver.solve(x1, x2, _R, models);
   }

--- a/src/aliceVision/multiview/relativePose/EssentialKernel.hpp
+++ b/src/aliceVision/multiview/relativePose/EssentialKernel.hpp
@@ -41,8 +41,8 @@ public:
 
   void fit(const std::vector<std::size_t>& samples, std::vector<ModelT>& models) const override
   {
-    const Mat x1 = ExtractColumns(KernelBase::_x1, samples);
-    const Mat x2 = ExtractColumns(KernelBase::_x2, samples);
+    const Mat x1 = buildSubsetMatrix(KernelBase::_x1, samples);
+    const Mat x2 = buildSubsetMatrix(KernelBase::_x2, samples);
 
     assert(2 == x1.rows());
     assert(KernelBase::_kernelSolver.getMinimumNbRequiredSamples() <= x1.cols());

--- a/src/aliceVision/multiview/resection/EPnPKernel.hpp
+++ b/src/aliceVision/multiview/resection/EPnPKernel.hpp
@@ -46,8 +46,8 @@ class EPnPKernel : public robustEstimation::PointFittingKernel<EPnPSolver, Proje
 
   void fit(const std::vector<std::size_t>& samples, std::vector<robustEstimation::Mat34Model>& models) const override
   {
-    Mat2X x = ExtractColumns(x_camera_, samples);
-    Mat3X X = ExtractColumns(X_, samples);
+    Mat2X x = buildSubsetMatrix(x_camera_, samples);
+    Mat3X X = buildSubsetMatrix(X_, samples);
     Mat34 P;
     Mat3 R;
     Vec3 t;

--- a/src/aliceVision/multiview/resection/ResectionKernel.hpp
+++ b/src/aliceVision/multiview/resection/ResectionKernel.hpp
@@ -31,8 +31,8 @@ public:
 
   void fit(const std::vector<std::size_t>& samples, std::vector<ModelT>& models) const override
   {
-    const Mat x2d = ExtractColumns(KernelBase::_x1, samples);
-    const Mat x3d = ExtractColumns(KernelBase::_x2, samples);
+    const Mat x2d = buildSubsetMatrix(KernelBase::_x1, samples);
+    const Mat x3d = buildSubsetMatrix(KernelBase::_x2, samples);
 
     assert(2 == x2d.rows());
     assert(3 == x3d.rows());

--- a/src/aliceVision/multiview/triangulation/NViewsTriangulationLORansac.hpp
+++ b/src/aliceVision/multiview/triangulation/NViewsTriangulationLORansac.hpp
@@ -261,15 +261,11 @@ struct AngularError
   }
 };
 
-/// A kernel for robust triangulation with reprojection error
-//typedef NViewsTriangulationLORansac<TriangulateNViewsSolver, 
-//                                    ReprojectionError, 
-//                                    UnnormalizerT,
-//                                    TriangulateNViewsSolver> LORansacTriangulationKernel;
 
-using LORansacTriangulationSolver = TriangulateNViewsSolver<Mat2X>;
+using ContainerType = std::vector<Vec2>; 
+using LORansacTriangulationSolver = TriangulateNViewsSolver<ContainerType>;
 
 template<typename ErrorCost = ReprojectionError<robustEstimation::MatrixModel<Vec4>>>
-using LORansacTriangulationKernel =  NViewsTriangulationLORansac<LORansacTriangulationSolver, ErrorCost, UnnormalizerT, robustEstimation::MatrixModel<Vec4>, LORansacTriangulationSolver, Mat2X>;
+using LORansacTriangulationKernel =  NViewsTriangulationLORansac<LORansacTriangulationSolver, ErrorCost, UnnormalizerT, robustEstimation::MatrixModel<Vec4>, LORansacTriangulationSolver, ContainerType>;
 } // namespace multiview
 } // namespace aliceVision

--- a/src/aliceVision/multiview/triangulation/NViewsTriangulationLORansac.hpp
+++ b/src/aliceVision/multiview/triangulation/NViewsTriangulationLORansac.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <aliceVision/numeric/numeric.hpp>
+#include <aliceVision/numeric/Container.hpp>
 #include <aliceVision/robustEstimation/conditioning.hpp>
 #include <aliceVision/robustEstimation/LORansac.hpp> 
 #include <aliceVision/robustEstimation/ISolver.hpp>
@@ -38,7 +39,7 @@ namespace multiview {
  * a solution from any set of data larger than the minimum required, usually a 
  * DLT algorithm.
  */
-template <typename SolverT_, typename ErrorT_, typename UnnormalizerT_, typename ModelT_ = robustEstimation::MatrixModel<Vec4>, typename SolverLsT_ = robustEstimation::UndefinedSolver<ModelT_>>
+template <typename SolverT_, typename ErrorT_, typename UnnormalizerT_, typename ModelT_ = robustEstimation::MatrixModel<Vec4>, typename SolverLsT_ = robustEstimation::UndefinedSolver<ModelT_>, typename ContainerT = Mat2X>
 class NViewsTriangulationLORansac
     : public robustEstimation::IRansacKernel<ModelT_>
 {
@@ -78,11 +79,11 @@ public:
    * @param[in] _pt2d The feature points, a 2xN matrix.
    * @param[in] projMatrices The N projection matrix for each view.
    */
-  NViewsTriangulationLORansac(const Mat2X& _pt2d, const std::vector<Mat34>& projMatrices)
+  NViewsTriangulationLORansac(const ContainerT & _pt2d, const std::vector<Mat34>& projMatrices)
   : _pt2d(_pt2d)
   , _projMatrices(projMatrices)
   {
-    assert(_projMatrices.size() == _pt2d.cols());
+    assert(_projMatrices.size() == CountElements(_pt2d));
   }
 
   /**
@@ -92,7 +93,7 @@ public:
    */
   void fit(const std::vector<std::size_t>& samples, std::vector<ModelT_>& models) const override
   {
-    const Mat p2d = ExtractColumns(_pt2d, samples);
+    const ContainerT p2d = buildSubsetMatrix(_pt2d, samples);
     std::vector<Mat34> sampledMats;
     pick(sampledMats, _projMatrices, samples);
     _kernelSolver.solve(p2d, sampledMats, models);
@@ -108,7 +109,7 @@ public:
              std::vector<ModelT_>& models,
              const std::vector<double> *weights = nullptr) const override
   {
-    const Mat p2d = ExtractColumns(_pt2d, inliers);
+    const ContainerT p2d = buildSubsetMatrix(_pt2d, inliers);
     std::vector<Mat34> sampledMats;
     pick(sampledMats, _projMatrices, inliers);
     _kernelSolverLs.solve(p2d, sampledMats, models, *weights);
@@ -133,7 +134,8 @@ public:
     for(std::size_t sample = 0; sample < numInliers; ++sample)
     {
       const auto idx = inliers[sample];
-      vec_weights[sample] = _errorEstimator.error(_pt2d.col(idx), _projMatrices[idx], model);
+      vec_weights[sample] = _errorEstimator.error(getElement(_pt2d, idx), _projMatrices[idx], model);
+      
       // avoid division by zero
       vec_weights[sample] = 1/std::pow(std::max(eps, vec_weights[sample]), 2);
     }
@@ -147,7 +149,7 @@ public:
    */
   double error(std::size_t sample, const ModelT_& model) const override
   {
-    return _errorEstimator.error(_pt2d.col(sample), _projMatrices[sample], model);
+    return _errorEstimator.error(getElement(_pt2d, sample), _projMatrices[sample], model);
   }
 
   /**
@@ -158,7 +160,7 @@ public:
   void errors(const ModelT_& model, std::vector<double>& errors) const override
   {
     errors.resize(nbSamples());
-    for(Mat::Index i = 0; i < _pt2d.cols(); ++i)
+    for(Mat::Index i = 0; i < CountElements(_pt2d); ++i)
       errors[i] = error(i, model);
   }
 
@@ -175,7 +177,7 @@ public:
    */
   std::size_t nbSamples() const override
   {
-    return _pt2d.cols();
+    return CountElements(_pt2d);
   }
   
   double logalpha0() const override
@@ -209,7 +211,7 @@ public:
   }
 
 private:
-  const Mat2X& _pt2d;
+  const ContainerT & _pt2d;
   const std::vector<Mat34>& _projMatrices;
 
   const SolverT _kernelSolver = SolverT();
@@ -264,7 +266,10 @@ struct AngularError
 //                                    ReprojectionError, 
 //                                    UnnormalizerT,
 //                                    TriangulateNViewsSolver> LORansacTriangulationKernel;
+
+using LORansacTriangulationSolver = TriangulateNViewsSolver<Mat2X>;
+
 template<typename ErrorCost = ReprojectionError<robustEstimation::MatrixModel<Vec4>>>
-using LORansacTriangulationKernel =  NViewsTriangulationLORansac<TriangulateNViewsSolver, ErrorCost, UnnormalizerT, robustEstimation::MatrixModel<Vec4>, TriangulateNViewsSolver>;
+using LORansacTriangulationKernel =  NViewsTriangulationLORansac<LORansacTriangulationSolver, ErrorCost, UnnormalizerT, robustEstimation::MatrixModel<Vec4>, LORansacTriangulationSolver, Mat2X>;
 } // namespace multiview
 } // namespace aliceVision

--- a/src/aliceVision/multiview/triangulation/Triangulation.cpp
+++ b/src/aliceVision/multiview/triangulation/Triangulation.cpp
@@ -37,7 +37,7 @@ void TriangulateNView(const Mat2X &x,
   X = X_and_alphas.head(4);
 }
 
-void TriangulateNViewLORANSAC(const Mat2X& x,
+void TriangulateNViewLORANSAC(const std::vector<Vec2> & pts,
                               const std::vector<Mat34>& Ps,
                               std::mt19937 & generator,
                               Vec4 & X,
@@ -45,7 +45,7 @@ void TriangulateNViewLORANSAC(const Mat2X& x,
                               const double& thresholdError)
 {
   using TriangulationKernel = multiview::LORansacTriangulationKernel<>;
-  TriangulationKernel kernel(x, Ps);
+  TriangulationKernel kernel(pts, Ps);
   robustEstimation::ScoreEvaluator<TriangulationKernel> scorer(thresholdError);
   robustEstimation::MatrixModel<Vec4> model;
   model = robustEstimation::LO_RANSAC(kernel, scorer, generator, inliersIndex);
@@ -126,23 +126,7 @@ Vec3 Triangulation::compute(int iter) const
   return X;
 }
 
-template <>
-void TriangulateNViewsSolver<Mat2X>::solve(const Mat2X& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>> &X) const
-{
-  Vec4 pt3d;
-  TriangulateNViewAlgebraic(x, Ps, pt3d);
-  X.push_back(robustEstimation::MatrixModel<Vec4>(pt3d));
-  assert(X.size() == 1);
-}
 
-template <>
-void TriangulateNViewsSolver<Mat2X>::solve(const Mat2X& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>> &X, const std::vector<double> &weights) const
-{
-  Vec4 pt3d;
-  TriangulateNViewAlgebraic(x, Ps, pt3d, &weights);
-  X.push_back(robustEstimation::MatrixModel<Vec4>(pt3d));
-  assert(X.size() == 1);
-}
 
 } // namespace multiview
 } // namespace aliceVision

--- a/src/aliceVision/multiview/triangulation/Triangulation.hpp
+++ b/src/aliceVision/multiview/triangulation/Triangulation.hpp
@@ -10,6 +10,7 @@
 
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/robustEstimation/ISolver.hpp>
+#include <aliceVision/numeric/algebra.hpp>
 
 #include <vector>
 #include <random>
@@ -31,7 +32,7 @@ namespace multiview {
  */
 void TriangulateNView(const Mat2X &x, 
                       const std::vector< Mat34 > &Ps, 
-                      Vec4 *X, 
+                      Vec4 & X, 
                       const std::vector<double> *weights = nullptr);
 
 /**
@@ -41,15 +42,32 @@ void TriangulateNView(const Mat2X &x,
  * It also allows to specify some (optional) weight for each point (solving the 
  * weighted least squared problem)
  * 
- * @param[in] x are 2D coordinates (x,y,1) in each image
+ * @param[in] x are 2D coordinates (x,y) in each image
  * @param[in] Ps is the list of projective matrices for each camera
  * @param[out] X is the estimated 3D point
  * @param[in] weights a (optional) list of weights for each point
  */
-void TriangulateNViewAlgebraic(const Mat2X &x, 
+template <class ContainerT>
+void TriangulateNViewAlgebraic(const ContainerT &x, 
                                const std::vector< Mat34 > &Ps,
-                               Vec4 *X, 
-                               const std::vector<double> *weights = nullptr);
+                               Vec4 & X, 
+                               const std::vector<double> *weights = nullptr)
+
+{
+  Mat2X::Index nviews = CountElements(x);
+  assert(static_cast<std::size_t>(nviews) == Ps.size());
+
+  Mat design(2 * nviews, 4);
+  for(Mat2X::Index i = 0; i < nviews; ++i)
+  {
+    design.block<2, 4>(2 * i, 0) = SkewMatMinimal(getElement<ContainerT>(x, i)) * Ps[i];
+    if(weights != nullptr)
+    {
+      design.block<2, 4>(2 * i, 0) *= (*weights)[i];
+    }
+  }
+  Nullspace(design, X);
+}
 
 /**
  * @brief Compute a 3D position of a point from several images of it. In particular,
@@ -66,7 +84,7 @@ void TriangulateNViewAlgebraic(const Mat2X &x,
 void TriangulateNViewLORANSAC(const Mat2X &x, 
                               const std::vector< Mat34 > &Ps,
                               std::mt19937 & generator,
-                              Vec4 *X,
+                              Vec4 & X,
                               std::vector<std::size_t> *inliersIndex = NULL,
                               const double & thresholdError = 4.0);                               
 
@@ -108,6 +126,7 @@ protected:
   std::vector< std::pair<Mat34, Vec2> > views; // Proj matrix and associated image point
 };
 
+template <class ContainerT>
 struct TriangulateNViewsSolver 
 {
 
@@ -129,9 +148,9 @@ struct TriangulateNViewsSolver
     return 1;
   }
 
-  void solve(const Mat2X& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X) const;
+  void solve(const ContainerT& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X) const;
   
-  void solve(const Mat2X& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X, const std::vector<double>& weights) const;
+  void solve(const ContainerT& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X, const std::vector<double>& weights) const;
 
 };
 

--- a/src/aliceVision/multiview/triangulation/Triangulation.hpp
+++ b/src/aliceVision/multiview/triangulation/Triangulation.hpp
@@ -80,8 +80,8 @@ void TriangulateNViewAlgebraic(const ContainerT &x,
  * @param[out] X is the estimated 3D point
  * @param[out] inliersIndex (optional) store the index of the cameras (following Ps ordering, not the view_id) set as Inliers by Lo-RANSAC
  * @param[in] thresholdError (optional) set a threashold value to the Lo-RANSAC scorer
- */                               
-void TriangulateNViewLORANSAC(const Mat2X &x, 
+ */                        
+void TriangulateNViewLORANSAC(const std::vector<Vec2> &x, 
                               const std::vector< Mat34 > &Ps,
                               std::mt19937 & generator,
                               Vec4 & X,
@@ -148,9 +148,23 @@ struct TriangulateNViewsSolver
     return 1;
   }
 
-  void solve(const ContainerT& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X) const;
+  void solve(const ContainerT& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X) const
+  {
+    Vec4 pt3d;
+    TriangulateNViewAlgebraic(x, Ps, pt3d);
+    X.push_back(robustEstimation::MatrixModel<Vec4>(pt3d));
+    assert(X.size() == 1);
+  }
+
+
   
-  void solve(const ContainerT& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X, const std::vector<double>& weights) const;
+  void solve(const ContainerT& x, const std::vector<Mat34>& Ps, std::vector<robustEstimation::MatrixModel<Vec4>>& X, const std::vector<double>& weights) const
+  {
+    Vec4 pt3d;
+    TriangulateNViewAlgebraic(x, Ps, pt3d, &weights);
+    X.push_back(robustEstimation::MatrixModel<Vec4>(pt3d));
+    assert(X.size() == 1);
+  }
 
 };
 

--- a/src/aliceVision/multiview/triangulation/triangulation_test.cpp
+++ b/src/aliceVision/multiview/triangulation/triangulation_test.cpp
@@ -198,18 +198,18 @@ BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_LORANSAC)
     Vec4 pt3d(Vec3::Random().homogeneous());
 
     // project the 3D point and prepare weights
-    Mat2X pt2d(2, nbViews);
+    std::vector<Vec2> pt2d;
     for(std::size_t j = 0; j < nbViews; ++j)
     {
       if(j < nbViews - nbOutliers)
       {
         // project the 3D point
-        pt2d.col(j) = (Ps[j] * pt3d).hnormalized();
+        pt2d.push_back((Ps[j] * pt3d).hnormalized());
       }
       else
       {
         // for the outliers just set them to some random value
-        pt2d.col(j) = Vec2::Random();
+        pt2d.push_back(Vec2::Random());
         // set the weight to 0 for the outliers
       }
     }
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_LORANSAC)
     for (std::size_t j = 0; j < nbInliers; ++j)
     {
       const Vec2 x_reprojected = (Ps[j] * X).hnormalized();
-      const double error = (x_reprojected - pt2d.col(j)).norm();
+      const double error = (x_reprojected - pt2d[j]).norm();
 //      EXPECT_NEAR(error, 0.0, 1e-4);
       BOOST_CHECK_SMALL(error, 1e-5);
     }

--- a/src/aliceVision/multiview/triangulation/triangulation_test.cpp
+++ b/src/aliceVision/multiview/triangulation/triangulation_test.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(TriangulateNView_FiveViews)
       xs.col(j) = d._x[j].col(i);
     }
     Vec4 X;
-    multiview::TriangulateNView(xs, Ps, &X);
+    multiview::TriangulateNView(xs, Ps, X);
 
     // Check reprojection error. Should be nearly zero.
     for (int j = 0; j < nviews; ++j)
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(TriangulateNViewAlgebraic_FiveViews) {
       xs.col(j) = d._x[j].col(i);
     }
     Vec4 X;
-    multiview::TriangulateNViewAlgebraic(xs, Ps, &X);
+    multiview::TriangulateNViewAlgebraic(xs, Ps, X);
 
     // Check reprojection error. Should be nearly zero.
     for (int j = 0; j < nviews; ++j)
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(Triangulate_NViewAlgebraic_WithWeights)
   }
 
   Vec4 X;
-  multiview::TriangulateNViewAlgebraic(pt2d, Ps, &X, &weights);
+  multiview::TriangulateNViewAlgebraic(pt2d, Ps, X, &weights);
 
   // Check the reprojection error is nearly zero for inliers.
   for (std::size_t j = 0; j < nbViews - nbOutliers; ++j)
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(Triangulate_NViewIterative_LORANSAC)
     std::vector<std::size_t> inliers;
     Vec4 X;
     double const threshold = 0.01; // modify the default value: 4 pixels is too much in this configuration.
-    multiview::TriangulateNViewLORANSAC(pt2d, Ps, randomNumberGenerator, &X, &inliers, threshold);
+    multiview::TriangulateNViewLORANSAC(pt2d, Ps, randomNumberGenerator, X, &inliers, threshold);
     
     // check inliers are correct
     BOOST_CHECK_EQUAL(inliers.size(), nbInliers);

--- a/src/aliceVision/numeric/CMakeLists.txt
+++ b/src/aliceVision/numeric/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Headers
 set(numeric_files_headers
   numeric.hpp
+  Container.hpp
   projection.hpp
   gps.hpp
   algebra.hpp
@@ -9,6 +10,7 @@ set(numeric_files_headers
 # Sources
 set(numeric_files_sources
   numeric.cpp
+  Container.cpp
   projection.cpp
   gps.cpp
 )

--- a/src/aliceVision/numeric/Container.cpp
+++ b/src/aliceVision/numeric/Container.cpp
@@ -1,0 +1,111 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Container.hpp"
+
+namespace aliceVision {
+
+template <>
+size_t CountElements<Mat2X>(const Mat2X &A)
+{
+    return A.cols();
+}
+
+template <>
+size_t CountElements<Mat3X>(const Mat3X &A)
+{
+    return A.cols();
+}
+
+template <>
+size_t CountElements<Mat>(const Mat &A)
+{
+    return A.cols();
+}
+
+template <>
+size_t CountElements<std::vector<Vec2>>(const std::vector<Vec2> &A)
+{
+    return A.size();
+}
+
+template <>
+size_t ElementSize<Mat2X>(const Mat2X &A)
+{
+    return 2;
+}
+
+template <>
+size_t ElementSize<Mat3X>(const Mat3X &A)
+{
+    return 3;
+}
+
+template <>
+size_t ElementSize<Mat>(const Mat &A)
+{
+    return A.rows();
+}
+
+template <>
+size_t ElementSize<std::vector<Vec2>>(const std::vector<Vec2> &A)
+{
+    return 2;
+}
+
+template <>
+Element<Mat2X>::const_type getElement<Mat2X>(const Mat2X & A, size_t index)
+{
+    return A.col(index);
+}
+
+template <>
+Element<Mat2X>::type getElement<Mat2X>(Mat2X & A, size_t index)
+{
+    return A.col(index);
+}
+
+
+template <>
+Element<Mat3X>::const_type getElement<Mat3X>(const Mat3X & A, size_t index)
+{
+    return A.col(index);
+}
+
+template <>
+Element<Mat3X>::type getElement<Mat3X>(Mat3X & A, size_t index)
+{
+    return A.col(index);
+}
+
+
+template <>
+Element<Mat>::const_type getElement<Mat>(const Mat & A, size_t index)
+{
+    return A.col(index);
+}
+
+template <>
+Element<Mat>::type getElement<Mat>(Mat & A, size_t index)
+{
+    return A.col(index);
+}
+
+template <>
+Element<std::vector<Vec2>>::const_type getElement<std::vector<Vec2>>(const std::vector<Vec2> & A, size_t index)
+{
+    return A[index];
+}
+
+template <>
+Element<std::vector<Vec2>>::type getElement<std::vector<Vec2>>(std::vector<Vec2> & A, size_t index)
+{
+    return A[index];
+}
+
+
+}  // namespace aliceVision
+

--- a/src/aliceVision/numeric/Container.hpp
+++ b/src/aliceVision/numeric/Container.hpp
@@ -1,0 +1,135 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/numeric/numeric.hpp>
+
+namespace aliceVision {
+
+template <typename TMat>
+size_t CountElements(const TMat &A)
+{
+  static_assert(sizeof(TMat)!=sizeof(TMat), "CountElements must be specialized");
+  return 0;
+}
+
+template <> size_t CountElements<Mat2X>(const Mat2X &A);
+template <> size_t CountElements<Mat3X>(const Mat3X &A);
+template <> size_t CountElements<Mat>(const Mat &A);
+template <> size_t CountElements<std::vector<Vec2>>(const std::vector<Vec2> &A);
+
+template <typename TMat>
+size_t ElementSize(const TMat &A)
+{
+  static_assert(sizeof(TMat)!=sizeof(TMat), "CountElements must be specialized");
+  return 0;
+}
+
+template <> size_t ElementSize<Mat2X>(const Mat2X &A);
+template <> size_t ElementSize<Mat3X>(const Mat3X &A);
+template <> size_t ElementSize<Mat>(const Mat &A);
+template <> size_t ElementSize<std::vector<Vec2>>(const std::vector<Vec2> &A);
+
+template <typename T>
+struct Element;
+
+template <>
+struct Element<Mat2X>
+{
+    typedef Mat2X::ConstColXpr const_type;
+    typedef Mat2X::ColXpr type;
+    
+    static Mat2X create(size_t elementSize, size_t count)
+    {
+        return Mat2X(elementSize, count);
+    }
+};
+
+template <>
+struct Element<Mat3X>
+{
+    typedef Mat3X::ConstColXpr const_type;
+    typedef Mat3X::ColXpr type;
+
+    static Mat3X create(size_t elementSize, size_t count)
+    {
+        return Mat3X(elementSize, count);
+    }
+};
+
+template <>
+struct Element<Mat>
+{
+    typedef Mat::ConstColXpr const_type;
+    typedef Mat::ColXpr type;
+
+    static Mat create(size_t elementSize, size_t count)
+    {
+        return Mat(elementSize, count);
+    }
+};
+
+template <>
+struct Element<std::vector<Vec2>>
+{
+    typedef const Vec2 & const_type;
+    typedef Vec2 & type;
+
+    static  std::vector<Vec2> create(size_t elementSize, size_t count)
+    {
+        return std::vector<Vec2>(count);
+    }
+};
+
+template <typename TMat>
+typename Element<TMat>::const_type getElement(const TMat & A, size_t index)
+{
+    static_assert(sizeof(TMat)!=sizeof(TMat), "CountElements must be specialized");
+    return 0;
+}
+
+template <typename TMat>
+typename Element<TMat>::type getElement(TMat & A, size_t index)
+{
+    static_assert(sizeof(TMat)!=sizeof(TMat), "CountElements must be specialized");
+    return 0;
+}
+
+template <> typename Element<Mat2X>::const_type getElement<Mat2X>(const Mat2X & A, size_t index);
+template <> typename Element<Mat3X>::const_type getElement<Mat3X>(const Mat3X & A, size_t index);
+template <> typename Element<Mat>::const_type getElement<Mat>(const Mat & A, size_t index);
+template <> typename Element<std::vector<Vec2>>::const_type getElement<std::vector<Vec2>>(const std::vector<Vec2> & A, size_t index);
+
+template <> typename Element<Mat2X>::type getElement<Mat2X>(Mat2X & A, size_t index);
+template <> typename Element<Mat3X>::type getElement<Mat3X>(Mat3X & A, size_t index);
+template <> typename Element<Mat>::type getElement<Mat>(Mat & A, size_t index);
+template <> typename Element<std::vector<Vec2>>::type getElement<std::vector<Vec2>>(std::vector<Vec2> & A, size_t index);
+
+/**
+ * @brief It extracts the columns of given indices from the given matrix
+ * 
+ * @param[in] A The NxM input matrix
+ * @param[in] columns The list of K indices to extract
+ * @return A NxK matrix
+ */
+template <typename TMat, typename TCols>
+TMat buildSubsetMatrix(const TMat &A, const TCols &columns)
+{
+  using T = Element<TMat>;
+  TMat compressed = T::create(ElementSize(A), columns.size());
+  for(std::size_t i = 0; i < static_cast<std::size_t> (columns.size()); ++i)
+  {
+    // check for indices out of range
+    assert(columns[i]<CountElements(A));
+    getElement(compressed, i) = getElement(A, columns[i]);
+  }
+
+  return compressed;
+}
+
+
+} // namespace aliceVision

--- a/src/aliceVision/numeric/numeric.hpp
+++ b/src/aliceVision/numeric/numeric.hpp
@@ -378,25 +378,6 @@ double CosinusBetweenMatrices(const TMat &a, const TMat &b)
           FrobeniusNorm(a) / FrobeniusNorm(b);
 }
 
-/**
- * @brief It extracts the columns of given indices from the given matrix
- * 
- * @param[in] A The NxM input matrix
- * @param[in] columns The list of K indices to extract
- * @return A NxK matrix
- */
-template <typename TMat, typename TCols>
-TMat ExtractColumns(const TMat &A, const TCols &columns)
-{
-  TMat compressed(A.rows(), columns.size());
-  for(std::size_t i = 0; i < static_cast<std::size_t> (columns.size()); ++i)
-  {
-    // check for indices out of range
-    assert(columns[i]<A.cols());
-    compressed.col(i) = A.col(columns[i]);
-  }
-  return compressed;
-}
 
 /**
  * @brief Given a vector of element and a vector containing a selection of its indices,

--- a/src/aliceVision/numeric/numeric_test.cpp
+++ b/src/aliceVision/numeric/numeric_test.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <aliceVision/system/Logger.hpp>
 #include "aliceVision/numeric/numeric.hpp"
+#include <aliceVision/numeric/Container.hpp>
 
 #define BOOST_TEST_MODULE numeric
 
@@ -87,12 +88,12 @@ BOOST_AUTO_TEST_CASE(TinyMatrix_LookAt) {
   EXPECT_MATRIX_NEAR(I, RTR, 1e-15);
 }
 
-BOOST_AUTO_TEST_CASE(Numeric_ExtractColumns) {
+BOOST_AUTO_TEST_CASE(Numeric_buildSubsetMatrix) {
   Mat2X A(2, 5);
   A << 1, 2, 3, 4, 5,
        6, 7, 8, 9, 10;
   Vec2i columns; columns << 0, 2;
-  Mat2X extracted = ExtractColumns(A, columns);
+  Mat2X extracted = buildSubsetMatrix(A, columns);
   BOOST_CHECK_SMALL(1- extracted(0,0), 1e-15);
   BOOST_CHECK_SMALL(3- extracted(0,1), 1e-15);
   BOOST_CHECK_SMALL(6- extracted(1,0), 1e-15);

--- a/src/aliceVision/robustEstimation/ISolver.hpp
+++ b/src/aliceVision/robustEstimation/ISolver.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <aliceVision/numeric/numeric.hpp>
+#include <aliceVision/numeric/Container.hpp>
 
 #include <vector>
 

--- a/src/aliceVision/robustEstimation/LineKernel.hpp
+++ b/src/aliceVision/robustEstimation/LineKernel.hpp
@@ -97,7 +97,7 @@ public:
     assert(samples.size() >= getMinimumNbRequiredSamples());
 
     // standard least squares solution.
-    const Mat2X sampled_xs = ExtractColumns(_xs, samples);
+    const Mat2X sampled_xs = buildSubsetMatrix(_xs, samples);
 
     Mat X(sampled_xs.cols(), 2);
     X.col(0).setOnes();
@@ -131,7 +131,7 @@ public:
     assert(samples.size() >= getMinimumNbRequiredSamples());
 
     // standard least squares solution.
-    const Mat2X sampled_xs = ExtractColumns(_xs, samples);
+    const Mat2X sampled_xs = buildSubsetMatrix(_xs, samples);
 
 
     const std::size_t numPts = sampled_xs.cols();

--- a/src/aliceVision/robustEstimation/PointFittingKernel.hpp
+++ b/src/aliceVision/robustEstimation/PointFittingKernel.hpp
@@ -83,8 +83,8 @@ public:
    */
   inline virtual void fit(const std::vector<std::size_t>& samples, std::vector<ModelT>& models) const
   {
-    const Mat x1 = ExtractColumns(_x1, samples);
-    const Mat x2 = ExtractColumns(_x2, samples);
+    const Mat x1 = buildSubsetMatrix(_x1, samples);
+    const Mat x2 = buildSubsetMatrix(_x2, samples);
     _kernelSolver.solve(x1, x2, models);
   }
 
@@ -150,8 +150,8 @@ public:
    */
   inline void fit(const std::vector<std::size_t>& samples, std::vector<ModelT_>& models) const override
   {
-    const Mat x1 = ExtractColumns(KernelBase::_x1, samples);
-    const Mat x2 = ExtractColumns(KernelBase::_x2, samples);
+    const Mat x1 = buildSubsetMatrix(KernelBase::_x1, samples);
+    const Mat x2 = buildSubsetMatrix(KernelBase::_x2, samples);
 
     assert(2 == x1.rows());
     assert(KernelBase::getMinimumNbRequiredSamples() <= x1.cols());

--- a/src/aliceVision/robustEstimation/PointFittingRansacKernel.hpp
+++ b/src/aliceVision/robustEstimation/PointFittingRansacKernel.hpp
@@ -79,8 +79,8 @@ public:
 
   void fitLS(const std::vector<std::size_t>& inliers, std::vector<ModelT_>& models, const std::vector<double>* weights = nullptr) const override
   {
-    const Mat x1 = ExtractColumns(PFKernel::_x1, inliers);
-    const Mat x2 = ExtractColumns(PFKernel::_x2, inliers);
+    const Mat x1 = buildSubsetMatrix(PFKernel::_x1, inliers);
+    const Mat x2 = buildSubsetMatrix(PFKernel::_x2, inliers);
 
     if(weights == nullptr)
       _solverLs.solve(x1, x2, models);

--- a/src/aliceVision/sfm/pipeline/global/TranslationTripletKernelACRansac.hpp
+++ b/src/aliceVision/sfm/pipeline/global/TranslationTripletKernelACRansac.hpp
@@ -74,9 +74,9 @@ public:
   {
 
     // create a model from the points
-    _kernelSolver.solve(ExtractColumns(_x1n, samples),
-                        ExtractColumns(_x2n, samples),
-                        ExtractColumns(_x3n, samples),
+    _kernelSolver.solve(buildSubsetMatrix(_x1n, samples),
+                        buildSubsetMatrix(_x2n, samples),
+                        buildSubsetMatrix(_x3n, samples),
                         _vecKR, models, _thresholdUpperBound);
   }
 

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1880,7 +1880,7 @@ void ReconstructionEngine_sequentialSfM::triangulate_multiViewsLORANSAC(SfMData&
        * ------------------------------------------------------- */ 
      
       // -- Prepare:
-      Mat2X features(2, observations.size()); // undistorted 2D features (one per pose)
+      std::vector<Vec2> features; // undistorted 2D features (one per pose)
       std::vector<Mat34> Ps; // projective matrices (one per pose)
       {
         const track::Track& track = _map_tracks.at(trackId);
@@ -1894,8 +1894,7 @@ void ReconstructionEngine_sequentialSfM::triangulate_multiViewsLORANSAC(SfMData&
             continue;
           }
 
-          features(0,i) = o.xUd(0);
-          features(1,i) = o.xUd(1);
+          features.push_back(o.xUd);
           Ps.push_back(o.P);
           i++;
         }

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1905,7 +1905,7 @@ void ReconstructionEngine_sequentialSfM::triangulate_multiViewsLORANSAC(SfMData&
       Vec4 X_homogeneous = Vec4::Zero();
       std::vector<std::size_t> inliersIndex;
       
-      multiview::TriangulateNViewLORANSAC(features, Ps, _randomNumberGenerator, &X_homogeneous, &inliersIndex, 8.0);
+      multiview::TriangulateNViewLORANSAC(features, Ps, _randomNumberGenerator, X_homogeneous, &inliersIndex, 8.0);
       
       homogeneousToEuclidean(X_homogeneous, X_euclidean);     
       


### PR DESCRIPTION
Some low level changes to enable use of std::vector<Vec2/Vec3> instead of Matrices for points collections when calling ransac.

Remove the need to know the collection size before creating the object.
