### PR TITLE
Input color space setting

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -738,9 +738,13 @@ void readImage(const std::string& path,
         ALICEVISION_THROW_ERROR("You must specify a requested color space for image file '" + path + "'.");
 
     // Get color space name. Default image color space is sRGB
-    std::string fromColorSpaceName = (isRawImage && imageReadOptions.rawColorInterpretation == ERawColorInterpretation::DcpLinearProcessing) ? "aces2065-1" :
-                                       (isRawImage ? "linear" :
-                                        inBuf.spec().get_string_attribute("aliceVision:ColorSpace", inBuf.spec().get_string_attribute("oiio:ColorSpace", "sRGB")));
+    std::string fromColorSpaceName = (isRawImage && imageReadOptions.rawColorInterpretation == ERawColorInterpretation::DcpLinearProcessing)
+                ? "aces2065-1"
+                : (isRawImage
+                   ? "linear"
+                   : (imageReadOptions.inputColorSpace == EImageColorSpace::AUTO
+                      ? inBuf.spec().get_string_attribute("aliceVision:ColorSpace", inBuf.spec().get_string_attribute("oiio:ColorSpace", "sRGB"))
+                      : EImageColorSpace_enumToString(imageReadOptions.inputColorSpace)));
 
     ALICEVISION_LOG_TRACE("Read image " << path << " (encoded in " << fromColorSpaceName << " colorspace).");
 

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -738,12 +738,14 @@ void readImage(const std::string& path,
         ALICEVISION_THROW_ERROR("You must specify a requested color space for image file '" + path + "'.");
 
     // Get color space name. Default image color space is sRGB
+    const std::string colorSpaceFromMetadata = inBuf.spec().get_string_attribute("aliceVision:ColorSpace", inBuf.spec().get_string_attribute("oiio:ColorSpace", "sRGB"));
+
     std::string fromColorSpaceName = (isRawImage && imageReadOptions.rawColorInterpretation == ERawColorInterpretation::DcpLinearProcessing)
                 ? "aces2065-1"
                 : (isRawImage
                    ? "linear"
                    : (imageReadOptions.inputColorSpace == EImageColorSpace::AUTO
-                      ? inBuf.spec().get_string_attribute("aliceVision:ColorSpace", inBuf.spec().get_string_attribute("oiio:ColorSpace", "sRGB"))
+                      ? colorSpaceFromMetadata
                       : EImageColorSpace_enumToString(imageReadOptions.inputColorSpace)));
 
     ALICEVISION_LOG_TRACE("Read image " << path << " (encoded in " << fromColorSpaceName << " colorspace).");

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -215,16 +215,21 @@ std::istream& operator>>(std::istream& in, EImageQuality& imageQuality);
  */
 struct ImageReadOptions
 {
-    ImageReadOptions(EImageColorSpace colorSpace = EImageColorSpace::AUTO,
+    ImageReadOptions(EImageColorSpace workingColorSpace = EImageColorSpace::AUTO, EImageColorSpace inputColorSpace = EImageColorSpace::AUTO,
         ERawColorInterpretation rawColorInterpretation = ERawColorInterpretation::LibRawWhiteBalancing,
         const std::string& colorProfile = "", const bool useDCPColorMatrixOnly = true, const oiio::ROI& roi = oiio::ROI()) :
-        workingColorSpace(colorSpace), rawColorInterpretation(rawColorInterpretation), colorProfileFileName(colorProfile), useDCPColorMatrixOnly(useDCPColorMatrixOnly),
+        workingColorSpace(workingColorSpace),
+        inputColorSpace(inputColorSpace),
+        rawColorInterpretation(rawColorInterpretation),
+        colorProfileFileName(colorProfile),
+        useDCPColorMatrixOnly(useDCPColorMatrixOnly),
         doWBAfterDemosaicing(false), demosaicingAlgo("AHD"), highlightMode(0), rawAutoBright(false), rawExposureAdjustment(1.0),
         correlatedColorTemperature(-1.0), subROI(roi)
     {
     }
 
     EImageColorSpace workingColorSpace;
+    EImageColorSpace inputColorSpace;
     ERawColorInterpretation rawColorInterpretation;
     std::string colorProfileFileName;
     bool useDCPColorMatrixOnly;

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -919,6 +919,7 @@ int aliceVision_main(int argc, char * argv[])
     std::vector<std::string> metadataFolders;
     std::string outputPath;
     EImageFormat outputFormat = EImageFormat::RGBA;
+    image::EImageColorSpace inputColorSpace = image::EImageColorSpace::AUTO;
     image::EImageColorSpace workingColorSpace = image::EImageColorSpace::LINEAR;
     image::EImageColorSpace outputColorSpace = image::EImageColorSpace::LINEAR;
     image::EStorageDataType storageDataType = image::EStorageDataType::Float;
@@ -1036,6 +1037,9 @@ int aliceVision_main(int argc, char * argv[])
             " * HColor: Parameter regulating filter strength for color images only. Normally same as Filtering Parameter H. Not necessary for grayscale images\n "
             " * templateWindowSize: Size in pixels of the template patch that is used to compute weights. Should be odd. \n"
             " * searchWindowSize:Size in pixels of the window that is used to compute weighted average for given pixel. Should be odd. Affect performance linearly: greater searchWindowsSize - greater denoising time.")
+
+        ("inputColorSpace", po::value<image::EImageColorSpace>(&inputColorSpace)->default_value(inputColorSpace),
+         ("Input image color space: " + image::EImageColorSpace_informations()).c_str())
 
         ("workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
          ("Working color space: " + image::EImageColorSpace_informations()).c_str())
@@ -1254,6 +1258,10 @@ int aliceVision_main(int argc, char * argv[])
                 options.correlatedColorTemperature = correlatedColorTemperature;
                 pParams.correlatedColorTemperature = correlatedColorTemperature;
                 pParams.enableColorTempProcessing = options.rawColorInterpretation == image::ERawColorInterpretation::DcpLinearProcessing;
+            }
+            else
+            {
+                options.inputColorSpace = inputColorSpace;
             }
 
             if (pParams.lensCorrection.enabled && pParams.lensCorrection.vignetting)
@@ -1683,6 +1691,10 @@ int aliceVision_main(int argc, char * argv[])
                 {
                     workingColorSpace = image::EImageColorSpace::ACES2065_1;
                 }
+            }
+            else
+            {
+                readOptions.inputColorSpace = inputColorSpace;
             }
 
             readOptions.workingColorSpace = pParams.applyDcpMetadata ? image::EImageColorSpace::NO_CONVERSION : workingColorSpace;


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Add a choice param in the imageProcessing node to force the color space of the input images. Default value set to AUTO. In that case, the input color space is extracted from the metadata as it is implemented in the current version.

linked to https://github.com/alicevision/Meshroom/pull/2219

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

