### PR TITLE
Add Bundle Adjustment unit tests

### DIFF
--- a/src/aliceVision/camera/DistortionBrown.cpp
+++ b/src/aliceVision/camera/DistortionBrown.cpp
@@ -5,39 +5,131 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "DistortionBrown.hpp"
-
+#include <aliceVision/system/Logger.hpp>
 #include <vector>
 
 namespace aliceVision {
 namespace camera {
 
-Vec2 DistortionBrown::distoFunction(const std::vector<double>& params, const Vec2& p)
-{
-    const double &k1 = params[0], k2 = params[1], k3 = params[2], t1 = params[3], t2 = params[4];
-    const double r2 = p(0) * p(0) + p(1) * p(1);
+Vec2 DistortionBrown::addDistortion(const Vec2& p) const 
+{ 
+    const double k1 = _distortionParams[0];
+    const double k2 = _distortionParams[1];
+    const double k3 = _distortionParams[2];
+    const double t1 = _distortionParams[3]; 
+    const double t2 = _distortionParams[4];
+
+    double px = p(0);
+    double py = p(1);
+
+    const double r2 = px * px + py * py;
     const double r4 = r2 * r2;
     const double r6 = r4 * r2;
-    const double k_diff = (k1 * r2 + k2 * r4 + k3 * r6);
-    const double t_x = t2 * (r2 + 2 * p(0) * p(0)) + 2 * t1 * p(0) * p(1);
-    const double t_y = t1 * (r2 + 2 * p(1) * p(1)) + 2 * t2 * p(0) * p(1);
-    Vec2 d(p(0) * k_diff + t_x, p(1) * k_diff + t_y);
 
-    return d;
+    const double k_diff = (k1 * r2 + k2 * r4 + k3 * r6);
+    const double t_x = t2 * (r2 + 2 * px * px) + 2 * t1 * px * py;
+    const double t_y = t1 * (r2 + 2 * py * py) + 2 * t2 * px * py;
+    
+    Vec2 result;
+    
+    result(0) = px + px * k_diff + t_x;
+    result(1) = py + py * k_diff + t_y;
+
+    return result; 
 }
 
-Vec2 DistortionBrown::addDistortion(const Vec2& p) const { return (p + distoFunction(_distortionParams, p)); }
+Eigen::Matrix2d DistortionBrown::getDerivativeAddDistoWrtPt(const Vec2& p) const 
+{
+    const double k1 = _distortionParams[0];
+    const double k2 = _distortionParams[1];
+    const double k3 = _distortionParams[2];
+    const double t1 = _distortionParams[3]; 
+    const double t2 = _distortionParams[4];
+
+    double px = p(0);
+    double py = p(1);
+
+    const double r2 = px * px + py * py;
+    const double r4 = r2 * r2;
+    const double r6 = r4 * r2;
+
+    Eigen::Matrix2d ret;
+    ret(0, 0) = k1*r2 + k2*r4 + k3*r6 + 2*px*px*(k1 + 2*k2*r2 + 3*k3*r4) + 6*px*t2 + 2*py*t1 + 1;
+    ret(0, 1) = 2*px*py*(k1 + 2*k2*r2 + 3*k3*r4) + 2*px*t1 + 2*py*t2;
+    ret(1, 0) = 2*px*py*(k1 + 2*k2*r2 + 3*k3*r4) + 2*px*t1 + 2*py*t2;
+    ret(1, 1) = k1*r2 + k2*r4 + k3*r6 + 2*px*t2 + 2*py*py*(k1 + 2*k2*r2 + 3*k3*r4) + 6*py*t1 + 1;
+
+
+    return ret;
+}
+
+Eigen::MatrixXd DistortionBrown::getDerivativeAddDistoWrtDisto(const Vec2& p) const
+{
+    const double k1 = _distortionParams[0];
+    const double k2 = _distortionParams[1];
+    const double k3 = _distortionParams[2];
+    const double t1 = _distortionParams[3]; 
+    const double t2 = _distortionParams[4];
+
+    double px = p(0);
+    double py = p(1);
+
+    const double r2 = px * px + py * py;
+    const double r4 = r2 * r2;
+    const double r6 = r4 * r2;
+
+    Eigen::Matrix<double, 2, 5> ret = Eigen::Matrix<double, 2, 5>::Zero();
+
+    ret(0, 0) = px*r2;
+    ret(0, 1) = px*r4;
+    ret(0, 2) = px*r6;
+    ret(0, 3) = 2*px*py;
+    ret(0, 4) = 3*px*px + py*py;
+
+
+    ret(1, 0) = py*r2;
+    ret(1, 1) = py*r4;
+    ret(1, 2) = py*r6;
+    ret(1, 3) = px*px + 3*py*py;
+    ret(1, 4) = 2*px*py;
+
+    return ret;
+}
 
 Vec2 DistortionBrown::removeDistortion(const Vec2& p) const
 {
-    const double epsilon = 1e-8;  // criteria to stop the iteration
-    Vec2 p_u = p;
+    double epsilon = 1e-8;
+    Vec2 undistorted_value = p;
 
-    while ((addDistortion(p_u) - p).lpNorm<1>() > epsilon)  // manhattan distance between the two points
+    
+    Vec2 diff = addDistortion(undistorted_value) - p;
+
+    int iter = 0;
+    while (diff.norm() > epsilon)
     {
-        p_u = p - distoFunction(_distortionParams, p_u);
+        undistorted_value = undistorted_value - getDerivativeAddDistoWrtPt(undistorted_value).inverse() * diff;
+        
+        diff = addDistortion(undistorted_value) - p;
+        iter++;
+        if (iter > 10)
+        {
+            break;
+        }        
     }
 
-    return p_u;
+    return undistorted_value;
+}
+
+Eigen::Matrix2d DistortionBrown::getDerivativeRemoveDistoWrtPt(const Vec2& p) const
+{
+    ALICEVISION_THROW_ERROR("Brown inverse jacobian are not implemented");
+    return Eigen::Matrix2d::Identity();
+}
+
+Eigen::MatrixXd DistortionBrown::getDerivativeRemoveDistoWrtDisto(const Vec2& p) const
+{
+    ALICEVISION_THROW_ERROR("Brown inverse jacobian are not implemented");
+    return Eigen::Matrix<double, 2, 5>::Zero();
 }
 
 }  // namespace camera

--- a/src/aliceVision/camera/DistortionBrown.hpp
+++ b/src/aliceVision/camera/DistortionBrown.hpp
@@ -29,8 +29,13 @@ class DistortionBrown : public Distortion
     /// Remove distortion (return p' such that disto(p') = p)
     Vec2 removeDistortion(const Vec2& p) const override;
 
-    // Functor to calculate distortion offset accounting for both radial and tangential distortion
-    static Vec2 distoFunction(const std::vector<double>& params, const Vec2& p);
+    Eigen::Matrix2d getDerivativeAddDistoWrtPt(const Vec2& p) const override;
+
+    Eigen::MatrixXd getDerivativeAddDistoWrtDisto(const Vec2& p) const override;
+
+    Eigen::Matrix2d getDerivativeRemoveDistoWrtPt(const Vec2& p) const override;
+
+    Eigen::MatrixXd getDerivativeRemoveDistoWrtDisto(const Vec2& p) const override;
 
     ~DistortionBrown() override = default;
 };

--- a/src/aliceVision/camera/DistortionFisheye1.cpp
+++ b/src/aliceVision/camera/DistortionFisheye1.cpp
@@ -11,18 +11,155 @@ namespace camera {
 
 Vec2 DistortionFisheye1::addDistortion(const Vec2& p) const
 {
+    const double eps = 1e-8;
     const double& k1 = _distortionParams.at(0);
-    const double r = std::hypot(p(0), p(1));
+    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
+    if (k1 * r < eps)
+    {
+        return p;
+    }
+        
     const double coef = (std::atan(2.0 * r * std::tan(0.5 * k1)) / k1) / r;
+
     return p * coef;
+}
+
+Eigen::Matrix2d DistortionFisheye1::getDerivativeAddDistoWrtPt(const Vec2& p) const
+{
+    const double& k1 = _distortionParams.at(0);
+    const double eps = 1e-8;
+    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
+    if (k1 * r < eps)
+    {
+        return Eigen::Matrix2d::Identity();
+    }
+
+    Eigen::Matrix<double, 1, 2> d_r_d_p;
+    d_r_d_p(0) = p(0) / r;
+    d_r_d_p(1) = p(1) / r;
+
+    const double part1 = 2.0 * r * std::tan(0.5 * k1);
+    const double part2 = std::atan(part1);
+    const double part3 = k1 * r;
+    const double coef = part2 / part3;
+
+    double d_part3_d_r = k1;
+    double d_part2_d_part1 = 1.0 / (part1 * part1 + 1.0);
+    double d_part1_d_r = 2.0 * std::tan(0.5 * k1);
+
+    double d_coef_d_part2 = 1.0 / part3;
+    double d_coef_d_part3 = - part2 / (part3 * part3);
+    double d_coef_d_r = d_coef_d_part2 * d_part2_d_part1 * d_part1_d_r + d_coef_d_part3 * d_part3_d_r;
+    Eigen::Matrix<double, 1, 2> d_coef_d_p = d_coef_d_r * d_r_d_p;
+
+    return Eigen::Matrix2d::Identity() * coef + p * d_coef_d_p;
+}
+
+Eigen::MatrixXd DistortionFisheye1::getDerivativeAddDistoWrtDisto(const Vec2& p) const
+{
+    const double& k1 = _distortionParams.at(0);
+    const double eps = 1e-21;
+    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
+    if (k1 * r < eps)
+    {
+        return Eigen::Matrix<double, 2, 1>::Zero();
+    }
+
+    /* const double eps = 1e-8;
+    const double& k1 = _distortionParams.at(0);
+    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
+    if (k1 * r < eps)
+    {
+        return p;
+    }
+        
+    const double coef = (std::atan(2.0 * r * std::tan(0.5 * k1)) / k1) / r;
+
+    return p * coef;
+}*/
+
+    const double part1 = 2.0 * r * std::tan(0.5 * k1);
+    const double part2 = std::atan(part1);
+    const double part3 = k1 * r;
+    const double coef = part2 / part3;
+
+    double ca = cos(0.5 * k1);
+    double d_part1_d_params = r / (ca * ca);
+    double d_part3_d_params = r;
+    double d_part2_d_part1 = 1.0 / (part1 * part1 + 1.0);
+    double d_coef_d_part2 = 1.0 / part3;
+    double d_coef_d_part3 = - part2 / (part3 * part3);
+
+    double d_coef_d_params = d_coef_d_part3 * d_part3_d_params + d_coef_d_part2 * d_part2_d_part1 * d_part1_d_params;
+
+    return p * d_coef_d_params;
 }
 
 Vec2 DistortionFisheye1::removeDistortion(const Vec2& p) const
 {
+    const double eps = 1e-8;
     const double& k1 = _distortionParams.at(0);
     const double r = std::hypot(p(0), p(1));
+    if (k1 * r < eps)
+    {
+        return p;
+    }
+
     const double coef = 0.5 * std::tan(r * k1) / (std::tan(0.5 * k1) * r);
     return p * coef;
+}
+
+Eigen::Matrix2d DistortionFisheye1::getDerivativeRemoveDistoWrtPt(const Vec2& p) const
+{
+    const double& k1 = _distortionParams.at(0);
+    const double eps = 1e-8;
+    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
+    if (k1 * r < eps)
+    {
+        return Eigen::Matrix2d::Identity();
+    }
+
+    const Vec2 undist = removeDistortion(p);
+
+    const Eigen::Matrix2d Jinv = getDerivativeAddDistoWrtPt(undist);
+
+    return Jinv.inverse();
+}
+
+
+Eigen::MatrixXd DistortionFisheye1::getDerivativeRemoveDistoWrtDisto(const Vec2& p) const
+{
+    const double& k1 = _distortionParams.at(0);
+    double r_dist = sqrt(p(0) * p(0) + p(1) * p(1));
+    const double eps = 1e-8;
+    if (k1 * r_dist < eps)
+    {
+        return Eigen::Matrix<double, 2, 1>::Zero();
+    }
+
+    const Vec2 p_undist = removeDistortion(p);
+    const double r = sqrt(p_undist(0) * p_undist(0) + p_undist(1) * p_undist(1));
+
+
+    const double part1 = 2.0 * r * std::tan(0.5 * k1);
+    const double part2 = std::atan(part1);
+    const double part3 = k1 * r;
+    const double coef = part2 / part3;
+
+    double ca = cos(0.5 * k1);
+    double d_part1_d_params = r / (ca * ca);
+    double d_part3_d_params = r;
+    double d_part2_d_part1 = 1.0 / (part1 * part1 + 1.0);
+    double d_coef_d_part2 = (part2 * part2) / part3;
+    double d_coef_d_part3 = - part2 / (part3 * part3);
+    double d_coef_d_params = d_coef_d_part3 * d_part3_d_params + d_coef_d_part2 * d_part2_d_part1 * d_part1_d_params;
+
+    //p'/coef
+    Eigen::Matrix<double, 2, 1> ret;
+    ret(0, 0) = - p(0) * d_coef_d_params / (coef * coef);
+    ret(1, 0) = - p(1) * d_coef_d_params / (coef * coef);
+
+    return ret;
 }
 
 }  // namespace camera

--- a/src/aliceVision/camera/DistortionFisheye1.hpp
+++ b/src/aliceVision/camera/DistortionFisheye1.hpp
@@ -29,6 +29,14 @@ class DistortionFisheye1 : public Distortion
     /// Remove distortion (return p' such that disto(p') = p)
     Vec2 removeDistortion(const Vec2& p) const override;
 
+    Eigen::Matrix2d getDerivativeAddDistoWrtPt(const Vec2& p) const override;
+
+    Eigen::MatrixXd getDerivativeAddDistoWrtDisto(const Vec2& p) const override;
+
+    Eigen::Matrix2d getDerivativeRemoveDistoWrtPt(const Vec2& p) const override;
+
+    Eigen::MatrixXd getDerivativeRemoveDistoWrtDisto(const Vec2& p) const override;
+
     ~DistortionFisheye1() override = default;
 };
 

