### PR TITLE
fixed unnecessary descriptor load for sequential image matching

### DIFF
--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -176,7 +176,7 @@ int aliceVision_main(int argc, char** argv)
 
   std::map<IndexT, std::string> descriptorsFilesA, descriptorsFilesB;
 
-  if(method != EImageMatchingMethod::EXHAUSTIVE)
+  if(method != EImageMatchingMethod::EXHAUSTIVE && method != EImageMatchingMethod::SEQUENTIAL)
   {
       // load descriptor filenames
       aliceVision::voctree::getListOfDescriptorFiles(sfmDataA, featuresFolders, descriptorsFilesA);


### PR DESCRIPTION
## Description

Sequential matching was loading descriptors and not using it.