### PR TITLE
E57 importer is now generating multiple sfmData

### DIFF
--- a/src/aliceVision/dataio/E57Reader.hpp
+++ b/src/aliceVision/dataio/E57Reader.hpp
@@ -32,7 +32,8 @@ public:
     _paths(paths),
     _idPath(-1),
     _idMesh(-1),
-    _countMeshesForFile(0)
+    _countMeshesForFile(0),
+    _requiredIntensity(0.0)
     {
 
     }
@@ -171,6 +172,11 @@ public:
                 {
                     continue;
                 }
+                
+                if (data3DPoints.intensity[pos] < _requiredIntensity)
+                {
+                    continue;
+                }
 
                 Eigen::Vector3d pt;
                 pt(0) = data3DPoints.cartesianX[pos];
@@ -266,6 +272,11 @@ public:
         return _idMesh;
     }
 
+    void setRequiredIntensity(double requirement)
+    {
+        _requiredIntensity = requirement;
+    }
+
 private:
     std::vector<std::string> _paths;
     std::unique_ptr<e57::Reader> _reader;
@@ -273,6 +284,7 @@ private:
     int _idPath;
     int _idMesh;
     size_t _countMeshesForFile;
+    double _requiredIntensity;
 };
 
 }  // namespace dataio

--- a/src/aliceVision/fuseCut/CMakeLists.txt
+++ b/src/aliceVision/fuseCut/CMakeLists.txt
@@ -9,6 +9,8 @@ set(fuseCut_files_headers
   OctreeTracks.hpp
   ReconstructionPlan.hpp
   VoxelsGrid.hpp
+  Octree.hpp
+  InputSet.hpp
 )
 
 # Sources
@@ -21,6 +23,7 @@ set(fuseCut_files_sources
   OctreeTracks.cpp
   ReconstructionPlan.cpp
   VoxelsGrid.cpp
+  InputSet.cpp
 )
 
 alicevision_add_library(aliceVision_fuseCut
@@ -37,6 +40,7 @@ alicevision_add_library(aliceVision_fuseCut
   PRIVATE_LINKS
     nanoflann
     Boost::boost
+    Boost::json
 )
 
 # Unit tests

--- a/src/aliceVision/fuseCut/InputSet.cpp
+++ b/src/aliceVision/fuseCut/InputSet.cpp
@@ -1,0 +1,35 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+#include "InputSet.hpp"
+
+#include <iostream>
+
+namespace aliceVision {
+namespace fuseCut {
+
+Input tag_invoke(boost::json::value_to_tag<Input>, boost::json::value const& jv)
+{
+    const boost::json::object& obj = jv.as_object();
+
+    Input ret;
+    ret.sfmPath = boost::json::value_to<std::string>(obj.at("sfmPath"));
+    ret.subMeshPath = boost::json::value_to<std::string>(obj.at("subMeshPath"));
+
+    return ret;
+}
+
+void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, Input const& t)
+{
+    jv = {
+            {"sfmPath", t.sfmPath},
+            {"subMeshPath", t.subMeshPath},
+          };
+}
+
+}
+}

--- a/src/aliceVision/fuseCut/InputSet.cpp
+++ b/src/aliceVision/fuseCut/InputSet.cpp
@@ -4,7 +4,6 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 #include "InputSet.hpp"
 
 #include <iostream>
@@ -26,10 +25,10 @@ Input tag_invoke(boost::json::value_to_tag<Input>, boost::json::value const& jv)
 void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, Input const& t)
 {
     jv = {
-            {"sfmPath", t.sfmPath},
-            {"subMeshPath", t.subMeshPath},
-          };
+      {"sfmPath", t.sfmPath},
+      {"subMeshPath", t.subMeshPath},
+    };
 }
 
-}
-}
+}  // namespace fuseCut
+}  // namespace aliceVision

--- a/src/aliceVision/fuseCut/InputSet.hpp
+++ b/src/aliceVision/fuseCut/InputSet.hpp
@@ -29,6 +29,5 @@ Input tag_invoke(boost::json::value_to_tag<Input>, boost::json::value const& jv)
  */
 void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, Input const& t);
 
-}
-}
-
+}  // namespace fuseCut
+}  // namespace aliceVision

--- a/src/aliceVision/fuseCut/InputSet.hpp
+++ b/src/aliceVision/fuseCut/InputSet.hpp
@@ -1,0 +1,34 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <boost/json.hpp>
+
+namespace aliceVision {
+namespace fuseCut {
+
+struct Input
+{
+    std::string sfmPath;
+    std::string subMeshPath;
+};
+
+using InputSet = std::vector<Input>;
+
+/**
+ * @brief Deserialize JSON object to Input.
+ */
+Input tag_invoke(boost::json::value_to_tag<Input>, boost::json::value const& jv);
+
+/**
+ * @brief Serialize Input to JSON object.
+ */
+void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, Input const& t);
+
+}
+}
+

