### PR TITLE
Add estimator states to sfmdata

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# Estimator states in SfMData: Apply clang-format across all files
+938c0e83497c94ef6506c00ded61cf1da00e4ca5
 # Reformat src/aliceVision with latest clang-format rules
 580ebb7f344787126008af972f765aea9eacb2ac
 # [sfmData] imageInfo: Clean-up: Harmonize and use 4-space indentation everywhere

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <aliceVision/types.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/camera/cameraCommon.hpp>
 #include <aliceVision/camera/IntrinsicInitMode.hpp>
@@ -429,11 +430,34 @@ class IntrinsicBase
     */
     virtual double getVerticalFov() const = 0;
 
+    virtual void initializeState() 
+    {
+        if (_locked)
+        {
+            _state = EParameterState::CONSTANT;
+        }
+        else
+        {
+            _state = EParameterState::REFINED;
+        }
+    }
+
+    EParameterState getState() const 
+    {
+        return _state;
+    }
+
+    void setState(EParameterState state) 
+    {
+        _state = state;
+    }
+
   protected:
     /// initialization mode
     EInitMode _initializationMode = EInitMode::NONE;
     /// intrinsic lock
     bool _locked = false;
+    EParameterState _state = EParameterState::REFINED;
     unsigned int _w = 0;
     unsigned int _h = 0;
     double _sensorWidth = 36.0;

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -434,20 +434,20 @@ class IntrinsicBase
     {
         if (_locked)
         {
-            _state = EParameterState::CONSTANT;
+            _state = EEstimatorParameterState::CONSTANT;
         }
         else
         {
-            _state = EParameterState::REFINED;
+            _state = EEstimatorParameterState::REFINED;
         }
     }
 
-    EParameterState getState() const 
+    EEstimatorParameterState getState() const
     {
         return _state;
     }
 
-    void setState(EParameterState state) 
+    void setState(EEstimatorParameterState state)
     {
         _state = state;
     }
@@ -457,7 +457,7 @@ class IntrinsicBase
     EInitMode _initializationMode = EInitMode::NONE;
     /// intrinsic lock
     bool _locked = false;
-    EParameterState _state = EParameterState::REFINED;
+    EEstimatorParameterState _state = EEstimatorParameterState::REFINED;
     unsigned int _w = 0;
     unsigned int _h = 0;
     double _sensorWidth = 36.0;

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -421,16 +421,16 @@ class IntrinsicBase
     /**
      * @Brief get horizontal fov in radians
      * @return  horizontal fov in radians
-    */
+     */
     virtual double getHorizontalFov() const = 0;
 
     /**
      * @Brief get vertical fov in radians
      * @return  vertical fov in radians
-    */
+     */
     virtual double getVerticalFov() const = 0;
 
-    virtual void initializeState() 
+    virtual void initializeState()
     {
         if (_locked)
         {
@@ -442,15 +442,9 @@ class IntrinsicBase
         }
     }
 
-    EEstimatorParameterState getState() const
-    {
-        return _state;
-    }
+    EEstimatorParameterState getState() const { return _state; }
 
-    void setState(EEstimatorParameterState state)
-    {
-        _state = state;
-    }
+    void setState(EEstimatorParameterState state) { _state = state; }
 
   protected:
     /// initialization mode

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -60,15 +60,15 @@ void LocalBundleAdjustmentGraph::setAllParametersToRefine(const sfmData::SfMData
 
     // poses
     for (sfmData::Poses::const_iterator itPose = sfmData.getPoses().begin(); itPose != sfmData.getPoses().end(); ++itPose)
-        _statePerPoseId[itPose->first] = EParameterState::REFINED;
+        _statePerPoseId[itPose->first] = EEstimatorParameterState::REFINED;
 
     // instrinsics
     for (const auto& itIntrinsic : sfmData.getIntrinsics())
-        _statePerIntrinsicId[itIntrinsic.first] = EParameterState::REFINED;
+        _statePerIntrinsicId[itIntrinsic.first] = EEstimatorParameterState::REFINED;
 
     // landmarks
     for (const auto& itLandmark : sfmData.getLandmarks())
-        _statePerLandmarkId[itLandmark.first] = EParameterState::REFINED;
+        _statePerLandmarkId[itLandmark.first] = EEstimatorParameterState::REFINED;
 }
 
 void LocalBundleAdjustmentGraph::saveIntrinsicsToHistory(const sfmData::SfMData& sfmData)
@@ -215,15 +215,15 @@ int LocalBundleAdjustmentGraph::getViewDistance(const IndexT viewId) const
     return _distancePerViewId.at(viewId);
 }
 
