### PR TITLE
EXR STMaps use floating point precision

### DIFF
--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -260,7 +260,7 @@ int aliceVision_main(int argc, char** argv)
                 const std::string dstImage = (undistortedImagesFolderPath / (std::to_string(intrinsicPair.first) + "_UVMap_Undistort." +
                                                                              image::EImageFileType_enumToString(outputMapFileType)))
                                                .string();
-                image::writeImage(dstImage, image_dist, image::ImageWriteOptions());
+                image::writeImage(dstImage, image_dist, image::ImageWriteOptions().storageDataType(image::EStorageDataType::Float));
             }
 
             // UV Map: Distort
@@ -283,7 +283,7 @@ int aliceVision_main(int argc, char** argv)
                 const std::string dstImage = (undistortedImagesFolderPath / (std::to_string(intrinsicPair.first) + "_UVMap_Distort." +
                                                                              image::EImageFileType_enumToString(outputMapFileType)))
                                                .string();
-                image::writeImage(dstImage, image_dist, image::ImageWriteOptions());
+                image::writeImage(dstImage, image_dist, image::ImageWriteOptions().storageDataType(image::EStorageDataType::Float));
             }
         }
     }

--- a/src/software/export/main_exportDistortion.cpp
+++ b/src/software/export/main_exportDistortion.cpp
@@ -199,14 +199,14 @@ int aliceVision_main(int argc, char* argv[])
                 ALICEVISION_LOG_INFO("Export distortion STMap: stmap_" << intrinsicId << "_distort.exr");
                 std::stringstream ss;
                 ss << outputFilePath << "/stmap_" << intrinsicId << "_distort.exr";
-                image::writeImage(ss.str(), stmap_distort, image::ImageWriteOptions());
+                image::writeImage(ss.str(), stmap_distort, image::ImageWriteOptions().storageDataType(image::EStorageDataType::Float));
             }
 
             {
                 ALICEVISION_LOG_INFO("Export undistortion STMap: stmap_" << intrinsicId << "_undistort.exr");
                 std::stringstream ss;
                 ss << outputFilePath << "/stmap_" << intrinsicId << "_undistort.exr";
-                image::writeImage(ss.str(), stmap_undistort, image::ImageWriteOptions());
+                image::writeImage(ss.str(), stmap_undistort, image::ImageWriteOptions().storageDataType(image::EStorageDataType::Float));
             }
         }
 


### PR DESCRIPTION
The precision is critical for STMaps, so we move the STMaps export to full floating point precision (instead of half) to avoid color banding issues.