--- a/src/aliceVision/fuseCut/Octree.hpp
+++ b/src/aliceVision/fuseCut/Octree.hpp
@@ -1,0 +1,440 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/types.hpp>
+#include <Eigen/Dense>
+
+namespace aliceVision {
+namespace fuseCut {
+
+struct RayInfo
+{
+    IndexT start;
+    IndexT end;
+};
+
+class SimpleNode 
+{
+public:
+    using uptr = std::unique_ptr<SimpleNode>;
+    using ptr = SimpleNode *;
+
+public:
+    SimpleNode(const Eigen::Vector3d & bbmin, const Eigen::Vector3d & bbmax)
+    {
+        _bbMin = bbmin;
+        _bbMax = bbmax;
+    }
+
+    double getSize()
+    {
+        Eigen::Vector3d rel = _bbMax - _bbMin;
+        return rel.maxCoeff();
+    }
+
+    void store(const Eigen::Vector3d & pt)
+    {
+        if (!isInside(pt))
+        {
+            return;
+        }
+
+        double size = getSize();
+        if (size > _minSize)
+        {
+            subdivide();
+
+            for (auto& item : _nodes)
+            {
+                if (item == nullptr)
+                {
+                    continue;
+                }
+
+                item->store(pt);
+            }
+        }
+        else 
+        {
+            _count++;
+        }
+    }
+
+    bool isInside(const Eigen::Vector3d & pt) const
+    {
+
+        return (pt.x() >= _bbMin.x() && 
+                pt.y() >= _bbMin.y() && 
+                pt.z() >= _bbMin.z() && 
+                pt.x() <= _bbMax.x() && 
+                pt.y() <= _bbMax.y() && 
+                pt.z() <= _bbMax.z());
+    }
+
+    void subdivide()
+    {
+        if (_nodes[0] != nullptr)
+        {
+            return;
+        }
+
+        Eigen::Vector3d center = (_bbMin + _bbMax) * 0.5;
+        
+        
+        double xs[] = {_bbMin.x(), center.x(), _bbMax.x()};
+        double ys[] = {_bbMin.y(), center.y(), _bbMax.y()};
+        double zs[] = {_bbMin.z(), center.z(), _bbMax.z()};
+
+        int pos = 0;
+        for (int ix = 0; ix < 2; ix++)
+        {
+            for (int iy = 0; iy < 2; iy++)
+            {
+                for (int iz = 0; iz < 2; iz++)
+                {
+                    Eigen::Vector3d lmin;
+                    lmin.x() = xs[ix];
+                    lmin.y() = ys[iy];
+                    lmin.z() = zs[iz];
+
+                    Eigen::Vector3d lmax;
+                    lmax.x() = xs[ix + 1];
+                    lmax.y() = ys[iy + 1];
+                    lmax.z() = zs[iz + 1];
+                    
+                    _nodes[pos] = std::make_unique<SimpleNode>(lmin, lmax);
+                    pos++;
+                }
+            }
+        }
+    }
+
+    void visit(std::vector<SimpleNode::ptr> & list)
+    {
+        if (_count > 0)
+        {
+            list.push_back(this);
+        }
+
+        for (auto &item : _nodes)
+        {
+            if (item)
+            {
+                item->visit(list);
+            }
+        }
+    }
+
+    void regroup(size_t maxPointsPerNode)
+    {
+        size_t count = getCount();
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        if (count < maxPointsPerNode)
+        {
+            _count = count;
+
+            for (auto & item : _nodes)
+            {
+                item.reset();
+                item = nullptr;
+            }
+
+            return;
+        }        
+        
+        for (auto & item : _nodes)
+        {
+            if (item)
+            {
+                item->regroup(maxPointsPerNode);
+            }
+        }
+    }
+
+    const size_t getCount() const
+    {
+        size_t count = _count;
+
+        for (const auto & item : _nodes)
+        {
+            if (item) 
+            {
+                count += item->getCount();
+            }
+        }
+
+        return count;
+    }
+
+    const Eigen::Vector3d & getBBMin() const
+    {
+        return _bbMin;
+    }
+
+    const Eigen::Vector3d & getBBMax() const
+    {
+        return _bbMax;
+    }
+
+private:
+    std::array<SimpleNode::uptr, 8> _nodes;
+    Eigen::Vector3d _bbMin;
+    Eigen::Vector3d _bbMax;
+    size_t _count = 0;
+    double _minSize = 2.0;
+};
+
+class Node 
+{
+public:
+    using uptr = std::unique_ptr<Node>;
+    using ptr = Node *;
+
+public:
+    Node(const Eigen::Vector3d & bbmin, const Eigen::Vector3d & bbmax)
+    {
+        _bbMin = bbmin;
+        _bbMax = bbmax;
+    }
+
+    double getSize()
+    {
+        Eigen::Vector3d rel = _bbMax - _bbMin;
+        return rel.maxCoeff();
+    }
+
+    void storeRay(const Eigen::Vector3d & start, const Eigen::Vector3d & end, const RayInfo & info)
+    {
+        //Check that the ray intersect this cell
+        if (!intersect(start, end))
+        {
+            return;
+        }        
+
+        double size = getSize();
+        if (size > _minSize)
+        {
+            subdivide();
+
+            for (auto& item : _nodes)
+            {
+                if (item == nullptr)
+                {
+                    continue;
+                }
+
+                item->storeRay(start, end, info);
+            }
+        }
+        else 
+        {
+            if (isInside(end)) _rayInfos.push_back(info);
+        }
+    }
+
+    bool isInside(const Eigen::Vector3d & pt) const
+    {
+
+        return (pt.x() >= _bbMin.x() && 
+                pt.y() >= _bbMin.y() && 
+                pt.z() >= _bbMin.z() && 
+                pt.x() <= _bbMax.x() && 
+                pt.y() <= _bbMax.y() && 
+                pt.z() <= _bbMax.z());
+    }
+
+    void visit(std::vector<Node::ptr> & list)
+    {
+        if (_rayInfos.size() > 0)
+        {
+            list.push_back(this);
+        }
+
+        for (auto &item : _nodes)
+        {
+            if (item)
+            {
+                item->visit(list);
+            }
+        }
+    }
+
+    void getIntersect(const Eigen::Vector3d & start, const Eigen::Vector3d & end, double & boundsMin, double & boundsMax) const
+    {
+        // x+lambda*dx>bbmin.x
+        // y+lambda*dy>bbmin.y
+        // z+lambda*dz>bbmin.z
+        // x+lambda*dx<bbmax.x
+        // y+lambda*dy<bbmax.y
+        // z+lambda*dz<bbmax.z
+
+        // lambda > (bbmin.x-x)/dx
+        // lambda > (bbmin.y-y)/dy
+        // lambda > (bbmin.z-z)/dz
+        // lambda < (bbmax.x-x)/dx
+        // lambda < (bbmax.y-y)/dy
+        // lambda < (bbmax.z-z)/dz
+        
+
+        Eigen::Vector3d direction = end - start;
+
+        boundsMin = std::numeric_limits<double>::lowest();
+        boundsMax = std::numeric_limits<double>::max();
+
+        if (std::abs(direction.x()) > 1e-12)
+        {
+            double lmin = (_bbMin.x() - start.x()) / direction.x();
+            double lmax = (_bbMax.x() - start.x()) / direction.x();
+
+            if (direction.x() > 0.0)
+            {
+                boundsMin = std::max(boundsMin, lmin);
+                boundsMax = std::min(boundsMax, lmax);
+            }
+            else
+            {
+                boundsMin = std::max(boundsMin, lmax);
+                boundsMax = std::min(boundsMax, lmin);
+            }
+        }
+
+        if (std::abs(direction.y()) > 1e-12)
+        {
+            double lmin = (_bbMin.y() - start.y()) / direction.y();
+            double lmax = (_bbMax.y() - start.y()) / direction.y();
+
+            if (direction.y() > 0.0)
+            {
+                boundsMin = std::max(boundsMin, lmin);
+                boundsMax = std::min(boundsMax, lmax);
+            }
+            else
+            {
+                boundsMin = std::max(boundsMin, lmax);
+                boundsMax = std::min(boundsMax, lmin);
+            }
+        }   
+
+        if (std::abs(direction.z()) > 1e-12)
+        {
+            double lmin = (_bbMin.z() - start.z()) / direction.z();
+            double lmax = (_bbMax.z() - start.z()) / direction.z();
+
+            if (direction.z() > 0.0)
+            {
+                boundsMin = std::max(boundsMin, lmin);
+                boundsMax = std::min(boundsMax, lmax);
+            }
+            else
+            {
+                boundsMin = std::max(boundsMin, lmax);
+                boundsMax = std::min(boundsMax, lmin);
+            }
+        }  
+
+        boundsMin = std::min(boundsMin, 1.0);
+        boundsMax = std::min(boundsMax, 1.0);
+    }
+
+    bool intersect(const Eigen::Vector3d & start, const Eigen::Vector3d & end) const
+    {
+        double boundsMin, boundsMax;
+
+        getIntersect(start, end, boundsMin, boundsMax);
+
+        return (boundsMin < boundsMax);
+    }
+
+    bool getPointLeaving(const Eigen::Vector3d & start, const Eigen::Vector3d & end, Eigen::Vector3d & output) const
+    {
+        double boundsMin, boundsMax;
+
+        getIntersect(start, end, boundsMin, boundsMax);
+
+        output = start + boundsMax * (end - start); 
+
+        return (boundsMin < boundsMax);
+    }
+
+    bool intersectTriangle(const Eigen::Vector3d & A,const Eigen::Vector3d & B, const Eigen::Vector3d & C)
+    {
+        return true;
+    }
+
+    void subdivide()
+    {
+        if (_nodes[0] != nullptr)
+        {
+            return;
+        }
+
+        Eigen::Vector3d center = (_bbMin + _bbMax) * 0.5;
+        
+        
+        double xs[] = {_bbMin.x(), center.x(), _bbMax.x()};
+        double ys[] = {_bbMin.y(), center.y(), _bbMax.y()};
+        double zs[] = {_bbMin.z(), center.z(), _bbMax.z()};
+
+        int pos = 0;
+        for (int ix = 0; ix < 2; ix++)
+        {
+            for (int iy = 0; iy < 2; iy++)
+            {
+                for (int iz = 0; iz < 2; iz++)
+                {
+                    Eigen::Vector3d lmin;
+                    lmin.x() = xs[ix];
+                    lmin.y() = ys[iy];
+                    lmin.z() = zs[iz];
+
+                    Eigen::Vector3d lmax;
+                    lmax.x() = xs[ix + 1];
+                    lmax.y() = ys[iy + 1];
+                    lmax.z() = zs[iz + 1];
+                    
+                    _nodes[pos] = std::make_unique<Node>(lmin, lmax);
+                    pos++;
+                }
+            }
+        }
+    }
+
+    const std::vector<RayInfo> & getRayInfos()
+    {
+        return _rayInfos;
+    }
+
+    const Eigen::Vector3d & getBBMin() const
+    {
+        return _bbMin;
+    }
+
+    const Eigen::Vector3d & getBBMax() const
+    {
+        return _bbMax;
+    }
+
+private:
+    std::array<Node::uptr, 8> _nodes;
+
+    Eigen::Vector3d _bbMin;
+    Eigen::Vector3d _bbMax;
+
+    std::vector<RayInfo> _rayInfos;
+public:
+
+    double _minSize = 40.0;
+};
+
+}
+}