-EParameterState LocalBundleAdjustmentGraph::getStateFromDistance(int distance) const
+EEstimatorParameterState LocalBundleAdjustmentGraph::getStateFromDistance(int distance) const
 {
     if (distance >= 0 && distance <= _graphDistanceLimit)  // [0; D]
-        return EParameterState::REFINED;
+        return EEstimatorParameterState::REFINED;
     else if (distance == _graphDistanceLimit + 1)  // {D+1}
-        return EParameterState::CONSTANT;
+        return EEstimatorParameterState::CONSTANT;
 
     // [-inf; 0[ U [D+2; +inf.[  (-1: not connected to the new views)
-    return EParameterState::IGNORED;
+    return EEstimatorParameterState::IGNORED;
 }
 
 void LocalBundleAdjustmentGraph::updateGraphWithNewViews(const sfmData::SfMData& sfmData,
@@ -385,7 +385,7 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(sfmData::SfMData& sfmD
     {
         const IndexT poseId = posePair.first;
         const int distance = getPoseDistance(poseId);
-        const EParameterState state = getStateFromDistance(distance);
+        const EEstimatorParameterState state = getStateFromDistance(distance);
 
         posePair.second.setState(state);
 
@@ -399,13 +399,13 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(sfmData::SfMData& sfmD
     {
         if (isFocalLengthConstant(itIntrinsic.first))
         {
-            itIntrinsic.second->setState(EParameterState::CONSTANT);
-            _statePerIntrinsicId[itIntrinsic.first] = EParameterState::CONSTANT;
+            itIntrinsic.second->setState(EEstimatorParameterState::CONSTANT);
+            _statePerIntrinsicId[itIntrinsic.first] = EEstimatorParameterState::CONSTANT;
         }
         else
         {
-            itIntrinsic.second->setState(EParameterState::REFINED);
-            _statePerIntrinsicId[itIntrinsic.first] = EParameterState::REFINED;
+            itIntrinsic.second->setState(EEstimatorParameterState::REFINED);
+            _statePerIntrinsicId[itIntrinsic.first] = EEstimatorParameterState::REFINED;
         }
     }
 
@@ -421,7 +421,7 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(sfmData::SfMData& sfmD
         for (const auto& observationIt : observations)
         {
             const int distance = getViewDistance(observationIt.first);
-            const EParameterState viewState = getStateFromDistance(distance);
+            const EEstimatorParameterState viewState = getStateFromDistance(distance);
             states.at(static_cast<std::size_t>(viewState)) = true;
         }
 
@@ -431,16 +431,16 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(sfmData::SfMData& sfmD
         // for these particular cases, we can have landmarks with refined AND ignored cameras.
         // in this particular case, we prefer to ignore the landmark to avoid wrong/unconstraint refinements.
 
-        if (!states.at(static_cast<std::size_t>(EParameterState::REFINED)) ||
-            states.at(static_cast<std::size_t>(EParameterState::IGNORED)))
+        if (!states.at(static_cast<std::size_t>(EEstimatorParameterState::REFINED)) ||
+            states.at(static_cast<std::size_t>(EEstimatorParameterState::IGNORED)))
         {
-            itLandmark.second.state = EParameterState::IGNORED;
-            _statePerLandmarkId[landmarkId] = EParameterState::IGNORED;
+            itLandmark.second.state = EEstimatorParameterState::IGNORED;
+            _statePerLandmarkId[landmarkId] = EEstimatorParameterState::IGNORED;
         }
         else
         {
-            itLandmark.second.state = EParameterState::REFINED;
-            _statePerLandmarkId[landmarkId] = EParameterState::REFINED;
+            itLandmark.second.state = EEstimatorParameterState::REFINED;
+            _statePerLandmarkId[landmarkId] = EEstimatorParameterState::REFINED;
         }
     }
 }

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -60,15 +60,15 @@ void LocalBundleAdjustmentGraph::setAllParametersToRefine(const sfmData::SfMData
 
     // poses
     for (sfmData::Poses::const_iterator itPose = sfmData.getPoses().begin(); itPose != sfmData.getPoses().end(); ++itPose)
-        _statePerPoseId[itPose->first] = BundleAdjustment::EParameterState::REFINED;
+        _statePerPoseId[itPose->first] = EParameterState::REFINED;
 
     // instrinsics
     for (const auto& itIntrinsic : sfmData.getIntrinsics())
-        _statePerIntrinsicId[itIntrinsic.first] = BundleAdjustment::EParameterState::REFINED;
+        _statePerIntrinsicId[itIntrinsic.first] = EParameterState::REFINED;
 
     // landmarks
     for (const auto& itLandmark : sfmData.getLandmarks())
-        _statePerLandmarkId[itLandmark.first] = BundleAdjustment::EParameterState::REFINED;
+        _statePerLandmarkId[itLandmark.first] = EParameterState::REFINED;
 }
 
 void LocalBundleAdjustmentGraph::saveIntrinsicsToHistory(const sfmData::SfMData& sfmData)
@@ -215,15 +215,15 @@ int LocalBundleAdjustmentGraph::getViewDistance(const IndexT viewId) const
     return _distancePerViewId.at(viewId);
 }
 
-BundleAdjustment::EParameterState LocalBundleAdjustmentGraph::getStateFromDistance(int distance) const
+EParameterState LocalBundleAdjustmentGraph::getStateFromDistance(int distance) const
 {
     if (distance >= 0 && distance <= _graphDistanceLimit)  // [0; D]
-        return BundleAdjustment::EParameterState::REFINED;
+        return EParameterState::REFINED;
     else if (distance == _graphDistanceLimit + 1)  // {D+1}
-        return BundleAdjustment::EParameterState::CONSTANT;
+        return EParameterState::CONSTANT;
 
     // [-inf; 0[ U [D+2; +inf.[  (-1: not connected to the new views)
-    return BundleAdjustment::EParameterState::IGNORED;
+    return EParameterState::IGNORED;
 }
 
 void LocalBundleAdjustmentGraph::updateGraphWithNewViews(const sfmData::SfMData& sfmData,
@@ -353,8 +353,10 @@ void LocalBundleAdjustmentGraph::computeGraphDistances(const sfmData::SfMData& s
     }
 }
 
-void LocalBundleAdjustmentGraph::convertDistancesToStates(const sfmData::SfMData& sfmData)
+void LocalBundleAdjustmentGraph::convertDistancesToStates(sfmData::SfMData& sfmData)
 {
+    sfmData.resetParameterStates();
+
     // reset the maps
     _statePerPoseId.clear();
     _statePerIntrinsicId.clear();
@@ -379,11 +381,13 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(const sfmData::SfMData
     //    - Refined <=> its connected to a refined camera
 
     // poses
-    for (const auto& posePair : sfmData.getPoses())
+    for (auto& posePair : sfmData.getPoses())
     {
         const IndexT poseId = posePair.first;
         const int distance = getPoseDistance(poseId);
-        const BundleAdjustment::EParameterState state = getStateFromDistance(distance);
+        const EParameterState state = getStateFromDistance(distance);
+
+        posePair.second.setState(state);
 
         _statePerPoseId[poseId] = state;
     }
@@ -391,16 +395,22 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(const sfmData::SfMData
     // instrinsics
     checkFocalLengthsConsistency(kWindowSize, kStdevPercentage);
 
-    for (const auto& itIntrinsic : sfmData.getIntrinsics())
+    for (auto& itIntrinsic : sfmData.getIntrinsics())
     {
         if (isFocalLengthConstant(itIntrinsic.first))
-            _statePerIntrinsicId[itIntrinsic.first] = BundleAdjustment::EParameterState::CONSTANT;
+        {
+            itIntrinsic.second->setState(EParameterState::CONSTANT);
+            _statePerIntrinsicId[itIntrinsic.first] = EParameterState::CONSTANT;
+        }
         else
-            _statePerIntrinsicId[itIntrinsic.first] = BundleAdjustment::EParameterState::REFINED;
+        {
+            itIntrinsic.second->setState(EParameterState::REFINED);
+            _statePerIntrinsicId[itIntrinsic.first] = EParameterState::REFINED;
+        }
     }
 
     // landmarks
-    for (const auto& itLandmark : sfmData.getLandmarks())
+    for (auto& itLandmark : sfmData.getLandmarks())
     {
         const IndexT landmarkId = itLandmark.first;
         const sfmData::Observations& observations = itLandmark.second.observations;
@@ -411,7 +421,7 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(const sfmData::SfMData
         for (const auto& observationIt : observations)
         {
             const int distance = getViewDistance(observationIt.first);
-            const BundleAdjustment::EParameterState viewState = getStateFromDistance(distance);
+            const EParameterState viewState = getStateFromDistance(distance);
             states.at(static_cast<std::size_t>(viewState)) = true;
         }
 
@@ -421,11 +431,17 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(const sfmData::SfMData
         // for these particular cases, we can have landmarks with refined AND ignored cameras.
         // in this particular case, we prefer to ignore the landmark to avoid wrong/unconstraint refinements.
 
-        if (!states.at(static_cast<std::size_t>(BundleAdjustment::EParameterState::REFINED)) ||
-            states.at(static_cast<std::size_t>(BundleAdjustment::EParameterState::IGNORED)))
-            _statePerLandmarkId[landmarkId] = BundleAdjustment::EParameterState::IGNORED;
+        if (!states.at(static_cast<std::size_t>(EParameterState::REFINED)) ||
+            states.at(static_cast<std::size_t>(EParameterState::IGNORED)))
+        {
+            itLandmark.second.state = EParameterState::IGNORED;
+            _statePerLandmarkId[landmarkId] = EParameterState::IGNORED;
+        }
         else
-            _statePerLandmarkId[landmarkId] = BundleAdjustment::EParameterState::REFINED;
+        {
+            itLandmark.second.state = EParameterState::REFINED;
+            _statePerLandmarkId[landmarkId] = EParameterState::REFINED;
+        }
     }
 }
 

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
@@ -36,32 +36,32 @@ class LocalBundleAdjustmentGraph
     std::map<int, std::size_t> getDistancesHistogram() const;
 
     /**
-     * @brief Return the EParameterState for a specific pose.
+     * @brief Return the EEstimatorParameterState for a specific pose.
      * @param[in] poseId The given pose Id
-     * @return EParameterState
+     * @return EEstimatorParameterState
      */
-    inline EParameterState getPoseState(const IndexT poseId) const { return _statePerPoseId.at(poseId); }
+    inline EEstimatorParameterState getPoseState(const IndexT poseId) const { return _statePerPoseId.at(poseId); }
 
     /**
-     * @brief Return the EParameterState for a specific intrinsic.
+     * @brief Return the EEstimatorParameterState for a specific intrinsic.
      * @param[in] intrinsicId The given intrinsic Id
-     * @return EParameterState
+     * @return EEstimatorParameterState
      */
-    inline EParameterState getIntrinsicState(const IndexT intrinsicId) const { return _statePerIntrinsicId.at(intrinsicId); }
+    inline EEstimatorParameterState getIntrinsicState(const IndexT intrinsicId) const { return _statePerIntrinsicId.at(intrinsicId); }
 
     /**
-     * @brief Return the EParameterState for a specific landmark.
+     * @brief Return the EEstimatorParameterState for a specific landmark.
      * @param[in] landmarkId The given landmark Id
-     * @return EParameterState
+     * @return EEstimatorParameterState
      */
-    inline EParameterState getLandmarkState(const IndexT landmarkId) const { return _statePerLandmarkId.at(landmarkId); }
+    inline EEstimatorParameterState getLandmarkState(const IndexT landmarkId) const { return _statePerLandmarkId.at(landmarkId); }
 
     /**
-     * @brief Return the number of poses with the given EParameterState.
-     * @param[in] state The given EParameterState.
-     * @return number of poses with the given EParameterState.
+     * @brief Return the number of poses with the given EEstimatorParameterState.
+     * @param[in] state The given EEstimatorParameterState.
+     * @return number of poses with the given EEstimatorParameterState.
      */
-    inline std::size_t getNbPosesPerState(EParameterState state) const
+    inline std::size_t getNbPosesPerState(EEstimatorParameterState state) const
     {
         std::size_t nb = 0;
         for (const auto& poseStatePair : _statePerPoseId)
@@ -71,11 +71,11 @@ class LocalBundleAdjustmentGraph
     }
 
     /**
-     * @brief Return the number of intrinsics with the given EParameterState.
-     * @param[in] state The given EParameterState.
-     * @return number of intrinsics with the given EParameterState.
+     * @brief Return the number of intrinsics with the given EEstimatorParameterState.
+     * @param[in] state The given EEstimatorParameterState.
+     * @return number of intrinsics with the given EEstimatorParameterState.
      */
-    inline std::size_t getNbIntrinsicsPerState(EParameterState state) const
+    inline std::size_t getNbIntrinsicsPerState(EEstimatorParameterState state) const
     {
         std::size_t nb = 0;
         for (const auto& intrinsicStatePair : _statePerIntrinsicId)
@@ -85,11 +85,11 @@ class LocalBundleAdjustmentGraph
     }
 
     /**
-     * @brief Return the number of landmarks with the given EParameterState.
-     * @param[in] state The given EParameterState.
-     * @return number of landmarks with the given EParameterState.
+     * @brief Return the number of landmarks with the given EEstimatorParameterState.
+     * @param[in] state The given EEstimatorParameterState.
+     * @return number of landmarks with the given EEstimatorParameterState.
      */
-    inline std::size_t getNbLandmarksPerState(EParameterState state) const
+    inline std::size_t getNbLandmarksPerState(EEstimatorParameterState state) const
     {
         std::size_t nb = 0;
         for (const auto& landmarkStatePair : _statePerLandmarkId)
@@ -218,9 +218,9 @@ class LocalBundleAdjustmentGraph
     /**
      * @brief Return the state for a given distance
      * @param[in] distance between two views
-     * @return EParameterState
+     * @return EEstimatorParameterState
      */
-    EParameterState getStateFromDistance(int distance) const;
+    EEstimatorParameterState getStateFromDistance(int distance) const;
 
     /**
      * @brief Draw the current graph in the given directory.
@@ -307,12 +307,12 @@ class LocalBundleAdjustmentGraph
     std::map<IndexT, int> _distancePerViewId;
     /// Store the graph-distances from the new poses (0: is a new pose, -1: is not connected to the new poses)
     std::map<IndexT, int> _distancePerPoseId;
-    /// Store the \c EParameterState of each pose in the scene.
-    std::map<IndexT, EParameterState> _statePerPoseId;
-    /// Store the \c EParameterState of each intrinsic in the scene.
-    std::map<IndexT, EParameterState> _statePerIntrinsicId;
-    /// Store the \c EParameterState of each landmark in the scene.
-    std::map<IndexT, EParameterState> _statePerLandmarkId;
+    /// Store the \c EEstimatorParameterState of each pose in the scene.
+    std::map<IndexT, EEstimatorParameterState> _statePerPoseId;
+    /// Store the \c EEstimatorParameterState of each intrinsic in the scene.
+    std::map<IndexT, EEstimatorParameterState> _statePerIntrinsicId;
+    /// Store the \c EEstimatorParameterState of each landmark in the scene.
+    std::map<IndexT, EEstimatorParameterState> _statePerLandmarkId;
 
     // Intrinsics data
     // - Local BA needs to know the evolution of all the intrinsics parameters.

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.hpp
@@ -36,32 +36,32 @@ class LocalBundleAdjustmentGraph
     std::map<int, std::size_t> getDistancesHistogram() const;
 
     /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific pose.
+     * @brief Return the EParameterState for a specific pose.
      * @param[in] poseId The given pose Id
-     * @return BundleAdjustment::EParameterState
+     * @return EParameterState
      */
-    inline BundleAdjustment::EParameterState getPoseState(const IndexT poseId) const { return _statePerPoseId.at(poseId); }
+    inline EParameterState getPoseState(const IndexT poseId) const { return _statePerPoseId.at(poseId); }
 
     /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific intrinsic.
+     * @brief Return the EParameterState for a specific intrinsic.
      * @param[in] intrinsicId The given intrinsic Id
-     * @return BundleAdjustment::EParameterState
+     * @return EParameterState
      */
-    inline BundleAdjustment::EParameterState getIntrinsicState(const IndexT intrinsicId) const { return _statePerIntrinsicId.at(intrinsicId); }
+    inline EParameterState getIntrinsicState(const IndexT intrinsicId) const { return _statePerIntrinsicId.at(intrinsicId); }
 
     /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific landmark.
+     * @brief Return the EParameterState for a specific landmark.
      * @param[in] landmarkId The given landmark Id
-     * @return BundleAdjustment::EParameterState
+     * @return EParameterState
      */
-    inline BundleAdjustment::EParameterState getLandmarkState(const IndexT landmarkId) const { return _statePerLandmarkId.at(landmarkId); }
+    inline EParameterState getLandmarkState(const IndexT landmarkId) const { return _statePerLandmarkId.at(landmarkId); }
 
     /**
-     * @brief Return the number of poses with the given BundleAdjustment::EParameterState.
-     * @param[in] state The given BundleAdjustment::EParameterState.
-     * @return number of poses with the given BundleAdjustment::EParameterState.
+     * @brief Return the number of poses with the given EParameterState.
+     * @param[in] state The given EParameterState.
+     * @return number of poses with the given EParameterState.
      */
-    inline std::size_t getNbPosesPerState(BundleAdjustment::EParameterState state) const
+    inline std::size_t getNbPosesPerState(EParameterState state) const
     {
         std::size_t nb = 0;
         for (const auto& poseStatePair : _statePerPoseId)
@@ -71,11 +71,11 @@ class LocalBundleAdjustmentGraph
     }
 
     /**
-     * @brief Return the number of intrinsics with the given BundleAdjustment::EParameterState.
-     * @param[in] state The given BundleAdjustment::EParameterState.
-     * @return number of intrinsics with the given BundleAdjustment::EParameterState.
+     * @brief Return the number of intrinsics with the given EParameterState.
+     * @param[in] state The given EParameterState.
+     * @return number of intrinsics with the given EParameterState.
      */
-    inline std::size_t getNbIntrinsicsPerState(BundleAdjustment::EParameterState state) const
+    inline std::size_t getNbIntrinsicsPerState(EParameterState state) const
     {
         std::size_t nb = 0;
         for (const auto& intrinsicStatePair : _statePerIntrinsicId)
@@ -85,11 +85,11 @@ class LocalBundleAdjustmentGraph
     }
 
     /**
-     * @brief Return the number of landmarks with the given BundleAdjustment::EParameterState.
-     * @param[in] state The given BundleAdjustment::EParameterState.
-     * @return number of landmarks with the given BundleAdjustment::EParameterState.
+     * @brief Return the number of landmarks with the given EParameterState.
+     * @param[in] state The given EParameterState.
+     * @return number of landmarks with the given EParameterState.
      */
-    inline std::size_t getNbLandmarksPerState(BundleAdjustment::EParameterState state) const
+    inline std::size_t getNbLandmarksPerState(EParameterState state) const
     {
         std::size_t nb = 0;
         for (const auto& landmarkStatePair : _statePerLandmarkId)
@@ -179,7 +179,7 @@ class LocalBundleAdjustmentGraph
      *        - \a Refined <=> its connected to a refined camera
      * @param[in] sfmData contains all the information about the reconstruction
      */
-    void convertDistancesToStates(const sfmData::SfMData& sfmData);
+    void convertDistancesToStates(sfmData::SfMData& sfmData);
 
     /**
      * @brief Update rigs edges.
@@ -218,9 +218,9 @@ class LocalBundleAdjustmentGraph
     /**
      * @brief Return the state for a given distance
      * @param[in] distance between two views
-     * @return BundleAdjustment::EParameterState
+     * @return EParameterState
      */
-    BundleAdjustment::EParameterState getStateFromDistance(int distance) const;
+    EParameterState getStateFromDistance(int distance) const;
 
     /**
      * @brief Draw the current graph in the given directory.
@@ -308,11 +308,11 @@ class LocalBundleAdjustmentGraph
     /// Store the graph-distances from the new poses (0: is a new pose, -1: is not connected to the new poses)
     std::map<IndexT, int> _distancePerPoseId;
     /// Store the \c EParameterState of each pose in the scene.
-    std::map<IndexT, BundleAdjustment::EParameterState> _statePerPoseId;
+    std::map<IndexT, EParameterState> _statePerPoseId;
     /// Store the \c EParameterState of each intrinsic in the scene.
-    std::map<IndexT, BundleAdjustment::EParameterState> _statePerIntrinsicId;
+    std::map<IndexT, EParameterState> _statePerIntrinsicId;
     /// Store the \c EParameterState of each landmark in the scene.
-    std::map<IndexT, BundleAdjustment::EParameterState> _statePerLandmarkId;
+    std::map<IndexT, EParameterState> _statePerLandmarkId;
 
     // Intrinsics data
     // - Local BA needs to know the evolution of all the intrinsics parameters.

--- a/src/aliceVision/sfm/bundle/BundleAdjustment.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustment.hpp
@@ -87,16 +87,6 @@ class BundleAdjustment
     };
 
     /**
-     * @brief Defines the state of the all parameter of the reconstruction during bundle adjustment.
-     */
-    enum class EParameterState : std::uint8_t
-    {
-        REFINED = 0,   //< will be adjusted by the BA solver
-        CONSTANT = 1,  //< will be set as constant in the sover
-        IGNORED = 2    //< will not be set into the BA solver
-    };
-
-    /**
      * @brief Defines all the refine options that can be used in a bundle adjustment.
      */
     enum ERefineOptions

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -420,11 +420,12 @@ bool BundleAdjustmentCeres::Statistics::exportToFile(const std::string& folder, 
         if (it.first >= 10)
             posesWithDistUpperThanTen += it.second;
 
-    os << time << ";" << states[EParameter::POSE][EEstimatorParameterState::REFINED] << ";" << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";"
-       << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";"
-       << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
-       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT] << ";"
-       << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
+    os << time << ";" << states[EParameter::POSE][EEstimatorParameterState::REFINED] << ";"
+       << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";" << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT]
+       << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT]
+       << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
        << nbUnsuccessfullIterations << ";" << RMSEinitial << ";" << RMSEfinal << ";";
 
     for (int i = -1; i < 10; ++i)
@@ -813,8 +814,8 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
             // each residual block takes a point and a camera as input and outputs a 2
             // dimensional residual. Internally, the cost function stores the observed
             // image location and compares the reprojection against the observation.
-            const auto & pose = sfmData.getPose(view);
-            const auto & intrinsic = sfmData.getIntrinsicsharedPtr(view);
+            const auto& pose = sfmData.getPose(view);
+            const auto& intrinsic = sfmData.getIntrinsicsharedPtr(view);
 
             assert(pose.getState() != EEstimatorParameterState::IGNORED);
             assert(intrinsic->getState() != EEstimatorParameterState::IGNORED);
@@ -881,10 +882,10 @@ void BundleAdjustmentCeres::addConstraints2DToProblem(const sfmData::SfMData& sf
         const sfmData::View& view_1 = sfmData.getView(constraint.ViewFirst);
         const sfmData::View& view_2 = sfmData.getView(constraint.ViewSecond);
 
-        const auto & pose_1 = sfmData.getPose(view_1);
-        const auto & pose_2 = sfmData.getPose(view_2);
-        const auto & intrinsic_1 = sfmData.getIntrinsicsharedPtr(view_1);
-        const auto & intrinsic_2 = sfmData.getIntrinsicsharedPtr(view_2);
+        const auto& pose_1 = sfmData.getPose(view_1);
+        const auto& pose_2 = sfmData.getPose(view_2);
+        const auto& intrinsic_1 = sfmData.getIntrinsicsharedPtr(view_1);
+        const auto& intrinsic_2 = sfmData.getIntrinsicsharedPtr(view_2);
 
         assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
         assert(intrinsic_1->getState() != EEstimatorParameterState::IGNORED);
@@ -917,8 +918,8 @@ void BundleAdjustmentCeres::addRotationPriorsToProblem(const sfmData::SfMData& s
         const sfmData::View& view_1 = sfmData.getView(prior.ViewFirst);
         const sfmData::View& view_2 = sfmData.getView(prior.ViewSecond);
 
-        const auto & pose_1 = sfmData.getPose(view_1);
-        const auto & pose_2 = sfmData.getPose(view_2);
+        const auto& pose_1 = sfmData.getPose(view_1);
+        const auto& pose_2 = sfmData.getPose(view_2);
 
         assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
         assert(pose_2.getState() != EEstimatorParameterState::IGNORED);
@@ -1028,7 +1029,7 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
         {
             const IndexT intrinsicId = intrinsicBlockPair.first;
 
-            const auto & intrinsic = sfmData.getIntrinsicsharedPtr(intrinsicId);
+            const auto& intrinsic = sfmData.getIntrinsicsharedPtr(intrinsicId);
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
             if (intrinsic->getState() != EEstimatorParameterState::REFINED)

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -413,18 +413,18 @@ bool BundleAdjustmentCeres::Statistics::exportToFile(const std::string& folder, 
               "d=5;d=6;d=7;d=8;d=9;d=10+;\n";
     }
 
-    std::map<EParameter, std::map<EParameterState, std::size_t>> states = parametersStates;
+    std::map<EParameter, std::map<EEstimatorParameterState, std::size_t>> states = parametersStates;
     std::size_t posesWithDistUpperThanTen = 0;
 
     for (const auto& it : nbCamerasPerDistance)
         if (it.first >= 10)
             posesWithDistUpperThanTen += it.second;
 
-    os << time << ";" << states[EParameter::POSE][EParameterState::REFINED] << ";" << states[EParameter::POSE][EParameterState::CONSTANT] << ";"
-       << states[EParameter::POSE][EParameterState::IGNORED] << ";" << states[EParameter::LANDMARK][EParameterState::REFINED] << ";"
-       << states[EParameter::LANDMARK][EParameterState::CONSTANT] << ";" << states[EParameter::LANDMARK][EParameterState::IGNORED] << ";"
-       << states[EParameter::INTRINSIC][EParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EParameterState::CONSTANT] << ";"
-       << states[EParameter::INTRINSIC][EParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
+    os << time << ";" << states[EParameter::POSE][EEstimatorParameterState::REFINED] << ";" << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";"
+       << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";"
+       << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT] << ";"
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
        << nbUnsuccessfullIterations << ";" << RMSEinitial << ";" << RMSEfinal << ";";
 
     for (int i = -1; i < 10; ++i)
@@ -444,7 +444,7 @@ bool BundleAdjustmentCeres::Statistics::exportToFile(const std::string& folder, 
 
 void BundleAdjustmentCeres::Statistics::show() const
 {
-    std::map<EParameter, std::map<EParameterState, std::size_t>> states = parametersStates;
+    std::map<EParameter, std::map<EEstimatorParameterState, std::size_t>> states = parametersStates;
     std::stringstream ss;
 
     if (!nbCamerasPerDistance.empty())
@@ -481,17 +481,17 @@ void BundleAdjustmentCeres::Statistics::show() const
     ALICEVISION_LOG_INFO("Bundle Adjustment Statistics:\n"
                          << ss.str() << "\t- adjustment duration: " << time << " s\n"
                          << "\t- poses:\n"
-                         << "\t    - # refined:  " << states[EParameter::POSE][EParameterState::REFINED] << "\n"
-                         << "\t    - # constant: " << states[EParameter::POSE][EParameterState::CONSTANT] << "\n"
-                         << "\t    - # ignored:  " << states[EParameter::POSE][EParameterState::IGNORED] << "\n"
+                         << "\t    - # refined:  " << states[EParameter::POSE][EEstimatorParameterState::REFINED] << "\n"
+                         << "\t    - # constant: " << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << "\n"
+                         << "\t    - # ignored:  " << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << "\n"
                          << "\t- landmarks:\n"
-                         << "\t    - # refined:  " << states[EParameter::LANDMARK][EParameterState::REFINED] << "\n"
-                         << "\t    - # constant: " << states[EParameter::LANDMARK][EParameterState::CONSTANT] << "\n"
-                         << "\t    - # ignored:  " << states[EParameter::LANDMARK][EParameterState::IGNORED] << "\n"
+                         << "\t    - # refined:  " << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << "\n"
+                         << "\t    - # constant: " << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT] << "\n"
+                         << "\t    - # ignored:  " << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << "\n"
                          << "\t- intrinsics:\n"
-                         << "\t    - # refined:  " << states[EParameter::INTRINSIC][EParameterState::REFINED] << "\n"
-                         << "\t    - # constant: " << states[EParameter::INTRINSIC][EParameterState::CONSTANT] << "\n"
-                         << "\t    - # ignored:  " << states[EParameter::INTRINSIC][EParameterState::IGNORED] << "\n"
+                         << "\t    - # refined:  " << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << "\n"
+                         << "\t    - # constant: " << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT] << "\n"
+                         << "\t    - # ignored:  " << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << "\n"
                          << "\t- # residual blocks: " << nbResidualBlocks << "\n"
                          << "\t- # successful iterations: " << nbSuccessfullIterations << "\n"
                          << "\t- # unsuccessful iterations: " << nbUnsuccessfullIterations << "\n"
@@ -553,7 +553,7 @@ void BundleAdjustmentCeres::addExtrinsicsToProblem(const sfmData::SfMData& sfmDa
         if (cameraPose.isLocked() || isConstant || (!refineTranslation && !refineRotation))
         {
             // set the whole parameter block as constant.
-            _statistics.addState(EParameter::POSE, EParameterState::CONSTANT);
+            _statistics.addState(EParameter::POSE, EEstimatorParameterState::CONSTANT);
             problem.SetParameterBlockConstant(poseBlockPtr);
             return;
         }
@@ -584,7 +584,7 @@ void BundleAdjustmentCeres::addExtrinsicsToProblem(const sfmData::SfMData& sfmDa
             problem.SetManifold(poseBlockPtr, subsetManifold);
         }
 
-        _statistics.addState(EParameter::POSE, EParameterState::REFINED);
+        _statistics.addState(EParameter::POSE, EEstimatorParameterState::REFINED);
     };
 
     // setup poses data
@@ -594,13 +594,13 @@ void BundleAdjustmentCeres::addExtrinsicsToProblem(const sfmData::SfMData& sfmDa
         const sfmData::CameraPose& pose = posePair.second;
 
         // skip camera pose set as Ignored in the Local strategy
-        if (pose.getState() == EParameterState::IGNORED)
+        if (pose.getState() == EEstimatorParameterState::IGNORED)
         {
-            _statistics.addState(EParameter::POSE, EParameterState::IGNORED);
+            _statistics.addState(EParameter::POSE, EEstimatorParameterState::IGNORED);
             continue;
         }
 
-        const bool isConstant = (pose.getState() == EParameterState::CONSTANT);
+        const bool isConstant = (pose.getState() == EEstimatorParameterState::CONSTANT);
 
         addPose(pose, isConstant, _posesBlocks[poseId]);
     }
@@ -661,9 +661,9 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
         const std::size_t usageCount = usageIt->second;
 
         // do not refine an intrinsic does not used by any reconstructed view
-        if (usageCount <= 0 || intrinsicPtr->getState() == EParameterState::IGNORED)
+        if (usageCount <= 0 || intrinsicPtr->getState() == EEstimatorParameterState::IGNORED)
         {
-            _statistics.addState(EParameter::INTRINSIC, EParameterState::IGNORED);
+            _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::IGNORED);
             continue;
         }
 
@@ -680,10 +680,10 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
         _allParametersBlocks.push_back(intrinsicBlockPtr);
 
         // keep the camera intrinsic constant
-        if (intrinsicPtr->isLocked() || !refineIntrinsics || intrinsicPtr->getState() == EParameterState::CONSTANT)
+        if (intrinsicPtr->isLocked() || !refineIntrinsics || intrinsicPtr->getState() == EEstimatorParameterState::CONSTANT)
         {
             // set the whole parameter block as constant.
-            _statistics.addState(EParameter::INTRINSIC, EParameterState::CONSTANT);
+            _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::CONSTANT);
             problem.SetParameterBlockConstant(intrinsicBlockPtr);
             continue;
         }
@@ -769,7 +769,7 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
           new IntrinsicsManifold(intrinsicBlock.size(), focalRatio, lockFocal, lockRatio, lockCenter, lockDistortion);
         problem.SetManifold(intrinsicBlockPtr, subsetManifold);
 
-        _statistics.addState(EParameter::INTRINSIC, EParameterState::REFINED);
+        _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::REFINED);
     }
 }
 
@@ -789,9 +789,9 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
 
         // do not create a residual block if the landmark
         // have been set as Ignored by the Local BA strategy
-        if (landmark.state == EParameterState::IGNORED)
+        if (landmark.state == EEstimatorParameterState::IGNORED)
         {
-            _statistics.addState(EParameter::LANDMARK, EParameterState::IGNORED);
+            _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::IGNORED);
             continue;
         }
 
@@ -816,8 +816,8 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
             const auto & pose = sfmData.getPose(view);
             const auto & intrinsic = sfmData.getIntrinsicsharedPtr(view);
 
-            assert(pose.getState() != EParameterState::IGNORED);
-            assert(intrinsic->getState() != EParameterState::IGNORED);
+            assert(pose.getState() != EEstimatorParameterState::IGNORED);
+            assert(intrinsic->getState() != EEstimatorParameterState::IGNORED);
 
             // needed parameters to create a residual block (K, pose)
             double* poseBlockPtr = _posesBlocks.at(view.getPoseId()).data();
@@ -856,15 +856,15 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                                          landmarkBlockPtr);  // do we need to copy 3D point to avoid false motion, if failure ?
             }
 
-            if (!refineStructure || landmark.state == EParameterState::CONSTANT)
+            if (!refineStructure || landmark.state == EEstimatorParameterState::CONSTANT)
             {
                 // set the whole landmark parameter block as constant.
-                _statistics.addState(EParameter::LANDMARK, EParameterState::CONSTANT);
+                _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::CONSTANT);
                 problem.SetParameterBlockConstant(landmarkBlockPtr);
             }
             else
             {
-                _statistics.addState(EParameter::LANDMARK, EParameterState::REFINED);
+                _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::REFINED);
             }
         }
     }
