### PR TITLE
[sfmData] imageInfo: Retrieve focal length when it's available in non-standard metadata keys

### DIFF
--- a/src/aliceVision/sfmData/imageInfo.cpp
+++ b/src/aliceVision/sfmData/imageInfo.cpp
@@ -21,21 +21,21 @@ double ImageInfo::getEv() const
 std::map<std::string, std::string>::const_iterator ImageInfo::findMetadataIterator(const std::string& name) const
 {
     auto it = _metadata.find(name);
-    if(it != _metadata.end())
+    if (it != _metadata.end())
         return it;
     std::string nameLower = name;
     boost::algorithm::to_lower(nameLower);
-    for(auto mIt = _metadata.begin(); mIt != _metadata.end(); ++mIt)
+    for (auto mIt = _metadata.begin(); mIt != _metadata.end(); ++mIt)
     {
         std::string key = mIt->first;
         boost::algorithm::to_lower(key);
-        if(key.size() > name.size())
+        if (key.size() > name.size())
         {
             auto delimiterIt = key.find_last_of("/:");
-            if(delimiterIt != std::string::npos)
+            if (delimiterIt != std::string::npos)
                 key = key.substr(delimiterIt + 1);
         }
-        if(key == nameLower)
+        if (key == nameLower)
         {
             return mIt;
         }
@@ -46,7 +46,7 @@ std::map<std::string, std::string>::const_iterator ImageInfo::findMetadataIterat
 bool ImageInfo::hasMetadata(const std::vector<std::string>& names) const
 {
     return std::any_of(names.cbegin(), names.cend(),
-                       [this](const std::string& name){
+                       [this](const std::string& name) {
                            return (findMetadataIterator(name) != _metadata.end());
                        });
 }
@@ -56,11 +56,11 @@ bool ImageInfo::hasDigitMetadata(const std::vector<std::string>& names, bool isP
     bool hasDigitMetadata = false;
     double value = -1.0;
 
-    for(const std::string& name : names)
+    for (const std::string& name : names)
     {
         const auto it = findMetadataIterator(name);
 
-        if(it == _metadata.end() || it->second.empty())
+        if (it == _metadata.end() || it->second.empty())
         {
             continue;
         }
@@ -71,7 +71,7 @@ bool ImageInfo::hasDigitMetadata(const std::vector<std::string>& names, bool isP
             hasDigitMetadata = true;
             break;
         }
-        catch(std::exception&)
+        catch (std::exception&)
         {
             value = -1.0;
         }
@@ -82,10 +82,10 @@ bool ImageInfo::hasDigitMetadata(const std::vector<std::string>& names, bool isP
 const std::string& ImageInfo::getMetadata(const std::vector<std::string>& names) const
 {
     static const std::string emptyString;
-    for(const std::string& name : names)
+    for (const std::string& name : names)
     {
         const auto it = findMetadataIterator(name);
-        if(it != _metadata.end())
+        if (it != _metadata.end())
             return it->second;
     }
     return emptyString;
@@ -98,7 +98,7 @@ double ImageInfo::readRealNumber(const std::string& str) const
         std::smatch m;
         std::regex pattern_frac("([0-9]+)\\/([0-9]+)");
 
-        if(!std::regex_search(str, m, pattern_frac))
+        if (!std::regex_search(str, m, pattern_frac))
         {
             return std::stod(str);
         }
@@ -106,12 +106,12 @@ double ImageInfo::readRealNumber(const std::string& str) const
         const int num = std::stoi(m[1].str());
         const int denum = std::stoi(m[2].str());
 
-        if(denum != 0)
+        if (denum != 0)
             return double(num) / double(denum);
         else
             return 0.0;
     }
-    catch(std::exception&)
+    catch (std::exception&)
     {
         return -1.0;
     }
@@ -137,13 +137,13 @@ bool ImageInfo::getDoubleMetadata(const std::vector<std::string>& names, double&
 int ImageInfo::getIntMetadata(const std::vector<std::string>& names) const
 {
     const std::string value = getMetadata(names);
-    if(value.empty())
+    if (value.empty())
         return -1;
     try
     {
         return std::stoi(value);
     }
-    catch(std::exception&)
+    catch (std::exception&)
     {
         return -1;
     }
@@ -152,7 +152,7 @@ int ImageInfo::getIntMetadata(const std::vector<std::string>& names) const
 bool ImageInfo::hasGpsMetadata() const
 {
     const auto tags = GPSExifTags::all();
-    return std::all_of(tags.cbegin(), tags.cend(), [this](const std::string& t){ return hasMetadata({t}); });
+    return std::all_of(tags.cbegin(), tags.cend(), [this](const std::string& t) { return hasMetadata({t}); });
 }
 
 Vec3 ImageInfo::getGpsPositionFromMetadata() const
@@ -187,8 +187,9 @@ Vec3 ImageInfo::getGpsPositionWGS84FromMetadata() const
     return {lat, lon, alt};
 }
 
-int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatabase, double& sensorWidth, double& sensorHeight,
-                        double& focalLengthmm, camera::EInitMode& intrinsicInitMode, bool verbose)
+int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatabase, double& sensorWidth,
+                             double& sensorHeight, double& focalLengthmm, camera::EInitMode& intrinsicInitMode,
+                             bool verbose)
 {
     int errCode = 0;
 
@@ -214,10 +215,11 @@ int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatab
             if (verbose)
             {
                 // sensor is in the database
-                ALICEVISION_LOG_TRACE("Sensor width found in sensor database: " << std::endl
-                                                                                << "\t- brand: " << make << std::endl
-                                                                                << "\t- model: " << model << std::endl
-                                                                                << "\t- sensor width: " << datasheet._sensorWidth << " mm");
+                ALICEVISION_LOG_TRACE("Sensor width found in sensor database: "
+                                      << std::endl
+                                      << "\t- brand: " << make << std::endl
+                                      << "\t- model: " << model << std::endl
+                                      << "\t- sensor width: " << datasheet._sensorWidth << " mm");
             }
 
             if ((datasheet._model != model) && (datasheet._model != make + " " + model))
@@ -227,13 +229,17 @@ int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatab
 
                 if (verbose)
                 {
-                    ALICEVISION_LOG_WARNING("The camera found in the sensor database is slightly different for image " << getImagePath());
-                    ALICEVISION_LOG_WARNING("\t- image camera brand: " << make << std::endl
-                                                                       << "\t- image camera model: " << model << std::endl
-                                                                       << "\t- sensor database camera brand: " << datasheet._brand << std::endl
-                                                                       << "\t- sensor database camera model: " << datasheet._model << std::endl
-                                                                       << "\t- sensor database camera sensor width: " << datasheet._sensorWidth << " mm");
-                    ALICEVISION_LOG_WARNING("Please check and correct camera model(s) name in the sensor database." << std::endl);
+                    ALICEVISION_LOG_WARNING("The camera found in the sensor database is slightly different for image "
+                                            << getImagePath());
+                    ALICEVISION_LOG_WARNING("\t- image camera brand: "
+                                            << make << std::endl
+                                            << "\t- image camera model: " << model << std::endl
+                                            << "\t- sensor database camera brand: " << datasheet._brand << std::endl
+                                            << "\t- sensor database camera model: " << datasheet._model << std::endl
+                                            << "\t- sensor database camera sensor width: " << datasheet._sensorWidth
+                                            << " mm");
+                    ALICEVISION_LOG_WARNING("Please check and correct camera model(s) name in the sensor database."
+                                            << std::endl);
                 }
             }
 
@@ -299,7 +305,8 @@ int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatab
             if (verbose)
             {
                 std::stringstream ss;
-                ss << "Intrinsic(s) initialized from 'FocalLengthIn35mmFilm' exif metadata in image " << getImagePath() << "\n";
+                ss << "Intrinsic(s) initialized from 'FocalLengthIn35mmFilm' exif metadata in image " << getImagePath()
+                   << "\n";
                 ss << "\t- sensor width: " << sensorWidth << "\n";
                 ss << "\t- focal length: " << focalLengthmm << "\n";
                 ALICEVISION_LOG_DEBUG(ss.str());

--- a/src/aliceVision/sfmData/imageInfo.hpp
+++ b/src/aliceVision/sfmData/imageInfo.hpp
@@ -25,600 +25,597 @@ class ImageInfo
 {
 public:
 
-  /**
-   * @brief Image Constructor
-   * @param[in] imagePath The image path on disk
-   * @param[in] width The image width
-   * @param[in] height The image height
-   * @param[in] metadata The image metadata
-   */
-  ImageInfo(const std::string& imagePath = "",
-       std::size_t width = 0,
-       std::size_t height = 0,
-       const std::map<std::string, std::string>& metadata = std::map<std::string, std::string>())
-    : _imagePath(imagePath)
-    , _width(width)
-    , _height(height)
-    , _metadata(metadata)
-  {}
+    /**
+     * @brief Image Constructor
+     * @param[in] imagePath The image path on disk
+     * @param[in] width The image width
+     * @param[in] height The image height
+     * @param[in] metadata The image metadata
+    */
+    ImageInfo(const std::string& imagePath = "",
+              std::size_t width = 0,
+              std::size_t height = 0,
+              const std::map<std::string, std::string>& metadata = std::map<std::string, std::string>()) :
+             _imagePath(imagePath), _width(width), _height(height), _metadata(metadata)
+    {}
 
-  bool operator==(const ImageInfo& other) const
-  {
-    // image paths can be different
-    return 
-           _width == other._width &&
-           _height == other._height;
-  }
+    bool operator==(const ImageInfo& other) const
+    {
+        // image paths can be different
+        return 
+            _width == other._width &&
+            _height == other._height;
+    }
 
-  inline bool operator!=(const ImageInfo& other) const { return !(*this == other); }
+    inline bool operator!=(const ImageInfo& other) const { return !(*this == other); }
 
-  /**
-   * @brief Get view image path
-   * @return image path
-   */
-  const std::string& getImagePath() const
-  {
-    return _imagePath;
-  }
+    /**
+     * @brief Get view image path
+     * @return image path
+     */
+    const std::string& getImagePath() const
+    {
+        return _imagePath;
+    }
 
-  /**
-   * @brief Get view image width
-   * @return image width
-   */
-  std::size_t getWidth() const
-  {
-    return _width;
-  }
+    /**
+     * @brief Get view image width
+     * @return image width
+     */
+    std::size_t getWidth() const
+    {
+        return _width;
+    }
 
-  /**
-   * @brief Get view image height
-   * @return image height
-   */
-  std::size_t getHeight() const
-  {
-    return _height;
-  }
+    /**
+     * @brief Get view image height
+     * @return image height
+     */
+    std::size_t getHeight() const
+    {
+        return _height;
+    }
 
-  /**
-   * @brief Get view image size
-   * @return image size
-   */
-  std::pair<std::size_t, std::size_t> getImgSize() const
-  {
-    return {_width, _height};
-  }
+    /**
+     * @brief Get view image size
+     * @return image size
+     */
+    std::pair<std::size_t, std::size_t> getImgSize() const
+    {
+        return {_width, _height};
+    }
 
-  /**
-   * @brief Get the Camera Exposure Setting value.
-   * For the same scene, this value is linearly proportional to the amount of light captured by the camera according to
-   * the shooting parameters (shutter speed, f-number, iso).
-   */
-  ExposureSetting getCameraExposureSetting() const
-  {
-      return ExposureSetting(
-          getMetadataShutter(),
-          getMetadataFNumber(),
-          getMetadataISO());
-  }
+    /**
+     * @brief Get the Camera Exposure Setting value.
+     * For the same scene, this value is linearly proportional to the amount of light captured by the camera according to
+     * the shooting parameters (shutter speed, f-number, iso).
+     */
+    ExposureSetting getCameraExposureSetting() const
+    {
+        return ExposureSetting(
+            getMetadataShutter(),
+            getMetadataFNumber(),
+            getMetadataISO());
+    }
 
-  /**
-   * @brief Get the Exposure Value. EV is a number that represents a combination of a camera's shutter speed and
-   * f-number, such that all combinations that yield the same exposure have the same EV.
-   * It progresses in a linear sequence as camera exposure is changed in power-of-2 steps.
-   */
-  double getEv() const;
+    /**
+     * @brief Get the Exposure Value. EV is a number that represents a combination of a camera's shutter speed and
+     * f-number, such that all combinations that yield the same exposure have the same EV.
+     * It progresses in a linear sequence as camera exposure is changed in power-of-2 steps.
+     */
+    double getEv() const;
 
-  /**
-   * @brief Get an iterator on the map of metadata from a given name.
-   */
-  std::map<std::string, std::string>::const_iterator findMetadataIterator(const std::string& name) const;
+    /**
+     * @brief Get an iterator on the map of metadata from a given name.
+     */
+    std::map<std::string, std::string>::const_iterator findMetadataIterator(const std::string& name) const;
 
-  /**
-   * @brief Return true if the given metadata name exists
-   * @param[in] names List of possible names for the metadata
-   * @return true if the corresponding metadata value exists
-   */
-  bool hasMetadata(const std::vector<std::string>& names) const;
+    /**
+     * @brief Return true if the given metadata name exists
+     * @param[in] names List of possible names for the metadata
+     * @return true if the corresponding metadata value exists
+     */
+    bool hasMetadata(const std::vector<std::string>& names) const;
 
-  /**
-   * @brief Return true if the metadata for longitude and latitude exist.
-   * It checks that all the tags from GPSExifTags exists
-   * @return true if GPS data is available
-   */
-  bool hasGpsMetadata() const;
+    /**
+     * @brief Return true if the metadata for longitude and latitude exist.
+     * It checks that all the tags from GPSExifTags exists
+     * @return true if GPS data is available
+     */
+    bool hasGpsMetadata() const;
 
-  /**
-   * @brief Return true if the given metadata name exists and is a digit
-   * @param[in] names List of possible names for the metadata
-   * @param[in] isPositive true if the metadata must be positive
-   * @return true if the corresponding metadata value exists
-   */
-  bool hasDigitMetadata(const std::vector<std::string>& names, bool isPositive = true) const;
+    /**
+     * @brief Return true if the given metadata name exists and is a digit
+     * @param[in] names List of possible names for the metadata
+     * @param[in] isPositive true if the metadata must be positive
+     * @return true if the corresponding metadata value exists
+     */
+    bool hasDigitMetadata(const std::vector<std::string>& names, bool isPositive = true) const;
 
-  /**
-   * @brief Get the metadata value as a string
-   * @param[in] names List of possible names for the metadata
-   * @return the metadata value as a string or an empty string if it does not exist
-   */
-  const std::string& getMetadata(const std::vector<std::string>& names) const;
+    /**
+     * @brief Get the metadata value as a string
+     * @param[in] names List of possible names for the metadata
+     * @return the metadata value as a string or an empty string if it does not exist
+     */
+    const std::string& getMetadata(const std::vector<std::string>& names) const;
 
-  /**
-   * @brief Read a floating point value from a string. It support an integer, a floating point value or a fraction.
-   * @param[in] str string with the number to evaluate
-   * @return the extracted floating point value or -1.0 if it fails to convert the string
-   */
-  double readRealNumber(const std::string& str) const;
+    /**
+     * @brief Read a floating point value from a string. It support an integer, a floating point value or a fraction.
+     * @param[in] str string with the number to evaluate
+     * @return the extracted floating point value or -1.0 if it fails to convert the string
+     */
+    double readRealNumber(const std::string& str) const;
 
-  /**
-   * @brief Get the metadata value as a double
-   * @param[in] names List of possible names for the metadata
-   * @return the metadata value as a double or -1.0 if it does not exist
-   */
-  double getDoubleMetadata(const std::vector<std::string>& names) const;
+    /**
+     * @brief Get the metadata value as a double
+     * @param[in] names List of possible names for the metadata
+     * @return the metadata value as a double or -1.0 if it does not exist
+     */
+    double getDoubleMetadata(const std::vector<std::string>& names) const;
 
-  /**
-   * @brief Get the metadata value as a double
-   * @param[in] names List of possible names for the metadata
-   * @param[in] val Data to be set with the metadata value
-   * @return true if the metadata is found or false if it does not exist
-   */
-  bool getDoubleMetadata(const std::vector<std::string>& names, double& val) const;
+    /**
+     * @brief Get the metadata value as a double
+     * @param[in] names List of possible names for the metadata
+     * @param[in] val Data to be set with the metadata value
+     * @return true if the metadata is found or false if it does not exist
+     */
+    bool getDoubleMetadata(const std::vector<std::string>& names, double& val) const;
 
-  /**
-   * @brief Get the metadata value as an integer
-   * @param[in] names List of possible names for the metadata
-   * @return the metadata value as an integer or -1 if it does not exist
-   */
-  int getIntMetadata(const std::vector<std::string>& names) const;
+    /**
+     * @brief Get the metadata value as an integer
+     * @param[in] names List of possible names for the metadata
+     * @return the metadata value as an integer or -1 if it does not exist
+     */
+    int getIntMetadata(const std::vector<std::string>& names) const;
 
-  /**
-   * @brief Get the corresponding "Make" metadata value
-   * @return the metadata value string or "" if no corresponding value
-   */
-  const std::string& getMetadataMake() const
-  {
-    return getMetadata({"Make", "cameraMake", "camera make"});
-  }
+    /**
+     * @brief Get the corresponding "Make" metadata value
+     * @return the metadata value string or "" if no corresponding value
+     */
+    const std::string& getMetadataMake() const
+    {
+        return getMetadata({"Make", "cameraMake", "camera make"});
+    }
 
-  /**
-   * @brief Get the corresponding "Model" metadata value
-   * @return the metadata value string or "" if no corresponding value
-   */
-  const std::string& getMetadataModel() const
-  {
-      return getMetadata({"Model", "cameraModel", "cameraModelName", "camera model", "camera model name"});
-  }
+    /**
+     * @brief Get the corresponding "Model" metadata value
+     * @return the metadata value string or "" if no corresponding value
+     */
+    const std::string& getMetadataModel() const
+    {
+        return getMetadata({"Model", "cameraModel", "cameraModelName", "camera model", "camera model name"});
+    }
 
-  /**
-   * @brief Get the corresponding "BodySerialNumber" metadata value
-   * @return the metadata value string or "" if no corresponding value
-   */
-  const std::string& getMetadataBodySerialNumber() const
-  {
-    return getMetadata({"Exif:BodySerialNumber", "cameraSerialNumber", "SerialNumber", "Serial Number"});
-  }
+    /**
+     * @brief Get the corresponding "BodySerialNumber" metadata value
+     * @return the metadata value string or "" if no corresponding value
+     */
+    const std::string& getMetadataBodySerialNumber() const
+    {
+        return getMetadata({"Exif:BodySerialNumber", "cameraSerialNumber", "SerialNumber", "Serial Number"});
+    }
 
-  /**
-   * @brief Get the corresponding "LensModel" metadata value
-   * @return the metadata value string or "" if no corresponding value
-   */
-  const std::string& getMetadataLensModel() const
-  {
-      return getMetadata({ "Exif:LensModel", "lensModel", "lens model" });
-  }
+    /**
+     * @brief Get the corresponding "LensModel" metadata value
+     * @return the metadata value string or "" if no corresponding value
+     */
+    const std::string& getMetadataLensModel() const
+    {
+        return getMetadata({ "Exif:LensModel", "lensModel", "lens model" });
+    }
 
-  /**
-   * @brief Get the corresponding "LensID" metadata value
-   * @return the metadata value -1 if no corresponding value
-   */
-  int getMetadataLensID() const
-  {
-      return getIntMetadata({ "Exif:LensID", "lensID", "lensType"});
-  }
+    /**
+     * @brief Get the corresponding "LensID" metadata value
+     * @return the metadata value -1 if no corresponding value
+     */
+    int getMetadataLensID() const
+    {
+        return getIntMetadata({ "Exif:LensID", "lensID", "lensType"});
+    }
 
-  /**
-   * @brief Get the corresponding "LensSerialNumber" metadata value
-   * @return the metadata value string or "" if no corresponding value
-   */
-  const std::string& getMetadataLensSerialNumber() const
-  {
-      return getMetadata({ "Exif:LensSerialNumber", "lensSerialNumber", "lens serial number" });
-  }
+    /**
+     * @brief Get the corresponding "LensSerialNumber" metadata value
+     * @return the metadata value string or "" if no corresponding value
+     */
+    const std::string& getMetadataLensSerialNumber() const
+    {
+        return getMetadata({ "Exif:LensSerialNumber", "lensSerialNumber", "lens serial number" });
+    }
 
-  /**
-   * @brief Get the corresponding "FocalLength" metadata value
-   * @return the metadata value float or -1 if no corresponding value
-   */
-  double getMetadataFocalLength() const
-  {
-    return getDoubleMetadata({"Exif:FocalLength", "focalLength", "focal length"});
-  }
+    /**
+     * @brief Get the corresponding "FocalLength" metadata value
+     * @return the metadata value float or -1 if no corresponding value
+     */
+    double getMetadataFocalLength() const
+    {
+        return getDoubleMetadata({"Exif:FocalLength", "focalLength", "focal length"});
+    }
 
-  /**
-   * @brief Get the corresponding "ExposureTime" (shutter) metadata value
-   * @return the metadata value float or -1 if no corresponding value
-   */
-  double getMetadataShutter() const
-  {
-      return getDoubleMetadata({"ExposureTime", "Shutter Speed Value"});
-  }
+    /**
+     * @brief Get the corresponding "ExposureTime" (shutter) metadata value
+     * @return the metadata value float or -1 if no corresponding value
+     */
+    double getMetadataShutter() const
+    {
+        return getDoubleMetadata({"ExposureTime", "Shutter Speed Value"});
+    }
 
-  /**
-   * @brief Get the corresponding "FNumber" (relative aperture) metadata value
-   * @return the metadata value float or -1 if no corresponding value
-   */
-  double getMetadataFNumber() const
-  {
-      if(hasDigitMetadata({"FNumber"}))
-      {
-          return getDoubleMetadata({"FNumber"});
-      }
-      if (hasDigitMetadata({"ApertureValue", "Aperture Value"}))
-      {
-          const double aperture = getDoubleMetadata({"ApertureValue", "Aperture Value"});
-          // fnumber = 2^(aperture/2)
-          return std::pow(2.0, aperture / 2.0);
-      }
-      return -1;
-  }
+    /**
+     * @brief Get the corresponding "FNumber" (relative aperture) metadata value
+     * @return the metadata value float or -1 if no corresponding value
+     */
+    double getMetadataFNumber() const
+    {
+        if (hasDigitMetadata({"FNumber"}))
+        {
+            return getDoubleMetadata({"FNumber"});
+        }
+        if (hasDigitMetadata({"ApertureValue", "Aperture Value"}))
+        {
+            const double aperture = getDoubleMetadata({"ApertureValue", "Aperture Value"});
+            // fnumber = 2^(aperture/2)
+            return std::pow(2.0, aperture / 2.0);
+        }
+        return -1;
+    }
 
-  /**
+    /**
      * @brief Get the corresponding "PhotographicSensitivity" (ISO) metadata value
      * @return the metadata value int or -1 if no corresponding value
      */
-  double getMetadataISO() const
-  {
-    return getDoubleMetadata({"Exif:PhotographicSensitivity", "PhotographicSensitivity", "Photographic Sensitivity", "ISO"});
-  }
-
-  /**
-   * @brief Get the corresponding "Orientation" metadata value
-   * @return the enum EEXIFOrientation
-   */
-  EEXIFOrientation getMetadataOrientation() const
-  {
-    const int orientation = getIntMetadata({"Exif:Orientation", "Orientation"});
-    if(orientation < 0)
-      return EEXIFOrientation::UNKNOWN;
-    return static_cast<EEXIFOrientation>(orientation);
-  }
-
-  /**
-   * @brief Get the gps position in the absolute cartesian reference system.
-   * @return The position x, y, z as a three dimensional vector.
-   */
-  Vec3 getGpsPositionFromMetadata() const;
-
-  /**
-   * @brief Get the gps position in the WGS84 reference system.
-   * @param[out] lat the latitude
-   * @param[out] lon the longitude
-   * @param[out] alt the altitude
-   */
-  void getGpsPositionWGS84FromMetadata(double& lat, double& lon, double& alt) const;
-
-  /**
-   * @brief Get the gps position in the WGS84 reference system as a vector.
-   * @return A three dimensional vector with latitude, logitude and altitude.
-   */
-  Vec3 getGpsPositionWGS84FromMetadata() const;
-
-  const std::string& getColorProfileFileName() const
-  {
-      return getMetadata({ "AliceVision:DCP:colorProfileFileName" });
-  }
-
-  const std::string& getRawColorInterpretation() const
-  {
-      return getMetadata({ "AliceVision:rawColorInterpretation" });
-  }
-
-  const std::vector<int> getCameraMultiplicators() const
-  {
-      const std::string cam_mul = getMetadata({ "raw:cam_mul" });
-      std::vector<int> v_mult;
-
-      size_t last = 0;
-      size_t next = 0;
-      while ((next = cam_mul.find(" ", last)) != std::string::npos)
-      {
-          v_mult.push_back(std::stoi(cam_mul.substr(last, next - last)));
-          last = next + 1;
-      }
-      v_mult.push_back(std::stoi(cam_mul.substr(last)));
-
-      return v_mult;
-  }
-
-  const bool getVignettingParams(std::vector<float>& v_vignParam) const
-  {
-      v_vignParam.clear();
-      bool valid = true;
-      double value;
-
-      valid = valid && getDoubleMetadata({"AliceVision:VignParamFocX"}, value);
-      v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:VignParamFocY"}, value);
-      v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:VignParamCenterX"}, value);
-      v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:VignParamCenterY"}, value);
-      v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:VignParam1"}, value);
-      v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:VignParam2"}, value);
-      v_vignParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:VignParam3"}, value);
-      v_vignParam.push_back(static_cast<float>(value));
-      return valid;
-  }
-
-  const bool getChromaticAberrationParams(std::vector<float>& v_caGParam, std::vector<float>& v_caBGParam, std::vector<float>& v_caRGParam) const
-  {
-      v_caGParam.clear();
-      v_caBGParam.clear();
-      v_caRGParam.clear();
-      bool valid = true;
-      double value;
-
-      valid = valid && getDoubleMetadata({"AliceVision:CAGreenFocX"}, value);
-      v_caGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CAGreenFocY"}, value);
-      v_caGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CAGreenCenterX"}, value);
-      v_caGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CAGreenCenterY"}, value);
-      v_caGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam1"}, value);
-      v_caGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam2"}, value);
-      v_caGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam3"}, value);
-      v_caGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenFocX"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenFocY"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenCenterX"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenCenterY"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam1"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam2"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam3"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenScaleFactor"}, value);
-      v_caBGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenFocX"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenFocY"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenCenterX"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenCenterY"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam1"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam2"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam3"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-      valid = valid && getDoubleMetadata({"AliceVision:CARedGreenScaleFactor"}, value);
-      v_caRGParam.push_back(static_cast<float>(value));
-
-      return valid;
-  }
-
-  const bool hasMetadataDateTimeOriginal() const
-  {
-      return hasMetadata(
-          {"Exif:DateTimeOriginal", "DateTimeOriginal", "DateTime", "Date Time", "Create Date", "ctime"});
-  }
-
-  const std::string& getMetadataDateTimeOriginal() const
-  {
-    return getMetadata({"Exif:DateTimeOriginal", "DateTimeOriginal", "DateTime", "Date Time", "Create Date", "ctime"});
-  }
-
-  int64_t getMetadataDateTimestamp() const {
-
-    std::smatch sm;
-    std::string dtstring = getMetadataDateTimeOriginal();
-    std::regex regex("([\\d]+):([\\d]+):([\\d]+) ([\\d]+):([\\d]+):([\\d]+)");
-    
-    if (!std::regex_match(dtstring, sm, regex)) {
-      return -1;
+    double getMetadataISO() const
+    {
+        return getDoubleMetadata({"Exif:PhotographicSensitivity", "PhotographicSensitivity", "Photographic Sensitivity", "ISO"});
     }
-    
-    int64_t year = std::stoi(sm[1]);
-    int64_t month = std::stoi(sm[2]);
-    int64_t day = std::stoi(sm[3]);
-    int64_t hour = std::stoi(sm[4]);
-    int64_t minutes = std::stoi(sm[5]);
-    int64_t seconds = std::stoi(sm[6]);
-    int64_t timecode = ((((((((year * 12) + month) * 31) + day) * 24) + hour) * 60 + minutes) * 60) + seconds;
-
-    return timecode;
-  }
-
-  double getSensorWidth() const { return getDoubleMetadata({"AliceVision:SensorWidth"}); }
-
-  double getSensorHeight() const { return getDoubleMetadata({"AliceVision:SensorHeight"}); }
-
-  /**
-   * @brief Get the view metadata structure
-   * @return the view metadata
-   */
-  const std::map<std::string, std::string>& getMetadata() const
-  {
-    return _metadata;
-  }
-
-  /**
-   * @brief Set the given view image path
-   * @param[in] imagePath The given view image path
-   */
-  void setImagePath(const std::string& imagePath)
-  {
-    _imagePath = imagePath;
-  }
-
-  /**
-   * @brief  Set the given view image width
-   * @param[in] width The given view image width
-   */
-  void setWidth(std::size_t width)
-  {
-    _width = width;
-  }
-
-  /**
-   * @brief  Set the given view image height
-   * @param[in] height The given view image height
-   */
-  void setHeight(std::size_t height)
-  {
-    _height = height;
-  }
-
-
-  /**
-   * @brief Set view metadata
-   * @param[in] metadata The metadata map
-   */
-  void setMetadata(const std::map<std::string, std::string>& metadata)
-  {
-    _metadata = metadata;
-  }
-
-  /**
-   * @brief Add view metadata
-   * @param[in] key The metadata key
-   * @param[in] value The metadata value
-   */
-  void addMetadata(const std::string& key, const std::string& value)
-  {
-      _metadata[key] = value;
-  }
-
-  /**
-   * @brief Add DCP info in metadata
-   * @param[in] dcpProf The DCP color profile
-   */
-  void addDCPMetadata(image::DCPProfile& dcpProf)
-  {
-      addMetadata("AliceVision:DCP:colorProfileFileName", dcpProf.info.filename);
-
-      addMetadata("AliceVision:DCP:Temp1", std::to_string(dcpProf.info.temperature_1));
-      addMetadata("AliceVision:DCP:Temp2", std::to_string(dcpProf.info.temperature_2));
-
-      const int colorMatrixNumber = (dcpProf.info.has_color_matrix_1 && dcpProf.info.has_color_matrix_2) ? 2 :
-          (dcpProf.info.has_color_matrix_1 ? 1 : 0);
-      addMetadata("AliceVision:DCP:ColorMatrixNumber", std::to_string(colorMatrixNumber));
-
-      const int forwardMatrixNumber = (dcpProf.info.has_forward_matrix_1 && dcpProf.info.has_forward_matrix_2) ? 2 :
-          (dcpProf.info.has_forward_matrix_1 ? 1 : 0);
-      addMetadata("AliceVision:DCP:ForwardMatrixNumber", std::to_string(forwardMatrixNumber));
-
-      const int calibMatrixNumber = (dcpProf.info.has_camera_calibration_1 && dcpProf.info.has_camera_calibration_2) ? 2 :
-          (dcpProf.info.has_camera_calibration_1 ? 1 : 0);
-      addMetadata("AliceVision:DCP:CameraCalibrationMatrixNumber", std::to_string(calibMatrixNumber));
-
-      std::vector<std::string> v_strColorMatrix;
-      dcpProf.getMatricesAsStrings("color", v_strColorMatrix);
-      for (int k = 0; k < v_strColorMatrix.size(); k++)
-      {
-          addMetadata("AliceVision:DCP:ColorMat" + std::to_string(k + 1), v_strColorMatrix[k]);
-      }
-
-      std::vector<std::string> v_strForwardMatrix;
-      dcpProf.getMatricesAsStrings("forward", v_strForwardMatrix);
-      for (int k = 0; k < v_strForwardMatrix.size(); k++)
-      {
-          addMetadata("AliceVision:DCP:ForwardMat" + std::to_string(k + 1), v_strForwardMatrix[k]);
-      }
-
-      std::vector<std::string> v_strCalibMatrix;
-      dcpProf.getMatricesAsStrings("calib", v_strCalibMatrix);
-      for (int k = 0; k < v_strCalibMatrix.size(); k++)
-      {
-          addMetadata("AliceVision:DCP:CameraCalibrationMat" + std::to_string(k + 1), v_strCalibMatrix[k]);
-      }
-  }
-
-
-  /**
-   * @brief Add vignetting model parameters in metadata
-   * @param[in] The lens data extracted from a LCP file
-   */
-  void addVignettingMetadata(LensParam& lensParam)
-  {
-      addMetadata("AliceVision:VignParamFocX", std::to_string(lensParam.vignParams.FocalLengthX));
-      addMetadata("AliceVision:VignParamFocY", std::to_string(lensParam.vignParams.FocalLengthY));
-      addMetadata("AliceVision:VignParamCenterX", std::to_string(lensParam.vignParams.ImageXCenter));
-      addMetadata("AliceVision:VignParamCenterY", std::to_string(lensParam.vignParams.ImageYCenter));
-      addMetadata("AliceVision:VignParam1", std::to_string(lensParam.vignParams.VignetteModelParam1));
-      addMetadata("AliceVision:VignParam2", std::to_string(lensParam.vignParams.VignetteModelParam2));
-      addMetadata("AliceVision:VignParam3", std::to_string(lensParam.vignParams.VignetteModelParam3));
-  }
 
     /**
-   * @brief Add chromatic model parameters in metadata
-   * @param[in] The lens data extracted from a LCP file
-   */
-  void addChromaticMetadata(LensParam& lensParam)
-  {
-      addMetadata("AliceVision:CAGreenFocX", std::to_string(lensParam.ChromaticGreenParams.FocalLengthX));
-      addMetadata("AliceVision:CAGreenFocY", std::to_string(lensParam.ChromaticGreenParams.FocalLengthY));
-      addMetadata("AliceVision:CAGreenCenterX", std::to_string(lensParam.ChromaticGreenParams.ImageXCenter));
-      addMetadata("AliceVision:CAGreenCenterY", std::to_string(lensParam.ChromaticGreenParams.ImageYCenter));
-      addMetadata("AliceVision:CAGreenParam1", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam1));
-      addMetadata("AliceVision:CAGreenParam2", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam2));
-      addMetadata("AliceVision:CAGreenParam3", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam3));
-      addMetadata("AliceVision:CABlueGreenFocX", std::to_string(lensParam.ChromaticBlueGreenParams.FocalLengthX));
-      addMetadata("AliceVision:CABlueGreenFocY", std::to_string(lensParam.ChromaticBlueGreenParams.FocalLengthY));
-      addMetadata("AliceVision:CABlueGreenCenterX", std::to_string(lensParam.ChromaticBlueGreenParams.ImageXCenter));
-      addMetadata("AliceVision:CABlueGreenCenterY", std::to_string(lensParam.ChromaticBlueGreenParams.ImageYCenter));
-      addMetadata("AliceVision:CABlueGreenParam1", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam1));
-      addMetadata("AliceVision:CABlueGreenParam2", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam2));
-      addMetadata("AliceVision:CABlueGreenParam3", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam3));
-      addMetadata("AliceVision:CABlueGreenScaleFactor", std::to_string(lensParam.ChromaticBlueGreenParams.ScaleFactor));
-      addMetadata("AliceVision:CARedGreenFocX", std::to_string(lensParam.ChromaticRedGreenParams.FocalLengthX));
-      addMetadata("AliceVision:CARedGreenFocY", std::to_string(lensParam.ChromaticRedGreenParams.FocalLengthY));
-      addMetadata("AliceVision:CARedGreenCenterX", std::to_string(lensParam.ChromaticRedGreenParams.ImageXCenter));
-      addMetadata("AliceVision:CARedGreenCenterY", std::to_string(lensParam.ChromaticRedGreenParams.ImageYCenter));
-      addMetadata("AliceVision:CARedGreenParam1", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam1));
-      addMetadata("AliceVision:CARedGreenParam2", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam2));
-      addMetadata("AliceVision:CARedGreenParam3", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam3));
-      addMetadata("AliceVision:CARedGreenScaleFactor", std::to_string(lensParam.ChromaticRedGreenParams.ScaleFactor));
-  }
+     * @brief Get the corresponding "Orientation" metadata value
+     * @return the enum EEXIFOrientation
+     */
+    EEXIFOrientation getMetadataOrientation() const
+    {
+        const int orientation = getIntMetadata({"Exif:Orientation", "Orientation"});
+        if (orientation < 0)
+            return EEXIFOrientation::UNKNOWN;
+        return static_cast<EEXIFOrientation>(orientation);
+    }
 
