### PR TITLE
Remove lemon from public links

### DIFF
--- a/src/aliceVision/graph/CMakeLists.txt
+++ b/src/aliceVision/graph/CMakeLists.txt
@@ -11,9 +11,8 @@ alicevision_add_interface(aliceVision_graph
   SOURCES ${graph_files_headers}
   LINKS
     aliceVision_system
-    ${LEMON_LIBRARY}
 )
 
 # Unit tests
-alicevision_add_test(connectedComponent_test.cpp NAME "graph_connectedComponent" LINKS aliceVision_graph)
-alicevision_add_test(triplet_test.cpp            NAME "graph_triplet"            LINKS aliceVision_graph)
+alicevision_add_test(connectedComponent_test.cpp NAME "graph_connectedComponent" LINKS aliceVision_graph ${LEMON_LIBRARY})
+alicevision_add_test(triplet_test.cpp            NAME "graph_triplet"            LINKS aliceVision_graph ${LEMON_LIBRARY})

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -77,6 +77,8 @@ alicevision_add_library(aliceVision_sfm
     Boost::filesystem
     Boost::boost
     ${CERES_LIBRARIES}
+  PRIVATE_LINKS
+    ${LEMON_LIBRARY}
 )
 
 # Unit tests
@@ -88,6 +90,7 @@ alicevision_add_test(bundle/bundleAdjustment_test.cpp
         aliceVision_multiview_test_data
         aliceVision_feature
         aliceVision_system
+        ${LEMON_LIBRARY}
 )
 
 alicevision_add_test(utils/alignment_test.cpp
@@ -96,6 +99,7 @@ alicevision_add_test(utils/alignment_test.cpp
         aliceVision_sfm
         aliceVision_multiview
         aliceVision_multiview_test_data
+        ${LEMON_LIBRARY}
 )
 
 add_subdirectory(pipeline)

--- a/src/aliceVision/track/CMakeLists.txt
+++ b/src/aliceVision/track/CMakeLists.txt
@@ -19,8 +19,9 @@ alicevision_add_library(aliceVision_track
     aliceVision_feature
     aliceVision_matching
     aliceVision_stl
-    ${LEMON_LIBRARY}
     Boost::json
+  PRIVATE_LINKS
+    ${LEMON_LIBRARY}
 )
 
 # Unit tests

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -262,6 +262,7 @@ if(ALICEVISION_BUILD_SFM)
               Boost::filesystem
               Boost::boost
               Boost::timer
+              ${LEMON_LIBRARY}
     )
 
     # Keyframe selection


### PR DESCRIPTION
For some plaforms, we don't want lemon to appear in the alicevision-config.cmake