@@ -886,10 +886,10 @@ void BundleAdjustmentCeres::addConstraints2DToProblem(const sfmData::SfMData& sf
         const auto & intrinsic_1 = sfmData.getIntrinsicsharedPtr(view_1);
         const auto & intrinsic_2 = sfmData.getIntrinsicsharedPtr(view_2);
 
-        assert(pose_1.getState() != EParameterState::IGNORED);
-        assert(intrinsic_1->getState() != EParameterState::IGNORED);
-        assert(pose_2.getState() != EParameterState::IGNORED);
-        assert(intrinsic_2->getState() != EParameterState::IGNORED);
+        assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
+        assert(intrinsic_1->getState() != EEstimatorParameterState::IGNORED);
+        assert(pose_2.getState() != EEstimatorParameterState::IGNORED);
+        assert(intrinsic_2->getState() != EEstimatorParameterState::IGNORED);
 
         double* poseBlockPtr_1 = _posesBlocks.at(view_1.getPoseId()).data();
         double* poseBlockPtr_2 = _posesBlocks.at(view_2.getPoseId()).data();
@@ -920,8 +920,8 @@ void BundleAdjustmentCeres::addRotationPriorsToProblem(const sfmData::SfMData& s
         const auto & pose_1 = sfmData.getPose(view_1);
         const auto & pose_2 = sfmData.getPose(view_2);
 
-        assert(pose_1.getState() != EParameterState::IGNORED);
-        assert(pose_2.getState() != EParameterState::IGNORED);
+        assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
+        assert(pose_2.getState() != EEstimatorParameterState::IGNORED);
 
         double* poseBlockPtr_1 = _posesBlocks.at(view_1.getPoseId()).data();
         double* poseBlockPtr_2 = _posesBlocks.at(view_2.getPoseId()).data();
@@ -988,7 +988,7 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
             const IndexT poseId = posePair.first;
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
-            if (posePair.second.getState() != EParameterState::REFINED)
+            if (posePair.second.getState() != EEstimatorParameterState::REFINED)
                 continue;
 
             const std::array<double, 6>& poseBlock = _posesBlocks.at(poseId);
@@ -1031,7 +1031,7 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
             const auto & intrinsic = sfmData.getIntrinsicsharedPtr(intrinsicId);
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
-            if (intrinsic->getState() != EParameterState::REFINED)
+            if (intrinsic->getState() != EEstimatorParameterState::REFINED)
             {
                 continue;
             }
@@ -1049,7 +1049,7 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
             sfmData::Landmark& landmark = sfmData.getLandmarks().at(landmarkId);
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
-            if (landmark.state != EParameterState::REFINED)
+            if (landmark.state != EEstimatorParameterState::REFINED)
             {
                 continue;
             }

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
@@ -135,22 +135,10 @@ class BundleAdjustmentCeres : public BundleAdjustment
     bool adjust(sfmData::SfMData& sfmData, ERefineOptions refineOptions = REFINE_ALL);
 
     /**
-     * @brief Ajust parameters according to the local reconstruction graph in order do perfomr an optimezed bundle adjustmentor
-     * @param[in] localGraph The Local bundle adjustment graph pointer or nullptr (will refine everything)
-     */
-    inline void useLocalStrategyGraph(const std::shared_ptr<const LocalBundleAdjustmentGraph>& localGraph) { _localGraph = localGraph; }
-
-    /**
      * @brief Get bundle adjustment statistics structure
      * @return statistics structure const ptr
      */
     inline const Statistics& getStatistics() const { return _statistics; }
-
-    /**
-     * @brief Return true if the bundle adjustment use an external local graph
-     * @return true if use an external local graph
-     */
-    inline bool useLocalStrategy() const { return (_localGraph != nullptr); }
 
   private:
     /**
@@ -221,40 +209,7 @@ class BundleAdjustmentCeres : public BundleAdjustment
      */
     void updateFromSolution(sfmData::SfMData& sfmData, ERefineOptions refineOptions) const;
 
-    /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific pose.
-     * @param[in] poseId The pose id
-     * @return BundleAdjustment::EParameterState (always REFINED if no local strategy)
-     */
-    inline BundleAdjustment::EParameterState getPoseState(IndexT poseId) const
-    {
-        return (_localGraph != nullptr ? _localGraph->getPoseState(poseId) : BundleAdjustment::EParameterState::REFINED);
-    }
-
-    /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific intrinsic.
-     * @param[in] intrinsicId The intrinsic id
-     * @return BundleAdjustment::EParameterState (always REFINED if no local strategy)
-     */
-    inline BundleAdjustment::EParameterState getIntrinsicState(IndexT intrinsicId) const
-    {
-        return (_localGraph != nullptr ? _localGraph->getIntrinsicState(intrinsicId) : BundleAdjustment::EParameterState::REFINED);
-    }
-
-    /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific landmark.
-     * @param[in] landmarkId The landmark id
-     * @return BundleAdjustment::EParameterState (always REFINED if no local strategy)
-     */
-    inline BundleAdjustment::EParameterState getLandmarkState(IndexT landmarkId) const
-    {
-        return (_localGraph != nullptr ? _localGraph->getLandmarkState(landmarkId) : BundleAdjustment::EParameterState::REFINED);
-    }
-
     // private members
-
-    /// use or not the local budle adjustment strategy
-    std::shared_ptr<const LocalBundleAdjustmentGraph> _localGraph = nullptr;
 
     /// user Ceres options to use in the solver
     CeresOptions _ceresOptions;

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
@@ -69,7 +69,7 @@ class BundleAdjustmentCeres : public BundleAdjustment
          * @param[in] parameter A bundle adjustment parameter
          * @param[in] state A bundle adjustment state
          */
-        inline void addState(EParameter parameter, EParameterState state) { ++parametersStates[parameter][state]; }
+        inline void addState(EParameter parameter, EEstimatorParameterState state) { ++parametersStates[parameter][state]; }
 
         /**
          * @brief Export statistics about bundle adjustment in a CSV file
@@ -102,7 +102,7 @@ class BundleAdjustmentCeres : public BundleAdjustment
         /// time spent to solve the BA (s)
         double time = 0.0;
         /// number of states per parameter
-        std::map<EParameter, std::map<EParameterState, std::size_t>> parametersStates;
+        std::map<EParameter, std::map<EEstimatorParameterState, std::size_t>> parametersStates;
         /// The distribution of the cameras for each graph distance <distance, numOfCam>
         std::map<int, std::size_t> nbCamerasPerDistance;
     };

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.cpp
@@ -58,7 +58,7 @@ void BundleAdjustmentSymbolicCeres::addPose(const sfmData::CameraPose& cameraPos
     if (cameraPose.isLocked() || isConstant || (!refineTranslation && !refineRotation))
     {
         // set the whole parameter block as constant.
-        _statistics.addState(EParameter::POSE, EParameterState::CONSTANT);
+        _statistics.addState(EParameter::POSE, EEstimatorParameterState::CONSTANT);
 
         problem.SetParameterBlockConstant(poseBlockPtr);
         return;
@@ -73,7 +73,7 @@ void BundleAdjustmentSymbolicCeres::addPose(const sfmData::CameraPose& cameraPos
         ALICEVISION_THROW_ERROR("BundleAdjustmentSymbolicCeres: Constant extrinsics not supported at this time");
     }
 
-    _statistics.addState(EParameter::POSE, EParameterState::REFINED);
+    _statistics.addState(EParameter::POSE, EEstimatorParameterState::REFINED);
 }
 
 void BundleAdjustmentSymbolicCeres::CeresOptions::setDenseBA()
@@ -142,7 +142,7 @@ bool BundleAdjustmentSymbolicCeres::Statistics::exportToFile(const std::string& 
               "d=5;d=6;d=7;d=8;d=9;d=10+;\n";
     }
 
-    std::map<EParameter, std::map<EParameterState, std::size_t>> states = parametersStates;
+    std::map<EParameter, std::map<EEstimatorParameterState, std::size_t>> states = parametersStates;
     std::size_t posesWithDistUpperThanTen = 0;
 
     for (const auto& it : nbCamerasPerDistance)
@@ -153,11 +153,11 @@ bool BundleAdjustmentSymbolicCeres::Statistics::exportToFile(const std::string& 
         }
     }
 
-    os << time << ";" << states[EParameter::POSE][EParameterState::REFINED] << ";" << states[EParameter::POSE][EParameterState::CONSTANT] << ";"
-       << states[EParameter::POSE][EParameterState::IGNORED] << ";" << states[EParameter::LANDMARK][EParameterState::REFINED] << ";"
-       << states[EParameter::LANDMARK][EParameterState::CONSTANT] << ";" << states[EParameter::LANDMARK][EParameterState::IGNORED] << ";"
-       << states[EParameter::INTRINSIC][EParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EParameterState::CONSTANT] << ";"
-       << states[EParameter::INTRINSIC][EParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
+    os << time << ";" << states[EParameter::POSE][EEstimatorParameterState::REFINED] << ";" << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";"
+       << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";"
+       << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT] << ";"
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
        << nbUnsuccessfullIterations << ";" << RMSEinitial << ";" << RMSEfinal << ";";
 
     for (int i = -1; i < 10; ++i)
@@ -177,7 +177,7 @@ bool BundleAdjustmentSymbolicCeres::Statistics::exportToFile(const std::string& 
 
 void BundleAdjustmentSymbolicCeres::Statistics::show() const
 {
-    std::map<EParameter, std::map<EParameterState, std::size_t>> states = parametersStates;
+    std::map<EParameter, std::map<EEstimatorParameterState, std::size_t>> states = parametersStates;
     std::stringstream ss;
 
     if (!nbCamerasPerDistance.empty())
@@ -214,17 +214,17 @@ void BundleAdjustmentSymbolicCeres::Statistics::show() const
     ALICEVISION_LOG_INFO("Bundle Adjustment Statistics:\n"
                          << ss.str() << "\t- adjustment duration: " << time << " s\n"
                          << "\t- poses:\n"
-                         << "\t    - # refined:  " << states[EParameter::POSE][EParameterState::REFINED] << "\n"
-                         << "\t    - # constant: " << states[EParameter::POSE][EParameterState::CONSTANT] << "\n"
-                         << "\t    - # ignored:  " << states[EParameter::POSE][EParameterState::IGNORED] << "\n"
+                         << "\t    - # refined:  " << states[EParameter::POSE][EEstimatorParameterState::REFINED] << "\n"
+                         << "\t    - # constant: " << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << "\n"
+                         << "\t    - # ignored:  " << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << "\n"
                          << "\t- landmarks:\n"
-                         << "\t    - # refined:  " << states[EParameter::LANDMARK][EParameterState::REFINED] << "\n"
-                         << "\t    - # constant: " << states[EParameter::LANDMARK][EParameterState::CONSTANT] << "\n"
-                         << "\t    - # ignored:  " << states[EParameter::LANDMARK][EParameterState::IGNORED] << "\n"
+                         << "\t    - # refined:  " << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << "\n"
+                         << "\t    - # constant: " << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT] << "\n"
+                         << "\t    - # ignored:  " << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << "\n"
                          << "\t- intrinsics:\n"
-                         << "\t    - # refined:  " << states[EParameter::INTRINSIC][EParameterState::REFINED] << "\n"
-                         << "\t    - # constant: " << states[EParameter::INTRINSIC][EParameterState::CONSTANT] << "\n"
-                         << "\t    - # ignored:  " << states[EParameter::INTRINSIC][EParameterState::IGNORED] << "\n"
+                         << "\t    - # refined:  " << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << "\n"
+                         << "\t    - # constant: " << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT] << "\n"
+                         << "\t    - # ignored:  " << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << "\n"
                          << "\t- # residual blocks: " << nbResidualBlocks << "\n"
                          << "\t- # successful iterations: " << nbSuccessfullIterations << "\n"
                          << "\t- # unsuccessful iterations: " << nbUnsuccessfullIterations << "\n"
@@ -270,13 +270,13 @@ void BundleAdjustmentSymbolicCeres::addExtrinsicsToProblem(const sfmData::SfMDat
         const sfmData::CameraPose& pose = posePair.second;
 
         // skip camera pose set as Ignored in the Local strategy
-        if (pose.getState() == EParameterState::IGNORED)
+        if (pose.getState() == EEstimatorParameterState::IGNORED)
         {
-            _statistics.addState(EParameter::POSE, EParameterState::IGNORED);
+            _statistics.addState(EParameter::POSE, EEstimatorParameterState::IGNORED);
             continue;
         }
 
-        const bool isConstant = (pose.getState() == EParameterState::CONSTANT);
+        const bool isConstant = (pose.getState() == EEstimatorParameterState::CONSTANT);
 
         addPose(pose, isConstant, _posesBlocks[poseId], problem, refineTranslation, refineRotation);
     }
@@ -341,9 +341,9 @@ void BundleAdjustmentSymbolicCeres::addIntrinsicsToProblem(const sfmData::SfMDat
         const std::size_t usageCount = usageIt->second;
 
         // do not refine an intrinsic does not used by any reconstructed view
-        if (usageCount <= 0 || intrinsicPtr->getState() == EParameterState::IGNORED)
+        if (usageCount <= 0 || intrinsicPtr->getState() == EEstimatorParameterState::IGNORED)
         {
-            _statistics.addState(EParameter::INTRINSIC, EParameterState::IGNORED);
+            _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::IGNORED);
             continue;
         }
 
@@ -361,10 +361,10 @@ void BundleAdjustmentSymbolicCeres::addIntrinsicsToProblem(const sfmData::SfMDat
         _allParametersBlocks.push_back(intrinsicBlockPtr);
 
         // keep the camera intrinsic constant
-        if (intrinsicPtr->isLocked() || !refineIntrinsics || intrinsicPtr->getState() == EParameterState::CONSTANT)
+        if (intrinsicPtr->isLocked() || !refineIntrinsics || intrinsicPtr->getState() == EEstimatorParameterState::CONSTANT)
         {
             // set the whole parameter block as constant.
-            _statistics.addState(EParameter::INTRINSIC, EParameterState::CONSTANT);
+            _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::CONSTANT);
             problem.SetParameterBlockConstant(intrinsicBlockPtr);
             continue;
         }
@@ -448,7 +448,7 @@ void BundleAdjustmentSymbolicCeres::addIntrinsicsToProblem(const sfmData::SfMDat
         IntrinsicsManifoldSymbolic* subsetManifold =
           new IntrinsicsManifoldSymbolic(intrinsicBlock.size(), focalRatio, lockFocal, lockRatio, lockCenter, lockDistortion);
         problem.SetManifold(intrinsicBlockPtr, subsetManifold);
-        _statistics.addState(EParameter::INTRINSIC, EParameterState::REFINED);
+        _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::REFINED);
     }
 }
 
@@ -469,9 +469,9 @@ void BundleAdjustmentSymbolicCeres::addLandmarksToProblem(const sfmData::SfMData
 
         // do not create a residual block if the landmark
         // have been set as Ignored by the Local BA strategy
-        if (landmark.state == EParameterState::IGNORED)
+        if (landmark.state == EEstimatorParameterState::IGNORED)
         {
-            _statistics.addState(EParameter::LANDMARK, EParameterState::IGNORED);
+            _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::IGNORED);
             continue;
         }
 
@@ -503,8 +503,8 @@ void BundleAdjustmentSymbolicCeres::addLandmarksToProblem(const sfmData::SfMData
             // dimensional residual. Internally, the cost function stores the observed
             // image location and compares the reprojection against the observation.
 
-            assert(pose.getState() != EParameterState::IGNORED);
-            assert(intrinsic->getState() != EParameterState::IGNORED);
+            assert(pose.getState() != EEstimatorParameterState::IGNORED);
+            assert(intrinsic->getState() != EEstimatorParameterState::IGNORED);
 
             // needed parameters to create a residual block (K, pose)
             double* poseBlockPtr = _posesBlocks.at(view.getPoseId()).data();
@@ -540,15 +540,15 @@ void BundleAdjustmentSymbolicCeres::addLandmarksToProblem(const sfmData::SfMData
                 problem.AddResidualBlock(costFunction, lossFunction, poseBlockPtr, intrinsicBlockPtr, landmarkBlockPtr);
             }
 
-            if (!refineStructure || landmark.state == EParameterState::CONSTANT)
+            if (!refineStructure || landmark.state == EEstimatorParameterState::CONSTANT)
             {
                 // set the whole landmark parameter block as constant.
-                _statistics.addState(EParameter::LANDMARK, EParameterState::CONSTANT);
+                _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::CONSTANT);
                 problem.SetParameterBlockConstant(landmarkBlockPtr);
             }
             else
             {
-                _statistics.addState(EParameter::LANDMARK, EParameterState::REFINED);
+                _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::REFINED);
             }
         }
     }
@@ -570,10 +570,10 @@ void BundleAdjustmentSymbolicCeres::addConstraints2DToProblem(const sfmData::SfM
         const auto & intrinsic_1 = sfmData.getIntrinsicsharedPtr(view_1);
         const auto & intrinsic_2 = sfmData.getIntrinsicsharedPtr(view_2);
 
-        assert(pose_1.getState() != EParameterState::IGNORED);
-        assert(intrinsic_1->getState() != EParameterState::IGNORED);
-        assert(pose_2.getState() != EParameterState::IGNORED);
-        assert(intrinsic_2->getState() != EParameterState::IGNORED);
+        assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
+        assert(intrinsic_1->getState() != EEstimatorParameterState::IGNORED);
+        assert(pose_2.getState() != EEstimatorParameterState::IGNORED);
+        assert(intrinsic_2->getState() != EEstimatorParameterState::IGNORED);
 
         /* Get pose */
         double* poseBlockPtr_1 = _posesBlocks.at(view_1.getPoseId()).data();
@@ -630,8 +630,8 @@ void BundleAdjustmentSymbolicCeres::addRotationPriorsToProblem(const sfmData::Sf
         const auto & pose_1 = sfmData.getPose(view_1);
         const auto & pose_2 = sfmData.getPose(view_2);
 
-        assert(pose_1.getState() != EParameterState::IGNORED);
-        assert(pose_2.getState() != EParameterState::IGNORED);
+        assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
+        assert(pose_2.getState() != EEstimatorParameterState::IGNORED);
 
         double* poseBlockPtr_1 = _posesBlocks.at(view_1.getPoseId()).data();
         double* poseBlockPtr_2 = _posesBlocks.at(view_2.getPoseId()).data();
@@ -684,7 +684,7 @@ void BundleAdjustmentSymbolicCeres::updateFromSolution(sfmData::SfMData& sfmData
             const IndexT poseId = posePair.first;
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
-            if (posePair.second.getState() != EParameterState::REFINED)
+            if (posePair.second.getState() != EEstimatorParameterState::REFINED)
             {
                 continue;
             }
@@ -721,7 +721,7 @@ void BundleAdjustmentSymbolicCeres::updateFromSolution(sfmData::SfMData& sfmData
             const auto & intrinsic = sfmData.getIntrinsicsharedPtr(intrinsicId);
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
-            if (intrinsic->getState() != EParameterState::REFINED)
+            if (intrinsic->getState() != EEstimatorParameterState::REFINED)
             {
                 continue;
             }
@@ -739,7 +739,7 @@ void BundleAdjustmentSymbolicCeres::updateFromSolution(sfmData::SfMData& sfmData
             sfmData::Landmark& landmark = sfmData.getLandmarks().at(landmarkId);
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
-            if (landmark.state != EParameterState::REFINED)
+            if (landmark.state != EEstimatorParameterState::REFINED)
             {
                 continue;
             }

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.cpp
@@ -153,11 +153,12 @@ bool BundleAdjustmentSymbolicCeres::Statistics::exportToFile(const std::string& 
         }
     }
 
-    os << time << ";" << states[EParameter::POSE][EEstimatorParameterState::REFINED] << ";" << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";"
-       << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";"
-       << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
-       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT] << ";"
-       << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
+    os << time << ";" << states[EParameter::POSE][EEstimatorParameterState::REFINED] << ";"
+       << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";" << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT]
+       << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT]
+       << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
        << nbUnsuccessfullIterations << ";" << RMSEinitial << ";" << RMSEfinal << ";";
 
     for (int i = -1; i < 10; ++i)
@@ -497,7 +498,7 @@ void BundleAdjustmentSymbolicCeres::addLandmarksToProblem(const sfmData::SfMData
 
             // Get shared object clone
             const std::shared_ptr<IntrinsicBase> intrinsic = _intrinsicObjects[view.getIntrinsicId()];
-            const auto & pose = sfmData.getPose(view);
+            const auto& pose = sfmData.getPose(view);
 
             // each residual block takes a point and a camera as input and outputs a 2
             // dimensional residual. Internally, the cost function stores the observed
@@ -565,10 +566,10 @@ void BundleAdjustmentSymbolicCeres::addConstraints2DToProblem(const sfmData::SfM
         const sfmData::View& view_1 = sfmData.getView(constraint.ViewFirst);
         const sfmData::View& view_2 = sfmData.getView(constraint.ViewSecond);
 
-        const auto & pose_1 = sfmData.getPose(view_1);
-        const auto & pose_2 = sfmData.getPose(view_2);
-        const auto & intrinsic_1 = sfmData.getIntrinsicsharedPtr(view_1);
-        const auto & intrinsic_2 = sfmData.getIntrinsicsharedPtr(view_2);
+        const auto& pose_1 = sfmData.getPose(view_1);
+        const auto& pose_2 = sfmData.getPose(view_2);
+        const auto& intrinsic_1 = sfmData.getIntrinsicsharedPtr(view_1);
+        const auto& intrinsic_2 = sfmData.getIntrinsicsharedPtr(view_2);
 
         assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
         assert(intrinsic_1->getState() != EEstimatorParameterState::IGNORED);
@@ -627,8 +628,8 @@ void BundleAdjustmentSymbolicCeres::addRotationPriorsToProblem(const sfmData::Sf
         const sfmData::View& view_1 = sfmData.getView(prior.ViewFirst);
         const sfmData::View& view_2 = sfmData.getView(prior.ViewSecond);
 
-        const auto & pose_1 = sfmData.getPose(view_1);
-        const auto & pose_2 = sfmData.getPose(view_2);
+        const auto& pose_1 = sfmData.getPose(view_1);
+        const auto& pose_2 = sfmData.getPose(view_2);
 
         assert(pose_1.getState() != EEstimatorParameterState::IGNORED);
         assert(pose_2.getState() != EEstimatorParameterState::IGNORED);
@@ -718,7 +719,7 @@ void BundleAdjustmentSymbolicCeres::updateFromSolution(sfmData::SfMData& sfmData
         {
             const IndexT intrinsicId = intrinsicBlockPair.first;
 
-            const auto & intrinsic = sfmData.getIntrinsicsharedPtr(intrinsicId);
+            const auto& intrinsic = sfmData.getIntrinsicsharedPtr(intrinsicId);
 
             // do not update a camera pose set as Ignored or Constant in the Local strategy
             if (intrinsic->getState() != EEstimatorParameterState::REFINED)

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.hpp
@@ -76,7 +76,7 @@ class BundleAdjustmentSymbolicCeres : public BundleAdjustment, ceres::Evaluation
          * @param[in] parameter A bundle adjustment parameter
          * @param[in] state A bundle adjustment state
          */
-        inline void addState(EParameter parameter, EParameterState state) { ++parametersStates[parameter][state]; }
+        inline void addState(EParameter parameter, EEstimatorParameterState state) { ++parametersStates[parameter][state]; }
 
         /**
          * @brief Export statistics about bundle adjustment in a CSV file
@@ -109,7 +109,7 @@ class BundleAdjustmentSymbolicCeres : public BundleAdjustment, ceres::Evaluation
         /// time spent to solve the BA (s)
         double time = 0.0;
         /// number of states per parameter
-        std::map<EParameter, std::map<EParameterState, std::size_t>> parametersStates;
+        std::map<EParameter, std::map<EEstimatorParameterState, std::size_t>> parametersStates;
         /// The distribution of the cameras for each graph distance <distance, numOfCam>
         std::map<int, std::size_t> nbCamerasPerDistance;
     };

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.hpp
@@ -142,22 +142,10 @@ class BundleAdjustmentSymbolicCeres : public BundleAdjustment, ceres::Evaluation
     bool adjust(sfmData::SfMData& sfmData, ERefineOptions refineOptions = REFINE_ALL);
 
     /**
-     * @brief Ajust parameters according to the local reconstruction graph in order do perfomr an optimezed bundle adjustmentor
-     * @param[in] localGraph The Local bundle adjustment graph pointer or nullptr (will refine everything)
-     */
-    inline void useLocalStrategyGraph(const std::shared_ptr<const LocalBundleAdjustmentGraph>& localGraph) { _localGraph = localGraph; }
-
-    /**
      * @brief Get bundle adjustment statistics structure
      * @return statistics structure const ptr
      */
     inline const Statistics& getStatistics() const { return _statistics; }
-
-    /**
-     * @brief Return true if the bundle adjustment use an external local graph
-     * @return true if use an external local graph
-     */
-    inline bool useLocalStrategy() const { return (_localGraph != nullptr); }
 
     virtual void PrepareForEvaluation(bool evaluate_jacobians, bool new_evaluation_point);
 
@@ -247,41 +235,7 @@ class BundleAdjustmentSymbolicCeres : public BundleAdjustment, ceres::Evaluation
      */
     void updateFromSolution(sfmData::SfMData& sfmData, ERefineOptions refineOptions) const;
 
-    /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific pose.
-     * @param[in] poseId The pose id
-     * @return BundleAdjustment::EParameterState (always REFINED if no local strategy)
-     */
-    inline BundleAdjustment::EParameterState getPoseState(IndexT poseId) const
-    {
-        return (_localGraph != nullptr ? _localGraph->getPoseState(poseId) : BundleAdjustment::EParameterState::REFINED);
-    }
-
-    /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific intrinsic.
-     * @param[in] intrinsicId The intrinsic id
-     * @return BundleAdjustment::EParameterState (always REFINED if no local strategy)
-     */
-    inline BundleAdjustment::EParameterState getIntrinsicState(IndexT intrinsicId) const
-    {
-        return (_localGraph != nullptr ? _localGraph->getIntrinsicState(intrinsicId) : BundleAdjustment::EParameterState::REFINED);
-    }
-
-    /**
-     * @brief Return the BundleAdjustment::EParameterState for a specific landmark.
-     * @param[in] landmarkId The landmark id
-     * @return BundleAdjustment::EParameterState (always REFINED if no local strategy)
-     */
-    inline BundleAdjustment::EParameterState getLandmarkState(IndexT landmarkId) const
-    {
-        return (_localGraph != nullptr ? _localGraph->getLandmarkState(landmarkId) : BundleAdjustment::EParameterState::REFINED);
-    }
-
     // private members
-
-    /// use or not the local budle adjustment strategy
-    std::shared_ptr<const LocalBundleAdjustmentGraph> _localGraph = nullptr;
-
     /// user Ceres options to use in the solver
     CeresOptions _ceresOptions;
     int _minNbImagesToRefineOpticalCenter = 3;

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
@@ -209,12 +209,12 @@ BOOST_AUTO_TEST_CASE(LOCAL_BUNDLE_ADJUSTMENT_EffectiveMinimization_Pinhole_Camer
     BOOST_CHECK_EQUAL(localBAGraph->countNodes(), 4);  // 4 views => 4 nodes
     BOOST_CHECK_EQUAL(localBAGraph->countEdges(), 6);  // landmarks connections: 6 edges created (see scheme)
 
-    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EParameterState::REFINED), 2);      // v0 & v1
-    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EParameterState::CONSTANT), 1);     // v2
-    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EParameterState::IGNORED), 1);      // v3
-    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EParameterState::REFINED), 2);  // p0 & p1
-    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EParameterState::CONSTANT), 0);
-    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EParameterState::IGNORED), 1);  // p2
+    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EEstimatorParameterState::REFINED), 2);      // v0 & v1
+    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EEstimatorParameterState::CONSTANT), 1);     // v2
+    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EEstimatorParameterState::IGNORED), 1);      // v3
+    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EEstimatorParameterState::REFINED), 2);  // p0 & p1
+    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EEstimatorParameterState::CONSTANT), 0);
+    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EEstimatorParameterState::IGNORED), 1);  // p2
 
     std::shared_ptr<BundleAdjustmentCeres> BA = std::make_shared<BundleAdjustmentCeres>(options);
     BOOST_CHECK(BA->adjust(sfmData));

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
@@ -209,16 +209,14 @@ BOOST_AUTO_TEST_CASE(LOCAL_BUNDLE_ADJUSTMENT_EffectiveMinimization_Pinhole_Camer
     BOOST_CHECK_EQUAL(localBAGraph->countNodes(), 4);  // 4 views => 4 nodes
     BOOST_CHECK_EQUAL(localBAGraph->countEdges(), 6);  // landmarks connections: 6 edges created (see scheme)
 
-    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(BundleAdjustment::EParameterState::REFINED), 2);      // v0 & v1
-    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(BundleAdjustment::EParameterState::CONSTANT), 1);     // v2
-    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(BundleAdjustment::EParameterState::IGNORED), 1);      // v3
-    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(BundleAdjustment::EParameterState::REFINED), 2);  // p0 & p1
-    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(BundleAdjustment::EParameterState::CONSTANT), 0);
-    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(BundleAdjustment::EParameterState::IGNORED), 1);  // p2
+    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EParameterState::REFINED), 2);      // v0 & v1
+    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EParameterState::CONSTANT), 1);     // v2
+    BOOST_CHECK_EQUAL(localBAGraph->getNbPosesPerState(EParameterState::IGNORED), 1);      // v3
+    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EParameterState::REFINED), 2);  // p0 & p1
+    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EParameterState::CONSTANT), 0);
+    BOOST_CHECK_EQUAL(localBAGraph->getNbLandmarksPerState(EParameterState::IGNORED), 1);  // p2
 
     std::shared_ptr<BundleAdjustmentCeres> BA = std::make_shared<BundleAdjustmentCeres>(options);