--- a/src/aliceVision/fuseCut/Octree.hpp
+++ b/src/aliceVision/fuseCut/Octree.hpp
@@ -18,14 +18,14 @@ struct RayInfo
     IndexT end;
 };
 
-class SimpleNode 
+class SimpleNode
 {
-public:
+  public:
     using uptr = std::unique_ptr<SimpleNode>;
-    using ptr = SimpleNode *;
+    using ptr = SimpleNode*;
 
-public:
-    SimpleNode(const Eigen::Vector3d & bbmin, const Eigen::Vector3d & bbmax)
+  public:
+    SimpleNode(const Eigen::Vector3d& bbmin, const Eigen::Vector3d& bbmax)
     {
         _bbMin = bbmin;
         _bbMax = bbmax;
@@ -37,7 +37,7 @@ public:
         return rel.maxCoeff();
     }
 
-    void store(const Eigen::Vector3d & pt)
+    void store(const Eigen::Vector3d& pt)
     {
         if (!isInside(pt))
         {
@@ -59,20 +59,15 @@ public:
                 item->store(pt);
             }
         }
-        else 
+        else
         {
             _count++;
         }
     }
 
-    bool isInside(const Eigen::Vector3d & pt) const
+    bool isInside(const Eigen::Vector3d& pt) const
     {
-
-        return (pt.x() >= _bbMin.x() && 
-                pt.y() >= _bbMin.y() && 
-                pt.z() >= _bbMin.z() && 
-                pt.x() <= _bbMax.x() && 
-                pt.y() <= _bbMax.y() && 
+        return (pt.x() >= _bbMin.x() && pt.y() >= _bbMin.y() && pt.z() >= _bbMin.z() && pt.x() <= _bbMax.x() && pt.y() <= _bbMax.y() &&
                 pt.z() <= _bbMax.z());
     }
 
@@ -84,8 +79,7 @@ public:
         }
 
         Eigen::Vector3d center = (_bbMin + _bbMax) * 0.5;
-        
-        
+
         double xs[] = {_bbMin.x(), center.x(), _bbMax.x()};
         double ys[] = {_bbMin.y(), center.y(), _bbMax.y()};
         double zs[] = {_bbMin.z(), center.z(), _bbMax.z()};
@@ -106,7 +100,7 @@ public:
                     lmax.x() = xs[ix + 1];
                     lmax.y() = ys[iy + 1];
                     lmax.z() = zs[iz + 1];
-                    
+
                     _nodes[pos] = std::make_unique<SimpleNode>(lmin, lmax);
                     pos++;
                 }
@@ -114,14 +108,14 @@ public:
         }
     }
 
-    void visit(std::vector<SimpleNode::ptr> & list)
+    void visit(std::vector<SimpleNode::ptr>& list)
     {
         if (_count > 0)
         {
             list.push_back(this);
         }
 
-        for (auto &item : _nodes)
+        for (auto& item : _nodes)
         {
             if (item)
             {
@@ -143,16 +137,16 @@ public:
         {
             _count = count;
 
-            for (auto & item : _nodes)
+            for (auto& item : _nodes)
             {
                 item.reset();
                 item = nullptr;
             }
 
             return;
-        }        
-        
-        for (auto & item : _nodes)
+        }
+
+        for (auto& item : _nodes)
         {
             if (item)
             {
@@ -165,9 +159,9 @@ public:
     {
         size_t count = _count;
 
-        for (const auto & item : _nodes)
+        for (const auto& item : _nodes)
         {
-            if (item) 
+            if (item)
             {
                 count += item->getCount();
             }
@@ -176,17 +170,11 @@ public:
         return count;
     }
 
-    const Eigen::Vector3d & getBBMin() const
-    {
-        return _bbMin;
-    }
+    const Eigen::Vector3d& getBBMin() const { return _bbMin; }
 
-    const Eigen::Vector3d & getBBMax() const
-    {
-        return _bbMax;
-    }
+    const Eigen::Vector3d& getBBMax() const { return _bbMax; }
 
-private:
+  private:
     std::array<SimpleNode::uptr, 8> _nodes;
     Eigen::Vector3d _bbMin;
     Eigen::Vector3d _bbMax;
@@ -194,14 +182,14 @@ private:
     double _minSize = 2.0;
 };
 
-class Node 
+class Node
 {
-public:
+  public:
     using uptr = std::unique_ptr<Node>;
-    using ptr = Node *;
+    using ptr = Node*;
 
-public:
-    Node(const Eigen::Vector3d & bbmin, const Eigen::Vector3d & bbmax)
+  public:
+    Node(const Eigen::Vector3d& bbmin, const Eigen::Vector3d& bbmax)
     {
         _bbMin = bbmin;
         _bbMax = bbmax;
@@ -213,13 +201,13 @@ public:
         return rel.maxCoeff();
     }
 
-    void storeRay(const Eigen::Vector3d & start, const Eigen::Vector3d & end, const RayInfo & info)
+    void storeRay(const Eigen::Vector3d& start, const Eigen::Vector3d& end, const RayInfo& info)
     {
-        //Check that the ray intersect this cell
+        // Check that the ray intersect this cell
         if (!intersect(start, end))
         {
             return;
-        }        
+        }
 
         double size = getSize();
         if (size > _minSize)
@@ -236,31 +224,27 @@ public:
                 item->storeRay(start, end, info);
             }
         }
-        else 
+        else
         {
-            if (isInside(end)) _rayInfos.push_back(info);
+            if (isInside(end))
+                _rayInfos.push_back(info);
         }
     }
 
-    bool isInside(const Eigen::Vector3d & pt) const
+    bool isInside(const Eigen::Vector3d& pt) const
     {
-
-        return (pt.x() >= _bbMin.x() && 
-                pt.y() >= _bbMin.y() && 
-                pt.z() >= _bbMin.z() && 
-                pt.x() <= _bbMax.x() && 
-                pt.y() <= _bbMax.y() && 
+        return (pt.x() >= _bbMin.x() && pt.y() >= _bbMin.y() && pt.z() >= _bbMin.z() && pt.x() <= _bbMax.x() && pt.y() <= _bbMax.y() &&
                 pt.z() <= _bbMax.z());
     }
 
-    void visit(std::vector<Node::ptr> & list)
+    void visit(std::vector<Node::ptr>& list)
     {
         if (_rayInfos.size() > 0)
         {
             list.push_back(this);
         }
 
-        for (auto &item : _nodes)
+        for (auto& item : _nodes)
         {
             if (item)
             {
@@ -269,7 +253,7 @@ public:
         }
     }
 
-    void getIntersect(const Eigen::Vector3d & start, const Eigen::Vector3d & end, double & boundsMin, double & boundsMax) const
+    void getIntersect(const Eigen::Vector3d& start, const Eigen::Vector3d& end, double& boundsMin, double& boundsMax) const
     {
         // x+lambda*dx>bbmin.x
         // y+lambda*dy>bbmin.y
@@ -284,7 +268,6 @@ public:
         // lambda < (bbmax.x-x)/dx
         // lambda < (bbmax.y-y)/dy
         // lambda < (bbmax.z-z)/dz
-        
 
         Eigen::Vector3d direction = end - start;
 
@@ -323,7 +306,7 @@ public:
                 boundsMin = std::max(boundsMin, lmax);
                 boundsMax = std::min(boundsMax, lmin);
             }
-        }   
+        }
 
         if (std::abs(direction.z()) > 1e-12)
         {
@@ -340,13 +323,13 @@ public:
                 boundsMin = std::max(boundsMin, lmax);
                 boundsMax = std::min(boundsMax, lmin);
             }
-        }  
+        }
 
         boundsMin = std::min(boundsMin, 1.0);
         boundsMax = std::min(boundsMax, 1.0);
     }
 
