### PR TITLE
Intrinsics update after auto reorientation

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -1039,7 +1039,7 @@ void writeImage(const std::string& path,
     imageSpec.attribute("AliceVision:ColorSpace",
                         (toColorSpace == EImageColorSpace::NO_CONVERSION) ? EImageColorSpace_enumToString(fromColorSpace)
                                                                           : EImageColorSpace_enumToString(toColorSpace));
-  
+
     const oiio::ImageBuf imgBuf = oiio::ImageBuf(imageSpec, const_cast<T*>(image.data())); // original image buffer
     const oiio::ImageBuf* outBuf = &imgBuf;  // buffer to write
         

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1392,7 +1392,7 @@ int aliceVision_main(int argc, char * argv[])
 
                 cam2->setWidth(image.Width());
                 cam2->setHeight(image.Height());
-                unsigned int sensorWidth = cam->sensorWidth();
+                double sensorWidth = cam->sensorWidth();
                 cam2->setSensorWidth(cam->sensorHeight());
                 cam2->setSensorHeight(sensorWidth);
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -604,7 +604,7 @@ void processImage(image::Image<image::RGBAfColor>& image, ProcessingParams& pPar
         image.swap(rescaled);
     }
     
-    if (pParams.reorient)
+    if ((pParams.reorient) && (imageMetadata.find("Orientation") != imageMetadata.end()))
     {
         oiio::ImageBuf inBuf(oiio::ImageSpec(image.Width(), image.Height(), nchannels, oiio::TypeDesc::FLOAT), image.data());
         inBuf.set_orientation(std::stoi(imageMetadata["Orientation"]));
@@ -1384,7 +1384,8 @@ int aliceVision_main(int argc, char * argv[])
             view.getImage().setWidth(image.Width());
             view.getImage().setHeight(image.Height());
             view.getImage().addMetadata("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(outputColorSpace));
-            view.getImage().addMetadata("Orientation", viewMetadata.at("Orientation"));
+            if (viewMetadata.find("Orientation") != viewMetadata.end())
+                view.getImage().addMetadata("Orientation", viewMetadata.at("Orientation"));
 
             if (image.Width() != cam->w()) // The image has been rotated by automatic reorientation 
             {

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1388,11 +1388,17 @@ int aliceVision_main(int argc, char * argv[])
 
             if (image.Width() != cam->w()) // The image has been rotated by automatic reorientation 
             {
-                cam->setWidth(image.Width());
-                cam->setHeight(image.Height());
+                camera::IntrinsicBase* cam2 = cam->clone();
+
+                cam2->setWidth(image.Width());
+                cam2->setHeight(image.Height());
                 unsigned int sensorWidth = cam->sensorWidth();
-                cam->setSensorWidth(cam->sensorHeight());
-                cam->setSensorHeight(sensorWidth);
+                cam2->setSensorWidth(cam->sensorHeight());
+                cam2->setSensorHeight(sensorWidth);
+
+                IndexT intrinsicId = cam2->hashValue();
+                view.setIntrinsicId(intrinsicId);
+                sfmData.getIntrinsics().emplace(intrinsicId, cam2);
             }
         }
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1385,6 +1385,15 @@ int aliceVision_main(int argc, char * argv[])
             view.getImage().setHeight(image.Height());
             view.getImage().addMetadata("AliceVision:ColorSpace", image::EImageColorSpace_enumToString(outputColorSpace));
             view.getImage().addMetadata("Orientation", viewMetadata.at("Orientation"));
+
+            if (image.Width() != cam->w()) // The image has been rotated by automatic reorientation 
+            {
+                cam->setWidth(image.Width());
+                cam->setHeight(image.Height());
+                unsigned int sensorWidth = cam->sensorWidth();
+                cam->setSensorWidth(cam->sensorHeight());
+                cam->setSensorHeight(sensorWidth);
+            }
         }
 
         if (pParams.scaleFactor != 1.0f)


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR updates the intrinsic parameters when an automatic reorientation applied on an image lead to an image rotation. In that case, a new set of intrinsic parameters is derived from the original one and associated to the image view.
In addition, this PR fixes a bug that occurs when the original image does not contain any metadata named "Orientation".

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

