### PR TITLE
ExportAnimatedCamera export alembic with complete cameras information

### DIFF
--- a/src/aliceVision/camera/Pinhole.cpp
+++ b/src/aliceVision/camera/Pinhole.cpp
@@ -40,7 +40,7 @@ Vec2 Pinhole::project(const Eigen::Matrix4d& pose, const Vec4& pt, bool applyDis
     const Vec4 X = pose * pt;  // apply pose
     const Vec2 P = X.head<2>() / X(2);
 
-    const Vec2 distorted = this->addDistortion(P);
+    const Vec2 distorted = (applyDistortion)?this->addDistortion(P):P;
     const Vec2 impt = this->cam2ima(distorted);
 
     return impt;

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -183,15 +183,19 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
     {
         CameraSample camSample;
 
+        const Vec2 & scale = intrinsicCasted->getScale();
+        const Vec2 & offset = intrinsicCasted->getOffset();
+        
         // Take the max of the image size to handle the case where the image is in portrait mode
         const float imgWidth = intrinsicCasted->w();
         const float imgHeight = intrinsicCasted->h();
         const float sensorWidth = intrinsicCasted->sensorWidth();
         const float sensorHeight = intrinsicCasted->sensorHeight();
         const float sensorWidth_pix = std::max(imgWidth, imgHeight);
-        const float focalLengthX_pix = static_cast<const float>(intrinsicCasted->getScale()(0));
-        const float focalLengthY_pix = static_cast<const float>(intrinsicCasted->getScale()(1));
+        const float focalLengthX_pix = static_cast<const float>(scale(0));
+        const float focalLengthY_pix = static_cast<const float>(scale(1));
         const float focalLength_mm = sensorWidth * focalLengthX_pix / sensorWidth_pix;
+        const float shiftX_mm = sensorWidth * focalLengthX_pix / sensorWidth_pix;
         const float squeeze = focalLengthX_pix / focalLengthY_pix;
         const float pix2mm = sensorWidth / sensorWidth_pix;
 
@@ -200,11 +204,15 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
         // Following values are in cm, hence the 0.1 multiplier
         const float haperture_cm = static_cast<const float>(0.1 * imgWidth * pix2mm);
         const float vaperture_cm = static_cast<const float>(0.1 * imgHeight * pix2mm);
+        const float offsetX_cm = static_cast<const float>(0.1 * offset(0) * pix2mm);
+        const float offsetY_cm = static_cast<const float>(0.1 * (-offset(1)) * pix2mm);
 
         camSample.setFocalLength(focalLength_mm);
         camSample.setHorizontalAperture(haperture_cm);
         camSample.setVerticalAperture(vaperture_cm);
         camSample.setLensSqueezeRatio(squeeze);
+        camSample.setHorizontalFilmOffset(offsetX_cm);
+        camSample.setVerticalFilmOffset(offsetY_cm);
 
         // Add sensor width (largest image side) in pixels as custom property
         std::vector<::uint32_t> sensorSize_pix = {intrinsicCasted->w(), intrinsicCasted->h()};
@@ -680,6 +688,8 @@ void AlembicExporter::addCameraKeyframe(const geometry::Pose3& pose,
     // Camera intrinsic parameters
     CameraSample camSample;
 
+    const Vec2 & scale = cam->getScale();
+    const Vec2 & offset = cam->getOffset();
     
     // Take the max of the image size to handle the case where the image is in portrait mode
     const float imgWidth = cam->w();
@@ -687,8 +697,8 @@ void AlembicExporter::addCameraKeyframe(const geometry::Pose3& pose,
     const float sensorWidth = cam->sensorWidth();
     const float sensorHeight = cam->sensorHeight();
     const float sensorWidth_pix = std::max(imgWidth, imgHeight);
-    const float focalLengthX_pix = static_cast<const float>(cam->getScale()(0));
-    const float focalLengthY_pix = static_cast<const float>(cam->getScale()(1));
+    const float focalLengthX_pix = static_cast<const float>(scale(0));
+    const float focalLengthY_pix = static_cast<const float>(scale(1));
     const float focalLength_mm = sensorWidth * focalLengthX_pix / sensorWidth_pix;
     const float squeeze = focalLengthX_pix / focalLengthY_pix;
     const float pix2mm = sensorWidth / sensorWidth_pix;
@@ -698,11 +708,17 @@ void AlembicExporter::addCameraKeyframe(const geometry::Pose3& pose,
     // Following values are in cm, hence the 0.1 multiplier
     const float haperture_cm = static_cast<const float>(0.1 * imgWidth * pix2mm);
     const float vaperture_cm = static_cast<const float>(0.1 * imgHeight * pix2mm);
+    
+    //Alembic Offset is the 2d motion of the camera which create the offset (opposite)
+    const float offsetX_cm = static_cast<const float>(-0.1 * offset(0) * pix2mm);
+    const float offsetY_cm = static_cast<const float>(-0.1 * (-offset(1)) * pix2mm);
 
     camSample.setFocalLength(focalLength_mm);
     camSample.setHorizontalAperture(haperture_cm);
     camSample.setVerticalAperture(vaperture_cm);
     camSample.setLensSqueezeRatio(squeeze);
+    camSample.setHorizontalFilmOffset(offsetX_cm);
+    camSample.setVerticalFilmOffset(offsetY_cm);
 
     // Add sensor size in pixels as custom property
     std::vector<::uint32_t> sensorSize_pix = {cam->w(), cam->h()};

--- a/src/aliceVision/sfmDataIO/AlembicExporter.hpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.hpp
@@ -85,14 +85,12 @@ class AlembicExporter
      * @param[in] imagePath The localized image path
      * @param[in] viewId View id
      * @param[in] intrinsicId Intrinsic id
-     * @param[in] sensorWidthMM Width of the sensor in millimeters
      */
     void addCameraKeyframe(const geometry::Pose3& pose,
                            const camera::Pinhole* cam,
                            const std::string& imagePath,
                            IndexT viewId,
-                           IndexT intrinsicId,
-                           float sensorWidthMM = 36.0);
+                           IndexT intrinsicId);
 
     /**
      * @brief Initiate an animated camera

--- a/src/aliceVision/sfmDataIO/checkMayaProjection.py
+++ b/src/aliceVision/sfmDataIO/checkMayaProjection.py
@@ -1,0 +1,47 @@
+# This file is part of the AliceVision project.
+# Copyright (c) 2024 AliceVision contributors.
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#Found on https://video.stackexchange.com/questions/23382/maya-python-worldspace-to-screenspace-coordinates
+
+#A snippet to use in maya to check the numerical correctness of the projection
+
+import maya.cmds as cmds
+import maya.OpenMaya as om
+import sys
+
+def worldSpaceToScreenSpace(camera, worldPoint):
+
+    # get current resolution, modify according to your needs
+    resWidth = 1100
+    resHeight = 850
+
+    # get the dagPath to the camera shape node to get the world inverse matrix
+    selList = om.MSelectionList()
+    selList.add(camera)
+    dagPath = om.MDagPath()
+    selList.getDagPath(0,dagPath)
+    dagPath.extendToShape()
+    camInvMtx = dagPath.inclusiveMatrix().inverse()
+
+    # use a camera function set to get projection matrix, convert the MFloatMatrix 
+    # into a MMatrix for multiplication compatibility
+    fnCam = om.MFnCamera(dagPath)
+    mFloatMtx = fnCam.projectionMatrix()
+    projMtx = om.MMatrix(mFloatMtx.matrix)
+        
+
+    # multiply all together and do the normalisation    
+    mPoint = om.MPoint(worldPoint[0],worldPoint[1],worldPoint[2]) * camInvMtx  * projMtx;
+    x = (((mPoint[0] / mPoint[3]) / 2.0) + 0.5) * resWidth
+    y = (((-mPoint[1] / mPoint[3]) / 2.0) + 0.5) * resHeight
+    
+    return [x,y]
+
+cameras = (cmds.ls(type="camera"))
+
+for camera in cameras:
+    print(camera)
+    print(worldSpaceToScreenSpace(camera, [0, 0, 1, 1]))

--- a/src/aliceVision/sfmDataIO/checkMayaProjection.py
+++ b/src/aliceVision/sfmDataIO/checkMayaProjection.py
@@ -34,7 +34,7 @@ def worldSpaceToScreenSpace(camera, worldPoint):
         
 
     # multiply all together and do the normalisation    
-    mPoint = om.MPoint(worldPoint[0],worldPoint[1],worldPoint[2]) * camInvMtx  * projMtx;
+    mPoint = om.MPoint(worldPoint[0], worldPoint[1], worldPoint[2]) * camInvMtx * projMtx
     x = (((mPoint[0] / mPoint[3]) / 2.0) + 0.5) * resWidth
     y = (((-mPoint[1] / mPoint[3]) / 2.0) + 0.5) * resHeight
     


### PR DESCRIPTION
For the abc export specific to ExportAnimatedCamera, the sensor width and height were not set correctly.
Moreover, this PR add the filmback offset needed for correct camera alignment
A maya file is included to compare values between maya and alicevision