### PR TITLE
[build] Update the list of installed features for OpenImageIO with VCPKG 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -167,7 +167,7 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.3.0
         id: vcpkgDownload
         with:
-          url: "https://gitlab.com/alicevision/vcpkgArchive/-/raw/main/aliceVisionDeps-2024.01.31.zip?ref_type=heads&inline=false"
+          url: "https://gitlab.com/alicevision/vcpkgArchive/-/raw/main/aliceVisionDeps-2024.02.06.zip?ref_type=heads&inline=false"
           target: "${{ env.vcpkgDir }}"
           filename: installed.zip
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,6 +50,8 @@ Other optional libraries can enable specific features (check "CMake Options" for
 * PopSift (feature extraction on GPU)
 * UncertaintyTE (Uncertainty computation)
 * Lemon >= 1.3
+* libe57format (support reading .e57 files)
+
 
 AliceVision also depends on some embedded libraries:
 
@@ -93,7 +95,7 @@ vcpkg install ^
           flann ^
           onnxruntime-gpu ^
           opencv[eigen,ffmpeg,webp,contrib,nonfree,cuda] ^
-          openimageio[libraw,ffmpeg,freetype,opencv,gif,openjpeg,webp] ^
+          openimageio[opencolorio,pybind11,libraw,ffmpeg,freetype,opencv,gif,openjpeg,webp] ^
           ceres[suitesparse,cxsparse] ^
           cuda ^
           tbb ^


### PR DESCRIPTION
## Description

This PR adds the `opencolorio` and `pybind11` features to the list of features to install for OpenImageIO with VCPKG. The installation documentation is updated, and the new VCPKG archive that contains these features is now used for the CI.