-  /**
-   * @brief Get sensor size by combining info in metadata and in sensor database
-   * @param[in] sensorDatabase The sensor database
-   * @param[out] sensorWidth The sensor width
-   * @param[out] sensorHeight The sensor height
-   * @param[out] focalLengthmm The focal length
-   * @param[out] intrinsicInitMode The intrinsic init mode
-   * @param[in] verbose Enable verbosity
-   * @return An Error or Warning code: 1 - Unknown sensor, 2 - No metadata, 3 - Unsure sensor, 4 - Computation from 35mm Focal
-   */
-  int getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatabase, double& sensorWidth, double& sensorHeight, double& focalLengthmm, camera::EInitMode& intrinsicInitMode,
-                    bool verbose = false);
+    /**
+     * @brief Get the gps position in the absolute cartesian reference system.
+     * @return The position x, y, z as a three dimensional vector.
+     */
+    Vec3 getGpsPositionFromMetadata() const;
+
+    /**
+     * @brief Get the gps position in the WGS84 reference system.
+     * @param[out] lat the latitude
+     * @param[out] lon the longitude
+     * @param[out] alt the altitude
+     */
+    void getGpsPositionWGS84FromMetadata(double& lat, double& lon, double& alt) const;
+
+    /**
+     * @brief Get the gps position in the WGS84 reference system as a vector.
+     * @return A three dimensional vector with latitude, logitude and altitude.
+     */
+    Vec3 getGpsPositionWGS84FromMetadata() const;
+
+    const std::string& getColorProfileFileName() const
+    {
+        return getMetadata({ "AliceVision:DCP:colorProfileFileName" });
+    }
+
+    const std::string& getRawColorInterpretation() const
+    {
+        return getMetadata({ "AliceVision:rawColorInterpretation" });
+    }
+
+    const std::vector<int> getCameraMultiplicators() const
+    {
+        const std::string cam_mul = getMetadata({ "raw:cam_mul" });
+        std::vector<int> v_mult;
+
+        size_t last = 0;
+        size_t next = 0;
+        while ((next = cam_mul.find(" ", last)) != std::string::npos)
+        {
+            v_mult.push_back(std::stoi(cam_mul.substr(last, next - last)));
+            last = next + 1;
+        }
+        v_mult.push_back(std::stoi(cam_mul.substr(last)));
+
+        return v_mult;
+    }
+
+    const bool getVignettingParams(std::vector<float>& v_vignParam) const
+    {
+        v_vignParam.clear();
+        bool valid = true;
+        double value;
+
+        valid = valid && getDoubleMetadata({"AliceVision:VignParamFocX"}, value);
+        v_vignParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:VignParamFocY"}, value);
+        v_vignParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:VignParamCenterX"}, value);
+        v_vignParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:VignParamCenterY"}, value);
+        v_vignParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:VignParam1"}, value);
+        v_vignParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:VignParam2"}, value);
+        v_vignParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:VignParam3"}, value);
+        v_vignParam.push_back(static_cast<float>(value));
+        return valid;
+    }
+
+    const bool getChromaticAberrationParams(std::vector<float>& v_caGParam, std::vector<float>& v_caBGParam,
+                                            std::vector<float>& v_caRGParam) const
+    {
+        v_caGParam.clear();
+        v_caBGParam.clear();
+        v_caRGParam.clear();
+        bool valid = true;
+        double value;
+
+        valid = valid && getDoubleMetadata({"AliceVision:CAGreenFocX"}, value);
+        v_caGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CAGreenFocY"}, value);
+        v_caGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CAGreenCenterX"}, value);
+        v_caGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CAGreenCenterY"}, value);
+        v_caGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam1"}, value);
+        v_caGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam2"}, value);
+        v_caGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CAGreenParam3"}, value);
+        v_caGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenFocX"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenFocY"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenCenterX"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenCenterY"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam1"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam2"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenParam3"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CABlueGreenScaleFactor"}, value);
+        v_caBGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenFocX"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenFocY"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenCenterX"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenCenterY"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam1"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam2"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenParam3"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+        valid = valid && getDoubleMetadata({"AliceVision:CARedGreenScaleFactor"}, value);
+        v_caRGParam.push_back(static_cast<float>(value));
+
+        return valid;
+    }
+
+    const bool hasMetadataDateTimeOriginal() const
+    {
+        return hasMetadata(
+            {"Exif:DateTimeOriginal", "DateTimeOriginal", "DateTime", "Date Time", "Create Date", "ctime"});
+    }
+
+    const std::string& getMetadataDateTimeOriginal() const
+    {
+        return getMetadata({"Exif:DateTimeOriginal", "DateTimeOriginal", "DateTime", "Date Time", "Create Date", "ctime"});
+    }
+
+    int64_t getMetadataDateTimestamp() const
+    {
+        std::smatch sm;
+        std::string dtstring = getMetadataDateTimeOriginal();
+        std::regex regex("([\\d]+):([\\d]+):([\\d]+) ([\\d]+):([\\d]+):([\\d]+)");
+        
+        if (!std::regex_match(dtstring, sm, regex)) {
+            return -1;
+        }
+        
+        int64_t year = std::stoi(sm[1]);
+        int64_t month = std::stoi(sm[2]);
+        int64_t day = std::stoi(sm[3]);
+        int64_t hour = std::stoi(sm[4]);
+        int64_t minutes = std::stoi(sm[5]);
+        int64_t seconds = std::stoi(sm[6]);
+        int64_t timecode = ((((((((year * 12) + month) * 31) + day) * 24) + hour) * 60 + minutes) * 60) + seconds;
+
+        return timecode;
+    }
+
+    double getSensorWidth() const { return getDoubleMetadata({"AliceVision:SensorWidth"}); }
+
+    double getSensorHeight() const { return getDoubleMetadata({"AliceVision:SensorHeight"}); }
+
+    /**
+     * @brief Get the view metadata structure
+     * @return the view metadata
+     */
+    const std::map<std::string, std::string>& getMetadata() const
+    {
+        return _metadata;
+    }
+
+    /**
+     * @brief Set the given view image path
+     * @param[in] imagePath The given view image path
+     */
+    void setImagePath(const std::string& imagePath)
+    {
+        _imagePath = imagePath;
+    }
+
+    /**
+     * @brief  Set the given view image width
+     * @param[in] width The given view image width
+     */
+    void setWidth(std::size_t width)
+    {
+        _width = width;
+    }
+
+    /**
+     * @brief  Set the given view image height
+     * @param[in] height The given view image height
+     */
+    void setHeight(std::size_t height)
+    {
+        _height = height;
+    }
+
+    /**
+     * @brief Set view metadata
+     * @param[in] metadata The metadata map
+     */
+    void setMetadata(const std::map<std::string, std::string>& metadata)
+    {
+        _metadata = metadata;
+    }
+
+    /**
+     * @brief Add view metadata
+     * @param[in] key The metadata key
+     * @param[in] value The metadata value
+     */
+    void addMetadata(const std::string& key, const std::string& value)
+    {
+        _metadata[key] = value;
+    }
+
+    /**
+     * @brief Add DCP info in metadata
+     * @param[in] dcpProf The DCP color profile
+     */
+    void addDCPMetadata(image::DCPProfile& dcpProf)
+    {
+        addMetadata("AliceVision:DCP:colorProfileFileName", dcpProf.info.filename);
+
+        addMetadata("AliceVision:DCP:Temp1", std::to_string(dcpProf.info.temperature_1));
+        addMetadata("AliceVision:DCP:Temp2", std::to_string(dcpProf.info.temperature_2));
+
+        const int colorMatrixNumber = (dcpProf.info.has_color_matrix_1 && dcpProf.info.has_color_matrix_2) ? 2 :
+            (dcpProf.info.has_color_matrix_1 ? 1 : 0);
+        addMetadata("AliceVision:DCP:ColorMatrixNumber", std::to_string(colorMatrixNumber));
+
+        const int forwardMatrixNumber = (dcpProf.info.has_forward_matrix_1 && dcpProf.info.has_forward_matrix_2) ? 2 :
+            (dcpProf.info.has_forward_matrix_1 ? 1 : 0);
+        addMetadata("AliceVision:DCP:ForwardMatrixNumber", std::to_string(forwardMatrixNumber));
+
+        const int calibMatrixNumber = (dcpProf.info.has_camera_calibration_1 && dcpProf.info.has_camera_calibration_2) ? 2 :
+            (dcpProf.info.has_camera_calibration_1 ? 1 : 0);
+        addMetadata("AliceVision:DCP:CameraCalibrationMatrixNumber", std::to_string(calibMatrixNumber));
+
+        std::vector<std::string> v_strColorMatrix;
+        dcpProf.getMatricesAsStrings("color", v_strColorMatrix);
+        for (int k = 0; k < v_strColorMatrix.size(); k++)
+        {
+            addMetadata("AliceVision:DCP:ColorMat" + std::to_string(k + 1), v_strColorMatrix[k]);
+        }
+
+        std::vector<std::string> v_strForwardMatrix;
+        dcpProf.getMatricesAsStrings("forward", v_strForwardMatrix);
+        for (int k = 0; k < v_strForwardMatrix.size(); k++)
+        {
+            addMetadata("AliceVision:DCP:ForwardMat" + std::to_string(k + 1), v_strForwardMatrix[k]);
+        }
+
+        std::vector<std::string> v_strCalibMatrix;
+        dcpProf.getMatricesAsStrings("calib", v_strCalibMatrix);
+        for (int k = 0; k < v_strCalibMatrix.size(); k++)
+        {
+            addMetadata("AliceVision:DCP:CameraCalibrationMat" + std::to_string(k + 1), v_strCalibMatrix[k]);
+        }
+    }
+
+
+    /**
+     * @brief Add vignetting model parameters in metadata
+     * @param[in] The lens data extracted from a LCP file
+     */
+    void addVignettingMetadata(LensParam& lensParam)
+    {
+        addMetadata("AliceVision:VignParamFocX", std::to_string(lensParam.vignParams.FocalLengthX));
+        addMetadata("AliceVision:VignParamFocY", std::to_string(lensParam.vignParams.FocalLengthY));
+        addMetadata("AliceVision:VignParamCenterX", std::to_string(lensParam.vignParams.ImageXCenter));
+        addMetadata("AliceVision:VignParamCenterY", std::to_string(lensParam.vignParams.ImageYCenter));
+        addMetadata("AliceVision:VignParam1", std::to_string(lensParam.vignParams.VignetteModelParam1));
+        addMetadata("AliceVision:VignParam2", std::to_string(lensParam.vignParams.VignetteModelParam2));
+        addMetadata("AliceVision:VignParam3", std::to_string(lensParam.vignParams.VignetteModelParam3));
+    }
+
+    /**
+     * @brief Add chromatic model parameters in metadata
+     * @param[in] The lens data extracted from a LCP file
+     */
+    void addChromaticMetadata(LensParam& lensParam)
+    {
+        addMetadata("AliceVision:CAGreenFocX", std::to_string(lensParam.ChromaticGreenParams.FocalLengthX));
+        addMetadata("AliceVision:CAGreenFocY", std::to_string(lensParam.ChromaticGreenParams.FocalLengthY));
+        addMetadata("AliceVision:CAGreenCenterX", std::to_string(lensParam.ChromaticGreenParams.ImageXCenter));
+        addMetadata("AliceVision:CAGreenCenterY", std::to_string(lensParam.ChromaticGreenParams.ImageYCenter));
+        addMetadata("AliceVision:CAGreenParam1", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam1));
+        addMetadata("AliceVision:CAGreenParam2", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam2));
+        addMetadata("AliceVision:CAGreenParam3", std::to_string(lensParam.ChromaticGreenParams.RadialDistortParam3));
+        addMetadata("AliceVision:CABlueGreenFocX", std::to_string(lensParam.ChromaticBlueGreenParams.FocalLengthX));
+        addMetadata("AliceVision:CABlueGreenFocY", std::to_string(lensParam.ChromaticBlueGreenParams.FocalLengthY));
+        addMetadata("AliceVision:CABlueGreenCenterX", std::to_string(lensParam.ChromaticBlueGreenParams.ImageXCenter));
+        addMetadata("AliceVision:CABlueGreenCenterY", std::to_string(lensParam.ChromaticBlueGreenParams.ImageYCenter));
+        addMetadata("AliceVision:CABlueGreenParam1", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam1));
+        addMetadata("AliceVision:CABlueGreenParam2", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam2));
+        addMetadata("AliceVision:CABlueGreenParam3", std::to_string(lensParam.ChromaticBlueGreenParams.RadialDistortParam3));
+        addMetadata("AliceVision:CABlueGreenScaleFactor", std::to_string(lensParam.ChromaticBlueGreenParams.ScaleFactor));
+        addMetadata("AliceVision:CARedGreenFocX", std::to_string(lensParam.ChromaticRedGreenParams.FocalLengthX));
+        addMetadata("AliceVision:CARedGreenFocY", std::to_string(lensParam.ChromaticRedGreenParams.FocalLengthY));
+        addMetadata("AliceVision:CARedGreenCenterX", std::to_string(lensParam.ChromaticRedGreenParams.ImageXCenter));
+        addMetadata("AliceVision:CARedGreenCenterY", std::to_string(lensParam.ChromaticRedGreenParams.ImageYCenter));
+        addMetadata("AliceVision:CARedGreenParam1", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam1));
+        addMetadata("AliceVision:CARedGreenParam2", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam2));
+        addMetadata("AliceVision:CARedGreenParam3", std::to_string(lensParam.ChromaticRedGreenParams.RadialDistortParam3));
+        addMetadata("AliceVision:CARedGreenScaleFactor", std::to_string(lensParam.ChromaticRedGreenParams.ScaleFactor));
+    }
+
+    /**
+     * @brief Get sensor size by combining info in metadata and in sensor database
+     * @param[in] sensorDatabase The sensor database
+     * @param[out] sensorWidth The sensor width
+     * @param[out] sensorHeight The sensor height
+     * @param[out] focalLengthmm The focal length
+     * @param[out] intrinsicInitMode The intrinsic init mode
+     * @param[in] verbose Enable verbosity
+     * @return An Error or Warning code: 1 - Unknown sensor, 2 - No metadata, 3 - Unsure sensor, 4 - Computation from 35mm Focal
+     */
+    int getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatabase, double& sensorWidth, double& sensorHeight,
+                      double& focalLengthmm, camera::EInitMode& intrinsicInitMode, bool verbose = false);
 
 private:
 
