### PR TITLE
Remove all remaining references to Boost-Filesystem

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut.cpp
@@ -26,8 +26,6 @@
 
 #include <geogram/points/kd_tree.h>
 
-#include <boost/filesystem/operations.hpp>
-
 #include <cmath>
 #include <filesystem>
 #include <random>

--- a/src/aliceVision/imageMasking/CMakeLists.txt
+++ b/src/aliceVision/imageMasking/CMakeLists.txt
@@ -15,6 +15,5 @@ alicevision_add_library(aliceVision_imageMasking
     ${OpenCV_LIBS}
   PRIVATE_LINKS
     aliceVision_image
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -12,9 +12,6 @@
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/mvsUtils/MultiViewParams.hpp>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
-
 namespace aliceVision {
 namespace mvsUtils {
 

--- a/src/aliceVision/sphereDetection/sphereDetection.cpp
+++ b/src/aliceVision/sphereDetection/sphereDetection.cpp
@@ -31,9 +31,6 @@
 #include <opencv2/core/utility.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-// Boost
-#include <boost/filesystem.hpp>
-
 // Boost JSON
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>

--- a/src/aliceVision/voctree/databaseIO.tcc
+++ b/src/aliceVision/voctree/databaseIO.tcc
@@ -11,7 +11,6 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/config.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
 #include <exception>

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -618,7 +618,7 @@ if(AV_BUILD_BOOST)
         INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
         CONFIGURE_COMMAND 
             cd <SOURCE_DIR> && 
-            ./bootstrap.${SCRIPT_EXTENSION} --prefix=<INSTALL_DIR> --with-libraries=atomic,container,date_time,exception,filesystem,graph,iostreams,json,log,math,program_options,regex,serialization,system,test,thread,stacktrace,timer
+            ./bootstrap.${SCRIPT_EXTENSION} --prefix=<INSTALL_DIR> --with-libraries=atomic,container,date_time,exception,graph,iostreams,json,log,math,program_options,regex,serialization,system,test,thread,stacktrace,timer
         BUILD_COMMAND 
             cd <SOURCE_DIR> && 
             ./b2 --prefix=<INSTALL_DIR> variant=${DEPS_CMAKE_BUILD_TYPE_LOWERCASE} cxxstd=11 link=shared threading=multi -j8

--- a/src/software/pipeline/main_depthMapEstimation.cpp
+++ b/src/software/pipeline/main_depthMapEstimation.cpp
@@ -18,7 +18,6 @@
 #include <aliceVision/gpu/gpu.hpp>
 
 #include <boost/program_options.hpp>
-#include <boost/filesystem.hpp>
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.

--- a/src/software/pipeline/main_depthMapFiltering.cpp
+++ b/src/software/pipeline/main_depthMapFiltering.cpp
@@ -19,7 +19,6 @@
 #include <aliceVision/depthMap/NormalMapEstimator.hpp>
 
 #include <boost/program_options.hpp>
-#include <boost/filesystem.hpp>
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.


### PR DESCRIPTION
## Description

Following https://github.com/alicevision/AliceVision/pull/1642, remove the very few remaining references to Boost-Filesystem, which has been completely replaced by the standard `filesystem` library.
