### PR TITLE
Add ASUS_I01WD (Asus ZenFone 6) to sensorDB

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -268,6 +268,7 @@ Asus;Asus ZenPad S 8.0 Z580CA;3.6;devicespecifications
 Asus;Asus ZenPad S 8.0 Z580CA 16GB;3.6;devicespecifications
 Asus;ASUS_I001DC;12.7;devicespecifications
 ASUS;ASUS_I006D;7.53;devicespecifications
+Asus;ASUS_I01WD;6.4;usercontribution
 Asus;ASUS_Z00ED;4.69;devicespecifications
 Axgio;Axgio N3;4.69;devicespecifications
 BenQ;BenQ AC100;6.16;digicamdb


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Adds the sensor of my smartphone's camera to the sensor database.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
- Add ASUS_I01WD (Asus ZenFone 6) to sensorDB

## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

This device [already appears in the database as "Asus ZenFone 6" and "Asus ZenFone 6z"](https://github.com/alicevision/AliceVision/blob/91ffed1/src/aliceVision/sensorDB/cameraSensors.db#L257:L258), but at least my phone, using the default camera app, records the model as "ASUS_I01WD", resulting in it not being recognized by Meshroom.

![image](https://github.com/alicevision/AliceVision/assets/52254981/a89e6590-c9bc-4b93-9c12-4fdb34c69e39)

I have simply copied the 6.4 sensor width given by kimovil and confirmed it's accuracy with multiple image sets I took using the smartphone in question.