-    bool intersect(const Eigen::Vector3d & start, const Eigen::Vector3d & end) const
+    bool intersect(const Eigen::Vector3d& start, const Eigen::Vector3d& end) const
     {
         double boundsMin, boundsMax;
 
@@ -355,21 +338,18 @@ public:
         return (boundsMin < boundsMax);
     }
 
-    bool getPointLeaving(const Eigen::Vector3d & start, const Eigen::Vector3d & end, Eigen::Vector3d & output) const
+    bool getPointLeaving(const Eigen::Vector3d& start, const Eigen::Vector3d& end, Eigen::Vector3d& output) const
     {
         double boundsMin, boundsMax;
 
         getIntersect(start, end, boundsMin, boundsMax);
 
-        output = start + boundsMax * (end - start); 
+        output = start + boundsMax * (end - start);
 
         return (boundsMin < boundsMax);
     }
 
-    bool intersectTriangle(const Eigen::Vector3d & A,const Eigen::Vector3d & B, const Eigen::Vector3d & C)
-    {
-        return true;
-    }
+    bool intersectTriangle(const Eigen::Vector3d& A, const Eigen::Vector3d& B, const Eigen::Vector3d& C) { return true; }
 
     void subdivide()
     {
@@ -379,8 +359,7 @@ public:
         }
 
         Eigen::Vector3d center = (_bbMin + _bbMax) * 0.5;
-        
-        
+
         double xs[] = {_bbMin.x(), center.x(), _bbMax.x()};
         double ys[] = {_bbMin.y(), center.y(), _bbMax.y()};
         double zs[] = {_bbMin.z(), center.z(), _bbMax.z()};
@@ -401,7 +380,7 @@ public:
                     lmax.x() = xs[ix + 1];
                     lmax.y() = ys[iy + 1];
                     lmax.z() = zs[iz + 1];
-                    
+
                     _nodes[pos] = std::make_unique<Node>(lmin, lmax);
                     pos++;
                 }
@@ -409,32 +388,23 @@ public:
         }
     }
 
-    const std::vector<RayInfo> & getRayInfos()
-    {
-        return _rayInfos;
-    }
+    const std::vector<RayInfo>& getRayInfos() { return _rayInfos; }
 
-    const Eigen::Vector3d & getBBMin() const
-    {
-        return _bbMin;
-    }
+    const Eigen::Vector3d& getBBMin() const { return _bbMin; }
 
-    const Eigen::Vector3d & getBBMax() const
-    {
-        return _bbMax;
-    }
+    const Eigen::Vector3d& getBBMax() const { return _bbMax; }
 
-private:
+  private:
     std::array<Node::uptr, 8> _nodes;
 
     Eigen::Vector3d _bbMin;
     Eigen::Vector3d _bbMax;
 
     std::vector<RayInfo> _rayInfos;
-public:
 
+  public:
     double _minSize = 40.0;
 };
 
-}
-}
+}  // namespace fuseCut
+}  // namespace aliceVision

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -20,6 +20,33 @@ using namespace aliceVision::image;
 
 namespace fs = std::filesystem;
 
+SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eigen::Vector3d & bbMax)
+{
+    _views = other._views;
+    _intrinsics  = other._intrinsics;
+    constraints2d = other.constraints2d;
+    rotationpriors = other.rotationpriors;
+    _absolutePath = other._absolutePath;
+    _featuresFolders = other._featuresFolders;
+    _matchesFolders = other._matchesFolders;
+    _poses = other._poses;
+    _rigs = other._rigs;
+
+    for (const auto & pl : other._landmarks)
+    {
+        const auto & pt = pl.second.X;
+
+        if (pt.x() < bbMin.x()) continue;
+        if (pt.y() < bbMin.y()) continue;
+        if (pt.z() < bbMin.z()) continue;
+        if (pt.x() > bbMax.x()) continue;
+        if (pt.y() > bbMax.y()) continue;
+        if (pt.z() > bbMax.z()) continue;
+
+        _landmarks.insert(pl);
+    }
+}
+
 bool SfMData::operator==(const SfMData& other) const
 {
     // Views
@@ -305,6 +332,24 @@ void SfMData::resetParameterStates()
     for (auto& pi : _intrinsics)
     {
         pi.second->initializeState();
+    }
+}
+
+void SfMData::getBoundingBox(Eigen::Vector3d & bbMin, Eigen::Vector3d & bbMax)
+{
+    bbMin.fill(std::numeric_limits<double>::max());
+    bbMax.fill(std::numeric_limits<double>::lowest());
+
+    for (const auto & pl : _landmarks)
+    {
+        const auto & pt = pl.second.X;
+
+        bbMin.x() = std::min(bbMin.x(), pt.x());
+        bbMin.y() = std::min(bbMin.y(), pt.y());
+        bbMin.z() = std::min(bbMin.z(), pt.z());
+        bbMax.x() = std::max(bbMax.x(), pt.x());
+        bbMax.y() = std::max(bbMax.y(), pt.y());
+        bbMax.z() = std::max(bbMax.z(), pt.z());
     }
 }
 

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -69,6 +69,14 @@ class SfMData
     /// Rotation priors
     RotationPriors rotationpriors;
 
+    SfMData() = default;
+
+    /**
+     * Copy constructor 
+     * Use a bounding box to restrict the copied landmarks to the selected region
+    */
+    SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eigen::Vector3d & bbMax);
+
     // Operators
 
     bool operator==(const SfMData& other) const;
@@ -519,6 +527,13 @@ class SfMData
      * state with respect to the associated lock
      */
     void resetParameterStates();
+
+    /**
+     * Compute the landmarks axis aligned bounding box
+     * @param bbMin the output minimal values of the bounding box
+     * @param bbMax the output maximal values of the bounding box
+    */
+    void getBoundingBox(Eigen::Vector3d & bbMin, Eigen::Vector3d & bbMax);
 
   private:
     /// Structure (3D points with their 2D observations)

--- a/src/software/convert/CMakeLists.txt
+++ b/src/software/convert/CMakeLists.txt
@@ -35,14 +35,16 @@ if(ALICEVISION_BUILD_SFM)
         alicevision_add_software(aliceVision_importE57
             SOURCE main_importE57.cpp
             FOLDER ${FOLDER_SOFTWARE_CONVERT}
-            LINKS aliceVision_system
+            LINKS 
+                aliceVision_system
                 aliceVision_cmdline
                 aliceVision_feature
                 aliceVision_sfmData
                 aliceVision_sfmDataIO
                 aliceVision_mesh
+                aliceVision_fuseCut
                 Boost::program_options
-                Boost::system
+                Boost::json
                 E57Format
                 nanoflann
         )

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -366,11 +366,11 @@ int aliceVision_main(int argc, char **argv)
         transformed += std::to_string(id);
         transformed += ".abc";
 
