### PR TITLE
Run CI on draft pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,6 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     container:
       image: alicevision/alicevision-deps:2023.10.12-centos7-cuda11.3.1
     env:
@@ -127,7 +126,6 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
-    if: github.event.pull_request.draft == false
     env:
       DEPS_INSTALL_DIR: '${{ github.workspace }}/install'
       buildDir: '${{ github.workspace }}/build/'


### PR DESCRIPTION
## Description

Re-enable the continuous integration on draft pull requests:
- Useful for people to check in Draft before submitting for Review.
- Also, switching from "Draft" to "Ready for Review" was not triggering the CI.
