### PR TITLE
Add "Generic" Feature Type

### DIFF
--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -228,9 +228,9 @@ std::unique_ptr<ImageDescriber> createImageDescriber(EImageDescriberType imageDe
         case EImageDescriberType::AKAZE_LIOP:
             describerPtr.reset(new ImageDescriber_AKAZE(AKAZEParams(AKAZEOptions(), feature::AKAZE_LIOP)));
             break;
-        //Unknown descriptor to be used when the descriptor is computed outside of alicevsion
-        case EImageDescriberType::UNKNOWN:
-            describerPtr.reset(new UnknownImageDescriber());
+        //Generic descriptor to be used when the descriptor is computed outside of alicevsion
+        case EImageDescriberType::GENERIC:
+            describerPtr.reset(new GenericImageDescriber());
             break;
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)

--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -228,6 +228,10 @@ std::unique_ptr<ImageDescriber> createImageDescriber(EImageDescriberType imageDe
         case EImageDescriberType::AKAZE_LIOP:
             describerPtr.reset(new ImageDescriber_AKAZE(AKAZEParams(AKAZEOptions(), feature::AKAZE_LIOP)));
             break;
+        //Unknown descriptor to be used when the descriptor is computed outside of alicevsion
+        case EImageDescriberType::UNKNOWN:
+            describerPtr.reset(new UnknownImageDescriber());
+            break;
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
         case EImageDescriberType::CCTAG3:

--- a/src/aliceVision/feature/ImageDescriber.hpp
+++ b/src/aliceVision/feature/ImageDescriber.hpp
@@ -10,6 +10,7 @@
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/feature/imageDescriberCommon.hpp>
 #include <aliceVision/feature/Regions.hpp>
+#include <aliceVision/feature/regionsFactory.hpp>
 #include <aliceVision/image/Image.hpp>
 #include <memory>
 
@@ -258,6 +259,115 @@ class ImageDescriber
     void Save(const Regions* regions, const std::string& sfileNameFeats, const std::string& sfileNameDescs) const;
 
     void LoadFeatures(Regions* regions, const std::string& sfileNameFeats) const { regions->LoadFeatures(sfileNameFeats); }
+};
+
+/**
+ * @brief Used to load descripters computed outside of meshroom.
+ */
+class UnknownImageDescriber  : public ImageDescriber
+{
+  public:
+    UnknownImageDescriber() = default;
+
+    virtual ~UnknownImageDescriber() = default;
+
+     /**
+     * @brief Check if the image describer use CUDA
+     * @return True if the image describer use CUDA
+     */
+    bool useCuda() const override { return false; }
+
+    /**
+     * @brief Check if the image describer use float image
+     * @return True if the image describer use float image
+     */
+    bool useFloatImage() const override { return false; }
+
+    /**
+     * @brief Get the corresponding EImageDescriberType
+     * @return EImageDescriberType
+     */
+    EImageDescriberType getDescriberType() const override { return EImageDescriberType::UNKNOWN; }
+
+    /**
+     * @brief Get the total amount of RAM needed for a
+     * feature extraction of an image of the given dimension.
+     * @param[in] width The image width
+     * @param[in] height The image height
+     * @return total amount of memory needed
+     */
+    std::size_t getMemoryConsumption(std::size_t width, std::size_t height) const override
+    {
+        return 0;
+    }
+
+    /**
+     * @brief Set image describer always upRight
+     * @param[in] upRight
+     */
+    void setUpRight(bool upRight) override
+    {}
+
+    /**
+     * @brief Set if yes or no imageDescriber need to use cuda implementation
+     * @param[in] useCuda
+     */
+    void setUseCuda(bool useCuda) override 
+    {}
+
+    /**
+     * @brief set the CUDA pipe
+     * @param[in] pipe The CUDA pipe id
+     */
+    void setCudaPipe(int pipe) override
+    {}
+
+    /**
+     * @brief Use a preset to control the number of detected regions
+     * @param[in] preset The preset configuration
+     */
+    void setConfigurationPreset(ConfigurationPreset preset) override
+    {}
+
+    /**
+     * @brief Detect regions on the 8-bit image and compute their attributes (description)
+     * @param[in] image Image.
+     * @param[out] regions The detected regions and attributes (the caller must delete the allocated data)
+     * @param[in] mask 8-bit grayscale image for keypoint filtering (optional)
+     *    Non-zero values depict the region of interest.
+     * @return True if detection succed.
+     */
+    bool describe(const image::Image<unsigned char>& image,
+                  std::unique_ptr<Regions>& regions,
+                  const image::Image<unsigned char>* mask = nullptr) override
+    {
+        return false;
+    }
+
+    /**
+     * @brief Detect regions on the float image and compute their attributes (description)
+     * @param[in] image Image.
+     * @param[out] regions The detected regions and attributes (the caller must delete the allocated data)
+     * @param[in] mask 8-bit gray image for keypoint filtering (optional).
+     *    Non-zero values depict the region of interest.
+     * @return True if detection succed.
+     */
+    bool describe(const image::Image<float>& image, std::unique_ptr<Regions>& regions, const image::Image<unsigned char>* mask = nullptr) override
+    {
+        return false;
+    }
+
+    /**
+     * @brief Allocate Regions type depending of the ImageDescriber
+     * @param[in,out] regions
+     */
+    void allocate(std::unique_ptr<Regions>& regions) const override 
+    {
+        regions.reset(new UNKNOWN_Regions);
+    }
+
+  private:
+    std::unique_ptr<ImageDescriber> _imageDescriberImpl = nullptr;
 };
 
 /**

--- a/src/aliceVision/feature/ImageDescriber.hpp
+++ b/src/aliceVision/feature/ImageDescriber.hpp
@@ -264,12 +264,12 @@ class ImageDescriber
 /**
  * @brief Used to load descripters computed outside of meshroom.
  */