-        ALICEVISION_LOG_INFO("Saving to " << transformed);
-        sfmDataIO::save(subSfmData, transformed, sfmDataIO::ESfMData::ALL);
-
         fuseCut::Input input;
-        input.sfmPath = transformed;
+        input.sfmPath = transformed.string();
+
+        ALICEVISION_LOG_INFO("Saving to " << input.sfmPath);
+        sfmDataIO::save(subSfmData, input.sfmPath, sfmDataIO::ESfMData::ALL);
 
         inputs.push_back(input);
     }

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -1,5 +1,5 @@
 // This file is part of the AliceVision project.
-// Copyright (c) 2024 AliceVision contributors.
+// Copyright (c) 2023 AliceVision contributors.
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -9,9 +9,11 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
-
+#include <aliceVision/fuseCut/Octree.hpp>
+#include <aliceVision/fuseCut/InputSet.hpp>
 #include <aliceVision/dataio/E57Reader.hpp>
 #include <aliceVision/camera/camera.hpp>
+#include <filesystem>
 
 #include <boost/program_options.hpp>
 #include "nanoflann.hpp"
@@ -29,20 +31,34 @@ struct PointInfoVectorAdaptator
 {
     using Derived = PointInfoVectorAdaptator;  //!< In this case the dataset class is myself.
 
-    const std::vector<dataio::E57Reader::PointInfo>& _data;
-
+    const std::vector<dataio::E57Reader::PointInfo> & _data;
+    
     PointInfoVectorAdaptator(const std::vector<dataio::E57Reader::PointInfo>& data)
       : _data(data)
-    {}
+    {
+    }
 
-    inline const Derived& derived() const { return *static_cast<const Derived*>(this); }
+    inline const Derived& derived() const 
+    { 
+        return *static_cast<const Derived*>(this); 
+    }
 
-    inline Derived& derived() { return *static_cast<Derived*>(this); }
+    inline Derived& derived() 
+    { 
+        return *static_cast<Derived*>(this); 
+    }
 
     // Must return the number of data points
-    inline size_t kdtree_get_point_count() const { return _data.size(); }
+    inline size_t kdtree_get_point_count() const 
+    { 
+        return _data.size(); 
+    }
 
-    inline double kdtree_get_pt(const size_t idx, int dim) const { return _data.at(idx).coords(dim); }
+    
+    inline double kdtree_get_pt(const size_t idx, int dim) const 
+    { 
+        return _data.at(idx).coords(dim); 
+    }
 
     // Let flann compute bbox
     template<class BBOX>
@@ -52,25 +68,24 @@ struct PointInfoVectorAdaptator
     }
 };
 
-using PointInfoKdTree =
-  nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, PointInfoVectorAdaptator>, PointInfoVectorAdaptator, 3>;
+using PointInfoKdTree = nanoflann::KDTreeSingleIndexAdaptor<
+                            nanoflann::L2_Simple_Adaptor<double, PointInfoVectorAdaptator>, 
+                            PointInfoVectorAdaptator, 
+                            3>;
 
 template<typename DistanceType, typename IndexType = size_t>
 class BestPointInRadius
 {
   public:
     const DistanceType m_radius;
-    const std::vector<dataio::E57Reader::PointInfo>& m_points;
-    const std::map<int, Eigen::Vector3d>& m_cameras;
+    const std::vector<dataio::E57Reader::PointInfo> & m_points;
+    const std::map<int, Eigen::Vector3d> & m_cameras;
 
     size_t m_result = 0;
     const int m_i;
     bool found = false;
 
-    BestPointInRadius(DistanceType radius_,
-                      const std::vector<dataio::E57Reader::PointInfo>& points,
-                      const std::map<int, Eigen::Vector3d>& cameras,
-                      int i)
+    BestPointInRadius(DistanceType radius_, const std::vector<dataio::E57Reader::PointInfo>& points, const std::map<int, Eigen::Vector3d> & cameras, int i)
       : m_radius(radius_),
         m_points(points),
         m_cameras(cameras),
@@ -79,8 +94,11 @@ class BestPointInRadius
         init();
     }
 
-    inline void init() { clear(); }
-
+    inline void init() 
+    { 
+        clear(); 
+    }
+    
     inline void clear() { m_result = 0; }
 
     inline size_t size() const { return m_result; }
@@ -93,7 +111,7 @@ class BestPointInRadius
      */
     inline bool addPoint(DistanceType dist, IndexType index)
     {
-        if (index == m_i)
+        if (index== m_i)
         {
             return true;
         }
@@ -116,32 +134,39 @@ class BestPointInRadius
         return true;
     }
 
-    // Upper bound on distance
-    inline DistanceType worstDist() const { return m_radius; }
+    //Upper bound on distance
+    inline DistanceType worstDist() const 
+    { 
+        return m_radius; 
+    }
 };
 
-int aliceVision_main(int argc, char** argv)
+// convert from a SfMData format to another
+int aliceVision_main(int argc, char **argv)
 {
-    // Command-line parameters
+    // command-line parameters
     std::vector<std::string> e57filenames;
-    std::string outputSfMDataFilename;
+    std::string outputJsonFilename;
     double maxDensity = 0.0;
+    double minIntensity = 0.03;
+    size_t maxPointsPerBlock = 1000000;
 
-    // clang-format off
+    
+
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-        ("input,i", po::value<std::vector<std::string>>(&e57filenames)->multitoken()->required(),
-         "Path to the input E57 files.")
-        ("output,o", po::value<std::string>(&outputSfMDataFilename)->required(),
-         "Path to the output SfMData file.");
-
+    ("input,i", po::value<std::vector<std::string>>(&e57filenames)->multitoken()->required(),
+      "Path to e57 fomes.")
+    ("output,o", po::value<std::string>(&outputJsonFilename)->required(),
+        "Path to the output json file.");
+    
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
-        ("maxDensity", po::value<double>(&maxDensity)->default_value(maxDensity),
-         "Ensure each point has no neighbour closer than maxDensity meters.");
-    // clang-format on
+        ("maxDensity", po::value<double>(&maxDensity)->default_value(maxDensity), "Each point has no neighboor closer than maxDensity meters")
+        ("minIntensity", po::value<double>(&minIntensity)->default_value(minIntensity), "Minimal intensity required to use lidar measure")
+        ("maxPointsPerBlock", po::value<size_t>(&maxPointsPerBlock)->default_value(maxPointsPerBlock), "Maximal number of points per computation block");
 
-    CmdLine cmdline("AliceVision importE57");
+    CmdLine cmdline("AliceVision importe57");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))
@@ -149,16 +174,26 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    if (maxPointsPerBlock == 0)
+    {
+        maxPointsPerBlock = std::numeric_limits<size_t>::max();
+    }
+    
     sfmData::SfMData sfmData;
 
-    // Create intrinsics
+    //Create intrinsics    
     auto cam = camera::createEquidistant(aliceVision::camera::EINTRINSIC::EQUIDISTANT_CAMERA, 1, 1, 1, 0, 0);
     sfmData.getIntrinsics().emplace(0, cam);
-
-    // Create a reader using all files
+    
+    //Create a reader using all files
     dataio::E57Reader reader(e57filenames);
+    reader.setRequiredIntensity(minIntensity);
 
-    // Retrieve all sensor positions
+    //Retrieve all sensor positions
     ALICEVISION_LOG_INFO("Extracting sensors");
     Eigen::Vector3d sensorPosition;
     std::map<int, Eigen::Vector3d> cameras;
@@ -166,23 +201,25 @@ int aliceVision_main(int argc, char** argv)
     {
         cameras[reader.getIdMesh()] = sensorPosition;
 
-        // Create pose for sfmData
+        //Create pose for sfmData
         const int idMesh = reader.getIdMesh();
         geometry::Pose3 pose(Eigen::Matrix3d::Identity(), sensorPosition);
         sfmData.getPoses().emplace(idMesh, pose);
 
-        // Create view for sfmData
+        //Create view for sfmData
         sfmData::View::sptr view = std::make_shared<sfmData::View>("nopath", idMesh, 0, idMesh, 1, 1);
         sfmData.getViews().emplace(idMesh, view);
     }
     reader.reset();