-    BA->useLocalStrategyGraph(localBAGraph);
-    BOOST_CHECK(BA->useLocalStrategy());
     BOOST_CHECK(BA->adjust(sfmData));
 
     // Check views:

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1452,8 +1452,10 @@ bool ReconstructionEngine_sequentialSfM::getBestInitialImagePairs(std::vector<Pa
                 multiview::TriangulateDLT(PI, xI.col(inlier_idx), PJ, xJ.col(inlier_idx), X);
                 IndexT trackId = commonTracksIds[inlier_idx];
                 auto iter = map_tracksCommon[trackId].featPerView.begin();
-                const Vec2 featI = _featuresPerView->getFeatures(I, map_tracksCommon[trackId].descType)[iter->second.featureId].coords().cast<double>();
-                const Vec2 featJ = _featuresPerView->getFeatures(J, map_tracksCommon[trackId].descType)[(++iter)->second.featureId].coords().cast<double>();
+                const Vec2 featI =
+                  _featuresPerView->getFeatures(I, map_tracksCommon[trackId].descType)[iter->second.featureId].coords().cast<double>();
+                const Vec2 featJ =
+                  _featuresPerView->getFeatures(J, map_tracksCommon[trackId].descType)[(++iter)->second.featureId].coords().cast<double>();
                 vec_angles[i] = angleBetweenRays(pose_I, camI, pose_J, camJ, featI, featJ);
                 validCommonTracksIds[i] = trackId;
                 ++i;

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -773,8 +773,8 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
         // use the graph-distances to assign a state (Refine, Constant & Ignore) for each parameter (poses, intrinsics & landmarks)
         _localStrategyGraph->convertDistancesToStates(_sfmData);
 
-        const std::size_t nbRefinedPoses = _localStrategyGraph->getNbPosesPerState(EParameterState::REFINED);
-        const std::size_t nbConstantPoses = _localStrategyGraph->getNbPosesPerState(EParameterState::CONSTANT);
+        const std::size_t nbRefinedPoses = _localStrategyGraph->getNbPosesPerState(EEstimatorParameterState::REFINED);
+        const std::size_t nbConstantPoses = _localStrategyGraph->getNbPosesPerState(EEstimatorParameterState::CONSTANT);
 
         // restore the Dense linear solver type if the number of cameras in the solver is <= 20
         if (nbRefinedPoses + nbConstantPoses <= 20)

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -773,8 +773,8 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
         // use the graph-distances to assign a state (Refine, Constant & Ignore) for each parameter (poses, intrinsics & landmarks)
         _localStrategyGraph->convertDistancesToStates(_sfmData);
 
-        const std::size_t nbRefinedPoses = _localStrategyGraph->getNbPosesPerState(BundleAdjustment::EParameterState::REFINED);
-        const std::size_t nbConstantPoses = _localStrategyGraph->getNbPosesPerState(BundleAdjustment::EParameterState::CONSTANT);
+        const std::size_t nbRefinedPoses = _localStrategyGraph->getNbPosesPerState(EParameterState::REFINED);
+        const std::size_t nbConstantPoses = _localStrategyGraph->getNbPosesPerState(EParameterState::CONSTANT);
 
         // restore the Dense linear solver type if the number of cameras in the solver is <= 20
         if (nbRefinedPoses + nbConstantPoses <= 20)
@@ -795,8 +795,10 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
     BundleAdjustmentCeres BA(options, _params.minNbCamerasToRefinePrincipalPoint);
 
     // give the local strategy graph is local strategy is enable
-    if (enableLocalStrategy)
-        BA.useLocalStrategyGraph(_localStrategyGraph);
+    if (!enableLocalStrategy)
+    {
+        _sfmData.resetParameterStates();
+    }
 
     // perform BA until all point are under the given precision
     do

--- a/src/aliceVision/sfmData/CameraPose.hpp
+++ b/src/aliceVision/sfmData/CameraPose.hpp
@@ -68,20 +68,20 @@ class CameraPose
     {
         if (_locked)
         {
-            _state = EParameterState::CONSTANT;
+            _state = EEstimatorParameterState::CONSTANT;
         }
         else
         {
-            _state = EParameterState::REFINED;
+            _state = EEstimatorParameterState::REFINED;
         }
     }
 
-    EParameterState getState() const 
+    EEstimatorParameterState getState() const
     {
         return _state;
     }
 
-    void setState(EParameterState state) 
+    void setState(EEstimatorParameterState state)
     {
         _state = state;
     }
@@ -92,7 +92,7 @@ class CameraPose
     /// camera lock
     bool _locked = false;
     /// Estimator state
-    EParameterState _state = EParameterState::REFINED;
+    EEstimatorParameterState _state = EEstimatorParameterState::REFINED;
 
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/aliceVision/sfmData/CameraPose.hpp
+++ b/src/aliceVision/sfmData/CameraPose.hpp
@@ -63,8 +63,7 @@ class CameraPose
      */
     inline void unlock() { _locked = false; }
 
-    
-    void initializeState() 
+    void initializeState()
     {
         if (_locked)
         {
@@ -76,15 +75,9 @@ class CameraPose
         }
     }
 
-    EEstimatorParameterState getState() const
-    {
-        return _state;
-    }
+    EEstimatorParameterState getState() const { return _state; }
 
-    void setState(EEstimatorParameterState state)
-    {
-        _state = state;
-    }
+    void setState(EEstimatorParameterState state) { _state = state; }
 
   private:
     /// camera 3d transformation

--- a/src/aliceVision/sfmData/CameraPose.hpp
+++ b/src/aliceVision/sfmData/CameraPose.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <aliceVision/types.hpp>
 #include <aliceVision/geometry/Pose3.hpp>
 
 namespace aliceVision {
@@ -62,11 +63,36 @@ class CameraPose
      */
     inline void unlock() { _locked = false; }
 
+    
+    void initializeState() 
+    {
+        if (_locked)
+        {
+            _state = EParameterState::CONSTANT;
+        }
+        else
+        {
+            _state = EParameterState::REFINED;
+        }
+    }
+
+    EParameterState getState() const 
+    {
+        return _state;
+    }
+
+    void setState(EParameterState state) 
+    {
+        _state = state;
+    }
+
   private:
     /// camera 3d transformation
     geometry::Pose3 _transform;
     /// camera lock
     bool _locked = false;
+    /// Estimator state
+    EParameterState _state = EParameterState::REFINED;
 
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -31,7 +31,6 @@ struct Observation
     Vec2 x;
     IndexT id_feat = UndefinedIndexT;
     double scale = 0.0;
-
     bool operator==(const Observation& other) const { return AreVecNearEqual(x, other.x, 1e-6) && id_feat == other.id_feat; }
 };
 
@@ -61,6 +60,7 @@ struct Landmark
     feature::EImageDescriberType descType = feature::EImageDescriberType::UNINITIALIZED;
     Observations observations;
     image::RGBColor rgb = image::WHITE;  //!> the color associated to the point
+    EParameterState state = EParameterState::REFINED;
 
     bool operator==(const Landmark& other) const
     {

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -60,7 +60,7 @@ struct Landmark
     feature::EImageDescriberType descType = feature::EImageDescriberType::UNINITIALIZED;
     Observations observations;
     image::RGBColor rgb = image::WHITE;  //!> the color associated to the point
-    EParameterState state = EParameterState::REFINED;
+    EEstimatorParameterState state = EEstimatorParameterState::REFINED;
 
     bool operator==(const Landmark& other) const
     {

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -291,6 +291,24 @@ void SfMData::clear()
     _rigs.clear();
 }
 
+void SfMData::resetParameterStates()
+{
+    for (auto & pp : _poses)
+    {
+        pp.second.initializeState();
+    }
+
+    for (auto & pl : _structure)
+    {
+        pl.second.state = EParameterState::REFINED;
+    }
+
+    for (auto & pi : _intrinsics)
+    {
+        pi.second->initializeState();
+    }
+}
+
 LandmarksPerView getLandmarksPerViews(const SfMData& sfmData)
 {
     LandmarksPerView landmarksPerView;
@@ -315,6 +333,7 @@ LandmarksPerView getLandmarksPerViews(const SfMData& sfmData)
 
     return landmarksPerView;
 }
+
 
 }  // namespace sfmData
 }  // namespace aliceVision

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -20,7 +20,6 @@ using namespace aliceVision::image;
 
 namespace fs = boost::filesystem;
 
