### PR TITLE
[aliceVision] Minor bugfixes across the project

### DIFF
--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -237,7 +237,7 @@ void Texturing::generateUVsBasicMethod(mvsUtils::MultiViewParams& mp)
                             uvPix.y = 1.0 - uvPix.y;
 
                             // sanity check: discard invalid UVs
-                            if (uvPix.x < 0 || uvPix.x > 1.0 || uvPix.y < 0 || uvPix.x > 1.0)
+                            if (uvPix.x < 0 || uvPix.x > 1.0 || uvPix.y < 0 || uvPix.y > 1.0)
                             {
                                 ALICEVISION_LOG_WARNING("Discarding invalid UV: " + std::to_string(uvPix.x) + ", " + std::to_string(uvPix.y));
                                 uvPix = Point2d();

--- a/src/aliceVision/numeric/numeric.hpp
+++ b/src/aliceVision/numeric/numeric.hpp
@@ -488,6 +488,7 @@ template<class T>
 constexpr T divideRoundUp(T x, T y)
 {
     static_assert(std::is_integral<T>::value, "divideRoundUp only works with integer arguments");
+    assert(y != 0);  // Prevents division by zero
     const auto xPos = x >= 0;
     const auto yPos = y >= 0;
     if (xPos == yPos)

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -458,7 +458,7 @@ void BundleAdjustmentCeres::Statistics::show() const
         {
             if (camdistIt.first < 0)
                 nbCamNotConnected += camdistIt.second;
-            else if (camdistIt.first == 1)
+            else if (camdistIt.first == 0)
                 nbCamDistEqZero += camdistIt.second;
             else if (camdistIt.first == 1)
                 nbCamDistEqOne += camdistIt.second;

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.cpp
@@ -192,7 +192,7 @@ void BundleAdjustmentSymbolicCeres::Statistics::show() const
         {
             if (camdistIt.first < 0)
                 nbCamNotConnected += camdistIt.second;
-            else if (camdistIt.first == 1)
+            else if (camdistIt.first == 0)
                 nbCamDistEqZero += camdistIt.second;
             else if (camdistIt.first == 1)
                 nbCamDistEqOne += camdistIt.second;


### PR DESCRIPTION
## Description

This PR fixes some minor issues in different parts of the project. Namely:
- In Texturing, a sanity check was erroneously checking the same condition twice instead of two different conditions;
- In Numeric, the `divideRoundUp` function had no protection against divisions by zero;
- In the Bundle Adjustement, the count of the cameras based on their distance was erroneous when it came to cameras with a distance equal to 0.