-
-    // Create buffers for reading
+    
+    
+    //Create buffers for reading
     std::vector<dataio::E57Reader::PointInfo> vertices;
     Eigen::Matrix<size_t, -1, -1> grid;
+    
 
     ALICEVISION_LOG_INFO("Extracting Meshes");
-    // Loop through all meshes
+    //Loop through all meshes
     std::vector<dataio::E57Reader::PointInfo> allVertices;
     while (reader.getNext(sensorPosition, vertices, grid))
     {
@@ -193,82 +230,156 @@ int aliceVision_main(int argc, char** argv)
         PointInfoKdTree tree(3, pointCloudRef, nanoflann::KDTreeSingleIndexAdaptorParams(100));
         tree.buildIndex();
 
-        // Angular definition of a ray
+        //Angular definition of a ray
         double angularRes = 2.0 * M_PI / std::max(grid.rows(), grid.cols());
-
-        double cord = 2.0 * sin(angularRes * 0.5);
+        
+        double cord =  2.0 * sin(angularRes * 0.5);
         double maxLength = 1.5 * maxDensity / cord;
 
         size_t originalSize = allVertices.size();
 
-// Loop trough all vertices
-#pragma omp parallel for
+        //Loop trough all vertices
+        #pragma omp parallel for
         for (int vIndex = 0; vIndex < vertices.size(); ++vIndex)
         {
             bool found = true;
 
-            // Check if the point is close to the sensor enough to be theorically close to a neighboor
+            //Check if the point is close to the sensor enough to be theorically close to a neighboor
             double length = (vertices[vIndex].coords - sensorPosition).norm();
             if (length < maxLength)
             {
                 found = false;
 
-                // Search in the vicinity if a better point exists
+                //Search in the vicinity if a better point exists
                 const double radius = maxDensity;
                 static const nanoflann::SearchParameters searchParams(0.f, false);
-                BestPointInRadius<double, std::size_t> resultSet(radius * radius, vertices, cameras, vIndex);
+                BestPointInRadius<double, std::size_t> resultSet(radius*radius, vertices, cameras, vIndex);
                 tree.findNeighbors(resultSet, vertices[vIndex].coords.data(), searchParams);
 
+                
                 if (!resultSet.found)
                 {
                     found = true;
                 }
             }
 
-#pragma omp critical
+            #pragma omp critical
             {
                 if (found)
                 {
                     allVertices.push_back(vertices[vIndex]);
                 }
             }
+
+            
         }
 
         ALICEVISION_LOG_INFO("Mesh has " << allVertices.size() - originalSize << " points");
     }
-
-    ALICEVISION_LOG_INFO("Building final point cloud");
-    PointInfoVectorAdaptator pointCloudRef(allVertices);
-    PointInfoKdTree tree(3, pointCloudRef, nanoflann::KDTreeSingleIndexAdaptorParams(10));
-    tree.buildIndex();
-
-    auto& landmarks = sfmData.getLandmarks();
-#pragma omp parallel for
-    for (int vIndex = 0; vIndex < allVertices.size(); ++vIndex)
+    
     {
-        // Search in the vicinity if a better point exists
-        const double radius = maxDensity;
-        static const nanoflann::SearchParameters searchParams(0.f, false);
-        BestPointInRadius<double, std::size_t> resultSet(radius * radius, allVertices, cameras, vIndex);
-        tree.findNeighbors(resultSet, allVertices[vIndex].coords.data(), searchParams);
+        ALICEVISION_LOG_INFO("Building final point cloud");
+        PointInfoVectorAdaptator pointCloudRef(allVertices);
+        PointInfoKdTree tree(3, pointCloudRef, nanoflann::KDTreeSingleIndexAdaptorParams(10));
+        tree.buildIndex();
 
-#pragma omp critical
+        auto & landmarks = sfmData.getLandmarks();
+        #pragma omp parallel for
+        for (int vIndex = 0; vIndex < allVertices.size(); ++vIndex)
         {
-            if (!resultSet.found)
-            {
-                const auto& v = allVertices[vIndex];
+            //Search in the vicinity if a better point exists
+            const double radius = maxDensity;
+            static const nanoflann::SearchParameters searchParams(0.f, false);
+            BestPointInRadius<double, std::size_t> resultSet(radius*radius, allVertices, cameras, vIndex);
+            tree.findNeighbors(resultSet, allVertices[vIndex].coords.data(), searchParams);
 
-                sfmData::Observation obs(Vec2(0.0, 0.0), landmarks.size(), 1.0);
-                sfmData::Landmark landmark(v.coords, feature::EImageDescriberType::SIFT);
-                landmark.getObservations().emplace(v.idMesh, obs);
-                landmarks.emplace(vIndex, landmark);
+            #pragma omp critical
+            {
+                if (!resultSet.found)
+                {
+                    const auto & v = allVertices[vIndex];
+
+                    sfmData::Observation obs(Vec2(0.0, 0.0), landmarks.size(), 1.0);
+                    sfmData::Landmark landmark(v.coords, feature::EImageDescriberType::SIFT);
+                    landmark.getObservations().emplace(v.idMesh, obs);
+                    landmarks.emplace(vIndex, landmark);
+                }
             }
         }
+
+        ALICEVISION_LOG_INFO("Final point cloud has " << landmarks.size() << " points");
+        
     }
 
-    ALICEVISION_LOG_INFO("Final point cloud has " << landmarks.size() << " points");
+    ALICEVISION_LOG_INFO("Get Final Global bounding box");
+    Eigen::Vector3d bbmin, bbmax;
+    sfmData.getBoundingBox(bbmin, bbmax);
 
-    sfmDataIO::save(sfmData, outputSfMDataFilename, sfmDataIO::ESfMData::ALL);
+    double sx = std::abs(bbmax.x() - bbmin.x());
+    double sy = std::abs(bbmax.y() - bbmin.y());
+    double sz = std::abs(bbmax.z() - bbmin.z());
+    ALICEVISION_LOG_INFO("Global Bounding box: " << sx << " x " << sy << " x " << sz);
+    
+
+    fuseCut::SimpleNode octree(bbmin, bbmax);
+    for (const auto & pt : sfmData.getLandmarks())
+    {
+        octree.store(pt.second.X);
+    }
+
+    //Now regroup cells as much as we can
+    octree.regroup(maxPointsPerBlock);
+
+    std::vector<fuseCut::SimpleNode::ptr> list;
+    octree.visit(list);
+
+    ALICEVISION_LOG_INFO("Generating " << list.size() << "sub regions");
+
+    fuseCut::InputSet inputs;
+   
+
+    for (int id = 0; id < list.size(); id++)
+    {
+        const auto & item = list[id];
+
+        Eigen::Vector3d bbmin = item->getBBMin();
+        Eigen::Vector3d bbmax = item->getBBMax();
+        
+        //Add borders of 20 cm
+        Eigen::Vector3d center = (bbmin + bbmax) * 0.5;
+        bbmin = center + 1.02 * (bbmin - center);
+        bbmax = center + 1.02 * (bbmax - center);
+
+        double sx = std::abs(bbmax.x() - bbmin.x());
+        double sy = std::abs(bbmax.y() - bbmin.y());
+        double sz = std::abs(bbmax.z() - bbmin.z());
+        
+        ALICEVISION_LOG_INFO("Local Bounding box: " << sx << " x " << sy << " x " << sz);
+
+        sfmData::SfMData subSfmData(sfmData, bbmin, bbmax);
+
+        ALICEVISION_LOG_INFO("local count : " << subSfmData.getLandmarks().size() << " points");
+
+        std::filesystem::path p = outputJsonFilename;
+        std::filesystem::path transformed = p.parent_path() / "sfm";
+        transformed += "_";
+        transformed += std::to_string(id);
+        transformed += ".abc";
+
+        ALICEVISION_LOG_INFO("Saving to " << transformed);
+        sfmDataIO::save(subSfmData, transformed, sfmDataIO::ESfMData::ALL);
+
+        fuseCut::Input input;
+        input.sfmPath = transformed;
+
+        inputs.push_back(input);
+    }
+
+    
+    std::ofstream of(outputJsonFilename);
+    boost::json::value jv = boost::json::value_from(inputs);
+    of << boost::json::serialize(jv);
+    of.close();
 
     return EXIT_SUCCESS;
 }

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -1,5 +1,5 @@
 // This file is part of the AliceVision project.
