### PR TITLE
[docker] Fix the build of Docker images for Ubuntu

### DIFF
--- a/docker/Dockerfile_ubuntu
+++ b/docker/Dockerfile_ubuntu
@@ -4,6 +4,7 @@ ARG CUDA_VERSION
 ARG UBUNTU_VERSION
 FROM alicevision/alicevision-deps:${AV_DEPS_VERSION}-ubuntu${UBUNTU_VERSION}-cuda${CUDA_VERSION}
 LABEL maintainer="AliceVision Team alicevision-team@googlegroups.com"
+ARG TARGET_ARCHITECTURE=core
 
 # use CUDA_VERSION to select the image version to use
 # see https://hub.docker.com/r/nvidia/cuda/
@@ -42,7 +43,7 @@ COPY docker ${AV_DEV}/docker
 RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`; \
          cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS:BOOL=ON \
-        -DTARGET_ARCHITECTURE=core \
+        -DTARGET_ARCHITECTURE=${TARGET_ARCHITECTURE} \
         -DALICEVISION_BUILD_DEPENDENCIES:BOOL=OFF \
         -DCMAKE_PREFIX_PATH:PATH="${AV_INSTALL}" \
         -DCMAKE_INSTALL_PREFIX:PATH="${AV_INSTALL}" \

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -41,7 +41,12 @@ RUN . ./etc/os-release && \
 		nasm \
 		automake \
 		cmake \
-		gfortran
+		gfortran \
+		clang-format \
+		gcc-10 \
+		g++-10 \
+		cpp-10 && \
+	update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
 
 ENV AV_DEV=/opt/AliceVision_git \
     AV_BUILD=/tmp/AliceVision_build \
@@ -69,6 +74,7 @@ WORKDIR "${AV_BUILD}"
 RUN cmake "${AV_DEV}" \
      -DCMAKE_BUILD_TYPE=Release \
      -DALICEVISION_BUILD_DEPENDENCIES:BOOL=ON \
+     -DAV_BUILD_ZLIB:BOOL=ON \
      -DAV_BUILD_ALICEVISION:BOOL=OFF \
      -DCMAKE_INSTALL_PREFIX="${AV_INSTALL}"
 
@@ -78,6 +84,8 @@ RUN mkdir -p "${AV_INSTALL}/lib" && \
 
 RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gnu/libcublas.so /usr/local/cuda/lib64/libcublas.so
 
+# RUN make -j ${CPU_CORES} onnxruntime
+# RUN make -j ${CPU_CORES} pcl
 # RUN make -j ${CPU_CORES} turbojpeg
 # RUN make -j ${CPU_CORES} boost
 # RUN make -j ${CPU_CORES} openexr
@@ -92,15 +100,14 @@ RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gn
 # RUN make -j ${CPU_CORES} tiff
 # RUN make -j ${CPU_CORES} png
 # RUN make -j ${CPU_CORES} libraw
-# RUN make -j ${CPU_CORES} boost
 # RUN make -j ${CPU_CORES} openimageio
 # RUN make -j ${CPU_CORES} alembic
 # RUN make -j ${CPU_CORES} ffmpeg
 # RUN make -j ${CPU_CORES} opencv
 # RUN make -j ${CPU_CORES} expat
 
-# RUN make -j ${CPU_CORES} cctag
 # RUN make -j ${CPU_CORES} popsift
+# RUN make -j ${CPU_CORES} cctag
 
 RUN cmake --build . -j ${CPU_CORES} && \
     mv "${AV_INSTALL}/bin" "${AV_INSTALL}/bin-deps" && \

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,23 +6,32 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.10.12
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2023.12.13
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=20.04
 test -z "$REPO_OWNER" && REPO_OWNER=alicevision
 test -z "$DOCKER_REGISTRY" && DOCKER_REGISTRY=docker.io
 
+echo "AV_VERSION: $AV_VERSION"
+echo "AV_DEPS_VERSION: $AV_DEPS_VERSION"
+echo "CUDA_VERSION: $CUDA_VERSION"
+echo "UBUNTU_VERSION: $UBUNTU_VERSION"
+
+echo "--== FETCH DEPENDENCIES ==--"
+
 ./docker/fetch.sh
 
-DEPS_DOCKER_TAG=${REPO_OWNER}/alicevision-deps:${AV_DEPS_VERSION}-centos${CENTOS_VERSION}-cuda${CUDA_VERSION}
+DEPS_DOCKER_TAG=${REPO_OWNER}/alicevision-deps:${AV_DEPS_VERSION}-ubuntu${UBUNTU_VERSION}-cuda${CUDA_VERSION}
+
+echo "--== BUILD DEPENDENCIES ==--"
 
 ## DEPENDENCIES
 docker build \
 	--rm \
 	--build-arg CUDA_VERSION=${CUDA_VERSION} \
 	--build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
-	--tag alicevision/alicevision-deps:${AV_VERSION}-ubuntu${UBUNTU_VERSION}-cuda${CUDA_VERSION} \
+	--tag ${DEPS_DOCKER_TAG} \
 	-f docker/Dockerfile_ubuntu_deps .
 
 echo ""
@@ -30,15 +39,19 @@ echo "  To upload results:"
 echo "docker push ${DEPS_DOCKER_TAG}"
 echo ""
 
-DOCKER_TAG=${REPO_OWNER}/alicevision:${AV_VERSION}-centos${CENTOS_VERSION}-cuda${CUDA_VERSION}
+
+DOCKER_TAG=${REPO_OWNER}/alicevision:${AV_VERSION}-ubuntu${UBUNTU_VERSION}-cuda${CUDA_VERSION}
+
+echo "--== BUILD ALICEVISION ==--"
 
 ## ALICEVISION
 docker build \
 	--rm \
 	--build-arg CUDA_VERSION=${CUDA_VERSION} \
 	--build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+	--build-arg AV_DEPS_VERSION=${AV_DEPS_VERSION} \
 	--build-arg AV_VERSION=${AV_VERSION} \
-	--tag alicevision/alicevision:${AV_VERSION}-ubuntu${UBUNTU_VERSION}-cuda${CUDA_VERSION} \
+	--tag ${DOCKER_TAG} \
 	-f docker/Dockerfile_ubuntu .
 
 echo ""


### PR DESCRIPTION
## Description

The Dockerfiles for Ubuntu had not been updated in a while and building the images led to errors.

This PR fixes the following:
- Use the correct tags for the dependencies and AliceVision images;
- Build the embedded zlib;
- Use devtoolset-10 instead of devtoolset-9 to be able to build CCTag correctly.