-  /// image path on disk
-  std::string _imagePath;
-  /// image width
-  std::size_t _width;
-  /// image height
-  std::size_t _height;
-  /// map for metadata
-  std::map<std::string, std::string> _metadata;
+    /// image path on disk
+    std::string _imagePath;
+    /// image width
+    std::size_t _width;
+    /// image height
+    std::size_t _height;
+    /// map for metadata
+    std::map<std::string, std::string> _metadata;
 };
 
-} // namespace sfmData
-} // namespace aliceVision
+}  // namespace sfmData
+}  // namespace aliceVision


### PR DESCRIPTION
## Description

For some live action cameras such as Sony, ARRI or RED, the focal length information might not be stored in the usual `Exif:FocalLength` metadata key. However, if it is available, we still want to retrieve it to be able to get an accurate sensor width.

This PR aims to cover corner cases and retrieve the focal length or, at least, the sensor width, if any of these information are available in the metadata.

The model of the camera as well as the lens serial number may also be stored in metadata keys that were not checked up until this PR.

## Features list

- [x] Add new metadata key to check for the camera model;
- [x] Add new metadata key to check for the lens serial number;
- [x] Add new metadata keys to check for the focal length and effective sensor size. 

## Implementation remarks

In some cases, no focal length information is available but the effective sensor size can be found. When this happens, the effective sensor size information is used instead of using the default 36x24mm size. 
