### PR TITLE
New utility nodes to create camera rigs and merge two sfmData

### DIFF
--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -195,6 +195,28 @@ if(ALICEVISION_BUILD_SFM)
               Boost::program_options
     )
 
+    # SfM to rig
+    alicevision_add_software(aliceVision_sfmToRig
+        SOURCE main_sfmToRig.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              Boost::program_options
+    )
+
+    # SfM Merge
+    alicevision_add_software(aliceVision_sfmMerge
+        SOURCE main_sfmMerge.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              Boost::program_options
+    )
+
     # SfM Regression
     alicevision_add_software(aliceVision_sfmRegression
         SOURCE main_sfmRegression.cpp

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -26,21 +26,19 @@ using namespace aliceVision;
 namespace po = boost::program_options;
 
 
-
 int aliceVision_main(int argc, char **argv)
 {
     // command-line parameters
     std::string sfmDataFilename1, sfmDataFilename2;
     std::string outSfMDataFilename;
 
-
     po::options_description requiredParams("Required parameters");
-    requiredParams.add_options() //
-        ("firstinput,i1", po::value<std::string>(&sfmDataFilename1)->required(), "First SfMData file to merge.") //
-        ("secondinput,i2", po::value<std::string>(&sfmDataFilename2)->required(), "Second SfMData file to merge.") //
+    requiredParams.add_options()
+        ("firstinput,i1", po::value<std::string>(&sfmDataFilename1)->required(), "First SfMData file to merge.")
+        ("secondinput,i2", po::value<std::string>(&sfmDataFilename2)->required(), "Second SfMData file to merge.")
         ("output,o", po::value<std::string>(&outSfMDataFilename)->required(), "Output SfMData scene.");
 
-    CmdLine cmdline("AliceVision sfmTransfer");
+    CmdLine cmdline("AliceVision sfmMerge");
     cmdline.add(requiredParams);
     if (!cmdline.execute(argc, argv))
     {
@@ -65,12 +63,12 @@ int aliceVision_main(int argc, char **argv)
     {
         auto & views1 = sfmData1.getViews();
         auto & views2 = sfmData2.getViews();
-        size_t totalSize = views1.size() + views2.size();
+        const size_t totalSize = views1.size() + views2.size();
 
         views1.insert(views2.begin(), views2.end());
         if (views1.size() < totalSize)
         {
-            ALICEVISION_LOG_ERROR("Unhandled error : common view id between both sfmdata");
+            ALICEVISION_LOG_ERROR("Unhandled error: common view ID between both SfMData");
             return EXIT_FAILURE;
         }
     }
@@ -78,12 +76,12 @@ int aliceVision_main(int argc, char **argv)
     {
         auto & intrinsics1 = sfmData1.getIntrinsics();
         auto & intrinsics2 = sfmData2.getIntrinsics();
-        size_t totalSize = intrinsics1.size() + intrinsics2.size();
+        const size_t totalSize = intrinsics1.size() + intrinsics2.size();
 
         intrinsics1.insert(intrinsics2.begin(), intrinsics2.end());
         if (intrinsics1.size() < totalSize)
         {
-            ALICEVISION_LOG_ERROR("Unhandled error : common intrinsics id between both sfmdata");
+            ALICEVISION_LOG_ERROR("Unhandled error: common intrinsics ID between both SfMData");
             return EXIT_FAILURE;
         }
     }
@@ -91,12 +89,12 @@ int aliceVision_main(int argc, char **argv)
     {
         auto & rigs1 = sfmData1.getRigs();
         auto & rigs2 = sfmData2.getRigs();
-        size_t totalSize = rigs1.size() + rigs2.size();
+        const size_t totalSize = rigs1.size() + rigs2.size();
 
         rigs1.insert(rigs2.begin(), rigs2.end());
         if (rigs1.size() < totalSize)
         {
-            ALICEVISION_LOG_ERROR("Unhandled error : common rigs id between both sfmdata");
+            ALICEVISION_LOG_ERROR("Unhandled error: common rigs ID between both SfMData");
             return EXIT_FAILURE;
         }
     }
@@ -104,24 +102,18 @@ int aliceVision_main(int argc, char **argv)
     {
         auto & landmarks1 = sfmData1.getLandmarks();
         auto & landmarks2 = sfmData2.getLandmarks();
-        size_t totalSize = landmarks1.size() + landmarks2.size();
+        const size_t totalSize = landmarks1.size() + landmarks2.size();
 
         landmarks1.insert(landmarks2.begin(), landmarks2.end());
         if (landmarks1.size() < totalSize)
         {
-            ALICEVISION_LOG_ERROR("Unhandled error : common rigs landmarks between both sfmdata");
+            ALICEVISION_LOG_ERROR("Unhandled error: common rigs landmarks between both SfMData");
             return EXIT_FAILURE;
         }
     }
 
-    {
-        sfmData1.addFeaturesFolders(sfmData2.getRelativeFeaturesFolders());
-    }
-
-    {
-        sfmData1.addMatchesFolders(sfmData2.getRelativeMatchesFolders());
-    }
-
+    sfmData1.addFeaturesFolders(sfmData2.getRelativeFeaturesFolders());
+    sfmData1.addMatchesFolders(sfmData2.getRelativeMatchesFolders());
 
     if (!sfmDataIO::Save(sfmData1, outSfMDataFilename, sfmDataIO::ESfMData::ALL))
     {

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -1,0 +1,133 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/stl/hash.hpp>
+#include <aliceVision/system/main.hpp>
+
+
+#include <boost/program_options.hpp>
+
+#include <string>
+#include <sstream>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+
+
+int aliceVision_main(int argc, char **argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename1, sfmDataFilename2;
+    std::string outSfMDataFilename;
+
+
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options() //
+        ("firstinput,i1", po::value<std::string>(&sfmDataFilename1)->required(), "First SfMData file to merge.") //
+        ("secondinput,i2", po::value<std::string>(&sfmDataFilename2)->required(), "Second SfMData file to merge.") //
+        ("output,o", po::value<std::string>(&outSfMDataFilename)->required(), "Output SfMData scene.");
+
+    CmdLine cmdline("AliceVision sfmTransfer");
+    cmdline.add(requiredParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // Load input scene
+    sfmData::SfMData sfmData1;
+    if (!sfmDataIO::Load(sfmData1, sfmDataFilename1, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename1 << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    sfmData::SfMData sfmData2;
+    if (!sfmDataIO::Load(sfmData2, sfmDataFilename2, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename2 << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+    
+    {
+        auto & views1 = sfmData1.getViews();
+        auto & views2 = sfmData2.getViews();
+        size_t totalSize = views1.size() + views2.size();
+
+        views1.insert(views2.begin(), views2.end());
+        if (views1.size() < totalSize)
+        {
+            ALICEVISION_LOG_ERROR("Unhandled error : common view id between both sfmdata");
+            return EXIT_FAILURE;
+        }
+    }
+
+    {
+        auto & intrinsics1 = sfmData1.getIntrinsics();
+        auto & intrinsics2 = sfmData2.getIntrinsics();
+        size_t totalSize = intrinsics1.size() + intrinsics2.size();
+
+        intrinsics1.insert(intrinsics2.begin(), intrinsics2.end());
+        if (intrinsics1.size() < totalSize)
+        {
+            ALICEVISION_LOG_ERROR("Unhandled error : common intrinsics id between both sfmdata");
+            return EXIT_FAILURE;
+        }
+    }
+
+    {
+        auto & rigs1 = sfmData1.getRigs();
+        auto & rigs2 = sfmData2.getRigs();
+        size_t totalSize = rigs1.size() + rigs2.size();
+
+        rigs1.insert(rigs2.begin(), rigs2.end());
+        if (rigs1.size() < totalSize)
+        {
+            ALICEVISION_LOG_ERROR("Unhandled error : common rigs id between both sfmdata");
+            return EXIT_FAILURE;
+        }
+    }
+
+    {
+        auto & landmarks1 = sfmData1.getLandmarks();
+        auto & landmarks2 = sfmData2.getLandmarks();
+        size_t totalSize = landmarks1.size() + landmarks2.size();
+
+        landmarks1.insert(landmarks2.begin(), landmarks2.end());
+        if (landmarks1.size() < totalSize)
+        {
+            ALICEVISION_LOG_ERROR("Unhandled error : common rigs landmarks between both sfmdata");
+            return EXIT_FAILURE;
+        }
+    }
+
+    {
+        sfmData1.addFeaturesFolders(sfmData2.getRelativeFeaturesFolders());
+    }
+
+    {
+        sfmData1.addMatchesFolders(sfmData2.getRelativeMatchesFolders());
+    }
+
+
+    if (!sfmDataIO::Save(sfmData1, outSfMDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outSfMDataFilename << "'");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_sfmToRig.cpp
+++ b/src/software/utils/main_sfmToRig.cpp
@@ -1,0 +1,134 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/stl/hash.hpp>
+#include <aliceVision/system/main.hpp>
+
+
+#include <boost/program_options.hpp>
+
+#include <string>
+#include <sstream>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+
+
+int aliceVision_main(int argc, char **argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string outSfMDataFilename;
+
+
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options() //
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file") //
+        ("output,o", po::value<std::string>(&outSfMDataFilename)->required(), "Output SfMData scene.");
+
+    CmdLine cmdline("AliceVision sfmTransfer");
+    cmdline.add(requiredParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // Load input scene
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::Load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    if (sfmData.getRigs().size() > 0)
+    {
+        ALICEVISION_LOG_INFO("Ignoring existing rig");
+        sfmData.getRigs().clear();
+    }
+
+    //Remove existing landmarks
+    sfmData.getLandmarks().clear();
+    sfmData.getConstraints2D().clear();
+    sfmData.getRotationPriors().clear();
+
+    sfmData::Rig rig(sfmData.getPoses().size());
+
+    //Build rig
+    size_t indexRig = 0;
+    int index = 0;
+    std::map<IndexT, int> mapPoseToSubPose;
+    for (const auto & pp : sfmData.getPoses())
+    {
+        const auto & pose = pp.second;
+
+        sfmData::RigSubPose subPose(pose.getTransform(), sfmData::ERigSubPoseStatus::CONSTANT);
+        rig.setSubPose(index, subPose);
+
+        //Rig id is the combination of uid of poses
+        stl::hash_combine(indexRig, pp.first);
+
+        mapPoseToSubPose[pp.first] = index;
+        index++;
+    }
+
+    //Insert rig
+    sfmData.getRigs().emplace(indexRig, rig);
+
+    //Update
+    for (auto & pv : sfmData.getViews())
+    {
+        std::shared_ptr<sfmData::View> view = pv.second;
+        if (!sfmData.isPoseAndIntrinsicDefined(view.get()))
+        {
+            continue;
+        }
+
+        IndexT poseId = view->getPoseId();
+        int subPoseId = mapPoseToSubPose[poseId];
+       
+        //New commmon pose id is the same than the rig id for convenience
+        view->setPoseId(indexRig);
+        view->setRigAndSubPoseId(indexRig, subPoseId);
+        view->setIndependantPose(false);
+        
+        //Update intrinsicId
+        size_t intrinsicId = view->getIntrinsicId();
+        stl::hash_combine(intrinsicId, indexRig);
+        view->setIntrinsicId(intrinsicId);
+    }
+
+    //Update intrinsics
+    sfmData::Intrinsics intrinsics = sfmData.getIntrinsics();
+    sfmData.getIntrinsics().clear();
+    for (auto & pi : intrinsics)
+    {
+        size_t intrinsicId = pi.first;
+        stl::hash_combine(intrinsicId, indexRig);
+        sfmData.getIntrinsics().emplace(intrinsicId, pi.second);
+    }
+
+    //Remove all poses
+    sfmData.getPoses().clear();
+
+    if (!sfmDataIO::Save(sfmData, outSfMDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outSfMDataFilename << "'");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Create two new nodes :

- one node to merge two sfmData assuming both sfmData does contain only unique ids

- one node to create a rig from one input sfmData (All views are then a different subpose of a common rig)

Related Meshroom PR: https://github.com/alicevision/Meshroom/pull/2214