### PR TITLE
Pixel Aspect Ratio application

### DIFF
--- a/src/aliceVision/camera/IntrinsicBase.cpp
+++ b/src/aliceVision/camera/IntrinsicBase.cpp
@@ -92,10 +92,10 @@ std::size_t IntrinsicBase::hashValue() const
     return seed;
 }
 
-void IntrinsicBase::rescale(float factor)
+void IntrinsicBase::rescale(float factorW, float factorH)
 {
-    _w = static_cast<unsigned int>(floor(static_cast<float>(_w) * factor));
-    _h = static_cast<unsigned int>(floor(static_cast<float>(_h) * factor));
+    _w = static_cast<unsigned int>(floor(static_cast<float>(_w) * factorW));
+    _h = static_cast<unsigned int>(floor(static_cast<float>(_h) * factorH));
 }
 
 }  // namespace camera

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -407,9 +407,10 @@ class IntrinsicBase
 
     /**
      * @brief Rescale intrinsics to reflect a rescale of the camera image
-     * @param factor a scale factor
+     * @param factorW a scale factor for Width
+     * @param factorH a scale factor for Height
      */
-    virtual void rescale(float factor);
+    virtual void rescale(float factorW, float factorH);
 
     /**
      * @brief transform a given point (in pixels) to unit sphere in meters

--- a/src/aliceVision/camera/IntrinsicScaleOffset.cpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffset.cpp
@@ -96,12 +96,16 @@ Eigen::Matrix2d IntrinsicScaleOffset::getDerivativeIma2CamWrtPrincipalPoint() co
     return M;
 }
 
-void IntrinsicScaleOffset::rescale(float factor)
+void IntrinsicScaleOffset::rescale(float factorW, float factorH)
 {
-    IntrinsicBase::rescale(factor);
+    IntrinsicBase::rescale(factorW, factorH);
 
-    _scale *= factor;
-    _offset *= factor;
+    _scale(0) *= factorW;
+    _scale(1) *= factorH;
+    _offset(0) *= factorW;
+    _offset(1) *= factorH;
+    _initialScale(0) *= factorW;
+    _initialScale(1) *= factorH;
 }
 
 bool IntrinsicScaleOffset::updateFromParams(const std::vector<double>& params)

--- a/src/aliceVision/camera/IntrinsicScaleOffset.hpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffset.hpp
@@ -70,9 +70,10 @@ class IntrinsicScaleOffset : public IntrinsicBase
 
     /**
      * @brief Rescale intrinsics to reflect a rescale of the camera image
-     * @param factor a scale factor
+     * @param factorW a scale factor for Width
+     * @param factorH a scale factor for Height
      */
-    void rescale(float factor) override;
+    void rescale(float factorW, float factorH) override;
 
     // Data wrapper for non linear optimization (update from data)
     bool updateFromParams(const std::vector<double>& params) override;


### PR DESCRIPTION

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR enables Pixel Aspect Ratio (PAR) application by imageProcessing.

If imageProcessing is connected to a sfmData, the PAR is extracted from the intrinsics, applied and updated in the intrinsics. Otherwise, the PAR is extracted from the metadata, applied and updated in the metadata.

The PAR application can be done by increasing the image width (default) or by reducing the image height. 

linked to meshroom PR https://github.com/alicevision/Meshroom/pull/2273

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

Implementation of PAR application is combined with the rescaling feature already available in imageProcessing.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

