### PR TITLE
Rename Python `aliceVision` module into `pyalicevision`

### DIFF
--- a/pyTests/hdr/test_brackets.py
+++ b/pyTests/hdr/test_brackets.py
@@ -4,7 +4,7 @@ Collection of unit tests for the brackets detection.
 
 import pytest
 
-import aliceVision as av
+import pyalicevision as av
 
 ##################
 ### List of functions:

--- a/pyTests/sensorDB/test_datasheet.py
+++ b/pyTests/sensorDB/test_datasheet.py
@@ -2,7 +2,7 @@
 Collection of unit tests for the Datasheet structure.
 """
 
-from aliceVision import sensorDB as db
+from pyalicevision import sensorDB as db
 
 ##################
 ### List of functions:

--- a/pyTests/sensorDB/test_sensordb.py
+++ b/pyTests/sensorDB/test_sensordb.py
@@ -4,7 +4,7 @@ Collection of unit tests for the Sensor DB module.
 
 import os
 
-from aliceVision import sensorDB as db
+from pyalicevision import sensorDB as db
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_camerapose.py
+++ b/pyTests/sfmData/test_camerapose.py
@@ -4,7 +4,7 @@ Collection of unit tests for the CameraPose class.
 
 import pytest
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_constraint2d.py
+++ b/pyTests/sfmData/test_constraint2d.py
@@ -4,7 +4,7 @@ Collection of unit tests for the Constraint2D structure.
 
 import pytest
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_exposuresetting.py
+++ b/pyTests/sfmData/test_exposuresetting.py
@@ -2,7 +2,7 @@
 Collection of unit tests for the ExposureSetting class.
 """
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_imageinfo.py
+++ b/pyTests/sfmData/test_imageinfo.py
@@ -2,7 +2,7 @@
 Collection of unit tests for the ImageInfo class.
 """
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 from ..constants import IMAGE_PATH, IMAGE_WIDTH, IMAGE_HEIGHT, METADATA
 
 ##################

--- a/pyTests/sfmData/test_landmark.py
+++ b/pyTests/sfmData/test_landmark.py
@@ -4,7 +4,7 @@ Collection of unit tests for the Landmark class.
 
 import pytest
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_observation.py
+++ b/pyTests/sfmData/test_observation.py
@@ -4,7 +4,7 @@ Collection of unit tests for the Observation class.
 
 import pytest
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_rig.py
+++ b/pyTests/sfmData/test_rig.py
@@ -2,7 +2,7 @@
 Collection of unit tests for the Rig class.
 """
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_rotationprior.py
+++ b/pyTests/sfmData/test_rotationprior.py
@@ -4,7 +4,7 @@ Collection of unit tests for the RotationPrior structure.
 
 import pytest
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 
 ##################
 ### List of functions:

--- a/pyTests/sfmData/test_sfmdata.py
+++ b/pyTests/sfmData/test_sfmdata.py
@@ -4,7 +4,7 @@ Collection of unit tests for the SfMData class.
 
 import os
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 from ..constants import IMAGE_PATH, VIEW_ID, INTRINSIC_ID, POSE_ID, IMAGE_WIDTH, \
     IMAGE_HEIGHT, RIG_ID, SUBPOSE_ID, METADATA
 