--- a/src/aliceVision/camera/DistortionRadial.cpp
+++ b/src/aliceVision/camera/DistortionRadial.cpp
@@ -17,51 +17,28 @@ double DistortionRadialK1::distoFunctor(const std::vector<double>& params, doubl
 
 Vec2 DistortionRadialK1::addDistortion(const Vec2& p) const
 {
-    const double& k1 = _distortionParams.at(0);
-
+    const double k1 = _distortionParams.at(0);
     const double r2 = p(0) * p(0) + p(1) * p(1);
     const double r_coeff = (1. + k1 * r2);
-
     return (p * r_coeff);
 }
 
 Eigen::Matrix2d DistortionRadialK1::getDerivativeAddDistoWrtPt(const Vec2& p) const
 {
     const double k1 = _distortionParams[0];
-
-    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
-    const double eps = 1e-8;
-    if (r < eps)
-    {
-        return Eigen::Matrix2d::Identity();
-    }
-
-    Eigen::Matrix<double, 1, 2> d_r_d_p;
-    d_r_d_p(0) = p(0) / r;
-    d_r_d_p(1) = p(1) / r;
-
-    const double r2 = r * r;
+    const double r2 = p(0) * p(0) + p(1) * p(1);
     const double r_coeff = 1.0 + k1 * r2;
-
-    const double d_r_coeff_d_r = 2.0 * k1 * r;
-    const Eigen::Matrix<double, 1, 2> d_r_coeff_d_p = d_r_coeff_d_r * d_r_d_p;
-
+    Eigen::Matrix<double, 1, 2> d_r_coeff_d_p;
+    d_r_coeff_d_p(0, 0) = 2.0 * k1 * p(0);
+    d_r_coeff_d_p(0, 1) = 2.0 * k1 * p(1);
     return Eigen::Matrix2d::Identity() * r_coeff + p * d_r_coeff_d_p;
 }
 
 Eigen::MatrixXd DistortionRadialK1::getDerivativeAddDistoWrtDisto(const Vec2& p) const
 {
-    const double& k1 = _distortionParams[0];
-
-    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
-    const double eps = 1e-8;
-    if (r < eps)
-    {
-        return Eigen::Matrix<double, 2, 1>::Zero();
-    }
-
-    const Eigen::MatrixXd ret = p * r * r;
-
+    const double k1 = _distortionParams[0];
+    const double r2 = p(0) * p(0) + p(1) * p(1);
+    const Eigen::MatrixXd ret = p * r2;
     return ret;
 }
 

--- a/src/aliceVision/camera/Equidistant.cpp
+++ b/src/aliceVision/camera/Equidistant.cpp
@@ -141,7 +141,7 @@ Eigen::Matrix<double, 2, 16> Equidistant::getDerivativeProjectWrtPoseLeft(const 
     Eigen::Matrix4d T = pose;
     const Vec4 X = T * pt;  // apply pose
 
-    const Eigen::Matrix<double, 4, 16> d_X_d_T = getJacobian_AB_wrt_A<4, 4, 1>(T, pt);
+    const Eigen::Matrix<double, 4, 16> d_X_d_T = getJacobian_AB_wrt_A<4, 4, 1>(Eigen::Matrix4d::Identity(), X);
 
     /* Compute angle with optical center */
     double len2d = sqrt(X(0) * X(0) + X(1) * X(1));

--- a/src/aliceVision/camera/Equidistant.hpp
+++ b/src/aliceVision/camera/Equidistant.hpp
@@ -72,7 +72,7 @@ class Equidistant : public IntrinsicScaleOffsetDisto
         return project(pose.getHomogeneous(), pt3D, applyDistortion);
     }
 
-    Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const Eigen::Matrix4d& pose, const Vec4& pt);
+    Eigen::Matrix<double, 2, 9> getDerivativeProjectWrtRotation(const Eigen::Matrix4d& pose, const Vec4& pt) const;
 
     Eigen::Matrix<double, 2, 16> getDerivativeProjectWrtPose(const Eigen::Matrix4d& pose, const Vec4& pt) const override;
 
