### PR TITLE
[image] io: Rely on OIIO to determine if an image file exists or not

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -577,10 +577,7 @@ void readImage(const std::string& path, oiio::TypeDesc format, int nchannels, Im
     if (nchannels == 0)
         ALICEVISION_THROW_ERROR("Requested channels is 0. Image file: '" + path + "'.");
     if (nchannels == 2)
-        ALICEVISION_THROW_ERROR("Load of 2 channels is not supported. Image file: '" + path + "'.");
-
-    if(!fs::exists(path))
-        ALICEVISION_THROW_ERROR("No such image file: '" << path << "'.");
+        ALICEVISION_THROW_ERROR("Load of 2 channels is not supported. Image file: '" + path + "'.")
 
     oiio::ImageSpec configSpec;
 
@@ -740,8 +737,8 @@ void readImage(const std::string& path, oiio::TypeDesc format, int nchannels, Im
 
     inBuf.read(0, 0, true, oiio::TypeDesc::FLOAT); // force image convertion to float (for grayscale and color space convertion)
 
-    if(!inBuf.initialized())
-        ALICEVISION_THROW_ERROR("Failed to open the image file: '" << path << "'.");
+    if (!inBuf.initialized())
+        ALICEVISION_THROW_ERROR("Failed to open the image file: '" << path << "'. The file might not exist.");
 
     // check picture channels number
     if (inBuf.spec().nchannels == 0)


### PR DESCRIPTION
## Description

An image file's existence was checked prior to being passed to OIIO to be loaded, and if the test failed, an error was thrown. This worked fine for Linux platforms but in case a non-ASCII character was part of the image's path on Windows, that test always failed because non-ASCII characters are not correctly handled by default.

OIIO is however able to correctly read existing image files, independently from the type of characters their path contains. If a file with or without non-ASCII characters does not exist, the `ImageBuf` object will not be correctly initialized, and we will be able to catch it and throw an error. If it does exist, it will be correctly read in all cases.

There is thus no need for the test on the file's existence anymore.

With this PR, fatal errors that some of the executables were facing on Windows when using images with non-ASCII characters in their path, even though those images were valid and could be read by OIIO without any issue. (fixes https://github.com/alicevision/Meshroom/issues/2139#issuecomment-1850892428)