### PR TITLE
Sequential SfM: Replayable initial pair

### DIFF
--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1414,11 +1414,12 @@ bool ReconstructionEngine_sequentialSfM::getBestInitialImagePairs(std::vector<Pa
         RelativePoseInfo relativePose_info;
         relativePose_info.initial_residual_tolerance = 4.0;
 
+        std::mt19937 randomNumberGenerator(_randomNumberGenerator);
         const bool relativePoseSuccess = robustRelativePose(camI->K(),
                                                             camJ->K(),
                                                             xI,
                                                             xJ,
-                                                            _randomNumberGenerator,
+                                                            randomNumberGenerator,
                                                             relativePose_info,
                                                             std::make_pair(camI->w(), camI->h()),
                                                             std::make_pair(camJ->w(), camJ->h()),


### PR DESCRIPTION
The random generator was used in a multithread loop (non repetitive random number generation)