### PR TITLE
[build] Update Geogram to 1.8.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: alicevision/alicevision-deps:2024.01.31-centos7-cuda11.3.1
+      image: alicevision/alicevision-deps:2024.02.08-centos7-cuda11.3.1
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ AliceVision depends on external libraries:
 * [Eigen >= 3.3.4](https://gitlab.com/libeigen/eigen)
 * [Expat >= 2.4.8](https://libexpat.github.io/)
 * Flann >= 1.8.4, use [our fork](https://github.com/alicevision/flann) with a CMake build system
-* [Geogram >= 1.7.5](https://github.com/BrunoLevy/geogram)
+* [Geogram >= 1.7.5 (recommended >= 1.8.8)](https://github.com/BrunoLevy/geogram)
 * [OpenEXR >= 2.5](https://github.com/AcademySoftwareFoundation/openexr)
 * [OpenImageIO >= 2.1.0 (recommended >= 2.4.13)](https://github.com/OpenImageIO/oiio)
 * Open Solver Interface (Osi) >= 0.106.10 use [our fork](https://github.com/alicevision/Osi)) with a CMake build system

--- a/docker/build-centos.sh
+++ b/docker/build-centos.sh
@@ -7,7 +7,7 @@ test -e docker/fetch.sh || {
     exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2024.01.31
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2024.02.08
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$CENTOS_VERSION" && CENTOS_VERSION=7

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2024.01.31
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2024.02.08
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=20.04

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -172,8 +172,8 @@ if(AV_BUILD_GEOGRAM)
     set(GEOGRAM_TARGET geogram)
 
     ExternalProject_Add(${GEOGRAM_TARGET}
-        URL https://github.com/BrunoLevy/geogram/releases/download/v1.8.3/geogram_1.8.3.tar.gz
-        URL_HASH MD5=06fa5a70c05830d103ff71c55da5bb53
+        URL https://github.com/BrunoLevy/geogram/releases/download/v1.8.8/geogram_1.8.8.tar.gz
+        URL_HASH MD5=e66563683fad771ef19fdf8b42c8b2a4
         DOWNLOAD_DIR ${BUILD_DIR}/download/geogram
         PREFIX ${BUILD_DIR}
         BUILD_IN_SOURCE 0


### PR DESCRIPTION
## Description

This PR updates the Geogram dependency from version 1.8.3 to 1.8.8. The Docker images for the dependencies have been rebuilt, tagged and pushed, and are thus now used for the Linux CI and as the default dependencies images for any Docker build.