### PR TITLE
[keyframe] fix intrinsics UID

### DIFF
--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -647,7 +647,6 @@ bool KeyframeSelector::writeSelection(const std::vector<std::string>& brands,
                 oiio::ParamValueList metadata;
                 metadata.push_back(oiio::ParamValue("Make", brands[id]));
                 metadata.push_back(oiio::ParamValue("Model", models[id]));
-                metadata.push_back(oiio::ParamValue("Exif:BodySerialNumber", std::to_string(getRandomInt())));
                 metadata.push_back(oiio::ParamValue("Exif:FocalLength", mmFocals[id]));
                 metadata.push_back(oiio::ParamValue("Exif:ImageUniqueID", std::to_string(getRandomInt())));
                 metadata.push_back(oiio::ParamValue("Orientation", orientation));  // Will not propagate for PNG outputs


### PR DESCRIPTION
The keyframe selection generates new images with metadata.
BodySerialNumber is used (in combination with LensSerialNumber) to compute the intrinsic UID. So, the keyframeSelection should not set a random value on each frame as it will create one intrinsic per image.