-class UnknownImageDescriber  : public ImageDescriber
+class GenericImageDescriber  : public ImageDescriber
 {
   public:
-    UnknownImageDescriber() = default;
+    GenericImageDescriber() = default;
 
-    virtual ~UnknownImageDescriber() = default;
+    virtual ~GenericImageDescriber() = default;
 
      /**
      * @brief Check if the image describer use CUDA
@@ -287,7 +287,7 @@ class UnknownImageDescriber  : public ImageDescriber
      * @brief Get the corresponding EImageDescriberType
      * @return EImageDescriberType
      */
-    EImageDescriberType getDescriberType() const override { return EImageDescriberType::UNKNOWN; }
+    EImageDescriberType getDescriberType() const override { return EImageDescriberType::GENERIC; }
 
     /**
      * @brief Get the total amount of RAM needed for a
@@ -363,7 +363,7 @@ class UnknownImageDescriber  : public ImageDescriber
      */
     void allocate(std::unique_ptr<Regions>& regions) const override 
     {
-        regions.reset(new UNKNOWN_Regions);
+        regions.reset(new GENERIC_Regions);
     }
 
   private:

--- a/src/aliceVision/feature/imageDescriberCommon.cpp
+++ b/src/aliceVision/feature/imageDescriberCommon.cpp
@@ -61,6 +61,8 @@ std::string EImageDescriberType_enumToString(EImageDescriberType imageDescriberT
             return "akaze_liop";
         case EImageDescriberType::AKAZE_MLDB:
             return "akaze_mldb";
+        case EImageDescriberType::GENERIC:
+            return "generic";
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
         case EImageDescriberType::CCTAG3:
@@ -112,6 +114,9 @@ EImageDescriberType EImageDescriberType_stringToEnum(const std::string& imageDes
         return EImageDescriberType::AKAZE_LIOP;
     if (type == "akaze_mldb")
         return EImageDescriberType::AKAZE_MLDB;
+
+    if (type == "generic")
+        return EImageDescriberType::GENERIC;
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
     if (type == "cctag3")

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -23,9 +23,8 @@ enum class EImageDescriberType : unsigned char
     SIFT = 10,
     SIFT_FLOAT = 11,
     SIFT_UPRIGHT = 12,
-    DSPSIFT = 13
-
-    ,
+    DSPSIFT = 13,
+    
     AKAZE = 20,
     AKAZE_LIOP = 21,
     AKAZE_MLDB = 22

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -27,29 +27,25 @@ enum class EImageDescriberType : unsigned char
     
     AKAZE = 20,
     AKAZE_LIOP = 21,
-    AKAZE_MLDB = 22,
-
-    GENERIC = 100
+    AKAZE_MLDB = 22
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
-    ,
-    CCTAG3 = 30,
-    CCTAG4 = 31
+    , CCTAG3 = 30
+    , CCTAG4 = 31
 #endif
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
     #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OCVSIFT)
-    ,
-    SIFT_OCV = 40
+    , SIFT_OCV = 40
     #endif
-    ,
-    AKAZE_OCV = 41
+    , AKAZE_OCV = 41
 #endif
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_APRILTAG)
-    ,
-    APRILTAG16H5 = 50
+    , APRILTAG16H5 = 50
 #endif
+
+    , GENERIC = 100
 };
 
 /**

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -27,7 +27,9 @@ enum class EImageDescriberType : unsigned char
     
     AKAZE = 20,
     AKAZE_LIOP = 21,
-    AKAZE_MLDB = 22
+    AKAZE_MLDB = 22,
+
+    GENERIC = 100
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
     ,
@@ -111,7 +113,8 @@ inline float getStrongSupportCoeff(EImageDescriberType imageDescriberType)
         case EImageDescriberType::AKAZE_LIOP:
         case EImageDescriberType::AKAZE_MLDB:
             return 0.14f;
-
+        case EImageDescriberType::GENERIC:
+            return -1.0f;
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
         case EImageDescriberType::CCTAG3:
         case EImageDescriberType::CCTAG4:

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -112,9 +112,8 @@ inline float getStrongSupportCoeff(EImageDescriberType imageDescriberType)
         case EImageDescriberType::AKAZE:
         case EImageDescriberType::AKAZE_LIOP:
         case EImageDescriberType::AKAZE_MLDB:
-            return 0.14f;
         case EImageDescriberType::GENERIC:
-            return -1.0f;
+            return 0.14f;
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
         case EImageDescriberType::CCTAG3:
         case EImageDescriberType::CCTAG4:

--- a/src/aliceVision/feature/regionsFactory.hpp
+++ b/src/aliceVision/feature/regionsFactory.hpp
@@ -29,5 +29,8 @@ using AKAZE_Liop_Regions = ScalarRegions<unsigned char, 144>;
 /// Define the AKAZE Keypoint (with a binary descriptor saved in an uchar array)
 using AKAZE_BinaryRegions = BinaryRegions<64>;
 
+/// Define an unknown feature regions 
+using UNKNOWN_Regions = ScalarRegions<float, 128>;
+
 }  // namespace feature
 }  // namespace aliceVision

--- a/src/aliceVision/feature/regionsFactory.hpp
+++ b/src/aliceVision/feature/regionsFactory.hpp
@@ -30,7 +30,7 @@ using AKAZE_Liop_Regions = ScalarRegions<unsigned char, 144>;
 using AKAZE_BinaryRegions = BinaryRegions<64>;
 
 /// Define an unknown feature regions 
-using UNKNOWN_Regions = ScalarRegions<float, 128>;
+using GENERIC_Regions = ScalarRegions<float, 128>;
 
 }  // namespace feature
 }  // namespace aliceVision

--- a/src/aliceVision/matching/svgVisualization.cpp
+++ b/src/aliceVision/matching/svgVisualization.cpp
@@ -36,6 +36,10 @@ std::string describerTypeColor(feature::EImageDescriberType descType)
             return "purple";
         case feature::EImageDescriberType::AKAZE_MLDB:
             return "purple";
+
+        case feature::EImageDescriberType::GENERIC:
+            return "black";
+
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
         case feature::EImageDescriberType::CCTAG3:
             return "blue";

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -26,7 +26,7 @@ using namespace sfmData;
 std::unique_ptr<feature::Regions> loadRegions(const std::vector<std::string>& folders, IndexT viewId, const feature::ImageDescriber& imageDescriber)
 {
     assert(!folders.empty());
-
+    
     const std::string imageDescriberTypeName = feature::EImageDescriberType_enumToString(imageDescriber.getDescriberType());
     const std::string basename = std::to_string(viewId);
 
@@ -228,7 +228,7 @@ bool loadRegionsPerView(feature::RegionsPerView& regionsPerView,
                     std::unique_ptr<feature::Regions> regionsPtr;
                     try
                     {
-                        regionsPtr = loadRegions(featuresFolders, iter->second.get()->getViewId(), *(imageDescribers.at(i)));
+                        regionsPtr = loadRegions(featuresFolders, iter->second.get()->getViewId(), *(imageDescribers.at(i)));                        
                     }
                     catch (const std::exception& e)
                     {

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -26,7 +26,7 @@ using namespace sfmData;
 std::unique_ptr<feature::Regions> loadRegions(const std::vector<std::string>& folders, IndexT viewId, const feature::ImageDescriber& imageDescriber)
 {
     assert(!folders.empty());
-    
+
     const std::string imageDescriberTypeName = feature::EImageDescriberType_enumToString(imageDescriber.getDescriberType());
     const std::string basename = std::to_string(viewId);
 
@@ -228,7 +228,7 @@ bool loadRegionsPerView(feature::RegionsPerView& regionsPerView,
                     std::unique_ptr<feature::Regions> regionsPtr;
                     try
                     {
-                        regionsPtr = loadRegions(featuresFolders, iter->second.get()->getViewId(), *(imageDescribers.at(i)));                        
+                        regionsPtr = loadRegions(featuresFolders, iter->second.get()->getViewId(), *(imageDescribers.at(i)));
                     }
                     catch (const std::exception& e)
                     {

--- a/src/aliceVision/voctree/VocabularyTree.hpp
+++ b/src/aliceVision/voctree/VocabularyTree.hpp
@@ -360,6 +360,9 @@ inline std::unique_ptr<IVocabularyTree> createVoctreeForDescriberType(feature::E
         case EImageDescriberType::AKAZE_MLDB:
             res.reset(new VocabularyTree<AKAZE_BinaryRegions::DescriptorT>);
             break;
+        case EImageDescriberType::UNKNOWN:
+            res.reset(new VocabularyTree<UNKNOWN_Regions::DescriptorT>);
+            break;
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
         case EImageDescriberType::CCTAG3:

--- a/src/aliceVision/voctree/VocabularyTree.hpp
+++ b/src/aliceVision/voctree/VocabularyTree.hpp
@@ -360,8 +360,8 @@ inline std::unique_ptr<IVocabularyTree> createVoctreeForDescriberType(feature::E
         case EImageDescriberType::AKAZE_MLDB:
             res.reset(new VocabularyTree<AKAZE_BinaryRegions::DescriptorT>);
             break;
-        case EImageDescriberType::UNKNOWN:
-            res.reset(new VocabularyTree<UNKNOWN_Regions::DescriptorT>);
+        case EImageDescriberType::GENERIC:
+            res.reset(new VocabularyTree<GENERIC_Regions::DescriptorT>);
             break;
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)


### PR DESCRIPTION
## Description

Added a 'generic' feature type for importing features that are not computed by alicevision.

For now the descriptor size is set to 128, but may be extended and padded with 0 to support wider descriptors in the future.