### PR TITLE
FeatureExtraction: Add analytical fisheye mask

### DIFF
--- a/src/aliceVision/camera/Equidistant.hpp
+++ b/src/aliceVision/camera/Equidistant.hpp
@@ -128,6 +128,8 @@ class Equidistant : public IntrinsicScaleOffsetDisto
 
     inline void setCircleCenterY(double y) { _circleCenter(1) = y; }
 
+    inline Vec2 getCircleCenter() const { return _circleCenter; }
+
     /**
      * @Brief get horizontal fov in radians
      * @return  horizontal fov in radians


### PR DESCRIPTION
Make sure no keypoints are found outside of the fisheye circle (if the camera is fisheye and the circle has been detected).