-// Copyright (c) 2023 AliceVision contributors.
+// Copyright (c) 2024 AliceVision contributors.
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -31,34 +31,20 @@ struct PointInfoVectorAdaptator
 {
     using Derived = PointInfoVectorAdaptator;  //!< In this case the dataset class is myself.
 
-    const std::vector<dataio::E57Reader::PointInfo> & _data;
-    
+    const std::vector<dataio::E57Reader::PointInfo>& _data;
+
     PointInfoVectorAdaptator(const std::vector<dataio::E57Reader::PointInfo>& data)
       : _data(data)
-    {
-    }
+    {}
 
-    inline const Derived& derived() const 
-    { 
-        return *static_cast<const Derived*>(this); 
-    }
+    inline const Derived& derived() const { return *static_cast<const Derived*>(this); }
 
-    inline Derived& derived() 
-    { 
-        return *static_cast<Derived*>(this); 
-    }
+    inline Derived& derived() { return *static_cast<Derived*>(this); }
 
     // Must return the number of data points
-    inline size_t kdtree_get_point_count() const 
-    { 
-        return _data.size(); 
-    }
+    inline size_t kdtree_get_point_count() const { return _data.size(); }
 
-    
-    inline double kdtree_get_pt(const size_t idx, int dim) const 
-    { 
-        return _data.at(idx).coords(dim); 
-    }
+    inline double kdtree_get_pt(const size_t idx, int dim) const { return _data.at(idx).coords(dim); }
 
     // Let flann compute bbox
     template<class BBOX>
@@ -68,24 +54,25 @@ struct PointInfoVectorAdaptator
     }
 };
 
-using PointInfoKdTree = nanoflann::KDTreeSingleIndexAdaptor<
-                            nanoflann::L2_Simple_Adaptor<double, PointInfoVectorAdaptator>, 
-                            PointInfoVectorAdaptator, 
-                            3>;
+using PointInfoKdTree =
+  nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, PointInfoVectorAdaptator>, PointInfoVectorAdaptator, 3>;
 
 template<typename DistanceType, typename IndexType = size_t>
 class BestPointInRadius
 {
   public:
     const DistanceType m_radius;
-    const std::vector<dataio::E57Reader::PointInfo> & m_points;
-    const std::map<int, Eigen::Vector3d> & m_cameras;
+    const std::vector<dataio::E57Reader::PointInfo>& m_points;
+    const std::map<int, Eigen::Vector3d>& m_cameras;
 
     size_t m_result = 0;
     const int m_i;
     bool found = false;
 
-    BestPointInRadius(DistanceType radius_, const std::vector<dataio::E57Reader::PointInfo>& points, const std::map<int, Eigen::Vector3d> & cameras, int i)
+    BestPointInRadius(DistanceType radius_,
+                      const std::vector<dataio::E57Reader::PointInfo>& points,
+                      const std::map<int, Eigen::Vector3d>& cameras,
+                      int i)
       : m_radius(radius_),
         m_points(points),
         m_cameras(cameras),
@@ -94,11 +81,8 @@ class BestPointInRadius
         init();
     }
 
-    inline void init() 
-    { 
-        clear(); 
-    }
-    
+    inline void init() { clear(); }
+
     inline void clear() { m_result = 0; }
 
     inline size_t size() const { return m_result; }
@@ -111,7 +95,7 @@ class BestPointInRadius
      */
     inline bool addPoint(DistanceType dist, IndexType index)
     {
-        if (index== m_i)
+        if (index == m_i)
         {
             return true;
         }
@@ -134,15 +118,12 @@ class BestPointInRadius
         return true;
     }
 
-    //Upper bound on distance
-    inline DistanceType worstDist() const 
-    { 
-        return m_radius; 
-    }
+    // Upper bound on distance
+    inline DistanceType worstDist() const { return m_radius; }
 };
 
 // convert from a SfMData format to another
-int aliceVision_main(int argc, char **argv)
+int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
     std::vector<std::string> e57filenames;
@@ -151,22 +132,25 @@ int aliceVision_main(int argc, char **argv)
     double minIntensity = 0.03;
     size_t maxPointsPerBlock = 1000000;
 
-    
-
+    // clang-format off
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-    ("input,i", po::value<std::vector<std::string>>(&e57filenames)->multitoken()->required(),
-      "Path to e57 fomes.")
-    ("output,o", po::value<std::string>(&outputJsonFilename)->required(),
-        "Path to the output json file.");
+        ("input,i", po::value<std::vector<std::string>>(&e57filenames)->multitoken()->required(),
+         "Path to E57 files.")
+        ("output,o", po::value<std::string>(&outputJsonFilename)->required(),
+         "Path to the output JSON file.");
     
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
-        ("maxDensity", po::value<double>(&maxDensity)->default_value(maxDensity), "Each point has no neighboor closer than maxDensity meters")
-        ("minIntensity", po::value<double>(&minIntensity)->default_value(minIntensity), "Minimal intensity required to use lidar measure")
-        ("maxPointsPerBlock", po::value<size_t>(&maxPointsPerBlock)->default_value(maxPointsPerBlock), "Maximal number of points per computation block");
+        ("maxDensity", po::value<double>(&maxDensity)->default_value(maxDensity),
+         "Ensure each point has no neighbour closer than maxDensity meters.")
+        ("minIntensity", po::value<double>(&minIntensity)->default_value(minIntensity),
+         "Minimal intensity required to use LiDAR measure.")
+        ("maxPointsPerBlock", po::value<size_t>(&maxPointsPerBlock)->default_value(maxPointsPerBlock),
+         "Maximal number of points per computation block.");
+    // clang-format on
 
-    CmdLine cmdline("AliceVision importe57");
+    CmdLine cmdline("AliceVision importE57");
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))
@@ -174,7 +158,7 @@ int aliceVision_main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    // set maxThreads
+    // Set maxThreads
     HardwareContext hwc = cmdline.getHardwareContext();
     omp_set_num_threads(hwc.getMaxThreads());
 
@@ -182,18 +166,18 @@ int aliceVision_main(int argc, char **argv)
     {
         maxPointsPerBlock = std::numeric_limits<size_t>::max();
     }
-    
+
     sfmData::SfMData sfmData;
 
-    //Create intrinsics    
+    // Create intrinsics
     auto cam = camera::createEquidistant(aliceVision::camera::EINTRINSIC::EQUIDISTANT_CAMERA, 1, 1, 1, 0, 0);
     sfmData.getIntrinsics().emplace(0, cam);
-    
-    //Create a reader using all files
+
+    // Create a reader using all files
     dataio::E57Reader reader(e57filenames);
     reader.setRequiredIntensity(minIntensity);
 
-    //Retrieve all sensor positions
+    // Retrieve all sensor positions
     ALICEVISION_LOG_INFO("Extracting sensors");
     Eigen::Vector3d sensorPosition;
     std::map<int, Eigen::Vector3d> cameras;