@@ -82,19 +82,19 @@ class Equidistant : public IntrinsicScaleOffsetDisto
 
     Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4& pt) const override;
 
-    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtDisto(const Eigen::Matrix4d& pose, const Vec4& pt);
+    Eigen::Matrix<double, 2, 3> getDerivativeProjectWrtDisto(const Eigen::Matrix4d& pose, const Vec4& pt) const;
 
-    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtScale(const Eigen::Matrix4d& pose, const Vec4& pt);
+    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtScale(const Eigen::Matrix4d& pose, const Vec4& pt) const;
 
-    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtPrincipalPoint(const Eigen::Matrix4d& pose, const Vec4& pt);
+    Eigen::Matrix<double, 2, 2> getDerivativeProjectWrtPrincipalPoint(const Eigen::Matrix4d& pose, const Vec4& pt) const;
 
     Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeProjectWrtParams(const Eigen::Matrix4d& pose, const Vec4& pt3D) const override;
 
     Vec3 toUnitSphere(const Vec2& pt) const override;
 
-    Eigen::Matrix<double, 3, 2> getDerivativetoUnitSphereWrtPoint(const Vec2& pt);
+    Eigen::Matrix<double, 3, 2> getDerivativetoUnitSphereWrtPoint(const Vec2& pt) const;
 
