### PR TITLE
[ci] Update link to the VCPKG archive for the Windows CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -157,7 +157,7 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.3.0
         id: vcpkgDownload
         with:
-          url: "https://gdirect.cc/d/xnDHH&type=1"
+          url: "https://gitlab.com/alicevision/vcpkgArchive/-/raw/main/aliceVisionDeps-2023.10.02.zip?ref_type=heads&inline=false"
           target: "${{ env.vcpkgDir }}"
           filename: installed.zip
 


### PR DESCRIPTION
## Description

Provide a GitLab link to download the zip file containing all the pre-built VCPKG dependencies for Windows instead of a shortened Google Drive link that bypassed the security checks on large files.