### PR TITLE
[sfm] SequentialSfM: Initialize the resection ID in the constructor and set it for the initial pair

### DIFF
--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -346,6 +346,11 @@ void ReconstructionEngine_sequentialSfM::createInitialReconstruction(const std::
             updatedViews.insert(initialPairCandidate.first);
             updatedViews.insert(initialPairCandidate.second);
 
+            // Set the resection ID for the initial pair
+            _sfmData.getView(initialPairCandidate.first).setResectionId(_resectionId);
+            _sfmData.getView(initialPairCandidate.second).setResectionId(_resectionId);
+            ++_resectionId;
+
             return;
         }
     }

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -353,6 +353,9 @@ class ReconstructionEngine_sequentialSfM : public ReconstructionEngine
     // Parameters
     Params _params;
 
+    /// Current resection ID
+    IndexT _resectionId;
+
     // Data providers
 
     feature::FeaturesPerView* _featuresPerView;


### PR DESCRIPTION
## Description

This PR does the following:
1. Move the initialization of the resection ID from the reconstruction process to the constructor: the highest resection ID is searched and set in a class-member variable instead of being local to a function.
2. Set the resection ID of the SfM's initial pair: the resection ID for the initial pair was never set, meaning it always remained `UndefinedIndexT`. It is now set to 0, and the resection ID is incremented from there. A consequence of setting the resection ID of the initial pair is that it allows to visualize it clearly in Meshroom's 3D Viewer with https://github.com/alicevision/QtAliceVision/pull/51 and https://github.com/alicevision/Meshroom/pull/2235.