-    Eigen::Matrix<double, 3, 2> getDerivativetoUnitSphereWrtScale(const Vec2& pt);
+    Eigen::Matrix<double, 3, 2> getDerivativetoUnitSphereWrtScale(const Vec2& pt) const;
 
     double imagePlaneToCameraPlaneError(double value) const override;
 

--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -6,11 +6,13 @@ set(geometry_files_headers
     Pose3.hpp
     rigidTransformation3D.hpp
     Similarity3.hpp
+    Intersection.hpp
 )
 
 # Sources
 set(geometry_files_sources
     rigidTransformation3D.cpp
+    Intersection.cpp
 )
 
 alicevision_add_library(aliceVision_geometry

--- a/src/aliceVision/geometry/Intersection.cpp
+++ b/src/aliceVision/geometry/Intersection.cpp
@@ -1,0 +1,51 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Intersection.hpp"
+
+namespace aliceVision {
+namespace geometry {
+
+bool rayIntersectUnitSphere(Vec3 & coordinates, const Vec3 & start, const Vec3 & direction)
+{
+    /*
+    "Which point on the sphere relates to this point ?"
+    (lambda * directionx + startx)^2
+    + (lambda * directiony + starty)^2
+    + (lambda * directionz + startz)^2=1
+
+    (lambda * directionx)^2 + startx^2 + 2.0 * lambda * directionoriginx * directionx
+    + (lambda * directiony)^2 + starty^2 + 2.0 * lambda * directionoriginy * directiony
+    + (lambda * directionz)^2 + startz^2 + 2.0 * lambda * directionoriginz * directionz
+    = 1
+
+    (lambda^2) * (directionx^2 + directiony^2 + directionz^2) 
+    + lambda * (2.0 * directionoriginx * directionx + 2.0 * directionoriginy * directiony + 2.0 * directionoriginz * directionz) 
+    + (startx^2 + startx^2 + startx^2) - 1 = 0
+    */
+
+    double a = direction.dot(direction);
+    double b = direction.dot(start) * 2.0;
+    double c = start.dot(start) - 1.0;
+    double det = b*b - 4.0*a*c;
+    
+    if (det < 0)
+    {
+        return false;
+    }
+
+    double x1 = (-b + sqrt(det)) / (2.0 * a);
+    double x2 = (-b - sqrt(det)) / (2.0 * a);
+    double lambda = std::min(x1, x2);
+
+    coordinates = start + lambda * direction;
+
+    return true;
+}
+
+}  // namespace geometry
+}  // namespace aliceVision
+

--- a/src/aliceVision/geometry/Intersection.hpp
+++ b/src/aliceVision/geometry/Intersection.hpp
@@ -1,0 +1,25 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/numeric/numeric.hpp>
+
+namespace aliceVision {
+namespace geometry {
+
+/**
+ * @brief find the intersection of a ray (composed of a starting point and a direction) with the unit sphere centered on (0,0,0).
+ * @param coordinates the coordinates of the intersection closest to the starting point
+ * @param start the starting point of the ray
+ * @param direction the direction of the ray
+ * @return true if an intersection is found
+*/
+bool rayIntersectUnitSphere(Vec3 & coordinates, const Vec3 & start, const Vec3 & direction);
+
+}  // namespace geometry
+}  // namespace aliceVision
+

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -93,6 +93,16 @@ alicevision_add_test(bundle/bundleAdjustment_test.cpp
         ${LEMON_LIBRARY}
 )
 
+alicevision_add_test(bundle/bundleAdjustment_Enhanced_test.cpp
+  NAME "sfm_bundleAdjustment_Enhanced"
+  LINKS aliceVision_sfm
+        aliceVision_multiview
+        aliceVision_multiview_test_data
+        aliceVision_feature
+        aliceVision_system
+        ${LEMON_LIBRARY}
+)
+
 alicevision_add_test(utils/alignment_test.cpp
   NAME "sfm_alignment"
   LINKS

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
@@ -1,0 +1,309 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2023 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE bundleAdjustment_enhanced
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp>
+#include <aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.hpp>
+#include <aliceVision/geometry/lie.hpp>
+#include <aliceVision/geometry/Intersection.hpp>
+#include <aliceVision/sfm/utils/statistics.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+
+using namespace aliceVision;
+
+bool getPointOnSphere(Vec3 & result, const camera::IntrinsicBase & intrinsic, const Vec2 & pt, double distanceToUnitCenter)
+{
+    Vec3 campt = intrinsic.toUnitSphere(intrinsic.removeDistortion(intrinsic.ima2cam(pt)));
+    Vec3 camorigin(0.0, 0.0, -distanceToUnitCenter);
+    Vec3 worldcampt = campt + camorigin;
+
+    return geometry::rayIntersectUnitSphere(result, camorigin, campt);
+}
+
+void createScene(sfmData::SfMData & sfmData, const camera::IntrinsicBase & intrinsic)
+{
+    // Create a scene where the points lie on a sphere of unit 1
+    const int countNeededPointsPerImageLine = 30;
+    const int countNeededPointsPerImageColumn = 15;
+    double distanceToUnitCenter = 1.3;
+
+    // Simulate a camera at a given distance of the sphere
+    // The projected points will be used to determine the properties of the cameras
+    Vec3 borderLeft;
+    if (!getPointOnSphere(borderLeft, intrinsic, Vec2(0, intrinsic.h() / 2.0), distanceToUnitCenter))
+    {
+        borderLeft = Vec3(-1, 0, 0);
+    }
+    
+    Vec3 borderRight;
+    if (!getPointOnSphere(borderRight, intrinsic, Vec2(intrinsic.w(), intrinsic.h() / 2.0), distanceToUnitCenter))
+    {
+        borderRight = Vec3(1, 0, 0);
+    }
+
+    Vec3 borderTop;
+    if (!getPointOnSphere(borderTop, intrinsic, Vec2(intrinsic.w() / 2.0, 0.0), distanceToUnitCenter))
+    {
+        borderTop = Vec3(0, -1, 0);
+    }
+    
+    Vec3 borderBottom;
+    if (!getPointOnSphere(borderBottom, intrinsic, Vec2(intrinsic.w() / 2.0, intrinsic.h()), distanceToUnitCenter))
+    {
+        borderBottom = Vec3(0, 1, 0);
+    }
+
+    //The camera observe a part of the sphere, compute the arc length.
+    double horizontalAnglePerCamera = std::acos(borderLeft.normalized().dot(borderRight.normalized()));
+    double verticalAnglePerCamera = std::acos(borderBottom.normalized().dot(borderTop.normalized()));
+    
+    // Estimated the required number of cameras and the scene properties
+    double overlap = 0.5;
+    int countCameras = std::ceil(2.0 * M_PI / (horizontalAnglePerCamera * (1.0 - overlap)));
+    const int countNeededPointsPerLine = std::ceil(countNeededPointsPerImageLine * 2.0 * M_PI / horizontalAnglePerCamera);
+    const double angleBetweenLines = verticalAnglePerCamera / countNeededPointsPerImageColumn;
+
+
+    // Place landmarks on the unit sphere
+    size_t count = 0;
+    for (int y = - countNeededPointsPerImageColumn / 2; y <= countNeededPointsPerImageColumn / 2; y++)
+    {
+        for (int x = 0; x < countNeededPointsPerLine; x++)
+        {
+            double longitude = x * M_PI_2 / countNeededPointsPerLine;
+            double latitude = y * angleBetweenLines;
+
+            Vec3 pos;
+            pos.x() = cos(latitude) * sin(longitude);
+            pos.y() = sin(latitude);
+            pos.z() = cos(latitude) * cos(longitude);
+
+            sfmData.getLandmarks().emplace(count, pos);
+            count++;
+        }
+    }
+    
+
+    // Place cameras and observations
+    for (int idview = 0; idview < countCameras; idview++)
+    {
+        double angle = idview * (2.0 * M_PI / countCameras);
+        Eigen::Matrix4d T = Eigen::Matrix4d::Identity();
+        T.block<3, 3>(0, 0) = SO3::expm(Eigen::Vector3d::UnitY() * angle);
+        T.block<3, 1>(0, 3) = Eigen::Vector3d::UnitZ() * distanceToUnitCenter;
+
+        geometry::Pose3 pose(T);
+
+        sfmData.getPoses().emplace(idview, sfmData::CameraPose(pose));
+        sfmData.getViews().emplace(idview, std::make_shared<sfmData::View>("", idview, 0, idview, intrinsic.w(), intrinsic.h()));
+
+        Vec3 origin = pose(Vec3(0, 0, 0));
+
+        int count = 0;
+        for (auto & pl : sfmData.getLandmarks())
+        {
+            const auto & pt = pl.second.X;
+
+            Vec3 cpt = pose(pt);
+            Vec3 dir = (cpt - origin).normalized();
+
+            //Point normal is backward
+            if (dir.z() > 0.0)
+            {
+                continue;
+            }
+
+            Vec2 imagept = intrinsic.project(pose, pt.homogeneous(), true);
+            if (imagept.x() < 0 || imagept.y() < 0 || imagept.x() >= intrinsic.w()|| imagept.y() >= intrinsic.h())
+            {
+                continue;
+            }
+
+            sfmData::Observation obs(imagept, count, 1.0);
+
+            pl.second.getObservations().emplace(idview, obs);
+            count++;
+        }
+    }
+
+    //Create intrinsic storage
+    sfmData.getIntrinsics().emplace(0, intrinsic.clone());
+}
+
+using cameraPair = std::pair<std::shared_ptr<camera::IntrinsicBase>, std::shared_ptr<camera::IntrinsicBase>>;
+
+std::vector<cameraPair> buildIntrinsics()
+{
+    std::vector<cameraPair> cameras;
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA, 1920, 1080, 900, 900, 80, 50),
+        camera::createPinhole(camera::PINHOLE_CAMERA, 1920, 1080, 1200, 1200, 0, 0)
+    ));
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_RADIAL1, 1920, 1080, 900, 900, 80, 50, {0.5}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_RADIAL1, 1920, 1080, 1200, 1200, 0, 0, {0.0})
+    ));
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 900, 900, 80, 50, {0.5, -0.4, 1.2}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_RADIAL3, 1920, 1080, 1200, 1200, 0, 0, {0.0, 0.0, 0.0})
+    ));
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_BROWN, 1920, 1080, 900, 900, 80, 50, {-0.054, 0.014, 0.006, 0.001, -0.001}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_BROWN, 1920, 1080, 1200, 1200, 0, 0, {0, 0, 0, 0, 0})
+    ));
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_FISHEYE, 1920, 1080, 900, 900, 80, 50, {0.5, -0.4, 0.1, 0.2}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_FISHEYE, 1920, 1080, 1200, 1200, 0, 0, {0.0, 0.0, 0.0, 0.0})
+    ));
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_FISHEYE1, 1920, 1080, 900, 900, 80, 50, {0.5}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_FISHEYE1, 1920, 1080, 1200, 1200, 0, 0, {1.2})
+    ));
+
+    /*cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_3DEANAMORPHIC4, 1920, 1080, 900, 900, 80, 50, {0.1, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_3DEANAMORPHIC4, 1920, 1080, 1200, 1200, 0, 0, {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0})
+    ));*/
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_3DERADIAL4, 1920, 1080, 900, 900, 80, 50, {0.2, 0.0, 0.0, 0.0, 0.0, 0.0}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_3DERADIAL4, 1920, 1080, 1200, 1200, 0, 0, {0.0, 0.0, 0.0, 0.0, 0.0, 0.0})
+    ));
+
+    cameras.push_back(std::make_pair(
+        camera::createPinhole(camera::PINHOLE_CAMERA_3DECLASSICLD, 1920, 1080, 900, 900, 80, 50, {0.2, 1.0, 0.0, 0.0, 0.0}),
+        camera::createPinhole(camera::PINHOLE_CAMERA_3DECLASSICLD, 1920, 1080, 1200, 1200, 0, 0, {0.0, 1.0, 0.0, 0.0, 0.0})
+    ));
+    
+    cameras.push_back(std::make_pair(
+        camera::createEquidistant(camera::EQUIDISTANT_CAMERA, 1920, 1080, 1500, 80, 50),
+        camera::createEquidistant(camera::EQUIDISTANT_CAMERA, 1920, 1080, 1300, 0, 0)
+    ));
+
+    cameras.push_back(std::make_pair(
+        camera::createEquidistant(camera::EQUIDISTANT_CAMERA_RADIAL3, 1920, 1080, 1500, 0, 0, {0.11, -0.30, 0.1}),
+        camera::createEquidistant(camera::EQUIDISTANT_CAMERA_RADIAL3, 1920, 1080, 900, 10, 20, {0.0, 0.0, 0.0})
+    ));
+        
+    return cameras;
+}
+
+BOOST_AUTO_TEST_CASE(test_intrinsics)
+{
+    auto listIntrinsics = buildIntrinsics();
+
+    for (auto pairIntrinsics : listIntrinsics)
+    {
+        sfmData::SfMData sfmData;
+
+        createScene (sfmData, *pairIntrinsics.first);
+
+        sfmData.getIntrinsics().at(0) = pairIntrinsics.second;
+
+        sfm::BundleAdjustmentSymbolicCeres::CeresOptions options;
+        sfm::BundleAdjustment::ERefineOptions refineOptions = sfm::BundleAdjustment::REFINE_INTRINSICS_FOCAL | sfm::BundleAdjustment::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS | sfm::BundleAdjustment::REFINE_INTRINSICS_DISTORTION;
+        options.summary = false;
+
+        double rmseBefore = sfm::RMSE(sfmData);
+        sfm::BundleAdjustmentSymbolicCeres BA(options);
+        const bool success = BA.adjust(sfmData, refineOptions);
+        double rmseAfter = sfm::RMSE(sfmData);
+
+        BOOST_TEST_CONTEXT(EINTRINSIC_enumToString(pairIntrinsics.first->getType()))
+        {
+            BOOST_CHECK_LT(rmseAfter, rmseBefore);
+            BOOST_CHECK_LT(rmseAfter, 1e-3);
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(test_landmarks)
+{
+    auto listIntrinsics = buildIntrinsics();
+
+    for (auto pairIntrinsics : listIntrinsics)
+    {
+        sfmData::SfMData sfmData;
+
+        createScene (sfmData, *pairIntrinsics.first);
+
+        srand(0);
+        for (auto & lpt : sfmData.getLandmarks())
+        {
+            lpt.second.X += Eigen::Vector3d::Random() * 0.1;
+        }
+
+        sfm::BundleAdjustmentSymbolicCeres::CeresOptions options;
+        sfm::BundleAdjustment::ERefineOptions refineOptions = sfm::BundleAdjustment::REFINE_STRUCTURE;
+        options.summary = false;
+
+        double rmseBefore = sfm::RMSE(sfmData);
+        sfm::BundleAdjustmentSymbolicCeres BA(options);
+        const bool success = BA.adjust(sfmData, refineOptions);
+        double rmseAfter = sfm::RMSE(sfmData);
+
+        BOOST_TEST_CONTEXT(EINTRINSIC_enumToString(pairIntrinsics.first->getType()))
+        {
+        BOOST_CHECK_LT(rmseAfter, rmseBefore);
+        BOOST_CHECK_LT(rmseAfter, 1e-3);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_poses)
+{
+    auto listIntrinsics = buildIntrinsics();
+
+    for (auto pairIntrinsics : listIntrinsics)
+    {
+        sfmData::SfMData sfmData;
+
+        createScene(sfmData, *pairIntrinsics.first);
+
+        srand(0);
+        for (auto & lps : sfmData.getPoses())
+        {
+            geometry::Pose3 pose3 = lps.second.getTransform();
+            Eigen::Matrix4d T = pose3.getHomogeneous();
+
+            Eigen::Vector3d nt = Eigen::Vector3d::Random() * 0.1 + Eigen::Vector3d::UnitZ() * 0.1;
+            Eigen::Matrix3d nR = SO3::expm(Eigen::Vector3d::Random() * 0.01);
+
+            Eigen::Matrix4d U = Eigen::Matrix4d::Identity();
+            U.block<3, 3>(0, 0) = nR;
+            U.block<3, 1>(0, 3) = nt;
+
+            lps.second.setTransform(geometry::Pose3(U * T));
+        }
+
+        sfm::BundleAdjustmentSymbolicCeres::CeresOptions options;
+        sfm::BundleAdjustment::ERefineOptions refineOptions = sfm::BundleAdjustment::REFINE_ROTATION | sfm::BundleAdjustment::REFINE_TRANSLATION;
+        options.summary = false;
+
+        double rmseBefore = sfm::RMSE(sfmData);
+        sfm::BundleAdjustmentSymbolicCeres BA(options);
+        const bool success = BA.adjust(sfmData, refineOptions);
+        double rmseAfter = sfm::RMSE(sfmData);
+
+        BOOST_TEST_CONTEXT(EINTRINSIC_enumToString(pairIntrinsics.first->getType()))
+        {
+            BOOST_CHECK_LT(rmseAfter, rmseBefore);
+            BOOST_CHECK_LT(rmseAfter, 1e-3);
+        }
+    }
+}
+

--- a/src/aliceVision/sfm/bundle/costfunctions/projectionSimple.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/projectionSimple.hpp
@@ -38,7 +38,7 @@ class CostProjectionSimple : public ceres::CostFunction
 
         const Vec4 cpt = T * pth;
 
-        Vec2 pt_est = _intrinsics->project(T, pth, false);
+        Vec2 pt_est = _intrinsics->project(T, pth, true);
         const double scale = (_measured.getScale() > 1e-12) ? _measured.getScale() : 1.0;
 
         residuals[0] = (pt_est(0) - _measured.getX()) / scale;


### PR DESCRIPTION
Add a new bundle adjustment unit test

The existing one is limited to pinhole cameras, and do not test all lens formats, with a per component minimization.