### PR TITLE
camera Lock is correctly casted to int in json

### DIFF
--- a/src/aliceVision/sfmDataIO/jsonIO.hpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.hpp
@@ -125,7 +125,7 @@ inline void loadCameraPose(const std::string& name, sfmData::CameraPose& cameraP
     loadPose3(name + ".transform", pose, cameraPoseTree);
     cameraPose.setTransform(pose);
 
-    if (cameraPoseTree.get<bool>("locked", false))
+    if (cameraPoseTree.get<int>("locked", 0))
         cameraPose.lock();
     else
         cameraPose.unlock();


### PR DESCRIPTION
Camera lock status was not read correctly by json loader