### PR TITLE
Bugfix when checking raw format

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -495,7 +495,9 @@ bool isRawFormat(const std::string& path)
 {
     std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(path));
     if(!in)
-        return false;
+    {
+        ALICEVISION_THROW_ERROR("The input image file '" << path << "' cannot be opened or does not exist.");
+    }
     std::string imgFormat = in->format_name();
 
     return (imgFormat.compare("raw") == 0);

--- a/src/aliceVision/image/io.hpp
+++ b/src/aliceVision/image/io.hpp
@@ -510,6 +510,8 @@ struct ColorTypeInfo<RGBAfColor>
     static const oiio::TypeDesc::BASETYPE typeDesc = oiio::TypeDesc::FLOAT;
 };
 
+bool isRawFormat(const std::string& path);
+
 bool tryLoadMask(Image<unsigned char>* mask, const std::vector<std::string>& masksFolders,
                  const IndexT viewId, const std::string& srcImage, const std::string& fileExtension);
 

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -390,9 +390,7 @@ int aliceVision_main(int argc, char** argv)
 
                     if (calibrationMethod == ECalibrationMethod::AUTO)
                     {
-                        const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(group.begin()->get()->getImage().getImagePath()));
-                        const std::string imgFormat = in->format_name();
-                        const bool isRAW = imgFormat.compare("raw") == 0;
+                        const bool isRAW = image::isRawFormat(group.begin()->get()->getImage().getImagePath());
 
                         calibrationMethod = isRAW ? ECalibrationMethod::LINEAR : ECalibrationMethod::DEBEVEC;
                         ALICEVISION_LOG_INFO("Calibration method automatically set to " << calibrationMethod << ".");

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -253,9 +253,7 @@ int aliceVision_main(int argc, char** argv)
     // Estimate working color space if set to AUTO
     if (workingColorSpace == image::EImageColorSpace::AUTO)
     {
-        const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(groupedViews[0][0]->getImage().getImagePath()));
-        const std::string imgFormat = in->format_name();
-        const bool isRAW = imgFormat.compare("raw") == 0;
+        const bool isRAW = image::isRawFormat(groupedViews[0][0]->getImage().getImagePath());
 
         workingColorSpace = isRAW ? image::EImageColorSpace::LINEAR : image::EImageColorSpace::SRGB;
         ALICEVISION_LOG_INFO("Working color space automatically set to " << workingColorSpace << ".");

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -243,9 +243,7 @@ int aliceVision_main(int argc, char** argv)
                     firstViewId = v->getViewId();
                     first = false;
 
-                    const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(v->getImage().getImagePath()));
-                    const std::string imgFormat = in->format_name();
-                    const bool isRAW = imgFormat.compare("raw") == 0;
+                    const bool isRAW = image::isRawFormat(v->getImage().getImagePath());
 
                     if (calibrationMethod == ECalibrationMethod::AUTO)
                     {

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -491,9 +491,7 @@ int aliceVision_main(int argc, char **argv)
     const std::string& model = view.getImage().getMetadataModel();
     const bool hasCameraMetadata = (!make.empty() || !model.empty());
 
-    std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(view.getImage().getImagePath()));
-
-    std::string imgFormat = in->format_name();
+    const bool isRaw = image::isRawFormat(view.getImage().getImagePath());
 
     bool dcpError = true;
 
@@ -501,7 +499,7 @@ int aliceVision_main(int argc, char **argv)
     // if yes and if metadata exist and image format is raw then update metadata with DCP info
     if((rawColorInterpretation == image::ERawColorInterpretation::DcpLinearProcessing ||
         rawColorInterpretation == image::ERawColorInterpretation::DcpMetadata) &&
-        hasCameraMetadata && (imgFormat.compare("raw") == 0))
+        hasCameraMetadata && isRaw)
     {
 
         if (dcpDatabase.empty() && errorOnMissingColorProfile)
@@ -534,7 +532,7 @@ int aliceVision_main(int argc, char **argv)
         }
     }
 
-    if (imgFormat.compare("raw") == 0)
+    if (isRaw)
     {
         // Store the color interpretation mode chosen for raw images in metadata,
         // so all future loads of this image will be interpreted in the same way.

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1206,9 +1206,7 @@ int aliceVision_main(int argc, char * argv[])
             const std::string viewPath = viewIt.second;
             sfmData::View& view = sfmData.getView(viewId);
 
-            const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(viewPath));
-            const std::string imgFormat = in->format_name();
-            const bool isRAW = imgFormat.compare("raw") == 0;
+            const bool isRAW = image::isRawFormat(viewPath);
 
             const fs::path fsPath = viewPath;
             const std::string fileName = fsPath.stem().string();
@@ -1462,9 +1460,7 @@ int aliceVision_main(int argc, char * argv[])
         int i = 0;
         for (const std::string& inputFilePath : filesStrPaths)
         {
-            const std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(inputFilePath));
-            const std::string imgFormat = in->format_name();
-            const bool isRAW = imgFormat.compare("raw") == 0;
+            const bool isRAW = image::isRawFormat(inputFilePath);
 
             const fs::path path = fs::path(inputFilePath);
             const std::string filename = path.stem().string();


### PR DESCRIPTION


<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Currently, when checking if an image is encoded in a raw format, if the image does not exist, a crash occurs without any information.

This PR corrects that behavior by throwing an error with an information message about the missing file.

Former duplicated code is now factorized.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

