### PR TITLE
Add fstream include to import e57

### DIFF
--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -18,6 +18,8 @@
 #include <boost/program_options.hpp>
 #include "nanoflann.hpp"
 
+#include <fstream>
+
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1


### PR DESCRIPTION
Missing include fstream which is not automatically included on some compilers