### PR TITLE
[build] SwigBinding: Add support for the Python binding with SWIG on Windows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,7 +59,7 @@ jobs:
            -DALICEVISION_USE_CUDA=ON \
            -DALICEVISION_USE_CCTAG="${BUILD_CCTAG}" \
            -DALICEVISION_USE_POPSIFT=ON \
-           -DALICEVISION_USE_ALEMBIC=ON  \
+           -DALICEVISION_USE_ALEMBIC=ON \
            -DOpenCV_DIR="${DEPS_INSTALL_DIR}/share/OpenCV" \
            -DALICEVISION_USE_OPENGV=ON \
            -DCeres_DIR="${DEPS_INSTALL_DIR}/share/Ceres" \
@@ -230,11 +230,27 @@ jobs:
                              -DALICEVISION_BUILD_SWIG_BINDING=ON
                              -DBOOST_NO_CXX11=ON
 
-          # This input tells run-cmake to consume the vcpkg.cmake toolchain file set by run-vcpkg.
           cmakeBuildType: Release
           buildWithCMake: true
 
-      - name: UnitTests
+      - name: Bundle
+        uses: lukka/run-cmake@v3
+        with:
+          cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+          cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+          buildDirectory: ${{ env.buildDir }}
+          buildWithCMakeArgs: '--config Release --target bundle'
+          cmakeAppendedArgs: -DCMAKE_INSTALL_PREFIX:PATH=${{ env.ALICEVISION_ROOT }}
+          cmakeBuildType: Release
+          buildWithCMake: true
+
+      - name: Python Binding - Unit Tests
+        run: |
+          dir ${{ env.ALICEVISION_ROOT }}
+          set PYTHONPATH=${{ env.ALICEVISION_ROOT }}\bundle\bin;${{ env.PYTHONPATH}}
+          ${{ env.VCPKG_ROOT }}\installed\x64-windows\tools\python3\python -m pytest ./pyTests
+
+      - name: Unit Tests
         uses: lukka/run-cmake@v3
         with:
           cmakeListsOrSettingsJson: CMakeListsTxtAdvanced

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -227,6 +227,7 @@ jobs:
                              -DALICEVISION_USE_OPENGV=OFF
                              -DALICEVISION_BUILD_PHOTOMETRICSTEREO=OFF
                              -DALICEVISION_BUILD_SEGMENTATION=OFF