@@ -201,25 +185,23 @@ int aliceVision_main(int argc, char **argv)
     {
         cameras[reader.getIdMesh()] = sensorPosition;
 
-        //Create pose for sfmData
+        // Create pose for sfmData
         const int idMesh = reader.getIdMesh();
         geometry::Pose3 pose(Eigen::Matrix3d::Identity(), sensorPosition);
         sfmData.getPoses().emplace(idMesh, pose);
 
-        //Create view for sfmData
+        // Create view for sfmData
         sfmData::View::sptr view = std::make_shared<sfmData::View>("nopath", idMesh, 0, idMesh, 1, 1);
         sfmData.getViews().emplace(idMesh, view);
     }
     reader.reset();
-    
-    
-    //Create buffers for reading
+
+    // Create buffers for reading
     std::vector<dataio::E57Reader::PointInfo> vertices;
     Eigen::Matrix<size_t, -1, -1> grid;
-    
 
     ALICEVISION_LOG_INFO("Extracting Meshes");
-    //Loop through all meshes
+    // Loop through all meshes
     std::vector<dataio::E57Reader::PointInfo> allVertices;
     while (reader.getNext(sensorPosition, vertices, grid))
     {
@@ -230,74 +212,71 @@ int aliceVision_main(int argc, char **argv)
         PointInfoKdTree tree(3, pointCloudRef, nanoflann::KDTreeSingleIndexAdaptorParams(100));
         tree.buildIndex();
 
-        //Angular definition of a ray
+        // Angular definition of a ray
         double angularRes = 2.0 * M_PI / std::max(grid.rows(), grid.cols());
-        
-        double cord =  2.0 * sin(angularRes * 0.5);
+
+        double cord = 2.0 * sin(angularRes * 0.5);
         double maxLength = 1.5 * maxDensity / cord;
 
         size_t originalSize = allVertices.size();
 
-        //Loop trough all vertices
-        #pragma omp parallel for
+// Loop trough all vertices
+#pragma omp parallel for
         for (int vIndex = 0; vIndex < vertices.size(); ++vIndex)
         {
             bool found = true;
 
-            //Check if the point is close to the sensor enough to be theorically close to a neighboor
+            // Check if the point is close to the sensor enough to be theorically close to a neighboor
             double length = (vertices[vIndex].coords - sensorPosition).norm();
             if (length < maxLength)
             {
                 found = false;
 
-                //Search in the vicinity if a better point exists
+                // Search in the vicinity if a better point exists
                 const double radius = maxDensity;
                 static const nanoflann::SearchParameters searchParams(0.f, false);
-                BestPointInRadius<double, std::size_t> resultSet(radius*radius, vertices, cameras, vIndex);
+                BestPointInRadius<double, std::size_t> resultSet(radius * radius, vertices, cameras, vIndex);
                 tree.findNeighbors(resultSet, vertices[vIndex].coords.data(), searchParams);
 
-                
                 if (!resultSet.found)
                 {
                     found = true;
                 }
             }
 
-            #pragma omp critical
+#pragma omp critical
             {
                 if (found)
                 {
                     allVertices.push_back(vertices[vIndex]);
                 }
             }
-
-            
         }
 
         ALICEVISION_LOG_INFO("Mesh has " << allVertices.size() - originalSize << " points");
     }
-    
+
     {
         ALICEVISION_LOG_INFO("Building final point cloud");
         PointInfoVectorAdaptator pointCloudRef(allVertices);
         PointInfoKdTree tree(3, pointCloudRef, nanoflann::KDTreeSingleIndexAdaptorParams(10));
         tree.buildIndex();
 
-        auto & landmarks = sfmData.getLandmarks();
-        #pragma omp parallel for
+        auto& landmarks = sfmData.getLandmarks();
+#pragma omp parallel for
         for (int vIndex = 0; vIndex < allVertices.size(); ++vIndex)
         {
-            //Search in the vicinity if a better point exists
+            // Search in the vicinity if a better point exists
             const double radius = maxDensity;
             static const nanoflann::SearchParameters searchParams(0.f, false);
-            BestPointInRadius<double, std::size_t> resultSet(radius*radius, allVertices, cameras, vIndex);
+            BestPointInRadius<double, std::size_t> resultSet(radius * radius, allVertices, cameras, vIndex);
             tree.findNeighbors(resultSet, allVertices[vIndex].coords.data(), searchParams);
 
-            #pragma omp critical
+#pragma omp critical
             {
                 if (!resultSet.found)
                 {
-                    const auto & v = allVertices[vIndex];
+                    const auto& v = allVertices[vIndex];
 
                     sfmData::Observation obs(Vec2(0.0, 0.0), landmarks.size(), 1.0);
                     sfmData::Landmark landmark(v.coords, feature::EImageDescriberType::SIFT);
@@ -308,7 +287,6 @@ int aliceVision_main(int argc, char **argv)
         }
 
         ALICEVISION_LOG_INFO("Final point cloud has " << landmarks.size() << " points");
-        
     }
 
     ALICEVISION_LOG_INFO("Get Final Global bounding box");
@@ -319,15 +297,14 @@ int aliceVision_main(int argc, char **argv)
     double sy = std::abs(bbmax.y() - bbmin.y());
     double sz = std::abs(bbmax.z() - bbmin.z());
     ALICEVISION_LOG_INFO("Global Bounding box: " << sx << " x " << sy << " x " << sz);
-    
 
     fuseCut::SimpleNode octree(bbmin, bbmax);
-    for (const auto & pt : sfmData.getLandmarks())
+    for (const auto& pt : sfmData.getLandmarks())
     {
         octree.store(pt.second.X);
     }
 
-    //Now regroup cells as much as we can
+    // Now regroup cells as much as we can
     octree.regroup(maxPointsPerBlock);
 
     std::vector<fuseCut::SimpleNode::ptr> list;
@@ -336,16 +313,15 @@ int aliceVision_main(int argc, char **argv)
     ALICEVISION_LOG_INFO("Generating " << list.size() << "sub regions");
 
     fuseCut::InputSet inputs;
-   
 
     for (int id = 0; id < list.size(); id++)
     {
-        const auto & item = list[id];
+        const auto& item = list[id];
 
         Eigen::Vector3d bbmin = item->getBBMin();
         Eigen::Vector3d bbmax = item->getBBMax();
-        
-        //Add borders of 20 cm
+
+        // Add borders of 20 cm
         Eigen::Vector3d center = (bbmin + bbmax) * 0.5;
         bbmin = center + 1.02 * (bbmin - center);
         bbmax = center + 1.02 * (bbmax - center);
@@ -353,7 +329,7 @@ int aliceVision_main(int argc, char **argv)
         double sx = std::abs(bbmax.x() - bbmin.x());
         double sy = std::abs(bbmax.y() - bbmin.y());
         double sz = std::abs(bbmax.z() - bbmin.z());
-        
+
         ALICEVISION_LOG_INFO("Local Bounding box: " << sx << " x " << sy << " x " << sz);
 
         sfmData::SfMData subSfmData(sfmData, bbmin, bbmax);
@@ -375,7 +351,6 @@ int aliceVision_main(int argc, char **argv)
         inputs.push_back(input);
     }
 
-    
     std::ofstream of(outputJsonFilename);
     boost::json::value jv = boost::json::value_from(inputs);
     of << boost::json::serialize(jv);


### PR DESCRIPTION
Instead of generating a single monolithic sfmdata which may be huge, importE57 now generate a set of sfmData with subregions of the scanned environment.

The output is : 

- a json specifying the different paths to sfm and later will contains per region information
- sfm data files

Relates to https://github.com/alicevision/Meshroom/pull/2318.