### PR TITLE
Update Color Space Extraction from image Metadata

### DIFF
--- a/src/aliceVision/image/colorspace.cpp
+++ b/src/aliceVision/image/colorspace.cpp
@@ -223,15 +223,17 @@ std::string EImageColorSpace_enumToOIIOString(const EImageColorSpace colorSpace)
 
 EImageColorSpace EImageColorSpace_OIIOstringToEnum(const std::string& colorspace)
 {
-    if (colorspace == "Linear")
+    const std::string cs = boost::to_lower_copy(colorspace);
+
+    if (cs == "linear")
         return EImageColorSpace::LINEAR;
-    if (colorspace == "sRGB")
+    if (cs == "srgb")
         return EImageColorSpace::SRGB;
-    if (colorspace == "aces2065-1")
+    if (cs == "aces2065-1")
         return EImageColorSpace::ACES2065_1;
-    if (colorspace == "ACEScg")
+    if (cs == "acescg")
         return EImageColorSpace::ACEScg;
-    if ((colorspace == "REC709") || (colorspace == "ACES_LUT"))
+    if ((cs == "rec709") || (colorspace == "aces_lut"))
         return EImageColorSpace::REC709;
 
     throw std::out_of_range("No EImageColorSpace defined for string: " + colorspace);
@@ -258,15 +260,17 @@ bool EImageColorSpace_isSupportedOIIOEnum(const EImageColorSpace& colorspace)
 
 bool EImageColorSpace_isSupportedOIIOstring(const std::string& colorspace)
 {
-    if (colorspace == "Linear")
+    const std::string cs = boost::to_lower_copy(colorspace);
+
+    if (cs == "linear")
         return true;
-    if (colorspace == "sRGB")
+    if (cs == "srgb")
         return true;
-    if (colorspace == "aces2065-1")
+    if (cs == "aces2065-1")
         return true;
-    if (colorspace == "ACEScg")
+    if (cs == "acescg")
         return true;
-    if (colorspace == "REC709")
+    if (cs == "rec709")
         return true;
     return false;
 }

--- a/src/aliceVision/image/colorspace.cpp
+++ b/src/aliceVision/image/colorspace.cpp
@@ -260,19 +260,20 @@ bool EImageColorSpace_isSupportedOIIOEnum(const EImageColorSpace& colorspace)
 
 bool EImageColorSpace_isSupportedOIIOstring(const std::string& colorspace)
 {
-    const std::string cs = boost::to_lower_copy(colorspace);
+    const OIIO::ColorConfig& ocioConf = getGlobalColorConfigOCIO();
 
-    if (cs == "linear")
-        return true;
-    if (cs == "srgb")
-        return true;
-    if (cs == "aces2065-1")
-        return true;
-    if (cs == "acescg")
-        return true;
-    if (cs == "rec709")
-        return true;
-    return false;
+    std::vector<std::string> knownColorSpaces = {"linear"};
+
+    for (auto cs : ocioConf.getColorSpaceNames())
+    {
+        knownColorSpaces.push_back(boost::to_lower_copy(cs));
+        for (auto alias : ocioConf.getAliases(cs))
+        {
+            knownColorSpaces.push_back(boost::to_lower_copy(alias));
+        }
+    }
+
+    return (std::find(knownColorSpaces.begin(), knownColorSpaces.end(), boost::to_lower_copy(colorspace)) != knownColorSpaces.end());
 }
 
 std::ostream& operator<<(std::ostream& os, EImageColorSpace dataType) { return os << EImageColorSpace_enumToString(dataType); }

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -94,7 +94,7 @@ std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::strin
 
     for (const auto& m : oiioSpec.extra_attribs)
     {
-        const std::string name = boost::to_lower_copy(m.name().string());
+        const std::string name = m.name().string();
 
         if (name.find("oiio:ColorSpace") != name.npos)
         {

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -82,63 +82,39 @@ EImageColorSpace getImageColorSpace(const std::string& imagePath)
     return EImageColorSpace_stringToEnum(colorSpace);
 }
 
-std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::string& defaulColorSpace = "")
+std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::string& defaultColorSpace = "", const std::string& imagePath = "")
 {
-    std::string meta = oiioSpec.serialize(OIIO::ImageSpec::SerialText);
-
-    std::vector<std::string> lines;
-
-    auto el = meta.find("\n");
-    while (el != meta.npos)
+    std::string colorSpaceFromFileName = "";
+    if (!imagePath.empty())
     {
-        std::string line = meta.substr(0, el);
-        meta = meta.substr(el + 1);
-        el = meta.find("\n");
-        lines.push_back(line);
-    }
-    if ((meta != "\n") && (meta != ""))
-    {
-        lines.push_back(meta);
+        colorSpaceFromFileName = getGlobalColorConfigOCIO().getColorSpaceFromFilepath(imagePath);
     }
 
     std::map<std::string, std::string> mapColorSpaces;
 
-    for (const auto& line : lines)
+    for (const auto& m : oiioSpec.extra_attribs)
     {
-        auto it = line.find(": ");
-        if (it != line.npos)
-        {
-            std::string key = line.substr(0, it);
-            auto it_1 = key.find_first_not_of(" ");
-            key = key.substr(it_1);
-            auto it_2 = key.find_last_of(":");
-            std::string keyAuthor = "";
-            if (it_2 != key.npos)
-            {
-                keyAuthor = key.substr(0, it_2);
-                key = key.substr(it_2 + 1);
-                auto it_3 = keyAuthor.find_last_of(":");
-                if (it_3 != keyAuthor.npos)
-                {
-                    keyAuthor = keyAuthor.substr(it_3 + 1);
-                }
-            }
-            std::string val = line.substr(it + 2);
+        const std::string name = boost::to_lower_copy(m.name().string());
 
-            // We retain only the metadata of type "string" with a name containing "ColorSpace" or "ColourSpace"
-            if (((key.find("ColorSpace") != key.npos) || (key.find("ColourSpace") != key.npos)) && (val.find("\"") != val.npos))
-            {
-                if (keyAuthor == "AliceVision" || keyAuthor == "oiio")
-                {
-                    key = keyAuthor + ":" + key;
-                }
-                val = val.substr(val.find_first_of("\"") + 1, val.find_last_of("\"") - 1);
-                mapColorSpaces.emplace(key, val);
-            }
+        if (name.find("oiio:ColorSpace") != name.npos)
+        {
+            mapColorSpaces.emplace("oiio:ColorSpace", m.get_string());
+        }
+        else if (name.find("AliceVision:ColorSpace") != name.npos)
+        {
+            mapColorSpaces.emplace("AliceVision:ColorSpace", m.get_string());
+        }
+        else if (name.find(":workPlateColourSpace") != name.npos)
+        {
+            mapColorSpaces.emplace("workPlateColourSpace", m.get_string());
+        }
+        else if (name.find(":originalPlateColourSpace") != name.npos)
+        {
+            mapColorSpaces.emplace("originalPlateColourSpace", m.get_string());
         }
     }
 
-    std::string colorSpace = defaulColorSpace;
+    std::string colorSpace = defaultColorSpace;
 
     if (mapColorSpaces.find("AliceVision:ColorSpace") != mapColorSpaces.end())
     {
@@ -152,9 +128,18 @@ std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::strin
     {
         colorSpace = mapColorSpaces.at("originalPlateColourSpace");
     }
+    else if (!colorSpaceFromFileName.empty())
+    {
+        colorSpace = colorSpaceFromFileName;
+    }
     else if (mapColorSpaces.find("oiio:ColorSpace") != mapColorSpaces.end())
     {
         colorSpace = mapColorSpaces.at("oiio:ColorSpace");
+    }
+
+    if (!EImageColorSpace_isSupportedOIIOstring(colorSpace))
+    {
+        colorSpace = defaultColorSpace;
     }
 
     return colorSpace;
@@ -828,7 +813,7 @@ void readImage(const std::string& path, oiio::TypeDesc format, int nchannels, Im
         ALICEVISION_THROW_ERROR("You must specify a requested color space for image file '" + path + "'.");
 
     // Get color space name. Default image color space is sRGB
-    const std::string colorSpaceFromMetadata = getImageColorSpace(inBuf.spec(), "sRGB");
+    const std::string colorSpaceFromMetadata = getImageColorSpace(inBuf.spec(), "sRGB", path);
 
     std::string fromColorSpaceName = (isRawImage && imageReadOptions.rawColorInterpretation == ERawColorInterpretation::DcpLinearProcessing)
                 ? "aces2065-1"

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -108,10 +108,6 @@ std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::strin
         {
             mapColorSpaces.emplace("workPlateColourSpace", m.get_string());
         }
-        else if (name.find(":originalPlateColourSpace") != name.npos)
-        {
-            mapColorSpaces.emplace("originalPlateColourSpace", m.get_string());
-        }
     }
 
     std::string colorSpace = defaultColorSpace;
@@ -131,10 +127,6 @@ std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::strin
     else if (mapColorSpaces.find("oiio:ColorSpace") != mapColorSpaces.end())
     {
         colorSpace = mapColorSpaces.at("oiio:ColorSpace");
-    }
-    else if (mapColorSpaces.find("originalPlateColourSpace") != mapColorSpaces.end())
-    {
-        colorSpace = mapColorSpaces.at("originalPlateColourSpace");
     }
 
     ALICEVISION_LOG_TRACE("Detected image color space: " << colorSpace);

--- a/src/aliceVision/image/share/aliceVision/config.ocio
+++ b/src/aliceVision/image/share/aliceVision/config.ocio
@@ -41,13 +41,13 @@ roles:
 #
 file_rules:
     #
-    # The next rule assigns the colorspace "ACEScg" to any files that contain "acescg" or "ACEScg" in the path.
+    # The next rule assigns the colorspace "ACEScg" to any exr files that contain "acescg" or "ACEScg" in the path.
     #
-  - !<Rule> {name: ACEScg, colorspace: ACEScg, regex: "acescg|ACEScg"}
+  - !<Rule> {name: exr_ACEScg, colorspace: ACEScg, regex: ".*(acescg|ACEScg).*\\.(exr|EXR)"}
     #
-    # The next rule assigns the colorspace "ACES" to any file that contain "aces or "ACES" in the path.
+    # The next rule assigns the colorspace "ACES2065-1" to any exr file that contain "aces or "ACES" in the path.
     #
-  - !<Rule> {name: ACES, colorspace: ACES, regex: "aces|ACES"}
+  - !<Rule> {name: exr_ACES, colorspace: ACES2065-1, regex: ".*(aces|ACES).*\\.(exr|EXR)"}
     #
     # The rules are ordered, highest priority first.  OCIO takes the path to a file and applies
     # the rules one-by-one until there is a match.  The last rule, "Default", always matches.

--- a/src/aliceVision/image/share/aliceVision/config.ocio
+++ b/src/aliceVision/image/share/aliceVision/config.ocio
@@ -91,7 +91,7 @@ colorspaces:
     #
   - !<ColorSpace>
     name: ACES2065-1
-    aliases: [ aces ]
+    aliases: [ aces, ACES 2065-1 (AP0) ]
     family: ACES
     description: |
       The Academy Color Encoding System reference color space
@@ -101,6 +101,7 @@ colorspaces:
 
   - !<ColorSpace>
     name: ACEScg
+    aliases: [ ACEScg (AP1) ]
     family: ACES
     description: |
       ACEScg working space


### PR DESCRIPTION

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR updates the way the image color space is extracted from the metadata contained in an oiio buffer spec when reading an image.

Up tp now, only AliceVision:Colorspace and oiio:ColorSpace keys were considered with the priority given to the first one and with sRGB as default color space if no key is available.

We consider now color spaces named "workColourSpace" and "originalColourSpace" in addition to the two color spaces already considered and whatever their prefix.

In case several keys are available in the metadata, the following priority order is applied:
1 AliceVision:ColorSpace
2 workColourSpace
3 Use filename through regex specified in config.ocio
4 oiio:ColorSpace
5 originalColourSpace

If no key is available, the default sRGB color space is assumed for non exr images and Linear is assumed for exr ones.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