--- a/pyTests/sfmData/test_view.py
+++ b/pyTests/sfmData/test_view.py
@@ -2,7 +2,7 @@
 Collection of unit tests for the View class.
 """
 
-from aliceVision import sfmData as av
+from pyalicevision import sfmData as av
 from ..constants import IMAGE_PATH, VIEW_ID, INTRINSIC_ID, POSE_ID, IMAGE_WIDTH, \
     IMAGE_HEIGHT, RIG_ID, SUBPOSE_ID, METADATA
 

--- a/pyTests/sfmDataIO/test_sfmdataio.py
+++ b/pyTests/sfmDataIO/test_sfmdataio.py
@@ -4,7 +4,7 @@ Collection of unit tests for the SfMDataIO class.
 
 import os
 
-import aliceVision as av
+import pyalicevision as av
 from ..constants import SFMDATA_PATH, IMAGE_PATH, VIEW_ID, INTRINSIC_ID, POSE_ID, \
     IMAGE_WIDTH, IMAGE_HEIGHT, RIG_ID, SUBPOSE_ID, METADATA
 

--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -85,20 +85,20 @@ endif()
 if(ALICEVISION_BUILD_SWIG_BINDING)
     set(UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
     set_property(SOURCE aliceVision.i PROPERTY CPLUSPLUS ON)
-    set_property(SOURCE aliceVision.i PROPERTY SWIG_MODULE_NAME aliceVision)
+    set_property(SOURCE aliceVision.i PROPERTY SWIG_MODULE_NAME pyalicevision)
 
-    swig_add_library(aliceVision
+    swig_add_library(pyalicevision
         TYPE MODULE
         LANGUAGE python
         SOURCES aliceVision.i
     )
 
     set_property(
-        TARGET aliceVision
+        TARGET pyalicevision
         PROPERTY SWIG_COMPILE_OPTIONS -doxygen
     )
 
-    target_include_directories(aliceVision
+    target_include_directories(pyalicevision
     PRIVATE
         ../include
         ${ALICEVISION_ROOT}/include
@@ -106,27 +106,27 @@ if(ALICEVISION_BUILD_SWIG_BINDING)
         ${Python3_NumPy_INCLUDE_DIRS}
     )
     set_property(
-        TARGET aliceVision
+        TARGET pyalicevision
         PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
     )
     set_property(
-        TARGET aliceVision
+        TARGET pyalicevision
         PROPERTY COMPILE_OPTIONS -std=c++17
     )
 
-    target_link_libraries(aliceVision
+    target_link_libraries(pyalicevision
     PUBLIC
         aliceVision_numeric
     )
     install(
     TARGETS
-        aliceVision
+        pyalicevision
     DESTINATION
         ${CMAKE_INSTALL_PREFIX}
     )
     install(
     FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/aliceVision.py
+        ${CMAKE_CURRENT_BINARY_DIR}/pyalicevision.py
     DESTINATION
         ${CMAKE_INSTALL_PREFIX}
     )

--- a/src/aliceVision/aliceVision.i
+++ b/src/aliceVision/aliceVision.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module aliceVision
+%module pyalicevision
 
 %include <aliceVision/global.i>
 

--- a/src/aliceVision/camera/Camera.i
+++ b/src/aliceVision/camera/Camera.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="aliceVision") camera
+%module (module="pyalicevision") camera
 
 %include <aliceVision/camera/IntrinsicBase.i>
 

--- a/src/aliceVision/hdr/Hdr.i
+++ b/src/aliceVision/hdr/Hdr.i
@@ -4,6 +4,6 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="aliceVision") hdr
+%module (module="pyalicevision") hdr
 
 %include <aliceVision/hdr/Brackets.i>

--- a/src/aliceVision/sensorDB/SensorDB.i
+++ b/src/aliceVision/sensorDB/SensorDB.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="aliceVision") sensorDB
+%module (module="pyalicevision") sensorDB
 
 %include <aliceVision/sensorDB/Datasheet.i>
 

--- a/src/aliceVision/sfmData/SfMData.i
+++ b/src/aliceVision/sfmData/SfMData.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="aliceVision") sfmData
+%module (module="pyalicevision") sfmData
 
 %include <aliceVision/sfmData/CameraPose.i>
 %include <aliceVision/sfmData/Constraint2D.i>

--- a/src/aliceVision/sfmDataIO/SfMDataIO.i
+++ b/src/aliceVision/sfmDataIO/SfMDataIO.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="aliceVision") sfmDataIO
+%module (module="pyalicevision") sfmDataIO
 
 %include <std_string.i>
 %include <aliceVision/sfmDataIO/sfmDataIO.hpp>


### PR DESCRIPTION
## Description

This PR renames the Python module `aliceVision` to `pyalicevision`: this prevents ambiguous imports (e.g. in Meshroom, if the import is made from a node that is located in the "aliceVision" folder), fixes issues with Windows (the target "aliceVision" already exists in the CMakeLists, and the VS solution cannot have two targets with the same name), and complies with PEP8 rules for the naming of modules.