-
 bool SfMData::operator==(const SfMData& other) const
 {
     // Views
@@ -293,17 +292,17 @@ void SfMData::clear()
 
 void SfMData::resetParameterStates()
 {
-    for (auto & pp : _poses)
+    for (auto& pp : _poses)
     {
         pp.second.initializeState();
     }
 
-    for (auto & pl : _structure)
+    for (auto& pl : _structure)
     {
         pl.second.state = EEstimatorParameterState::REFINED;
     }
 
-    for (auto & pi : _intrinsics)
+    for (auto& pi : _intrinsics)
     {
         pi.second->initializeState();
     }
@@ -333,7 +332,6 @@ LandmarksPerView getLandmarksPerViews(const SfMData& sfmData)
 
     return landmarksPerView;
 }
-
 
 }  // namespace sfmData
 }  // namespace aliceVision

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -300,7 +300,7 @@ void SfMData::resetParameterStates()
 
     for (auto & pl : _structure)
     {
-        pl.second.state = EParameterState::REFINED;
+        pl.second.state = EEstimatorParameterState::REFINED;
     }
 
     for (auto & pi : _intrinsics)

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -205,10 +205,36 @@ class SfMData
 
     /**
      * @brief Return a shared pointer to an intrinsic if available or nullptr otherwise.
+     * @param[in] v
+     */
+    std::shared_ptr<camera::IntrinsicBase> getIntrinsicsharedPtr(const View & v)
+    {   
+        IndexT intrinsicId = v.getIntrinsicId();
+
+        if (_intrinsics.count(intrinsicId))
+            return _intrinsics.at(intrinsicId);
+        return nullptr;
+    }
+
+    /**
+     * @brief Return a shared pointer to an intrinsic if available or nullptr otherwise.
      * @param[in] intrinsicId
      */
     const std::shared_ptr<camera::IntrinsicBase> getIntrinsicsharedPtr(IndexT intrinsicId) const
     {
+        if (_intrinsics.count(intrinsicId))
+            return _intrinsics.at(intrinsicId);
+        return nullptr;
+    }
+
+    /**
+     * @brief Return a shared pointer to an intrinsic if available or nullptr otherwise.
+     * @param[in] v
+     */
+    const std::shared_ptr<camera::IntrinsicBase> getIntrinsicsharedPtr(const View & v) const
+    {   
+        IndexT intrinsicId = v.getIntrinsicId();
+
         if (_intrinsics.count(intrinsicId))
             return _intrinsics.at(intrinsicId);
         return nullptr;
@@ -486,6 +512,12 @@ class SfMData
     void combine(const SfMData& sfmData);
 
     void clear();
+
+    /**
+     * @Brief For all required items, update the
+     * state with respect to the associated lock
+    */
+    void resetParameterStates();
 
   private:
     /// Structure (3D points with their 2D observations)

--- a/src/aliceVision/types.hpp
+++ b/src/aliceVision/types.hpp
@@ -49,7 +49,7 @@ struct EstimationStatus
 /**
  * @brief Defines the state of a parameter for an estimator
  */
-enum class EParameterState : std::uint8_t
+enum class EEstimatorParameterState : std::uint8_t
 {
     REFINED = 0,   //< will be adjusted by the estimator
     CONSTANT = 1,  //< will be set as constant in the estimator

--- a/src/aliceVision/types.hpp
+++ b/src/aliceVision/types.hpp
@@ -46,4 +46,14 @@ struct EstimationStatus
     bool hasStrongSupport = false;
 };
 
+/**
+ * @brief Defines the state of a parameter for an estimator
+ */
+enum class EParameterState : std::uint8_t
+{
+    REFINED = 0,   //< will be adjusted by the estimator
+    CONSTANT = 1,  //< will be set as constant in the estimator
+    IGNORED = 2    //< will not be set into the estimator
+};
+
 }  // namespace aliceVision


### PR DESCRIPTION
Goal : 
- cleanup
- Be able to provide multiple policies in an easier way

LocalBundleAdjustment was storing the state of the sfmData properties (constant, ignored, refined) as a set of map.

Here we just move this information in the sfmData distributed in the various structures.

I kept the original structure and duplicate the information for the moment to keep the test working. It will need an update when the new classes will be used.