### PR TITLE
Color space conversion update

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -815,11 +815,8 @@ void readImage(const std::string& path, oiio::TypeDesc format, int nchannels, Im
         // Do nothing. Note that calling imageAlgo::colorconvert() will copy the source buffer
         // even if no conversion is needed.
     }
-    else if ((imageReadOptions.workingColorSpace == EImageColorSpace::ACES2065_1) ||
-             (imageReadOptions.workingColorSpace == EImageColorSpace::ACEScg) ||
-             (EImageColorSpace_stringToEnum(fromColorSpaceName) == EImageColorSpace::ACES2065_1) ||
-             (EImageColorSpace_stringToEnum(fromColorSpaceName) == EImageColorSpace::ACEScg) ||
-             (EImageColorSpace_stringToEnum(fromColorSpaceName) == EImageColorSpace::REC709))
+    else if (EImageColorSpace_isSupportedOIIOEnum(imageReadOptions.workingColorSpace) &&
+             EImageColorSpace_isSupportedOIIOEnum(EImageColorSpace_stringToEnum(fromColorSpaceName)))
     {
         const auto colorConfigPath = getAliceVisionOCIOConfig();
         if (colorConfigPath.empty())
@@ -830,13 +827,13 @@ void readImage(const std::string& path, oiio::TypeDesc format, int nchannels, Im
         oiio::ColorConfig colorConfig(colorConfigPath);
         oiio::ImageBufAlgo::colorconvert(colorspaceBuf,
                                          inBuf,
-            fromColorSpaceName,
+                                         fromColorSpaceName,
                                          EImageColorSpace_enumToOIIOString(imageReadOptions.workingColorSpace),
                                          true,
                                          "",
                                          "",
-            &colorConfig);
-        inBuf = colorspaceBuf;
+                                         &colorConfig);
+                                         inBuf = colorspaceBuf;
     }
     else
     {
@@ -1049,9 +1046,7 @@ void writeImage(const std::string& path,
         // Do nothing. Note that calling imageAlgo::colorconvert() will copy the source buffer
         // even if no conversion is needed.
     }
-    else if ((toColorSpace == EImageColorSpace::ACES2065_1) || (toColorSpace == EImageColorSpace::ACEScg) ||
-             (fromColorSpace == EImageColorSpace::ACES2065_1) || (fromColorSpace == EImageColorSpace::ACEScg) ||
-             (fromColorSpace == EImageColorSpace::REC709))
+    else if (EImageColorSpace_isSupportedOIIOEnum(fromColorSpace) && EImageColorSpace_isSupportedOIIOEnum(toColorSpace))
     {
         const auto colorConfigPath = getAliceVisionOCIOConfig();
         if (colorConfigPath.empty())

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -212,8 +212,7 @@ void colorSpaceTransform(image::Image<image::RGBAfColor>& inputImage, image::EIm
         // Do nothing. Note that calling imageAlgo::colorconvert() will copy the source buffer
         // even if no conversion is needed.
     }
-    else if ((toColorSpace == image::EImageColorSpace::ACES2065_1) || (toColorSpace == image::EImageColorSpace::ACEScg) ||
-        (fromColorSpace == image::EImageColorSpace::ACES2065_1) || (fromColorSpace == image::EImageColorSpace::ACEScg))
+    else if (EImageColorSpace_isSupportedOIIOEnum(toColorSpace) && EImageColorSpace_isSupportedOIIOEnum(fromColorSpace))
     {
         const auto colorConfigPath = image::getAliceVisionOCIOConfig();
         if (colorConfigPath.empty())


### PR DESCRIPTION

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR forces to use the AliceVision "ocio.config" file for all conversion between color spaces defined in the config. Previously, the conversion between sRGB and Linear was handled by OpenImageIO, without specifying an "ocio.config" file leading to an undefined behavior depending on whether the $OCIO environment variable was defined or not.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

