### PR TITLE
Fix typo in bundle adjustment unit test

### DIFF
--- a/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
@@ -77,7 +77,7 @@ void createScene(sfmData::SfMData & sfmData, const camera::IntrinsicBase & intri
     {
         for (int x = 0; x < countNeededPointsPerLine; x++)
         {
-            double longitude = x * M_PI_2 / countNeededPointsPerLine;
+            double longitude = x * 2.0 * M_PI / countNeededPointsPerLine;
             double latitude = y * angleBetweenLines;
 
             Vec3 pos;


### PR DESCRIPTION
pi / 2 was used instead of 2 * pi

