### PR TITLE
Remove specifics required by Eigen prior to C++17

### DIFF
--- a/src/aliceVision/geometry/Pose3.hpp
+++ b/src/aliceVision/geometry/Pose3.hpp
@@ -78,9 +78,6 @@ class Pose3
     }
 
     const SE3::Matrix& getHomogeneous() const { return _homogeneous; }
-
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 /**

--- a/src/aliceVision/image/convolution.hpp
+++ b/src/aliceVision/image/convolution.hpp
@@ -91,7 +91,7 @@ void ImageHorizontalConvolution(const ImageTypeIn& img, const Kernel& kernel, Im
     const int kernel_width = kernel.size();
     const int half_kernel_width = kernel_width / 2;
 
-    std::vector<pix_t, Eigen::aligned_allocator<pix_t>> line(cols + kernel_width);
+    std::vector<pix_t> line(cols + kernel_width);
 
     for (int row = 0; row < rows; ++row)
     {
@@ -135,7 +135,7 @@ void ImageVerticalConvolution(const ImageTypeIn& img, const Kernel& kernel, Imag
 
     out.resize(cols, rows);
 
-    std::vector<pix_t, Eigen::aligned_allocator<pix_t>> line(rows + kernel_width);
+    std::vector<pix_t> line(rows + kernel_width);
 
     for (int col = 0; col < cols; ++col)
     {

--- a/src/aliceVision/sfmData/CameraPose.hpp
+++ b/src/aliceVision/sfmData/CameraPose.hpp
@@ -86,9 +86,6 @@ class CameraPose
     bool _locked = false;
     /// Estimator state
     EEstimatorParameterState _state = EEstimatorParameterState::REFINED;
-
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }  // namespace sfmData

--- a/src/aliceVision/types.hpp
+++ b/src/aliceVision/types.hpp
@@ -14,10 +14,6 @@
 #include <set>
 #include <vector>
 
-#ifdef ALICEVISION_STD_UNORDERED_MAP
-    #include <unordered_map>
-#endif
-
 namespace aliceVision {
 
 typedef uint32_t IndexT;
@@ -27,13 +23,8 @@ typedef std::pair<IndexT, IndexT> Pair;
 typedef std::set<Pair> PairSet;
 typedef std::vector<Pair> PairVec;
 
-#ifdef ALICEVISION_UNORDERED_MAP
 template<typename Key, typename Value>
-using HashMap = std::unordered_map<Key, Value>;
-#else
-template<typename K, typename V>
-using HashMap = std::map<K, V, std::less<K>, Eigen::aligned_allocator<std::pair<const K, V>>>;
-#endif
+using HashMap = std::map<Key, Value>;
 
 struct EstimationStatus
 {

--- a/src/aliceVision/voctree/MutableVocabularyTree.hpp
+++ b/src/aliceVision/voctree/MutableVocabularyTree.hpp
@@ -17,10 +17,10 @@ namespace voctree {
  *
  * When loading and using an existing vocabulary tree, use VocabularyTree instead.
  */
