### PR TITLE
[sfm] Sequential: Update default value for Ransac's max iterations

### DIFF
--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -68,7 +68,7 @@ class ReconstructionEngine_sequentialSfM : public ReconstructionEngine
         bool filterTrackForks = true;
         robustEstimation::ERobustEstimator localizerEstimator = robustEstimation::ERobustEstimator::ACRANSAC;
         double localizerEstimatorError = std::numeric_limits<double>::infinity();
-        std::size_t localizerEstimatorMaxIterations = 4096;
+        std::size_t localizerEstimatorMaxIterations = 50000;
 
         // Pyramid scoring
 


### PR DESCRIPTION
## Description

This PR updates the default value for the localizerEstimatorMaxIterations parameter of the StructureFromMotion node from 4096 to 50000.

It relates to alicevision/Meshroom#2341. 