+                             -DALICEVISION_BUILD_SWIG_BINDING=ON
                              -DBOOST_NO_CXX11=ON
 
           # This input tells run-cmake to consume the vcpkg.cmake toolchain file set by run-vcpkg.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -102,7 +102,7 @@ jobs:
           meshroom_avBranch=$(git ls-remote --heads https://github.com/alicevision/Meshroom.git $GITHUB_HEAD_REF | cut -f 1)
           if [ $meshroom_avBranch != "" ]; then git checkout $meshroom_avBranch; echo "Use Meshroom/$GITHUB_HEAD_REF"; fi
           export MESHROOM_INSTALL_DIR=$PWD
-          export PYTHONPATH=$PWD:${ALICEVISION_ROOT}:${PYTHONPATH}
+          export PYTHONPATH=$PWD:${ALICEVISION_ROOT}/bin:${PYTHONPATH}
           export PATH=$PATH:${ALICEVISION_ROOT}/bin
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
           mkdir ./outputData
@@ -121,7 +121,7 @@ jobs:
           cd SfM_quality_evaluation/
           # checkout a specific commit to ensure repeatability
           git checkout 36e3bf2d05c64d1726cb4a0e770923794f203f98
-          export PYTHONPATH=${ALICEVISION_ROOT}:${PYTHONPATH}
+          export PYTHONPATH=${ALICEVISION_ROOT}/bin:${PYTHONPATH}
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
           echo "ldd aliceVision_cameraInit"
           ldd ${ALICEVISION_ROOT}/bin/aliceVision_cameraInit
@@ -130,7 +130,7 @@ jobs:
 
       - name: Python Binding - Unit Tests
         run: |
-          export PYTHONPATH=${ALICEVISION_ROOT}:${PYTHONPATH}
+          export PYTHONPATH=${ALICEVISION_ROOT}/bin:${PYTHONPATH}
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
           pip3 install pytest
           pytest ./pyTests
@@ -146,6 +146,7 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: 1
       ALICEVISION_ROOT: '${{ github.workspace }}/install'
       VCPKG_ROOT: '${{ github.workspace}}\..\vcpkg'
+      PYTHONPATH: '${{ github.workspace }}/install/bundle/bin'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -246,8 +247,6 @@ jobs:
 
       - name: Python Binding - Unit Tests
         run: |
-          dir ${{ env.ALICEVISION_ROOT }}
-          set PYTHONPATH=${{ env.ALICEVISION_ROOT }}\bundle\bin;${{ env.PYTHONPATH}}
           ${{ env.VCPKG_ROOT }}\installed\x64-windows\tools\python3\python -m pytest ./pyTests
 
       - name: Unit Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 project(aliceVision LANGUAGES C CXX)
 
 option(ALICEVISION_BUILD_DEPENDENCIES "Build all AliceVision dependencies" OFF)

--- a/pyTests/sfmData/test_sfmdata.py
+++ b/pyTests/sfmData/test_sfmdata.py
@@ -340,7 +340,7 @@ def test_sfmdata_get_set_folders():
         data.getRelativeMatchesFolders()[0] == relative_folder
 
     # Add single features and matches folders
-    other_folder = "../other"
+    other_folder = os.path.join("..", "other")
     data.addFeaturesFolder(other_folder)
     data.addMatchesFolder(other_folder)
     assert len(data.getFeaturesFolders()) == 2, \
@@ -354,8 +354,8 @@ def test_sfmdata_get_set_folders():
     assert os.path.relpath(data.getMatchesFolders()[1], projectFolder) == other_folder
 
     # Reset features and matches folders and add new ones
-    new_folder1 = "../new"
-    new_folder2 = "../.."
+    new_folder1 = os.path.join("..", "new")
+    new_folder2 = os.path.join("..", "..")
     new_folder3 = "folder"
     new_folders = [new_folder1, new_folder2, new_folder3]
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -770,6 +770,9 @@ endif()
 if(ALICEVISION_BUILD_SWIG_BINDING)
   find_package(SWIG REQUIRED)  # SWIG dependency
   if(SWIG_FOUND)
+    # Remove CMake warnings related to SWIG old policies
+    cmake_policy(SET CMP0078 NEW)  # Use the specified module name for the target's name
+    cmake_policy(SET CMP0086 NEW)  # Use "-module {name}" when the module name has been set with SWIG_MODULE_NAME
     include(UseSWIG)
     message(STATUS "SWIG found.")
   else()

--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -93,9 +93,13 @@ if(ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES aliceVision.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET pyalicevision
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(pyalicevision
@@ -117,10 +121,12 @@ if(ALICEVISION_BUILD_SWIG_BINDING)
     target_link_libraries(pyalicevision
     PUBLIC
         aliceVision_numeric
+        ${Python3_LIBRARIES}
     )
     install(
     TARGETS
         pyalicevision
+
     DESTINATION
         ${CMAKE_INSTALL_PREFIX}
     )

--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -82,58 +82,17 @@ if (ALICEVISION_BUILD_PHOTOMETRICSTEREO)
 endif()
 
 
-if(ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE aliceVision.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE aliceVision.i PROPERTY SWIG_MODULE_NAME pyalicevision)
-
-    swig_add_library(pyalicevision
-        TYPE MODULE
-        LANGUAGE python
+if (ALICEVISION_BUILD_SWIG_BINDING)
+    alicevision_swig_add_library(pyalicevision
         SOURCES aliceVision.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET pyalicevision
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(pyalicevision
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET pyalicevision
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET pyalicevision
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(pyalicevision
-    PUBLIC
-        aliceVision_numeric
-        ${Python3_LIBRARIES}
-    )
-    install(
-    TARGETS
-        pyalicevision
-
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/pyalicevision.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_numeric
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()
 

--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -83,7 +83,6 @@ endif()
 
 
 if(ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE aliceVision.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE aliceVision.i PROPERTY SWIG_MODULE_NAME pyalicevision)
 

--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -127,13 +127,13 @@ if(ALICEVISION_BUILD_SWIG_BINDING)
         pyalicevision
 
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/pyalicevision.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()
 

--- a/src/aliceVision/camera/CMakeLists.txt
+++ b/src/aliceVision/camera/CMakeLists.txt
@@ -61,56 +61,15 @@ alicevision_add_test(equidistant_test.cpp       NAME "camera_equidistant"       
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE Camera.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE Camera.i PROPERTY SWIG_MODULE_NAME camera)
-
-    swig_add_library(camera
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(camera
         SOURCES Camera.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET camera
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(camera
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET camera
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET camera
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(camera
-    PUBLIC
-        aliceVision_camera
-        ${Python3_LIBRARIES}
-    )
-
-    install(
-    TARGETS
-    camera
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/camera.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_camera
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()

--- a/src/aliceVision/camera/CMakeLists.txt
+++ b/src/aliceVision/camera/CMakeLists.txt
@@ -105,12 +105,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     TARGETS
     camera
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/camera.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/camera/CMakeLists.txt
+++ b/src/aliceVision/camera/CMakeLists.txt
@@ -61,7 +61,6 @@ alicevision_add_test(equidistant_test.cpp       NAME "camera_equidistant"       
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE Camera.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE Camera.i PROPERTY SWIG_MODULE_NAME camera)
 

--- a/src/aliceVision/camera/CMakeLists.txt
+++ b/src/aliceVision/camera/CMakeLists.txt
@@ -71,9 +71,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES Camera.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET camera
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(camera
@@ -95,6 +99,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     target_link_libraries(camera
     PUBLIC
         aliceVision_camera
+        ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -48,9 +48,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES Geometry.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET geometry
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(geometry
@@ -72,6 +76,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     target_link_libraries(geometry
     PUBLIC
         aliceVision_geometry
+        ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -38,56 +38,15 @@ alicevision_add_test(frustumIntersection_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE Geometry.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE Geometry.i PROPERTY SWIG_MODULE_NAME geometry)
-
-    swig_add_library(geometry
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(geometry
         SOURCES Geometry.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET geometry
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(geometry
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET geometry
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET geometry
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(geometry
-    PUBLIC
-        aliceVision_geometry
-        ${Python3_LIBRARIES}
-    )
-
-    install(
-    TARGETS
-        geometry
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/geometry.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_geometry
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+             ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()

--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -82,12 +82,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     TARGETS
         geometry
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/geometry.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -38,7 +38,6 @@ alicevision_add_test(frustumIntersection_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE Geometry.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE Geometry.i PROPERTY SWIG_MODULE_NAME geometry)
 

--- a/src/aliceVision/global.i
+++ b/src/aliceVision/global.i
@@ -23,10 +23,18 @@
 %}
 
 %inline %{
-    typedef long unsigned int size_t;
     typedef uint32_t IndexT;
 %}
 
+#ifdef LINUXPLATFORM
+    %inline %{
+        typedef long unsigned int size_t;
+    %}
+#else
+    %inline %{
+        typedef unsigned long long size_t;
+    %}
+#endif
 
 %template(IntVector) std::vector<int>;
 %template(DoubleVector) std::vector<double>;

--- a/src/aliceVision/hdr/CMakeLists.txt
+++ b/src/aliceVision/hdr/CMakeLists.txt
@@ -61,9 +61,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES Hdr.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET hdr
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(hdr
@@ -89,6 +93,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         aliceVision_numeric
         aliceVision_image
         aliceVision_sfmData
+        ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/hdr/CMakeLists.txt
+++ b/src/aliceVision/hdr/CMakeLists.txt
@@ -51,60 +51,19 @@ alicevision_add_test(hdrLaguerre_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE Hdr.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE Hdr.i PROPERTY SWIG_MODULE_NAME hdr)
-
-    swig_add_library(hdr
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(hdr
         SOURCES Hdr.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET hdr
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(hdr
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET hdr
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET hdr
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(hdr
-    PUBLIC
-        aliceVision_hdr
-        aliceVision_system
-        aliceVision_numeric
-        aliceVision_image
-        aliceVision_sfmData
-        ${Python3_LIBRARIES}
-    )
-
-    install(
-    TARGETS
-        hdr
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/hdr.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_hdr
+            aliceVision_system
+            aliceVision_numeric
+            aliceVision_image
+            aliceVision_sfmData
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()

--- a/src/aliceVision/hdr/CMakeLists.txt
+++ b/src/aliceVision/hdr/CMakeLists.txt
@@ -99,12 +99,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     TARGETS
         hdr
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/hdr.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/hdr/CMakeLists.txt
+++ b/src/aliceVision/hdr/CMakeLists.txt
@@ -51,7 +51,6 @@ alicevision_add_test(hdrLaguerre_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE Hdr.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE Hdr.i PROPERTY SWIG_MODULE_NAME hdr)
 

--- a/src/aliceVision/numeric/CMakeLists.txt
+++ b/src/aliceVision/numeric/CMakeLists.txt
@@ -47,9 +47,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES numeric.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET numeric
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(numeric
@@ -71,6 +75,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     target_link_libraries(numeric
     PUBLIC
         aliceVision_numeric
+        ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/numeric/CMakeLists.txt
+++ b/src/aliceVision/numeric/CMakeLists.txt
@@ -81,12 +81,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     TARGETS
     numeric
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/numeric.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/numeric/CMakeLists.txt
+++ b/src/aliceVision/numeric/CMakeLists.txt
@@ -37,56 +37,15 @@ alicevision_add_test(gps_test.cpp NAME "numeric_gps" LINKS aliceVision_numeric)
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE numeric.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE numeric.i PROPERTY SWIG_MODULE_NAME numeric)
-
-    swig_add_library(numeric
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(numeric
         SOURCES numeric.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET numeric
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(numeric
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET numeric
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET numeric
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(numeric
-    PUBLIC
-        aliceVision_numeric
-        ${Python3_LIBRARIES}
-    )
-
-    install(
-    TARGETS
-    numeric
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/numeric.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_numeric
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()

--- a/src/aliceVision/numeric/CMakeLists.txt
+++ b/src/aliceVision/numeric/CMakeLists.txt
@@ -37,7 +37,6 @@ alicevision_add_test(gps_test.cpp NAME "numeric_gps" LINKS aliceVision_numeric)
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE numeric.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE numeric.i PROPERTY SWIG_MODULE_NAME numeric)
 

--- a/src/aliceVision/sensorDB/CMakeLists.txt
+++ b/src/aliceVision/sensorDB/CMakeLists.txt
@@ -29,7 +29,6 @@ alicevision_add_test(parseDatabase_test.cpp NAME "sensorDB_parseDatabase" LINKS 
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE SensorDB.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE SensorDB.i PROPERTY SWIG_MODULE_NAME sensorDB)
 

--- a/src/aliceVision/sensorDB/CMakeLists.txt
+++ b/src/aliceVision/sensorDB/CMakeLists.txt
@@ -39,9 +39,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES SensorDB.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET sensorDB
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(sensorDB
@@ -63,6 +67,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     target_link_libraries(sensorDB
     PUBLIC
         aliceVision_sensorDB
+        ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/sensorDB/CMakeLists.txt
+++ b/src/aliceVision/sensorDB/CMakeLists.txt
@@ -73,12 +73,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     TARGETS
         sensorDB
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/sensorDB.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/sensorDB/CMakeLists.txt
+++ b/src/aliceVision/sensorDB/CMakeLists.txt
@@ -29,56 +29,15 @@ alicevision_add_test(parseDatabase_test.cpp NAME "sensorDB_parseDatabase" LINKS 
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE SensorDB.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE SensorDB.i PROPERTY SWIG_MODULE_NAME sensorDB)
-
-    swig_add_library(sensorDB
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(sensorDB
         SOURCES SensorDB.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET sensorDB
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(sensorDB
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET sensorDB
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET sensorDB
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(sensorDB
-    PUBLIC
-        aliceVision_sensorDB
-        ${Python3_LIBRARIES}
-    )
-
-    install(
-    TARGETS
-        sensorDB
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/sensorDB.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_sensorDB
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -100,12 +100,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     TARGETS
         sfmData
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/sfmData.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -55,57 +55,16 @@ alicevision_add_test(view_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE SfMData.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE SfMData.i PROPERTY SWIG_MODULE_NAME sfmData)
-
-    swig_add_library(sfmData
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(sfmData
         SOURCES SfMData.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET sfmData
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(sfmData
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET sfmData
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET sfmData
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(sfmData
-    PUBLIC
-        aliceVision_sfmData
-        aliceVision_camera
-        ${Python3_LIBRARIES}
-    )
-
-    install(
-    TARGETS
-        sfmData
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/sfmData.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_sfmData
+            aliceVision_camera
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -55,7 +55,6 @@ alicevision_add_test(view_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE SfMData.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE SfMData.i PROPERTY SWIG_MODULE_NAME sfmData)
 

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -65,9 +65,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES SfMData.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET sfmData
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(sfmData
@@ -90,6 +94,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     PUBLIC
         aliceVision_sfmData
         aliceVision_camera
+        ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -37,7 +37,7 @@ class Landmark
         rgb(color)
     {}
 
-    Vec3 X;
+    Vec3 X = { 0.0, 0.0, 0.0 };
     feature::EImageDescriberType descType = feature::EImageDescriberType::UNINITIALIZED;
     image::RGBColor rgb = image::WHITE;  //!> the color associated to the point
     EEstimatorParameterState state = EEstimatorParameterState::REFINED;

--- a/src/aliceVision/sfmData/Observation.hpp
+++ b/src/aliceVision/sfmData/Observation.hpp
@@ -56,7 +56,7 @@ class Observation
     void setScale(double scale) { _scale = scale; }
 
   private:
-    Vec2 _coordinates;
+    Vec2 _coordinates = { 0.0, 0.0 };
     IndexT _idFeature = UndefinedIndexT;
     double _scale = 0.0;
 };

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -120,9 +120,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES SfMDataIO.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET sfmDataIO
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(sfmDataIO
@@ -144,6 +148,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     target_link_libraries(sfmDataIO
         PUBLIC
             aliceVision_sfmDataIO
+            ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -154,12 +154,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         TARGETS
             sfmDataIO
         DESTINATION
-            ${CMAKE_INSTALL_PREFIX}
+            ${CMAKE_INSTALL_BINDIR}
     )
     install(
         FILES
             ${CMAKE_CURRENT_BINARY_DIR}/sfmDataIO.py
         DESTINATION
-            ${CMAKE_INSTALL_PREFIX}
+            ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -110,7 +110,6 @@ alicevision_add_test(colmap_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE SfMDataIO.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE SfMDataIO.i PROPERTY SWIG_MODULE_NAME sfmDataIO)
 

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -110,56 +110,15 @@ alicevision_add_test(colmap_test.cpp
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE SfMDataIO.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE SfMDataIO.i PROPERTY SWIG_MODULE_NAME sfmDataIO)
-
-    swig_add_library(sfmDataIO
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(sfmDataIO
         SOURCES SfMDataIO.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET sfmDataIO
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(sfmDataIO
-        PRIVATE
+        PUBLIC_LINKS
+            aliceVision_sfmDataIO
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
             ../include
             ${ALICEVISION_ROOT}/include
             ${Python3_INCLUDE_DIRS}
             ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET sfmDataIO
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET sfmDataIO
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(sfmDataIO
-        PUBLIC
-            aliceVision_sfmDataIO
-            ${Python3_LIBRARIES}
-    )
-
-    install(
-        TARGETS
-            sfmDataIO
-        DESTINATION
-            ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-        FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/sfmDataIO.py
-        DESTINATION
-            ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/aliceVision/stl/CMakeLists.txt
+++ b/src/aliceVision/stl/CMakeLists.txt
@@ -19,58 +19,17 @@ alicevision_add_test(dynamicBitset_test.cpp NAME "stl_dynamicBitset" LINKS alice
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set_property(SOURCE Stl.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE Stl.i PROPERTY SWIG_MODULE_NAME stl)
-
-    swig_add_library(stl
-        TYPE MODULE
-        LANGUAGE python
+    alicevision_swig_add_library(stl
         SOURCES Stl.i
-    )
-
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
-        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
-    endif()
-
-    set_property(
-        TARGET stl
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
-    )
-
-    target_include_directories(stl
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
-    )
-    set_property(
-        TARGET stl
-        PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
-    )
-    set_property(
-        TARGET stl
-        PROPERTY COMPILE_OPTIONS -std=c++20
-    )
-
-    target_link_libraries(stl
-    PUBLIC
-        aliceVision_stl
-        aliceVision_system
-        Boost::container
-        ${Python3_LIBRARIES}
-    )
-
-    install(
-    TARGETS
-        stl
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
-    )
-    install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/stl.py
-    DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_LINKS
+            aliceVision_stl
+            aliceVision_system
+            Boost::container
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
 endif()

--- a/src/aliceVision/stl/CMakeLists.txt
+++ b/src/aliceVision/stl/CMakeLists.txt
@@ -29,9 +29,13 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         SOURCES Stl.i
     )
 
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+        list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+    endif()
+
     set_property(
         TARGET stl
-        PROPERTY SWIG_COMPILE_OPTIONS -doxygen
+        PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
     )
 
     target_include_directories(stl
@@ -55,6 +59,7 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
         aliceVision_stl
         aliceVision_system
         Boost::container
+        ${Python3_LIBRARIES}
     )
 
     install(

--- a/src/aliceVision/stl/CMakeLists.txt
+++ b/src/aliceVision/stl/CMakeLists.txt
@@ -19,7 +19,6 @@ alicevision_add_test(dynamicBitset_test.cpp NAME "stl_dynamicBitset" LINKS alice
 
 # SWIG Binding
 if (ALICEVISION_BUILD_SWIG_BINDING)
-    set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE Stl.i PROPERTY CPLUSPLUS ON)
     set_property(SOURCE Stl.i PROPERTY SWIG_MODULE_NAME stl)
 

--- a/src/aliceVision/stl/CMakeLists.txt
+++ b/src/aliceVision/stl/CMakeLists.txt
@@ -65,12 +65,12 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     TARGETS
         stl
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
     install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/stl.py
     DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -285,3 +285,56 @@ function(alicevision_add_test test_file)
   endif()
 
 endfunction()
+
+# Add SWIG library function
+function(alicevision_swig_add_library module_name)
+  set(multipleValues SOURCES PUBLIC_LINKS PRIVATE_INCLUDE_DIRS)
+  cmake_parse_arguments(SWIG_MODULE "" "" "${multipleValues}" ${ARGN})
+
+  set_property(SOURCE ${SWIG_MODULE_SOURCES} PROPERTY CPLUSPLUS ON)
+  set_property(SOURCE ${SWIG_MODULE_SOURCES} PROPERTY SWIG_MODULE_NAME ${module_name})
+
+  swig_add_library(${module_name}
+    TYPE MODULE
+    LANGUAGE python
+    SOURCES ${SWIG_MODULE_SOURCES}
+  )
+
+  if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX)
+    list(APPEND SWIG_EXTRA_COMPILE_OPTIONS "-DLINUXPLATFORM")
+  endif()
+
+  set_property(
+    TARGET ${module_name}
+    PROPERTY SWIG_COMPILE_OPTIONS -doxygen ${SWIG_EXTRA_COMPILE_OPTIONS}
+  )
+
+  target_include_directories(${module_name}
+    PRIVATE ${SWIG_MODULE_PRIVATE_INCLUDE_DIRS}
+  )
+  set_property(
+    TARGET ${module_name}
+    PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
+  )
+  set_property(
+    TARGET ${module_name}
+    PROPERTY COMPILE_OPTIONS -std=c++20
+  )
+
+  target_link_libraries(${module_name}
+    PUBLIC ${SWIG_MODULE_PUBLIC_LINKS}
+  )
+
+  install(
+    TARGETS
+      ${module_name}
+    DESTINATION
+      ${CMAKE_INSTALL_BINDIR}
+  )
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.py
+    DESTINATION
+      ${CMAKE_INSTALL_BINDIR}
+  )
+endfunction()

--- a/src/cmake/MakeBundle.cmake
+++ b/src/cmake/MakeBundle.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 # Perform bundle fixup on all executables of an install directory
 # and generates a standalone bundle with all required runtime dependencies.
 #


### PR DESCRIPTION
## Description

This PR adds support to build the Python binding introduced in #1647 on Windows.

In particular, the required Python3 libraries are now correctly linked to the binded modules, and platform-induced differences on `size_t` are handled. Similarly, elements that were not initialized with the same values when using the default constructor depending on the platform are now explicitly set (e.g. `Vec2` and `Vec3` in `Observation` and `Landmark` objects). 

The Python unit tests have also been updated to be compatible on both Linux and Windows platforms.

The binding, which used to be generated at the root folder, is now installed directly in the `bin` directory. The CI is updated accordingly to ensure that the Python unit tests keep on running.

Finally, the Windows CI now enables the generation of the binding and runs the Python unit tests.