-template<class Feature, template<typename, typename> class Distance = L2, class FeatureAllocator = typename DefaultAllocator<Feature>::type>
-class MutableVocabularyTree : public VocabularyTree<Feature, Distance, FeatureAllocator>
+template<class Feature, template<typename, typename> class Distance = L2>
+class MutableVocabularyTree : public VocabularyTree<Feature, Distance>
 {
-    typedef VocabularyTree<Feature, Distance, FeatureAllocator> BaseClass;
+    typedef VocabularyTree<Feature, Distance> BaseClass;
 
   public:
     MutableVocabularyTree() {}
@@ -34,9 +34,9 @@ class MutableVocabularyTree : public VocabularyTree<Feature, Distance, FeatureAl
 
     uint32_t nodes() const { return this->word_start_ + this->num_words_; }
 
-    std::vector<Feature, FeatureAllocator>& centers() { return this->centers_; }
+    std::vector<Feature>& centers() { return this->centers_; }
 
-    const std::vector<Feature, FeatureAllocator>& centers() const { return this->centers_; }
+    const std::vector<Feature>& centers() const { return this->centers_; }
 
     std::vector<uint8_t>& validCenters() { return this->valid_centers_; }
 

--- a/src/aliceVision/voctree/SimpleKmeans.hpp
+++ b/src/aliceVision/voctree/SimpleKmeans.hpp
@@ -32,10 +32,10 @@ namespace voctree {
  */
 struct InitRandom
 {
-    template<class Feature, class Distance, class FeatureAllocator>
+    template<class Feature, class Distance>
     void operator()(const std::vector<Feature*>& features,
                     size_t k,
-                    std::vector<Feature, FeatureAllocator>& centers,
+                    std::vector<Feature>& centers,
                     Distance distance,
                     const int verbose = 0)
     {
@@ -63,10 +63,10 @@ struct InitRandom
  */
 struct InitKmeanspp
 {
-    template<class Feature, class Distance, class FeatureAllocator>
+    template<class Feature, class Distance>
     void operator()(const std::vector<Feature*>& features,
                     size_t k,
-                    std::vector<Feature, FeatureAllocator>& centers,
+                    std::vector<Feature>& centers,
                     Distance distance,
                     const int verbose = 0)
     {
@@ -218,10 +218,10 @@ struct InitKmeanspp
  */
 struct InitGiven
 {
-    template<class Feature, class Distance, class FeatureAllocator>
+    template<class Feature, class Distance>
     void operator()(const std::vector<Feature*>& features,
                     std::size_t k,
-                    std::vector<Feature, FeatureAllocator>& centers,
+                    std::vector<Feature>& centers,
                     Distance distance,
                     const int verbose = 0)
     {
@@ -235,8 +235,8 @@ inline void printFeat(const Feature& f)
     ALICEVISION_LOG_DEBUG(f);
 }
 
-template<class Feature, class FeatureAllocator = typename DefaultAllocator<Feature>::type>
-void printFeatVector(const std::vector<Feature, FeatureAllocator>& f)
+template<class Feature>
+void printFeatVector(const std::vector<Feature>& f)
 {
     for (std::size_t j = 0; j < f.size(); ++j)
     {
@@ -279,8 +279,8 @@ bool checkElements(const Feature& f, const char* str)
  * @return true if everything is ok
  * @see checkElements( const Feature &f, const char* str )
  */
-template<class Feature, class FeatureAllocator = typename DefaultAllocator<Feature>::type>
-bool checkVectorElements(const std::vector<Feature, FeatureAllocator>& f, const char* str)
+template<class Feature>
+bool checkVectorElements(const std::vector<Feature>& f, const char* str)
 {
     bool correct = true;
     for (std::size_t i = 0; i < f.size(); ++i)
@@ -296,12 +296,12 @@ bool checkVectorElements(const std::vector<Feature, FeatureAllocator>& f, const 
  *
  * The standard Lloyd's algorithm is used. By default, cluster centers are initialized randomly.
  */
-template<class Feature, class Distance = L2<Feature, Feature>, class FeatureAllocator = typename DefaultAllocator<Feature>::type>
+template<class Feature, class Distance = L2<Feature, Feature>>
 class SimpleKmeans
 {
   public:
     typedef typename Distance::result_type squared_distance_type;
-    typedef boost::function<void(const std::vector<Feature*>&, std::size_t, std::vector<Feature, FeatureAllocator>&, Distance, const int verbose)>
+    typedef boost::function<void(const std::vector<Feature*>&, std::size_t, std::vector<Feature>&, Distance, const int verbose)>
       Initializer;
 
     /**
@@ -309,8 +309,6 @@ class SimpleKmeans
      *
      * @param zero Object representing zero in the feature space
      * @param d    Functor for calculating squared distance
-     *
-     * @todo FeatureAllocator parameter
      */
     SimpleKmeans(const Feature& zero = Feature(), Distance d = Distance(), const int verbose = 0);
 
@@ -338,9 +336,9 @@ class SimpleKmeans
      * @param[out] centers    A set of k cluster centers.
      * @param[out] membership Cluster assignment for each feature
      */
-    squared_distance_type cluster(const std::vector<Feature, FeatureAllocator>& features,
+    squared_distance_type cluster(const std::vector<Feature>& features,
                                   std::size_t k,
-                                  std::vector<Feature, FeatureAllocator>& centers,
+                                  std::vector<Feature>& centers,
                                   std::vector<unsigned int>& membership) const;
 
     /**
@@ -356,13 +354,13 @@ class SimpleKmeans
      */
     squared_distance_type clusterPointers(const std::vector<Feature*>& features,
                                           std::size_t k,
-                                          std::vector<Feature, FeatureAllocator>& centers,
+                                          std::vector<Feature>& centers,
                                           std::vector<unsigned int>& membership) const;
 
   private:
     squared_distance_type clusterOnce(const std::vector<Feature*>& features,
                                       std::size_t k,
-                                      std::vector<Feature, FeatureAllocator>& centers,
+                                      std::vector<Feature>& centers,
                                       std::vector<unsigned int>& membership) const;
 
     Feature zero_;
@@ -373,8 +371,8 @@ class SimpleKmeans
     int verbose_;
 };
 
-template<class Feature, class Distance, class FeatureAllocator>
-SimpleKmeans<Feature, Distance, FeatureAllocator>::SimpleKmeans(const Feature& zero, Distance d, const int verbose)
+template<class Feature, class Distance>
+SimpleKmeans<Feature, Distance>::SimpleKmeans(const Feature& zero, Distance d, const int verbose)
   : zero_(zero),
     distance_(d),
     //    choose_centers_( InitRandom( ) ),
@@ -384,11 +382,11 @@ SimpleKmeans<Feature, Distance, FeatureAllocator>::SimpleKmeans(const Feature& z
     restarts_(1)
 {}
 
-template<class Feature, class Distance, class FeatureAllocator>
-typename SimpleKmeans<Feature, Distance, FeatureAllocator>::squared_distance_type SimpleKmeans<Feature, Distance, FeatureAllocator>::cluster(
-  const std::vector<Feature, FeatureAllocator>& features,
+template<class Feature, class Distance>
+typename SimpleKmeans<Feature, Distance>::squared_distance_type SimpleKmeans<Feature, Distance>::cluster(
+  const std::vector<Feature>& features,
   size_t k,
-  std::vector<Feature, FeatureAllocator>& centers,
+  std::vector<Feature>& centers,
   std::vector<unsigned int>& membership) const
 {
     std::vector<Feature*> feature_ptrs;
@@ -398,14 +396,14 @@ typename SimpleKmeans<Feature, Distance, FeatureAllocator>::squared_distance_typ
     return clusterPointers(feature_ptrs, k, centers, membership);
 }
 
-template<class Feature, class Distance, class FeatureAllocator>
-typename SimpleKmeans<Feature, Distance, FeatureAllocator>::squared_distance_type SimpleKmeans<Feature, Distance, FeatureAllocator>::clusterPointers(
+template<class Feature, class Distance>
+typename SimpleKmeans<Feature, Distance>::squared_distance_type SimpleKmeans<Feature, Distance>::clusterPointers(
   const std::vector<Feature*>& features,
   size_t k,
-  std::vector<Feature, FeatureAllocator>& centers,
+  std::vector<Feature>& centers,
   std::vector<unsigned int>& membership) const
 {
-    std::vector<Feature, FeatureAllocator> new_centers(centers);
+    std::vector<Feature> new_centers(centers);
     new_centers.resize(k);
     std::vector<unsigned int> new_membership(features.size());
 
@@ -432,18 +430,18 @@ typename SimpleKmeans<Feature, Distance, FeatureAllocator>::squared_distance_typ
     return least_sse;
 }
 
-template<class Feature, class Distance, class FeatureAllocator>
-typename SimpleKmeans<Feature, Distance, FeatureAllocator>::squared_distance_type SimpleKmeans<Feature, Distance, FeatureAllocator>::clusterOnce(
+template<class Feature, class Distance>
+typename SimpleKmeans<Feature, Distance>::squared_distance_type SimpleKmeans<Feature, Distance>::clusterOnce(
   const std::vector<Feature*>& features,
   std::size_t k,
-  std::vector<Feature, FeatureAllocator>& centers,
+  std::vector<Feature>& centers,
   std::vector<unsigned int>& membership) const
 {
-    typedef typename std::vector<Feature, FeatureAllocator>::value_type centerType;
+    typedef typename std::vector<Feature>::value_type centerType;
     typedef typename Distance::value_type feature_value_type;
 
     std::vector<std::size_t> new_center_counts(k);
-    std::vector<Feature, FeatureAllocator> new_centers(k);
+    std::vector<Feature> new_centers(k);
     std::vector<std::mutex> centersLocks(k);
     squared_distance_type max_center_shift = std::numeric_limits<squared_distance_type>::max();
 

--- a/src/aliceVision/voctree/TreeBuilder.hpp
+++ b/src/aliceVision/voctree/TreeBuilder.hpp
@@ -18,14 +18,14 @@ namespace voctree {
  * @brief Class for building a new vocabulary by hierarchically clustering
  * a set of training features.
  */
-template<class Feature, template<typename, typename> class DistanceT = L2, class FeatureAllocator = typename DefaultAllocator<Feature>::type>
+template<class Feature, template<typename, typename> class DistanceT = L2>
 class TreeBuilder
 {
   public:
-    typedef MutableVocabularyTree<Feature, DistanceT, FeatureAllocator> Tree;
+    typedef MutableVocabularyTree<Feature, DistanceT> Tree;
     typedef DistanceT<Feature, Feature> Distance;
-    typedef SimpleKmeans<Feature, Distance, FeatureAllocator> Kmeans;
-    typedef std::vector<Feature, FeatureAllocator> FeatureVector;
+    typedef SimpleKmeans<Feature, Distance> Kmeans;
+    typedef std::vector<Feature> FeatureVector;
 
     /**
      * @brief Constructor
@@ -74,15 +74,15 @@ class TreeBuilder
     unsigned char verbose_;
 };
 
-template<class Feature, template<typename, typename> class DistanceT, class FeatureAllocator>
-TreeBuilder<Feature, DistanceT, FeatureAllocator>::TreeBuilder(const Feature& zero, Distance d, unsigned char verbose)
+template<class Feature, template<typename, typename> class DistanceT>
+TreeBuilder<Feature, DistanceT>::TreeBuilder(const Feature& zero, Distance d, unsigned char verbose)
   : kmeans_(zero, d, verbose),
     zero_(zero),
     verbose_(verbose)
 {}
 
-template<class Feature, template<typename, typename> class DistanceT, class FeatureAllocator>
-void TreeBuilder<Feature, DistanceT, FeatureAllocator>::build(const FeatureVector& training_features, uint32_t k, uint32_t levels)
+template<class Feature, template<typename, typename> class DistanceT>
+void TreeBuilder<Feature, DistanceT>::build(const FeatureVector& training_features, uint32_t k, uint32_t levels)
 {
     // Initial setup and memory allocation for the tree
     tree_.clear();

--- a/src/aliceVision/voctree/VocabularyTree.hpp
+++ b/src/aliceVision/voctree/VocabularyTree.hpp
@@ -97,12 +97,9 @@ inline IVocabularyTree::~IVocabularyTree() {}
  * \c Distance is a functor that computes the distance between two Feature objects. It must have a \c result_type
  * typedef specifying the type of the returned distance. For the purposes of VocabularyTree, this need not even be
  * a metric; distances simply need to be comparable.
- *
- * \c FeatureAllocator is an STL-compatible allocator used to allocate Features internally.
  */
 template<class Feature,
-         template<typename, typename> class Distance = L2,  // TODO: rename Feature into Descriptor
-         class FeatureAllocator = typename DefaultAllocator<Feature>::type>
+         template<typename, typename> class Distance = L2>  // TODO: rename Feature into Descriptor
 class VocabularyTree : public IVocabularyTree
 {
   public:
@@ -154,7 +151,7 @@ class VocabularyTree : public IVocabularyTree
     }
 
   protected:
-    std::vector<Feature, FeatureAllocator> centers_;
+    std::vector<Feature> centers_;
     std::vector<uint8_t> valid_centers_;  /// @todo Consider bit-vector
 
     uint32_t k_;  // splits, or branching factor
@@ -167,16 +164,16 @@ class VocabularyTree : public IVocabularyTree
     void setNodeCounts();
 };
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-VocabularyTree<Feature, Distance, FeatureAllocator>::VocabularyTree()
+template<class Feature, template<typename, typename> class Distance>
+VocabularyTree<Feature, Distance>::VocabularyTree()
   : k_(0),
     levels_(0),
     num_words_(0),
     word_start_(0)
 {}
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-VocabularyTree<Feature, Distance, FeatureAllocator>::VocabularyTree(const std::string& file)
+template<class Feature, template<typename, typename> class Distance>
+VocabularyTree<Feature, Distance>::VocabularyTree(const std::string& file)
   : k_(0),
     levels_(0),
     num_words_(0),
@@ -185,9 +182,9 @@ VocabularyTree<Feature, Distance, FeatureAllocator>::VocabularyTree(const std::s
     load(file);
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
+template<class Feature, template<typename, typename> class Distance>
 template<class DescriptorT>
-Word VocabularyTree<Feature, Distance, FeatureAllocator>::quantize(const DescriptorT& feature) const
+Word VocabularyTree<Feature, Distance>::quantize(const DescriptorT& feature) const
 {
     typedef typename Distance<Feature, DescriptorT>::result_type distance_type;
 
@@ -219,9 +216,9 @@ Word VocabularyTree<Feature, Distance, FeatureAllocator>::quantize(const Descrip
     return index - word_start_;
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
+template<class Feature, template<typename, typename> class Distance>
 template<class DescriptorT>
-std::vector<Word> VocabularyTree<Feature, Distance, FeatureAllocator>::quantize(const std::vector<DescriptorT>& features) const
+std::vector<Word> VocabularyTree<Feature, Distance>::quantize(const std::vector<DescriptorT>& features) const
 {
     // ALICEVISION_LOG_DEBUG("VocabularyTree quantize: " << features.size());
     std::vector<Word> imgVisualWords(features.size(), 0);
@@ -238,9 +235,9 @@ std::vector<Word> VocabularyTree<Feature, Distance, FeatureAllocator>::quantize(
     return imgVisualWords;
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
+template<class Feature, template<typename, typename> class Distance>
 template<class DescriptorT>
-SparseHistogram VocabularyTree<Feature, Distance, FeatureAllocator>::quantizeToSparse(const std::vector<DescriptorT>& features) const
+SparseHistogram VocabularyTree<Feature, Distance>::quantizeToSparse(const std::vector<DescriptorT>& features) const
 {
     SparseHistogram histo;
     std::vector<Word> doc = quantize(features);
@@ -248,34 +245,34 @@ SparseHistogram VocabularyTree<Feature, Distance, FeatureAllocator>::quantizeToS
     return histo;
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-uint32_t VocabularyTree<Feature, Distance, FeatureAllocator>::levels() const
+template<class Feature, template<typename, typename> class Distance>
+uint32_t VocabularyTree<Feature, Distance>::levels() const
 {
     return levels_;
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-uint32_t VocabularyTree<Feature, Distance, FeatureAllocator>::splits() const
+template<class Feature, template<typename, typename> class Distance>
+uint32_t VocabularyTree<Feature, Distance>::splits() const
 {
     return k_;
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-uint32_t VocabularyTree<Feature, Distance, FeatureAllocator>::words() const
+template<class Feature, template<typename, typename> class Distance>
+uint32_t VocabularyTree<Feature, Distance>::words() const
 {
     return num_words_;
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-void VocabularyTree<Feature, Distance, FeatureAllocator>::clear()
+template<class Feature, template<typename, typename> class Distance>
+void VocabularyTree<Feature, Distance>::clear()
 {
     centers_.clear();
     valid_centers_.clear();
     k_ = levels_ = num_words_ = word_start_ = 0;
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-void VocabularyTree<Feature, Distance, FeatureAllocator>::save(const std::string& file) const
+template<class Feature, template<typename, typename> class Distance>
+void VocabularyTree<Feature, Distance>::save(const std::string& file) const
 {
     /// @todo Support serializing of non-"simple" feature classes
     /// @todo Some identifying name for the distance used
@@ -290,8 +287,8 @@ void VocabularyTree<Feature, Distance, FeatureAllocator>::save(const std::string
     out.write((char*)(&valid_centers_[0]), valid_centers_.size());
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-void VocabularyTree<Feature, Distance, FeatureAllocator>::load(const std::string& file)
+template<class Feature, template<typename, typename> class Distance>
+void VocabularyTree<Feature, Distance>::load(const std::string& file)
 {
     clear();
 
@@ -319,8 +316,8 @@ void VocabularyTree<Feature, Distance, FeatureAllocator>::load(const std::string
     assert(size == num_words_ + word_start_);
 }
 
-template<class Feature, template<typename, typename> class Distance, class FeatureAllocator>
-void VocabularyTree<Feature, Distance, FeatureAllocator>::setNodeCounts()
+template<class Feature, template<typename, typename> class Distance>
+void VocabularyTree<Feature, Distance>::setNodeCounts()
 {
     num_words_ = k_;
     word_start_ = 0;

--- a/src/aliceVision/voctree/kmeans_test.cpp
+++ b/src/aliceVision/voctree/kmeans_test.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(kmeanInitializer)
     const std::size_t K = 10;
 
     typedef Eigen::Matrix<float, 1, DIMENSION> FeatureFloat;
-    typedef std::vector<FeatureFloat, Eigen::aligned_allocator<FeatureFloat>> FeatureFloatVector;
+    typedef std::vector<FeatureFloat> FeatureFloatVector;
     typedef std::vector<FeatureFloat*> FeaturePointerVector;
 
     FeatureFloatVector features;
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(kmeanInitializerVarying)
         ALICEVISION_LOG_DEBUG("\tTrial " << trial + 1 << "/" << numTrial << " with K = " << K << " and DIMENSION = " << DIMENSION);
 
         typedef Eigen::RowVectorXf FeatureFloat;
-        typedef std::vector<FeatureFloat, Eigen::aligned_allocator<FeatureFloat>> FeatureFloatVector;
+        typedef std::vector<FeatureFloat> FeatureFloatVector;
         typedef std::vector<FeatureFloat*> FeaturePointerVector;
 
         FeatureFloatVector features;
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(kmeanSimple)
     const std::size_t STEP = 5 * K;
 
     typedef Eigen::Matrix<float, 1, DIMENSION> FeatureFloat;
-    typedef std::vector<FeatureFloat, Eigen::aligned_allocator<FeatureFloat>> FeatureFloatVector;
+    typedef std::vector<FeatureFloat> FeatureFloatVector;
     typedef std::vector<FeatureFloat*> FeaturePointerVector;
 
     // generate a random vector of features
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(kmeanVarying)
         ALICEVISION_LOG_DEBUG("\tTrial " << trial + 1 << "/" << numTrial << " with K = " << K << " and DIMENSION = " << DIMENSION);
 
         typedef Eigen::RowVectorXf FeatureFloat;
-        typedef std::vector<FeatureFloat, Eigen::aligned_allocator<FeatureFloat>> FeatureFloatVector;
+        typedef std::vector<FeatureFloat> FeatureFloatVector;
         typedef std::vector<FeatureFloat*> FeaturePointerVector;
 
         // generate a random vector of features

--- a/src/aliceVision/voctree/vocabularyTreeBuild_test.cpp
+++ b/src/aliceVision/voctree/vocabularyTreeBuild_test.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(voctreeBuilder)
     const std::size_t STEP = 1;
 
     typedef Eigen::Matrix<float, 1, DIMENSION> FeatureFloat;
-    typedef std::vector<FeatureFloat, Eigen::aligned_allocator<FeatureFloat>> FeatureFloatVector;
+    typedef std::vector<FeatureFloat> FeatureFloatVector;
     typedef std::vector<FeatureFloat*> FeaturePointerVector;
 
     // generate a random vector of features


### PR DESCRIPTION
## Description

This PR updates the code base by removing all the specifics that were required to handle Eigen objects prior to C++17. In particular, the following are removed:

- `EIGEN_MAKE_ALIGNED_OPERATOR_NEW`: https://eigen.tuxfamily.org/dox-devel/group__TopicStructHavingEigenMembers.html
- Aligned allocators for STL containers: https://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html.

Any data structure or class that used Eigen aligned allocators is updated to stop using them.

## Features list

- [x] Remove all `EIGEN_MAKE_ALIGNED_OPERATOR_NEW` declarations
- [x] Remove all aligned allocators in the declarations of STL containers
- [x] Update `HashMap` alias to an `std::map` with no aligned allocator and remove option to use an `std::unordered_map` instead