### PR TITLE
Catch error codes thrown by `std::filesystem::exists` 

### DIFF
--- a/src/aliceVision/depthMap/NormalMapEstimator.cpp
+++ b/src/aliceVision/depthMap/NormalMapEstimator.cpp
@@ -8,6 +8,7 @@
 
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/mvsUtils/mapIO.hpp>
 #include <aliceVision/depthMap/depthMapUtils.hpp>
@@ -39,7 +40,7 @@ void NormalMapEstimator::compute(int cudaDeviceId, const std::vector<int>& cams)
     {
         const std::string normalMapFilepath = getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::normalMapFiltered);
 
-        if (!fs::exists(normalMapFilepath))
+        if (!utils::exists(normalMapFilepath))
         {
             const system::Timer timer;
 

--- a/src/aliceVision/featureEngine/FeatureExtractor.cpp
+++ b/src/aliceVision/featureEngine/FeatureExtractor.cpp
@@ -7,6 +7,7 @@
 #include "FeatureExtractor.hpp"
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/MemoryInfo.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/alicevision_omp.hpp>
 
 #include <filesystem>
@@ -31,7 +32,7 @@ void FeatureExtractorViewJob::setImageDescribers(const std::vector<std::shared_p
         const std::shared_ptr<feature::ImageDescriber>& imageDescriber = imageDescribers.at(i);
         feature::EImageDescriberType imageDescriberType = imageDescriber->getDescriberType();
 
-        if (fs::exists(getFeaturesPath(imageDescriberType)) && fs::exists(getDescriptorPath(imageDescriberType)))
+        if (utils::exists(getFeaturesPath(imageDescriberType)) && utils::exists(getDescriptorPath(imageDescriberType)))
         {
             continue;
         }
@@ -166,8 +167,6 @@ void FeatureExtractor::computeViewJob(const FeatureExtractorViewJob& job, bool u
     image::Image<unsigned char> imageGrayUChar;
     image::Image<unsigned char> mask;
 
-    
-
     image::readImage(job.view().getImage().getImagePath(), imageGrayFloat, workingColorSpace);
 
     double pixelRatio = 1.0;
@@ -187,17 +186,17 @@ void FeatureExtractor::computeViewJob(const FeatureExtractorViewJob& job, bool u
         imageGrayFloat.swap(resizedInput);
     }
 
-    if (!_masksFolder.empty() && fs::exists(_masksFolder))
+    if (!_masksFolder.empty() && utils::exists(_masksFolder))
     {
         const auto masksFolder = fs::path(_masksFolder);
         const auto idMaskPath = masksFolder / fs::path(std::to_string(job.view().getViewId())).replace_extension(_maskExtension);
         const auto nameMaskPath = masksFolder / fs::path(job.view().getImage().getImagePath()).filename().replace_extension(_maskExtension);
 
-        if (fs::exists(idMaskPath))
+        if (utils::exists(idMaskPath))
         {
             image::readImage(idMaskPath.string(), mask, image::EImageColorSpace::LINEAR);
         }
-        else if (fs::exists(nameMaskPath))
+        else if (utils::exists(nameMaskPath))
         {
             image::readImage(nameMaskPath.string(), mask, image::EImageColorSpace::LINEAR);
         }

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -7,6 +7,7 @@
 #include "Fuser.hpp"
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/mvsData/geometry.hpp>
 #include <aliceVision/mvsData/Pixel.hpp>
@@ -138,7 +139,7 @@ void Fuser::filterGroups(const std::vector<int>& cams, float pixToleranceFactor,
 // minNumOfModals number of other cams including this cam ... minNumOfModals /in 2,3,...
 bool Fuser::filterGroupsRC(int rc, float pixToleranceFactor, int pixSizeBall, int pixSizeBallWSP, int nNearestCams)
 {
-    if (fs::exists(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap)))
+    if (utils::exists(getFileNameFromIndex(_mp, rc, mvsUtils::EFileType::nmodMap)))
     {
         return true;
     }

--- a/src/aliceVision/fuseCut/PointCloud.cpp
+++ b/src/aliceVision/fuseCut/PointCloud.cpp
@@ -6,6 +6,8 @@
 
 #include "PointCloud.hpp"
 
+#include <aliceVision/utils/filesIO.hpp>
+
 #include <aliceVision/fuseCut/Fuser.hpp>
 #include <aliceVision/mvsUtils/mapIO.hpp>
 #include <aliceVision/mvsUtils/fileIO.hpp>
@@ -330,7 +332,7 @@ void PointCloud::fuseFromDepthMaps(const StaticVector<int>& cams, const Point3d 
                 const std::string nmodMapFilepath = getFileNameFromIndex(_mp, c, mvsUtils::EFileType::nmodMap);
                 // If we have an nModMap in input (from depthmapfilter) use it,
                 // else init with a constant value.
-                if (fs::exists(nmodMapFilepath))
+                if (utils::exists(nmodMapFilepath))
                 {
                     image::readImage(nmodMapFilepath, numOfModalsMap, image::EImageColorSpace::NO_CONVERSION);
                     if (numOfModalsMap.width() != width || numOfModalsMap.height() != height)

--- a/src/aliceVision/image/cache.cpp
+++ b/src/aliceVision/image/cache.cpp
@@ -82,7 +82,7 @@ bool CacheManager::prepareBlockGroup(size_t startBlockId, size_t blocksCount)
     std::filesystem::path path(pathname);
 
     std::ofstream file_index;
-    if (std::filesystem::exists(path))
+    if (utils::exists(path))
     {
         file_index.open(pathname, std::ios::binary | std::ios::out | std::ios::in);
     }

--- a/src/aliceVision/image/cache.cpp
+++ b/src/aliceVision/image/cache.cpp
@@ -73,25 +73,25 @@ void CacheManager::deleteIndexFiles()
 
 bool CacheManager::prepareBlockGroup(size_t startBlockId, size_t blocksCount)
 {
-    size_t index_id = startBlockId / _blockCountPerIndex;
-    size_t block_id_in_index = startBlockId % _blockCountPerIndex;
-    size_t position_in_index = block_id_in_index * _blockSize;
+    size_t indexId = startBlockId / _blockCountPerIndex;
+    size_t blockIdInIndex = startBlockId % _blockCountPerIndex;
+    size_t positionInIndex = blockIdInIndex * _blockSize;
     size_t len = _blockSize * blocksCount;
 
-    std::string pathname = getPathForIndex(index_id);
+    std::string pathname = getPathForIndex(indexId);
     std::filesystem::path path(pathname);
 
-    std::ofstream file_index;
+    std::ofstream fileIndex;
     if (utils::exists(path))
     {
-        file_index.open(pathname, std::ios::binary | std::ios::out | std::ios::in);
+        fileIndex.open(pathname, std::ios::binary | std::ios::out | std::ios::in);
     }
     else
     {
-        file_index.open(pathname, std::ios::binary | std::ios::out);
+        fileIndex.open(pathname, std::ios::binary | std::ios::out);
     }
 
-    if (!file_index.is_open())
+    if (!fileIndex.is_open())
     {
         return false;
     }
@@ -99,15 +99,15 @@ bool CacheManager::prepareBlockGroup(size_t startBlockId, size_t blocksCount)
     ALICEVISION_LOG_TRACE("CacheManager::prepareBlockGroup: " << blocksCount * _blockSize << " bytes to '" << path << "'.");
 
     /*write a dummy byte at the end of the tile to "book" this place on disk*/
-    file_index.seekp(position_in_index + len - 1, file_index.beg);
-    if (!file_index)
+    fileIndex.seekp(positionInIndex + len - 1, fileIndex.beg);
+    if (!fileIndex)
     {
         return false;
     }
 
     char c[1];
     c[0] = 0xff;
-    file_index.write(c, 1);
+    fileIndex.write(c, 1);
 
     return true;
 }

--- a/src/aliceVision/image/colorspace.cpp
+++ b/src/aliceVision/image/colorspace.cpp
@@ -7,6 +7,7 @@
 #include "colorspace.hpp"
 
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <OpenImageIO/color.h>
 
@@ -40,7 +41,7 @@ std::string getDefaultColorConfigFilePath()
     if (ALICEVISION_OCIO != NULL)
     {
         configOCIOFilePath = std::string(ALICEVISION_OCIO);
-        if (fs::exists(configOCIOFilePath))
+        if (utils::exists(configOCIOFilePath))
         {
             // Check if a sRGB linear color space named "scene-linear Rec.709-sRGB" is present and set as scene_linear role
             oiio::ColorConfig colorConfig(configOCIOFilePath);
@@ -76,7 +77,7 @@ std::string getDefaultColorConfigFilePath()
         if (OCIO != NULL)
         {
             configOCIOFilePath = std::string(OCIO);
-            if (fs::exists(configOCIOFilePath))
+            if (utils::exists(configOCIOFilePath))
             {
                 ALICEVISION_LOG_TRACE("OCIO configuration file: '" << configOCIOFilePath << "' found.");
                 return configOCIOFilePath;
@@ -96,7 +97,7 @@ std::string getDefaultColorConfigFilePath()
     if (ALICEVISION_ROOT == NULL)
     {
         const std::string configFromSource = getColorConfigFilePathFromSourceCode();
-        if (fs::exists(configFromSource))
+        if (utils::exists(configFromSource))
         {
             ALICEVISION_LOG_DEBUG("ALICEVISION_ROOT is not defined, use embedded OCIO config file from source code: " << configFromSource);
             return configFromSource;
@@ -108,10 +109,10 @@ std::string getDefaultColorConfigFilePath()
     configOCIOFilePath = std::string(ALICEVISION_ROOT);
     configOCIOFilePath.append("/share/aliceVision/config.ocio");
 
-    if (!fs::exists(configOCIOFilePath))
+    if (!utils::exists(configOCIOFilePath))
     {
         const std::string configFromSource = getColorConfigFilePathFromSourceCode();
-        if (fs::exists(configFromSource))
+        if (utils::exists(configFromSource))
         {
             ALICEVISION_LOG_DEBUG("Embedded OCIO config file in ALICEVISION_ROOT does not exist, use config from source code: " << configFromSource);
             return configFromSource;

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -1357,20 +1357,21 @@ bool tryLoadMask(Image<unsigned char>* mask,
                  const std::string& srcImage,
                  const std::string& fileExtension)
 {
+
     for (const auto& masksFolder_str : masksFolders)
     {
-        if (!masksFolder_str.empty() && fs::exists(masksFolder_str))
+        if (!masksFolder_str.empty() && utils::exists(masksFolder_str))
         {
             const auto masksFolder = fs::path(masksFolder_str);
             const auto idMaskPath = masksFolder / fs::path(std::to_string(viewId)).replace_extension(fileExtension);
             const auto nameMaskPath = masksFolder / fs::path(srcImage).filename().replace_extension(fileExtension);
 
-            if (fs::exists(idMaskPath))
+            if (utils::exists(idMaskPath))
             {
                 readImage(idMaskPath.string(), *mask, EImageColorSpace::LINEAR);
                 return true;
             }
-            else if (fs::exists(nameMaskPath))
+            else if (utils::exists(nameMaskPath))
             {
                 readImage(nameMaskPath.string(), *mask, EImageColorSpace::LINEAR);
                 return true;

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -1358,11 +1358,12 @@ bool tryLoadMask(Image<unsigned char>* mask,
                  const std::string& fileExtension)
 {
 
-    for (const auto& masksFolder_str : masksFolders)
+    for (const auto& masksFolderStr : masksFolders)
     {
-        if (!masksFolder_str.empty() && utils::exists(masksFolder_str))
+
+        if (!masksFolderStr.empty() && utils::exists(masksFolderStr))
         {
-            const auto masksFolder = fs::path(masksFolder_str);
+            const auto masksFolder = fs::path(masksFolderStr);
             const auto idMaskPath = masksFolder / fs::path(std::to_string(viewId)).replace_extension(fileExtension);
             const auto nameMaskPath = masksFolder / fs::path(srcImage).filename().replace_extension(fileExtension);
 

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -7,6 +7,7 @@
 #include "KeyframeSelector.hpp"
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <random>
 #include <tuple>
@@ -696,13 +697,13 @@ bool KeyframeSelector::writeSelection(const std::vector<std::string>& brands,
             if (_mediaPaths.size() > 1)
             {
                 const std::string rigFolder = _outputFolder + "/rig/";
-                if (!fs::exists(rigFolder))
+                if (!utils::exists(rigFolder))
                 {
                     fs::create_directory(rigFolder);
                 }
 
                 processedOutputFolder = rigFolder + std::to_string(id);
-                if (!fs::exists(processedOutputFolder))
+                if (!utils::exists(processedOutputFolder))
                 {
                     fs::create_directory(processedOutputFolder);
                 }
@@ -871,13 +872,13 @@ bool KeyframeSelector::exportFlowVisualisation(const std::size_t rescaledWidth)
         if (_mediaPaths.size() > 1)
         {
             const std::string rigFolder = _outputFolder + "/rig/";
-            if (!fs::exists(rigFolder))
+            if (!utils::exists(rigFolder))
             {
                 fs::create_directory(rigFolder);
             }
 
             processedOutputFolder = rigFolder + std::to_string(mediaIndex);
-            if (!fs::exists(processedOutputFolder))
+            if (!utils::exists(processedOutputFolder))
             {
                 fs::create_directory(processedOutputFolder);
             }

--- a/src/aliceVision/localization/CCTagLocalizer.cpp
+++ b/src/aliceVision/localization/CCTagLocalizer.cpp
@@ -18,6 +18,7 @@
 
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <cctag/ICCTag.hpp>
 
@@ -758,7 +759,7 @@ void CCTagLocalizer::getAllAssociations(const feature::CCTAG_Regions& queryRegio
 
             // the directory where to save the feature matches
             const auto baseDir = fs::path(param._visualDebug) / queryImage;
-            if ((!fs::exists(baseDir)))
+            if ((!utils::exists(baseDir)))
             {
                 ALICEVISION_LOG_DEBUG("created " << baseDir.string());
                 fs::create_directories(baseDir);

--- a/src/aliceVision/localization/VoctreeLocalizer.cpp
+++ b/src/aliceVision/localization/VoctreeLocalizer.cpp
@@ -26,6 +26,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <flann/algorithms/dist.h>
 
@@ -843,7 +844,7 @@ void VoctreeLocalizer::getAllAssociations(const feature::MapRegionsPerDesc& quer
 
             // the directory where to save the feature matches
             const auto baseDir = fs::path(param._visualDebug) / queryImage;
-            if ((!fs::exists(baseDir)))
+            if ((!utils::exists(baseDir)))
             {
                 ALICEVISION_LOG_DEBUG("created " << baseDir.string());
                 fs::create_directories(baseDir);

--- a/src/aliceVision/matching/guidedMatching.cpp
+++ b/src/aliceVision/matching/guidedMatching.cpp
@@ -10,7 +10,7 @@
 namespace aliceVision {
 namespace matching {
 
-unsigned int pix_to_bucket(const Vec2i& x, int W, int H)
+unsigned int pixToBucket(const Vec2i& x, int W, int H)
 {
     if (x(1) == 0)
         return x(0);  // Top border
@@ -21,7 +21,7 @@ unsigned int pix_to_bucket(const Vec2i& x, int W, int H)
     return 2 * (W + H - 2) - x(1);    // Left border
 }
 
-bool line_to_endPoints(const Vec3& line, int W, int H, Vec2& x0, Vec2& x1)
+bool lineToEndPoints(const Vec3& line, int W, int H, Vec2& x0, Vec2& x1)
 {
     const double a = line(0);
     const double b = line(1);

--- a/src/aliceVision/matching/guidedMatching.hpp
+++ b/src/aliceVision/matching/guidedMatching.hpp
@@ -316,12 +316,12 @@ void guidedMatching(const ModelT& mod,
  * @brief Compute a bucket index from an epipolar point
  *        (the one that is closer to image border intersection)
  */
-unsigned int pix_to_bucket(const Vec2i& x, int W, int H);
+unsigned int pixToBucket(const Vec2i& x, int W, int H);
 
 /**
  * @brief Compute intersection of the epipolar line with the image border
  */
-bool line_to_endPoints(const Vec3& line, int W, int H, Vec2& x0, Vec2& x1);
+bool lineToEndPoints(const Vec3& line, int W, int H, Vec2& x0, Vec2& x1);
 
 /**
  * @brief Guided Matching (features + descriptors with distance ratio):
@@ -348,7 +348,7 @@ bool line_to_endPoints(const Vec3& line, int W, int H, Vec2& x0, Vec2& x1);
  * @param[in] heightR
  * @param[in] errorTh Maximal authorized error threshold (consider it's a square threshold)
  * @param[in] distRatio Maximal authorized distance ratio
- * @param[out] vec_corresponding_index Ouput corresponding index
+ * @param[out] vecCorrespondingIndex Ouput corresponding index
  */
 template<typename ErrorT>
 void guidedMatchingFundamentalFast(const Mat3& FMat,
@@ -361,7 +361,7 @@ void guidedMatchingFundamentalFast(const Mat3& FMat,
                                    const int heightR,
                                    double errorTh,
                                    double distRatio,
-                                   matching::IndMatches& vec_corresponding_index)
+                                   matching::IndMatches& vecCorrespondingIndex)
 {
     // Looking for the corresponding points that have to satisfy:
     //   1. a geometric distance below the provided Threshold
@@ -384,11 +384,11 @@ void guidedMatchingFundamentalFast(const Mat3& FMat,
     //--
     //-- Store point in the corresponding epipolar line bucket
     //--
-    using Bucket_vec = std::vector<IndexT>;
-    using Buckets_vec = std::vector<Bucket_vec>;
+    using BucketVec = std::vector<IndexT>;
+    using BucketsVec = std::vector<BucketVec>;
     const int nb_buckets = 2 * (widthR + heightR - 2);
 
-    Buckets_vec buckets(nb_buckets);
+    BucketsVec buckets(nb_buckets);
     for (std::size_t i = 0; i < lRegions.RegionCount(); ++i)
     {
         // Compute epipolar line
@@ -396,10 +396,10 @@ void guidedMatchingFundamentalFast(const Mat3& FMat,
         const Vec3 line = F * Vec3(l_pt(0), l_pt(1), 1.);
         // If the epipolar line exists in Right image
         Vec2 x0, x1;
-        if (line_to_endPoints(line, widthR, heightR, x0, x1))
+        if (lineToEndPoints(line, widthR, heightR, x0, x1))
         {
             // Find in which cluster the point belongs
-            const auto bucket = pix_to_bucket(x0.cast<int>(), widthR, heightR);
+            const auto bucket = pixToBucket(x0.cast<int>(), widthR, heightR);
             buckets[bucket].push_back(i);
         }
     }
@@ -422,22 +422,22 @@ void guidedMatchingFundamentalFast(const Mat3& FMat,
 
         // Compute corresponding buckets
         Vec2 x0, x1;
-        if (!line_to_endPoints(l2min, widthR, heightR, x0, x1))
+        if (!lineToEndPoints(l2min, widthR, heightR, x0, x1))
             continue;
 
-        const auto bucket_start = pix_to_bucket(x0.cast<int>(), widthR, heightR);
+        const auto bucketStart = pixToBucket(x0.cast<int>(), widthR, heightR);
 
-        if (!line_to_endPoints(l2max, widthR, heightR, x0, x1))
+        if (!lineToEndPoints(l2max, widthR, heightR, x0, x1))
             continue;
 
-        const auto bucket_stop = pix_to_bucket(x0.cast<int>(), widthR, heightR);
+        const auto bucketStop = pixToBucket(x0.cast<int>(), widthR, heightR);
 
-        if (bucket_stop > bucket_start)
+        if (bucketStop > bucketStart)
         {
             // test candidate buckets
-            for (Buckets_vec::const_iterator itBs = buckets.begin() + bucket_start; itBs != buckets.begin() + bucket_stop; ++itBs)
+            for (BucketsVec::const_iterator itBs = buckets.begin() + bucketStart; itBs != buckets.begin() + bucketStop; ++itBs)
             {
-                const Bucket_vec& bucket = *itBs;
+                const BucketVec& bucket = *itBs;
                 for (unsigned int i : bucket)
                 {
                     // Compute descriptor distance
@@ -454,7 +454,7 @@ void guidedMatchingFundamentalFast(const Mat3& FMat,
         if (dR[i].isValid(distRatio))
         {
             // save the best corresponding index
-            vec_corresponding_index.emplace_back(i, dR[i].idx);
+            vecCorrespondingIndex.emplace_back(i, dR[i].idx);
         }
     }
 }

--- a/src/aliceVision/matching/io.cpp
+++ b/src/aliceVision/matching/io.cpp
@@ -29,7 +29,8 @@ bool LoadMatchFile(PairwiseMatches& matches, const std::string& filepath)
 {
     const std::string ext = fs::path(filepath).extension().string();
 
-    if (!fs::exists(filepath))
+
+    if (!utils::exists(filepath))
         return false;
 
     if (ext == ".txt")
@@ -232,7 +233,7 @@ bool Load(PairwiseMatches& matches,
     std::set<std::string> foldersSet;
     for (const auto& folder : folders)
     {
-        if (fs::exists(folder))
+        if (utils::exists(folder))
         {
             foldersSet.insert(fs::canonical(folder).string());
         }

--- a/src/aliceVision/matching/io.cpp
+++ b/src/aliceVision/matching/io.cpp
@@ -29,7 +29,6 @@ bool LoadMatchFile(PairwiseMatches& matches, const std::string& filepath)
 {
     const std::string ext = fs::path(filepath).extension().string();
 
-
     if (!utils::exists(filepath))
         return false;
 
@@ -231,6 +230,7 @@ bool Load(PairwiseMatches& matches,
 
     // build up a set with normalized paths to remove duplicates
     std::set<std::string> foldersSet;
+    std::error_code ec;
     for (const auto& folder : folders)
     {
         if (utils::exists(folder))

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
@@ -12,6 +12,8 @@
 #include "aliceVision/matchingImageCollection/geometricFilterUtils.hpp"
 #include "aliceVision/sfmData/SfMData.hpp"
 
+#include <aliceVision/utils/filesIO.hpp>
+
 #include <cmath>
 #include <filesystem>
 
@@ -239,7 +241,7 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
                 continue;
             }
 
-            if (std::filesystem::exists(outputSvgDir))
+            if (utils::exists(outputSvgDir))
             {
                 const std::size_t nbMatches = outGeometricInliers.size();
                 const std::string name = std::to_string(nbMatches) + "hmatches_" + std::to_string(viewI.getViewId()) + "_" +

--- a/src/aliceVision/mesh/Mesh.cpp
+++ b/src/aliceVision/mesh/Mesh.cpp
@@ -6,6 +6,7 @@
 
 #include "Mesh.hpp"
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/mesh/meshVisibility.hpp>
 #include <aliceVision/mvsData/geometry.hpp>
 #include <aliceVision/mvsData/OrientedPoint.hpp>
@@ -2358,7 +2359,7 @@ void Mesh::load(const std::string& filepath, bool mergeCoincidentVerts, Material
     normals.clear();
     pointsVisibilities.clear();
 
-    if (!std::filesystem::exists(filepath))
+    if (!utils::exists(filepath))
     {
         ALICEVISION_THROW_ERROR("Mesh::load: no such file: " << filepath);
     }

--- a/src/aliceVision/mvsUtils/MultiViewParams.cpp
+++ b/src/aliceVision/mvsUtils/MultiViewParams.cpp
@@ -122,7 +122,7 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
         oiio::ParamValueList::const_iterator scaleIt = metadata.end();
         oiio::ParamValueList::const_iterator pIt = metadata.end();
 
-        const bool fileExists = fs::exists(imgParams.path);
+        const bool fileExists = utils::exists(imgParams.path);
         if (fileExists)
         {
             metadata = image::readImageMetadata(imgParams.path);
@@ -168,7 +168,7 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
             const std::string fileNameP = getFileNameFromIndex(*this, i, EFileType::P);
             const std::string fileNameD = getFileNameFromIndex(*this, i, EFileType::D);
 
-            if (fs::exists(fileNameP) && fs::exists(fileNameD))
+            if (utils::exists(fileNameP) && utils::exists(fileNameD))
             {
                 ALICEVISION_LOG_DEBUG("Reading view " << getViewId(i) << " projection matrix from file '" << fileNameP << "'.");
 
@@ -234,7 +234,7 @@ MultiViewParams::MultiViewParams(const sfmData::SfMData& sfmData,
 
 void MultiViewParams::loadMatricesFromTxtFile(int index, const std::string& fileNameP, const std::string& fileNameD)
 {
-    if (!fs::exists(fileNameP))
+    if (!utils::exists(fileNameP))
         throw std::runtime_error(std::string("mv_multiview_params: no such file: ") + fileNameP);
 
     std::ifstream in{fileNameP};
@@ -269,7 +269,7 @@ void MultiViewParams::loadMatricesFromTxtFile(int index, const std::string& file
     iRArr[index] = RArr[index].inverse();
     iCamArr[index] = iRArr[index] * iKArr[index];
 
-    if (fs::exists(fileNameD))
+    if (utils::exists(fileNameD))
     {
         std::ifstream inD{fileNameD};
         inD >> FocK1K2Arr[index].x >> FocK1K2Arr[index].y >> FocK1K2Arr[index].z;

--- a/src/aliceVision/mvsUtils/mapIO.cpp
+++ b/src/aliceVision/mvsUtils/mapIO.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/mvsUtils/fileIO.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/image/io.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/regex.hpp>
 
@@ -326,7 +327,7 @@ void readMapFromFileOrTiles(int rc,
     const std::string mapPath = getFileNameFromIndex(mp, rc, fileType, customSuffix);
 
     // check single file fullsize map exists
-    if (fs::exists(mapPath))
+    if (utils::exists(mapPath))
     {
         ALICEVISION_LOG_TRACE("Load depth map (full image): " << mapPath << ", scale: " << scale << ", step: " << step);
         // read single file fullsize map
@@ -605,7 +606,7 @@ unsigned long getNbDepthValuesFromDepthMap(int rc, const MultiViewParams& mp, in
     bool fromTiles = false;
 
     // get nbDepthValues from metadata
-    if (fs::exists(depthMapPath))  // untilled
+    if (utils::exists(depthMapPath))  // untilled
     {
         fileExists = true;
         const oiio::ParamValueList metadata = image::readImageMetadata(depthMapPath);

--- a/src/aliceVision/photometricStereo/photometricDataIO.cpp
+++ b/src/aliceVision/photometricStereo/photometricDataIO.cpp
@@ -7,6 +7,7 @@
 #include "photometricDataIO.hpp"
 
 #include <aliceVision/image/io.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -242,7 +243,7 @@ void buildLightMatFromJSON(const std::string& fileName,
 
 void loadMask(std::string const& maskName, image::Image<float>& mask)
 {
-    if (maskName.empty() || !fs::exists(maskName))
+    if (maskName.empty() || !utils::exists(maskName))
     {
         if (maskName.empty())
         {

--- a/src/aliceVision/photometricStereo/photometricStereo.cpp
+++ b/src/aliceVision/photometricStereo/photometricStereo.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/imageAlgo.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 // Eigen
 #include <Eigen/Dense>
@@ -553,7 +554,7 @@ void loadPSData(const std::string& folderPath, const size_t HS_order, std::vecto
     // Convertion matrix
     Eigen::MatrixXf convertionMatrix = Eigen::Matrix<float, 3, 3>::Identity();
     pathToCM = folderPath + "/convertionMatrix.txt";
-    if (fs::exists(pathToCM))
+    if (utils::exists(pathToCM))
     {
         readMatrix(pathToCM, convertionMatrix);
     }

--- a/src/aliceVision/sensorDB/parseDatabase.cpp
+++ b/src/aliceVision/sensorDB/parseDatabase.cpp
@@ -7,6 +7,7 @@
 
 #include "parseDatabase.hpp"
 #include <aliceVision/sensorDB/Datasheet.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/algorithm/string.hpp>
 
@@ -26,7 +27,7 @@ namespace sensorDB {
 bool parseDatabase(const std::string& databaseFilePath, std::vector<Datasheet>& databaseStructure)
 {
     std::ifstream fileIn(databaseFilePath);
-    if (!fileIn || !fs::exists(databaseFilePath) || !fs::is_regular_file(databaseFilePath))
+    if (!fileIn || !utils::exists(databaseFilePath) || !fs::is_regular_file(databaseFilePath))
         return false;
 
     std::string line;

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -7,6 +7,7 @@
 #include "LocalBundleAdjustmentGraph.hpp"
 #include <aliceVision/stl/stl.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <lemon/bfs.h>
 
@@ -609,7 +610,7 @@ double LocalBundleAdjustmentGraph::standardDeviation(const std::vector<T>& data)
 
 void LocalBundleAdjustmentGraph::drawGraph(const sfmData::SfMData& sfmData, const std::string& folder, const std::string& nameComplement)
 {
-    if (!fs::exists(folder))
+    if (!utils::exists(folder))
         fs::create_directory(folder);
 
     std::stringstream dotStream;

--- a/src/aliceVision/sfm/pipeline/regionsIO.cpp
+++ b/src/aliceVision/sfm/pipeline/regionsIO.cpp
@@ -8,6 +8,7 @@
 #include "regionsIO.hpp"
 
 #include <aliceVision/system/ProgressDisplay.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <atomic>
 #include <cassert>
@@ -35,7 +36,7 @@ std::unique_ptr<feature::Regions> loadRegions(const std::vector<std::string>& fo
         const fs::path featPath = fs::path(folder) / std::string(basename + "." + imageDescriberTypeName + ".feat");
         const fs::path descPath = fs::path(folder) / std::string(basename + "." + imageDescriberTypeName + ".desc");
 
-        if (fs::exists(featPath) && fs::exists(descPath))
+        if (utils::exists(featPath) && utils::exists(descPath))
         {
             featFilename = featPath.string();
             descFilename = descPath.string();
@@ -84,7 +85,7 @@ std::unique_ptr<feature::Regions> loadFeatures(const std::vector<std::string>& f
     std::set<std::string> foldersSet;
     for (const auto& folder : folders)
     {
-        if (fs::exists(folder))
+        if (utils::exists(folder))
         {
             foldersSet.insert(fs::canonical(folder).string());
         }
@@ -93,7 +94,7 @@ std::unique_ptr<feature::Regions> loadFeatures(const std::vector<std::string>& f
     for (const auto& folder : foldersSet)
     {
         const fs::path featPath = fs::path(folder) / std::string(basename + "." + imageDescriberTypeName + ".feat");
-        if (fs::exists(featPath))
+        if (utils::exists(featPath))
             featFilename = featPath.string();
     }
 

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -30,6 +30,7 @@
 #include <aliceVision/system/MemoryInfo.hpp>
 #include <aliceVision/track/TracksBuilder.hpp>
 #include <aliceVision/track/tracksUtils.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <dependencies/htmlDoc/htmlDoc.hpp>
 
@@ -152,7 +153,7 @@ ReconstructionEngine_sequentialSfM::ReconstructionEngine_sequentialSfM(const SfM
     }
 
     // create sfm intermediate step folder
-    if (!fs::exists(_sfmStepFolder) && _params.logIntermediateSteps)
+    if (!utils::exists(_sfmStepFolder) && _params.logIntermediateSteps)
         fs::create_directory(_sfmStepFolder);
 
     // Set up the resection ID

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -8,6 +8,7 @@
 #include "SfMData.hpp"
 
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <filesystem>
 
@@ -153,7 +154,7 @@ std::vector<std::string> toAbsoluteFolders(const std::vector<std::string>& folde
     for (const auto& folder : folders)
     {
         const fs::path f = fs::absolute(folder);
-        if (fs::exists(f))
+        if (utils::exists(f))
         {
             // fs::canonical can only be used if the path exists
             absolutePaths.push_back(fs::canonical(f).string());

--- a/src/aliceVision/track/tracksUtils.cpp
+++ b/src/aliceVision/track/tracksUtils.cpp
@@ -14,30 +14,30 @@ namespace track {
 
 using namespace aliceVision::matching;
 
-bool getCommonTracksInImages(const std::set<std::size_t>& imageIndexes, const TracksMap& tracksIn, TracksMap& map_tracksOut)
+bool getCommonTracksInImages(const std::set<std::size_t>& imageIndexes, const TracksMap& tracksIn, TracksMap& tracksOut)
 {
     assert(!imageIndexes.empty());
-    map_tracksOut.clear();
+    tracksOut.clear();
 
     // go along the tracks
     for (auto& trackIn : tracksIn)
     {
         // look if the track contains the provided view index & save the point ids
-        Track map_temp;
+        Track mapTemp;
         for (std::size_t imageIndex : imageIndexes)
         {
             auto iterSearch = trackIn.second.featPerView.find(imageIndex);
             if (iterSearch == trackIn.second.featPerView.end())
                 break;  // at least one request image is not in the track
-            map_temp.featPerView[iterSearch->first] = iterSearch->second;
-            map_temp.descType = trackIn.second.descType;
+            mapTemp.featPerView[iterSearch->first] = iterSearch->second;
+            mapTemp.descType = trackIn.second.descType;
         }
         // if we have a feature for each input image
         // we can add it to the output tracks.
-        if (map_temp.featPerView.size() == imageIndexes.size())
-            map_tracksOut[trackIn.first] = std::move(map_temp);
+        if (mapTemp.featPerView.size() == imageIndexes.size())
+            tracksOut[trackIn.first] = std::move(mapTemp);
     }
-    return !map_tracksOut.empty();
+    return !tracksOut.empty();
 }
 
 void getCommonTracksInImages(const std::set<std::size_t>& imageIndexes, const TracksPerView& tracksPerView, std::set<std::size_t>& visibleTracks)
@@ -89,11 +89,11 @@ bool getCommonTracksInImagesFast(const std::set<std::size_t>& imageIndexes,
     assert(!imageIndexes.empty());
     tracksOut.clear();
 
-    std::set<std::size_t> set_visibleTracks;
-    getCommonTracksInImages(imageIndexes, tracksPerView, set_visibleTracks);
+    std::set<std::size_t> visibleTracks;
+    getCommonTracksInImages(imageIndexes, tracksPerView, visibleTracks);
 
     // go along the tracks
-    for (std::size_t visibleTrack : set_visibleTracks)
+    for (std::size_t visibleTrack : visibleTracks)
     {
         TracksMap::const_iterator itTrackIn = tracksIn.find(visibleTrack);
         if (itTrackIn == tracksIn.end())
@@ -185,7 +185,7 @@ void getTracksIdVector(const TracksMap& tracks, std::set<std::size_t>* tracksIds
         tracksIds->insert(iterT->first);
 }
 
-bool getFeatureIdInViewPerTrack(const TracksMap& allTracks, const std::set<std::size_t>& trackIds, IndexT viewId, std::vector<FeatureId>* out_featId)
+bool getFeatureIdInViewPerTrack(const TracksMap& allTracks, const std::set<std::size_t>& trackIds, IndexT viewId, std::vector<FeatureId>* outFeatId)
 {
     for (std::size_t trackId : trackIds)
     {
@@ -196,18 +196,18 @@ bool getFeatureIdInViewPerTrack(const TracksMap& allTracks, const std::set<std::
             continue;
 
         // try to find imageIndex
-        const Track& map_ref = iterT->second;
-        auto iterSearch = map_ref.featPerView.find(viewId);
-        if (iterSearch != map_ref.featPerView.end())
-            out_featId->emplace_back(map_ref.descType, iterSearch->second.featureId);
+        const Track& mapRef = iterT->second;
+        auto iterSearch = mapRef.featPerView.find(viewId);
+        if (iterSearch != mapRef.featPerView.end())
+            outFeatId->emplace_back(mapRef.descType, iterSearch->second.featureId);
     }
-    return !out_featId->empty();
+    return !outFeatId->empty();
 }
 
-void tracksToIndexedMatches(const TracksMap& tracks, const std::vector<IndexT>& filterIndex, std::vector<IndMatch>* out_index)
+void tracksToIndexedMatches(const TracksMap& tracks, const std::vector<IndexT>& filterIndex, std::vector<IndMatch>* outIndex)
 {
-    std::vector<IndMatch>& vec_indexref = *out_index;
-    vec_indexref.clear();
+    std::vector<IndMatch>& indexRef = *outIndex;
+    indexRef.clear();
 
     for (std::size_t i = 0; i < filterIndex.size(); ++i)
     {
@@ -215,15 +215,15 @@ void tracksToIndexedMatches(const TracksMap& tracks, const std::vector<IndexT>& 
         TracksMap::const_iterator itF = std::find_if(tracks.begin(), tracks.end(), FunctorMapFirstEqual(filterIndex[i]));
 
         // the current track.
-        const Track& map_ref = itF->second;
+        const Track& mapRef = itF->second;
 
         // check we have 2 elements for a track.
-        assert(map_ref.featPerView.size() == 2);
+        assert(mapRef.featPerView.size() == 2);
 
-        const IndexT indexI = (map_ref.featPerView.begin())->second.featureId;
-        const IndexT indexJ = (++map_ref.featPerView.begin())->second.featureId;
+        const IndexT indexI = (mapRef.featPerView.begin())->second.featureId;
+        const IndexT indexJ = (++mapRef.featPerView.begin())->second.featureId;
 
-        vec_indexref.emplace_back(indexI, indexJ);
+        indexRef.emplace_back(indexI, indexJ);
     }
 }
 
@@ -250,8 +250,8 @@ void imageIdInTracks(const TracksMap& tracks, std::set<std::size_t>& imagesId)
 {
     for (TracksMap::const_iterator iterT = tracks.begin(); iterT != tracks.end(); ++iterT)
     {
-        const Track& map_ref = iterT->second;
-        for (auto iter = map_ref.featPerView.begin(); iter != map_ref.featPerView.end(); ++iter)
+        const Track& mapRef = iterT->second;
+        for (auto iter = mapRef.featPerView.begin(); iter != mapRef.featPerView.end(); ++iter)
             imagesId.insert(iter->first);
     }
 }

--- a/src/aliceVision/track/tracksUtils.hpp
+++ b/src/aliceVision/track/tracksUtils.hpp
@@ -90,10 +90,10 @@ void getTracksIdVector(const TracksMap& tracks, std::set<std::size_t>* tracksIds
  * @param[in] allTracks all tracks of the scene as a map {trackId, track}
  * @param[in] trackIds the tracks in the images
  * @param[in] viewId: ImageId we are looking for features
- * @param[out] out_featId the number of features in the image as a vector
+ * @param[out] outFeatId the number of features in the image as a vector
  * @return true if the vector of features Ids is not empty
  */
-bool getFeatureIdInViewPerTrack(const TracksMap& allTracks, const std::set<std::size_t>& trackIds, IndexT viewId, std::vector<FeatureId>* out_featId);
+bool getFeatureIdInViewPerTrack(const TracksMap& allTracks, const std::set<std::size_t>& trackIds, IndexT viewId, std::vector<FeatureId>* outFeatId);
 
 struct FunctorMapFirstEqual
 {
@@ -108,17 +108,17 @@ struct FunctorMapFirstEqual
 /**
  * @brief Convert a trackId to a vector of indexed Matches.
  *
- * @param[in]  map_tracks: set of tracks with only 2 elements
+ * @param[in]  tracks: set of tracks with only 2 elements
  *             (image A and image B) in each Track.
- * @param[in]  vec_filterIndex: the track indexes to retrieve.
+ * @param[in]  filterIndex: the track indexes to retrieve.
  *             Only track indexes contained in this filter vector are kept.
- * @param[out] pvec_index: list of matches
+ * @param[out] outIndex: list of matches
  *             (feature index in image A, feature index in image B).
  *
  * @warning The input tracks must be composed of only two images index.
  * @warning Image index are considered sorted (increasing order).
  */
-void tracksToIndexedMatches(const TracksMap& tracks, const std::vector<IndexT>& filterIndex, std::vector<IndMatch>* out_index);
+void tracksToIndexedMatches(const TracksMap& tracks, const std::vector<IndexT>& filterIndex, std::vector<IndMatch>* outIndex);
 
 /**
  * @brief Return the occurrence of tracks length.

--- a/src/aliceVision/utils/filesIO.hpp
+++ b/src/aliceVision/utils/filesIO.hpp
@@ -115,5 +115,11 @@ inline std::time_t getLastWriteTime(const std::string& path)
     }
 }
 
+[[nodiscard]] inline bool exists(const fs::path& path) noexcept
+{
+    std::error_code ec;
+    return fs::exists(path, ec);
+}
+
 }  // namespace utils
 }  // namespace aliceVision

--- a/src/aliceVision/voctree/descriptorLoader.cpp
+++ b/src/aliceVision/voctree/descriptorLoader.cpp
@@ -7,6 +7,7 @@
 #include "descriptorLoader.hpp"
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -94,7 +95,7 @@ void getListOfDescriptorFiles(const sfmData::SfMData& sfmData,
                                                                                  feature::EImageDescriberType_enumToString(descType) + ".desc"))
                                                .string();
 
-                if (fs::exists(filepath))
+                if (utils::exists(filepath))
                 {
                     descriptorsFiles[view.first] = filepath;
                     found = true;

--- a/src/software/convert/main_convertMesh.cpp
+++ b/src/software/convert/main_convertMesh.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/mesh/Texturing.hpp>
 #include <aliceVision/mesh/Mesh.hpp>
 
@@ -60,7 +61,7 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // check first mesh file path
-    if (!inputMeshPath.empty() && !fs::exists(inputMeshPath) && !fs::is_regular_file(inputMeshPath))
+    if (!inputMeshPath.empty() && !utils::exists(inputMeshPath) && !fs::is_regular_file(inputMeshPath))
     {
         ALICEVISION_LOG_ERROR("The input mesh file doesn't exist");
         return EXIT_FAILURE;
@@ -77,7 +78,7 @@ int aliceVision_main(int argc, char** argv)
     {
         const std::string outputFolderPart = fs::path(outputFilePath).parent_path().string();
 
-        if (!outputFolderPart.empty() && !fs::exists(outputFolderPart))
+        if (!outputFolderPart.empty() && !utils::exists(outputFolderPart))
         {
             if (!fs::create_directory(outputFolderPart))
             {

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -7,12 +7,14 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/AlembicExporter.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/image/all.hpp>
-#include <aliceVision/system/ProgressDisplay.hpp>
+
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/utils/regexFilter.hpp>
 
 #include <boost/program_options.hpp>
@@ -213,7 +215,7 @@ int aliceVision_main(int argc, char** argv)
     const fs::path undistortedImagesFolderPath = fs::path(outFolder) / "undistort";
     const bool writeUndistordedResult = undistortedImages || exportSTMaps;
 
-    if (writeUndistordedResult && !fs::exists(undistortedImagesFolderPath))
+    if (writeUndistordedResult && !utils::exists(undistortedImagesFolderPath))
         fs::create_directory(undistortedImagesFolderPath);
 
     std::map<std::string, std::map<std::size_t, IndexT>> videoViewPerFrame;

--- a/src/software/export/main_exportColmap.cpp
+++ b/src/software/export/main_exportColmap.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/sfmDataIO/colmap.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 
 #include <boost/program_options.hpp>
@@ -53,7 +54,7 @@ int aliceVision_main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    if (!fs::exists(outDirectory))
+    if (!utils::exists(outDirectory))
     {
         fs::create_directory(outDirectory);
     }

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 
@@ -75,7 +76,7 @@ bool exportToMVE2Format(const SfMData& sfm_data,
     {
         // Create 'views' subfolder
         const std::string sOutViewsDirectory = (fs::path(sOutDirectory) / "views").string();
-        if (!fs::exists(sOutViewsDirectory))
+        if (!utils::exists(sOutViewsDirectory))
         {
             std::cout << "\033[1;31mCreating folder:  " << sOutViewsDirectory << "\033[0m\n";
             fs::create_directory(sOutViewsDirectory);
@@ -117,7 +118,7 @@ bool exportToMVE2Format(const SfMData& sfm_data,
             padding << std::setw(4) << std::setfill('0') << view_index;
 
             sOutViewIteratorDirectory = (fs::path(sOutViewsDirectory) / ("view_" + padding.str() + ".mve")).string();
-            if (!fs::exists(sOutViewIteratorDirectory))
+            if (!utils::exists(sOutViewIteratorDirectory))
             {
                 fs::create_directory(sOutViewIteratorDirectory);
             }
@@ -253,7 +254,7 @@ int aliceVision_main(int argc, char* argv[])
     }
 
     // Create output dir
-    if (!fs::exists(outDirectory))
+    if (!utils::exists(outDirectory))
         fs::create_directory(outDirectory);
 
     // Read the input SfM scene

--- a/src/software/export/main_exportMVSTexturing.cpp
+++ b/src/software/export/main_exportMVSTexturing.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 
@@ -53,7 +54,7 @@ int aliceVision_main(int argc, char** argv)
     bool bOneHaveDisto = false;
 
     // Create output dir
-    if (!fs::exists(outDirectory))
+    if (!utils::exists(outDirectory))
         fs::create_directory(outDirectory);
 
     // Read the SfM scene

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/image/conversion.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 
@@ -149,7 +150,7 @@ int aliceVision_main(int argc, char* argv[])
     // export
     {
         // Create output dir
-        if (!fs::exists(outputFolder))
+        if (!utils::exists(outputFolder))
             fs::create_directory(outputFolder);
 
         // Read the input SfM scene

--- a/src/software/export/main_exportMeshlab.cpp
+++ b/src/software/export/main_exportMeshlab.cpp
@@ -61,8 +61,8 @@ int aliceVision_main(int argc, char** argv)
         fs::create_directory(outDirectory);
 
     // Read the SfM scene
-    SfMData sfm_data;
-    if (!sfmDataIO::load(sfm_data, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::INTRINSICS | sfmDataIO::EXTRINSICS)))
+    SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::INTRINSICS | sfmDataIO::EXTRINSICS)))
     {
         std::cerr << std::endl << "The input SfMData file \"" << sfmDataFilename << "\" cannot be read." << std::endl;
         return EXIT_FAILURE;
@@ -79,14 +79,14 @@ int aliceVision_main(int argc, char** argv)
 
     outfile << " <RasterGroup>" << outfile.widen('\n');
 
-    for (Views::const_iterator iter = sfm_data.getViews().begin(); iter != sfm_data.getViews().end(); ++iter)
+    for (Views::const_iterator iter = sfmData.getViews().begin(); iter != sfmData.getViews().end(); ++iter)
     {
         const View* view = iter->second.get();
-        if (!sfm_data.isPoseAndIntrinsicDefined(view))
+        if (!sfmData.isPoseAndIntrinsicDefined(view))
             continue;
 
-        const Pose3 pose = sfm_data.getPose(*view).getTransform();
-        Intrinsics::const_iterator iterIntrinsic = sfm_data.getIntrinsics().find(view->getIntrinsicId());
+        const Pose3 pose = sfmData.getPose(*view).getTransform();
+        Intrinsics::const_iterator iterIntrinsic = sfmData.getIntrinsics().find(view->getIntrinsicId());
 
         // We have a valid view with a corresponding camera & pose
         const std::string srcImage = view->getImage().getImagePath();

--- a/src/software/export/main_exportMeshlab.cpp
+++ b/src/software/export/main_exportMeshlab.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 
@@ -56,7 +57,7 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // Create output dir
-    if (!fs::exists(outDirectory))
+    if (!utils::exists(outDirectory))
         fs::create_directory(outDirectory);
 
     // Read the SfM scene

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <boost/program_options.hpp>
 
@@ -42,7 +43,7 @@ bool exportToPMVSFormat(const SfMData& sfm_data,
                         const bool b_VisData = true)
 {
     bool bOk = true;
-    if (!fs::exists(sOutDirectory))
+    if (!utils::exists(sOutDirectory))
     {
         fs::create_directory(sOutDirectory);
         bOk = fs::is_directory(sOutDirectory);
@@ -330,7 +331,7 @@ int aliceVision_main(int argc, char* argv[])
     }
 
     // Create output dir
-    if (!fs::exists(outputFolder))
+    if (!utils::exists(outputFolder))
         fs::create_directory(outputFolder);
 
     SfMData sfmData;

--- a/src/software/export/main_exportUSD.cpp
+++ b/src/software/export/main_exportUSD.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/mesh/Texturing.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
@@ -321,7 +322,7 @@ int aliceVision_main(int argc, char** argv)
     {
         for (const auto& texture : texturing.material.getAllTextures())
         {
-            if (fs::exists(sourceFolder / texture))
+            if (utils::exists(sourceFolder / texture))
             {
                 fs::copy_file(sourceFolder / texture, destinationFolder / texture, fs::copy_options::update_existing);
             }
@@ -345,7 +346,7 @@ int aliceVision_main(int argc, char** argv)
         {
             for (const auto& texture : texturing.material.getAllTextures())
             {
-                if (fs::exists(destinationFolder / texture))
+                if (utils::exists(destinationFolder / texture))
                 {
                     writer.AddFile((destinationFolder / texture).string(), texture);
                 }

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/lensCorrectionProfile/lcp.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/image/io.cpp>
 #include <aliceVision/image/dcp.hpp>
@@ -272,14 +273,14 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // check input folder
-    if (!imageFolder.empty() && !fs::exists(imageFolder) && !fs::is_directory(imageFolder))
+    if (!imageFolder.empty() && !utils::exists(imageFolder) && !fs::is_directory(imageFolder))
     {
         ALICEVISION_LOG_ERROR("The input folder doesn't exist");
         return EXIT_FAILURE;
     }
 
     // check sfm file
-    if (!sfmFilePath.empty() && !fs::exists(sfmFilePath) && !fs::is_regular_file(sfmFilePath))
+    if (!sfmFilePath.empty() && !utils::exists(sfmFilePath) && !fs::is_regular_file(sfmFilePath))
     {
         ALICEVISION_LOG_ERROR("The input sfm file doesn't exist");
         return EXIT_FAILURE;
@@ -296,7 +297,7 @@ int aliceVision_main(int argc, char** argv)
     {
         const std::string outputFolderPart = fs::path(outputFilePath).parent_path().string();
 
-        if (!outputFolderPart.empty() && !fs::exists(outputFolderPart))
+        if (!outputFolderPart.empty() && !utils::exists(outputFolderPart))
         {
             if (!fs::create_directory(outputFolderPart))
             {

--- a/src/software/pipeline/main_cameraLocalization.cpp
+++ b/src/software/pipeline/main_cameraLocalization.cpp
@@ -23,6 +23,7 @@
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/utils/convert.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/program_options.hpp>
 #include <boost/accumulators/accumulators.hpp>
@@ -259,7 +260,7 @@ int aliceVision_main(int argc, char** argv)
 
     // if the provided folder for visual debugging does not exist create it
     // recursively
-    if ((!visualDebug.empty()) && (!fs::exists(visualDebug)))
+    if ((!visualDebug.empty()) && (!utils::exists(visualDebug)))
     {
         fs::create_directories(visualDebug);
     }

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -18,6 +18,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 
 #include <boost/program_options.hpp>
@@ -118,7 +119,7 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // create output folder
-    if (!fs::exists(outputFolder))
+    if (!utils::exists(outputFolder))
     {
         if (!fs::create_directory(outputFolder))
         {

--- a/src/software/pipeline/main_globalSfM.cpp
+++ b/src/software/pipeline/main_globalSfM.cpp
@@ -13,6 +13,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 
 #include <boost/program_options.hpp>
@@ -150,7 +151,7 @@ int aliceVision_main(int argc, char** argv)
     if (extraInfoFolder.empty())
         extraInfoFolder = fs::path(outSfMDataFilepath).parent_path().string();
 
-    if (!fs::exists(extraInfoFolder))
+    if (!utils::exists(extraInfoFolder))
         fs::create_directory(extraInfoFolder);
 
     // global SfM reconstruction process

--- a/src/software/pipeline/main_imageMasking.cpp
+++ b/src/software/pipeline/main_imageMasking.cpp
@@ -11,6 +11,7 @@
 #include <aliceVision/imageMasking/imageMasking.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 
 #include <OpenImageIO/imagebuf.h>
@@ -167,7 +168,7 @@ int main(int argc, char** argv)
     }
 
     // check sfm file
-    if (!sfmFilePath.empty() && !fs::exists(sfmFilePath) && !fs::is_regular_file(sfmFilePath))
+    if (!sfmFilePath.empty() && !utils::exists(sfmFilePath) && !fs::is_regular_file(sfmFilePath))
     {
         ALICEVISION_LOG_ERROR("The input sfm file doesn't exist");
         return EXIT_FAILURE;
@@ -188,7 +189,7 @@ int main(int argc, char** argv)
     }
 
     // ensure output folder exists
-    if (!outputFilePath.empty() && !fs::exists(outputFilePath))
+    if (!outputFilePath.empty() && !utils::exists(outputFilePath))
     {
         if (!fs::create_directory(outputFilePath))
         {
@@ -293,7 +294,7 @@ int main(int argc, char** argv)
                 if (pos != std::string::npos)
                     depthMapPath.replace(pos, k_stem.size(), fs::path(imgPath).extension().string().substr(1));
             }
-            if (!fs::exists(depthMapPath))
+            if (!utils::exists(depthMapPath))
             {
                 ALICEVISION_LOG_DEBUG("depthMapPath from expression: \"" << depthMapPath << "\" not found.");
                 depthMapPath.clear();
@@ -307,7 +308,7 @@ int main(int argc, char** argv)
         {
             // Look for View UID
             fs::path p = fs::path(depthMapFolder) / (std::to_string(view.getViewId()) + fs::path(imgPath).extension().string());
-            if (fs::exists(p))
+            if (utils::exists(p))
             {
                 depthMapPath = p.string();
                 ALICEVISION_LOG_DEBUG("depthMapPath found from folder and View UID: \"" << depthMapPath << "\".");
@@ -316,7 +317,7 @@ int main(int argc, char** argv)
             {
                 // Look for an image with the same filename
                 p = fs::path(depthMapFolder) / fs::path(imgPath).filename();
-                if (fs::exists(p))
+                if (utils::exists(p))
                 {
                     depthMapPath = p.string();
                     ALICEVISION_LOG_DEBUG("depthMapPath found from folder and input filename: \"" << depthMapPath << "\".");

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/sfm/FrustumFilter.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/config.hpp>
 
@@ -272,7 +273,7 @@ int aliceVision_main(int argc, char** argv)
 
     // check if the output folder exists
     const auto basePath = fs::path(outputFile).parent_path();
-    if (!basePath.empty() && !fs::exists(basePath))
+    if (!basePath.empty() && !utils::exists(basePath))
     {
         // then create the missing folder
         if (!fs::create_directories(basePath))

--- a/src/software/pipeline/main_incrementalSfM.cpp
+++ b/src/software/pipeline/main_incrementalSfM.cpp
@@ -13,6 +13,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/config.hpp>
@@ -262,7 +263,7 @@ int aliceVision_main(int argc, char** argv)
     if (extraInfoFolder.empty())
         extraInfoFolder = fs::path(outputSfM).parent_path().string();
 
-    if (!fs::exists(extraInfoFolder))
+    if (!utils::exists(extraInfoFolder))
         fs::create_directory(extraInfoFolder);
 
     // sequential reconstruction process

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/mesh/Mesh.hpp>
 #include <aliceVision/mvsUtils/common.hpp>
@@ -558,7 +559,7 @@ int main(int argc, char** argv)
     inputMesh.load(inputMeshPath);
 
     // check sfm file
-    if (!sfmFilePath.empty() && !fs::exists(sfmFilePath) && !fs::is_regular_file(sfmFilePath))
+    if (!sfmFilePath.empty() && !utils::exists(sfmFilePath) && !fs::is_regular_file(sfmFilePath))
     {
         ALICEVISION_LOG_ERROR("The input sfm file doesn't exist");
         return EXIT_FAILURE;
@@ -580,7 +581,7 @@ int main(int argc, char** argv)
 
     // ensure output folder exists
     fs::path outputDirectory = fs::path(outputMeshPath).parent_path();
-    if (!outputDirectory.empty() && !fs::exists(outputDirectory))
+    if (!outputDirectory.empty() && !utils::exists(outputDirectory))
     {
         if (!fs::create_directory(outputDirectory))
         {

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/image/all.hpp>
 
@@ -179,7 +180,7 @@ int aliceVision_main(int argc, char** argv)
 
     const std::string outDirectory = fs::path(outputSfMDataFilepath).parent_path().string();
 
-    if (!fs::exists(outDirectory))
+    if (!utils::exists(outDirectory))
     {
         ALICEVISION_LOG_ERROR("Output folder does not exist: " << outDirectory);
         return EXIT_FAILURE;

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -11,6 +11,7 @@
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/config.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 
@@ -343,7 +344,7 @@ int aliceVision_main(int argc, char* argv[])
     image::EImageFileType outputFileType = image::EImageFileType_stringToEnum(outImageFileTypeName);
 
     // Create output dir
-    if (!fs::exists(outFolder))
+    if (!utils::exists(outFolder))
         fs::create_directory(outFolder);
 
     // Read the input SfM scene

--- a/src/software/pipeline/main_sfmTriangulation.cpp
+++ b/src/software/pipeline/main_sfmTriangulation.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/config.hpp>
@@ -154,7 +155,7 @@ int aliceVision_main(int argc, char** argv)
     if (extraInfoFolder.empty())
         extraInfoFolder = fs::path(outputSfM).parent_path().string();
 
-    if (!fs::exists(extraInfoFolder))
+    if (!utils::exists(extraInfoFolder))
         fs::create_directory(extraInfoFolder);
 
     // triangulate

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -177,7 +177,7 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    if (fs::exists(inputData))
+    if (utils::exists(inputData))
     {
         // checkers collection
         std::vector<CChecker> ccheckers;

--- a/src/software/utils/main_frustumFiltering.cpp
+++ b/src/software/utils/main_frustumFiltering.cpp
@@ -8,11 +8,12 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/sfm.hpp>
-#include <aliceVision/system/Timer.hpp>
 #include <aliceVision/matchingImageCollection/ImagePairListIO.hpp>
-#include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -99,8 +100,8 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // check that we can create the output folder
-    if (!fs::exists(fs::path(outputFilename).parent_path()))
-        if (!fs::exists(fs::path(outputFilename).parent_path()))
+    if (!utils::exists(fs::path(outputFilename).parent_path()))
+        if (!utils::exists(fs::path(outputFilename).parent_path()))
             return EXIT_FAILURE;
 
     // load input SfMData scene

--- a/src/software/utils/main_mergeMeshes.cpp
+++ b/src/software/utils/main_mergeMeshes.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -169,14 +170,14 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // check first mesh file path
-    if (!inputFirstMeshPath.empty() && !fs::exists(inputFirstMeshPath) && !fs::is_regular_file(inputFirstMeshPath))
+    if (!inputFirstMeshPath.empty() && !utils::exists(inputFirstMeshPath) && !fs::is_regular_file(inputFirstMeshPath))
     {
         ALICEVISION_LOG_ERROR("The first mesh file doesn't exist");
         return EXIT_FAILURE;
     }
 
     // check second mesh file path
-    if (!inputSecondMeshPath.empty() && !fs::exists(inputSecondMeshPath) && !fs::is_regular_file(inputSecondMeshPath))
+    if (!inputSecondMeshPath.empty() && !utils::exists(inputSecondMeshPath) && !fs::is_regular_file(inputSecondMeshPath))
     {
         ALICEVISION_LOG_ERROR("The second mesh file doesn't exist");
         return EXIT_FAILURE;
@@ -193,7 +194,7 @@ int aliceVision_main(int argc, char** argv)
     {
         const std::string outputFolderPart = fs::path(outputFilePath).parent_path().string();
 
-        if (!outputFolderPart.empty() && !fs::exists(outputFolderPart))
+        if (!outputFolderPart.empty() && !utils::exists(outputFolderPart))
         {
             if (!fs::create_directory(outputFolderPart))
             {

--- a/src/software/utils/main_qualityEvaluation.cpp
+++ b/src/software/utils/main_qualityEvaluation.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/config.hpp>
 
 #include <software/utils/precisionEvaluationToGt.hpp>
@@ -64,7 +65,7 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    if (!fs::exists(outputFolder))
+    if (!utils::exists(outputFolder))
         fs::create_directory(outputFolder);
 
     // load GT camera rotations & positions [R|C]:

--- a/src/software/utils/main_sfmColorHarmonize.cpp
+++ b/src/software/utils/main_sfmColorHarmonize.cpp
@@ -89,7 +89,7 @@ int aliceVision_main(int argc, char** argv)
     ColorHarmonizationEngineGlobal colorHarmonizeEngine(
       sfmDataFilename, featuresFolders, matchesFolders, outputFolder, describerTypes, selectionMethod, imgRef);
 
-    if (colorHarmonizeEngine.Process())
+    if (colorHarmonizeEngine.process())
     {
         ALICEVISION_LOG_INFO("Color harmonization took: " << timer.elapsed() << " s");
         return EXIT_SUCCESS;

--- a/src/software/utils/main_sfmColorHarmonize.cpp
+++ b/src/software/utils/main_sfmColorHarmonize.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp>
 
@@ -78,7 +79,7 @@ int aliceVision_main(int argc, char** argv)
 
     const std::vector<feature::EImageDescriberType> describerTypes = feature::EImageDescriberType_stringToEnums(describerTypesName);
 
-    if (!fs::exists(outputFolder))
+    if (!utils::exists(outputFolder))
         fs::create_directory(outputFolder);
 
     // harmonization process

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 #include <aliceVision/panorama/sphericalMapping.hpp>
@@ -464,7 +465,7 @@ int aliceVision_main(int argc, char** argv)
     std::vector<std::string> imagePaths;
     {
         const fs::path path = fs::absolute(inputPath);
-        if (fs::exists(path))
+        if (utils::exists(path))
         {
             // Input is either :
             // - an image folder

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -15,6 +15,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/types.hpp>
 #include <aliceVision/utils/convert.hpp>
 
@@ -247,7 +248,7 @@ int aliceVision_main(int argc, char** argv)
         }
 
         // create recursively the provided out dir
-        if (!fs::exists(fs::path(outDir)))
+        if (!utils::exists(fs::path(outDir)))
         {
             // ALICEVISION_COUT("creating folder" << outDir);
             fs::create_directories(fs::path(outDir));

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -116,16 +116,17 @@ inline void pauseProcess()
     std::cin >> i;
 }
 
-bool ColorHarmonizationEngineGlobal::Process()
+bool ColorHarmonizationEngineGlobal::process()
 {
-    const std::string vec_harmonizeMethod[1] = {"quantifiedGainCompensation"};
+    const std::string vecHarmonizeMethod[1] = {"quantifiedGainCompensation"};
     const int harmonizeMethod = 0;
+    std::error_code ec;
 
     //-------------------
     // Load data
     //-------------------
 
-    if (!ReadInputData())
+    if (!readInputData())
         return false;
     if (_pairwiseMatches.empty())
     {
@@ -156,7 +157,7 @@ bool ColorHarmonizationEngineGlobal::Process()
     //-------------------
     // Keep the largest CC in the image graph
     //-------------------
-    if (!CleanGraph())
+    if (!cleanGraph())
     {
         std::cout << std::endl << "There is no largest CC in the graph" << std::endl;
         return false;
@@ -166,9 +167,9 @@ bool ColorHarmonizationEngineGlobal::Process()
     // Compute remaining camera node Id
     //-------------------
 
-    std::map<size_t, size_t> map_cameraNodeToCameraIndex;  // graph node Id to 0->Ncam
-    std::map<size_t, size_t> map_cameraIndexTocameraNode;  // 0->Ncam correspondance to graph node Id
-    std::set<size_t> set_indeximage;
+    std::map<size_t, size_t> mapCameraNodeToCameraIndex;  // graph node Id to 0->Ncam
+    std::map<size_t, size_t> mapCameraIndexTocameraNode;  // 0->Ncam correspondance to graph node Id
+    std::set<size_t> setIndexImage;
 
     for (size_t i = 0; i < _pairwiseMatches.size(); ++i)
     {
@@ -177,28 +178,28 @@ bool ColorHarmonizationEngineGlobal::Process()
 
         const size_t I = iter->first.first;
         const size_t J = iter->first.second;
-        set_indeximage.insert(I);
-        set_indeximage.insert(J);
+        setIndexImage.insert(I);
+        setIndexImage.insert(J);
     }
 
-    for (std::set<size_t>::const_iterator iterSet = set_indeximage.begin(); iterSet != set_indeximage.end(); ++iterSet)
+    for (std::set<size_t>::const_iterator iterSet = setIndexImage.begin(); iterSet != setIndexImage.end(); ++iterSet)
     {
-        map_cameraIndexTocameraNode[std::distance(set_indeximage.begin(), iterSet)] = *iterSet;
-        map_cameraNodeToCameraIndex[*iterSet] = std::distance(set_indeximage.begin(), iterSet);
+        mapCameraIndexTocameraNode[std::distance(setIndexImage.begin(), iterSet)] = *iterSet;
+        mapCameraNodeToCameraIndex[*iterSet] = std::distance(setIndexImage.begin(), iterSet);
     }
 
     std::cout << "\nRemaining cameras after CC filter : \n"
-              << map_cameraIndexTocameraNode.size() << " from a total of " << _fileNames.size() << std::endl;
+              << mapCameraIndexTocameraNode.size() << " from a total of " << _fileNames.size() << std::endl;
 
     size_t bin = 256;
     double minvalue = 0.0;
     double maxvalue = 255.0;
 
     // For each edge computes the selection masks and histograms (for the RGB channels)
-    std::vector<relativeColorHistogramEdge> map_relativeHistograms[3];
-    map_relativeHistograms[0].resize(_pairwiseMatches.size());
-    map_relativeHistograms[1].resize(_pairwiseMatches.size());
-    map_relativeHistograms[2].resize(_pairwiseMatches.size());
+    std::vector<relativeColorHistogramEdge> mapRelativeHistograms[3];
+    mapRelativeHistograms[0].resize(_pairwiseMatches.size());
+    mapRelativeHistograms[1].resize(_pairwiseMatches.size());
+    mapRelativeHistograms[2].resize(_pairwiseMatches.size());
 
     for (size_t i = 0; i < _pairwiseMatches.size(); ++i)
     {
@@ -274,13 +275,13 @@ bool ColorHarmonizationEngineGlobal::Process()
             if (!utils::exists(sEdge))
                 fs::create_directory(sEdge);
 
-            std::string out_filename_I = "00_mask_I.png";
-            out_filename_I = (fs::path(sEdge) / out_filename_I).string();
+            std::string outFilenameI = "00_mask_I.png";
+            outFilenameI = (fs::path(sEdge) / outFilenameI).string();
 
-            std::string out_filename_J = "00_mask_J.png";
-            out_filename_J = (fs::path(sEdge) / out_filename_J).string();
-            writeImage(out_filename_I, maskI, image::ImageWriteOptions());
-            writeImage(out_filename_J, maskJ, image::ImageWriteOptions());
+            std::string outFilenameJ = "00_mask_J.png";
+            outFilenameJ = (fs::path(sEdge) / outFilenameJ).string();
+            writeImage(outFilenameI, maskI, image::ImageWriteOptions());
+            writeImage(outFilenameJ, maskJ, image::ImageWriteOptions());
         }
 
         //-- Compute the histograms
@@ -294,37 +295,34 @@ bool ColorHarmonizationEngineGlobal::Process()
         int channelIndex = 0;  // RED channel
         colorHarmonization::CommonDataByPair::computeHisto(histoI, maskI, channelIndex, imageI);
         colorHarmonization::CommonDataByPair::computeHisto(histoJ, maskJ, channelIndex, imageJ);
-        relativeColorHistogramEdge& edgeR = map_relativeHistograms[channelIndex][i];
-        edgeR =
-          relativeColorHistogramEdge(map_cameraNodeToCameraIndex[viewI], map_cameraNodeToCameraIndex[viewJ], histoI.GetHist(), histoJ.GetHist());
+        relativeColorHistogramEdge& edgeR = mapRelativeHistograms[channelIndex][i];
+        edgeR = relativeColorHistogramEdge(mapCameraNodeToCameraIndex[viewI], mapCameraNodeToCameraIndex[viewJ], histoI.GetHist(), histoJ.GetHist());
 
         histoI = histoJ = utils::Histogram<double>(minvalue, maxvalue, bin);
         channelIndex = 1;  // GREEN channel
         colorHarmonization::CommonDataByPair::computeHisto(histoI, maskI, channelIndex, imageI);
         colorHarmonization::CommonDataByPair::computeHisto(histoJ, maskJ, channelIndex, imageJ);
-        relativeColorHistogramEdge& edgeG = map_relativeHistograms[channelIndex][i];
-        edgeG =
-          relativeColorHistogramEdge(map_cameraNodeToCameraIndex[viewI], map_cameraNodeToCameraIndex[viewJ], histoI.GetHist(), histoJ.GetHist());
+        relativeColorHistogramEdge& edgeG = mapRelativeHistograms[channelIndex][i];
+        edgeG = relativeColorHistogramEdge(mapCameraNodeToCameraIndex[viewI], mapCameraNodeToCameraIndex[viewJ], histoI.GetHist(), histoJ.GetHist());
 
         histoI = histoJ = utils::Histogram<double>(minvalue, maxvalue, bin);
         channelIndex = 2;  // BLUE channel
         colorHarmonization::CommonDataByPair::computeHisto(histoI, maskI, channelIndex, imageI);
         colorHarmonization::CommonDataByPair::computeHisto(histoJ, maskJ, channelIndex, imageJ);
-        relativeColorHistogramEdge& edgeB = map_relativeHistograms[channelIndex][i];
-        edgeB =
-          relativeColorHistogramEdge(map_cameraNodeToCameraIndex[viewI], map_cameraNodeToCameraIndex[viewJ], histoI.GetHist(), histoJ.GetHist());
+        relativeColorHistogramEdge& edgeB = mapRelativeHistograms[channelIndex][i];
+        edgeB = relativeColorHistogramEdge(mapCameraNodeToCameraIndex[viewI], mapCameraNodeToCameraIndex[viewJ], histoI.GetHist(), histoJ.GetHist());
     }
 
     std::cout << "\n -- \n SOLVE for color consistency with linear programming\n --" << std::endl;
     //-- Solve for the gains and offsets:
-    std::vector<size_t> vec_indexToFix;
-    vec_indexToFix.push_back(map_cameraNodeToCameraIndex[_imgRef]);
+    std::vector<size_t> vecIndexToFix;
+    vecIndexToFix.push_back(mapCameraNodeToCameraIndex[_imgRef]);
 
     using namespace aliceVision::linearProgramming;
 
-    std::vector<double> vec_solution_r(_fileNames.size() * 2 + 1);
-    std::vector<double> vec_solution_g(_fileNames.size() * 2 + 1);
-    std::vector<double> vec_solution_b(_fileNames.size() * 2 + 1);
+    std::vector<double> vecSolutionR(_fileNames.size() * 2 + 1);
+    std::vector<double> vecSolutionG(_fileNames.size() * 2 + 1);
+    std::vector<double> vecSolutionB(_fileNames.size() * 2 + 1);
 
     aliceVision::system::Timer timer;
 
@@ -335,108 +333,108 @@ bool ColorHarmonizationEngineGlobal::Process()
 #endif
     // Red channel
     {
-        SOLVER_LP_T lpSolver(vec_solution_r.size());
+        SOLVER_LP_T lpSolver(vecSolutionR.size());
 
-        GainOffsetConstraintBuilder cstBuilder(map_relativeHistograms[0], vec_indexToFix);
+        GainOffsetConstraintBuilder cstBuilder(mapRelativeHistograms[0], vecIndexToFix);
         LPConstraintsSparse constraint;
         cstBuilder.Build(constraint);
         lpSolver.setup(constraint);
         lpSolver.solve();
-        lpSolver.getSolution(vec_solution_r);
+        lpSolver.getSolution(vecSolutionR);
     }
     // Green channel
     {
-        SOLVER_LP_T lpSolver(vec_solution_g.size());
+        SOLVER_LP_T lpSolver(vecSolutionG.size());
 
-        GainOffsetConstraintBuilder cstBuilder(map_relativeHistograms[1], vec_indexToFix);
+        GainOffsetConstraintBuilder cstBuilder(mapRelativeHistograms[1], vecIndexToFix);
         LPConstraintsSparse constraint;
         cstBuilder.Build(constraint);
         lpSolver.setup(constraint);
         lpSolver.solve();
-        lpSolver.getSolution(vec_solution_g);
+        lpSolver.getSolution(vecSolutionG);
     }
     // Blue channel
     {
-        SOLVER_LP_T lpSolver(vec_solution_b.size());
+        SOLVER_LP_T lpSolver(vecSolutionB.size());
 
-        GainOffsetConstraintBuilder cstBuilder(map_relativeHistograms[2], vec_indexToFix);
+        GainOffsetConstraintBuilder cstBuilder(mapRelativeHistograms[2], vecIndexToFix);
         LPConstraintsSparse constraint;
         cstBuilder.Build(constraint);
         lpSolver.setup(constraint);
         lpSolver.solve();
-        lpSolver.getSolution(vec_solution_b);
+        lpSolver.getSolution(vecSolutionB);
     }
 
     std::cout << std::endl
               << " ColorHarmonization solving on a graph with: " << _pairwiseMatches.size() << " edges took (s): " << timer.elapsed() << std::endl
               << "LInfinity fitting error: \n"
-              << "- for the red channel is: " << vec_solution_r.back() << " gray level(s)" << std::endl
-              << "- for the green channel is: " << vec_solution_g.back() << " gray level(s)" << std::endl
-              << "- for the blue channel is: " << vec_solution_b.back() << " gray level(s)" << std::endl;
+              << "- for the red channel is: " << vecSolutionR.back() << " gray level(s)" << std::endl
+              << "- for the green channel is: " << vecSolutionG.back() << " gray level(s)" << std::endl
+              << "- for the blue channel is: " << vecSolutionB.back() << " gray level(s)" << std::endl;
 
     std::cout << "\n\nFound solution_r:\n";
-    std::copy(vec_solution_r.begin(), vec_solution_r.end(), std::ostream_iterator<double>(std::cout, " "));
+    std::copy(vecSolutionR.begin(), vecSolutionR.end(), std::ostream_iterator<double>(std::cout, " "));
 
     std::cout << "\n\nFound solution_g:\n";
-    std::copy(vec_solution_g.begin(), vec_solution_g.end(), std::ostream_iterator<double>(std::cout, " "));
+    std::copy(vecSolutionG.begin(), vecSolutionG.end(), std::ostream_iterator<double>(std::cout, " "));
 
     std::cout << "\n\nFound solution_b:\n";
-    std::copy(vec_solution_b.begin(), vec_solution_b.end(), std::ostream_iterator<double>(std::cout, " "));
+    std::copy(vecSolutionB.begin(), vecSolutionB.end(), std::ostream_iterator<double>(std::cout, " "));
     std::cout << std::endl;
 
-    std::cout << "\n\nThere is :\n" << set_indeximage.size() << " images to transform." << std::endl;
+    std::cout << "\n\nThere is :\n" << setIndexImage.size() << " images to transform." << std::endl;
 
     //-> convert solution to gain offset and creation of the LUT per image
-    auto progressDisplay = system::createConsoleProgressDisplay(set_indeximage.size(), std::cout);
-    for (std::set<size_t>::const_iterator iterSet = set_indeximage.begin(); iterSet != set_indeximage.end(); ++iterSet, ++progressDisplay)
+    auto progressDisplay = system::createConsoleProgressDisplay(setIndexImage.size(), std::cout);
+    for (std::set<size_t>::const_iterator iterSet = setIndexImage.begin(); iterSet != setIndexImage.end(); ++iterSet, ++progressDisplay)
     {
         const size_t imaNum = *iterSet;
         typedef Eigen::Matrix<double, 256, 1> Vec256;
-        std::vector<Vec256> vec_map_lut(3);
+        std::vector<Vec256> vecMapLut(3);
 
-        const size_t nodeIndex = std::distance(set_indeximage.begin(), iterSet);
+        const size_t nodeIndex = std::distance(setIndexImage.begin(), iterSet);
 
-        const double g_r = vec_solution_r[nodeIndex * 2];
-        const double offset_r = vec_solution_r[nodeIndex * 2 + 1];
-        const double g_g = vec_solution_g[nodeIndex * 2];
-        const double offset_g = vec_solution_g[nodeIndex * 2 + 1];
-        const double g_b = vec_solution_b[nodeIndex * 2];
-        const double offset_b = vec_solution_b[nodeIndex * 2 + 1];
+        const double gR = vecSolutionR[nodeIndex * 2];
+        const double offsetR = vecSolutionR[nodeIndex * 2 + 1];
+        const double gG = vecSolutionG[nodeIndex * 2];
+        const double offsetG = vecSolutionG[nodeIndex * 2 + 1];
+        const double gB = vecSolutionB[nodeIndex * 2];
+        const double offsetB = vecSolutionB[nodeIndex * 2 + 1];
 
         for (size_t k = 0; k < 256; ++k)
         {
-            vec_map_lut[0][k] = clamp(k * g_r + offset_r, 0., 255.);
-            vec_map_lut[1][k] = clamp(k * g_g + offset_g, 0., 255.);
-            vec_map_lut[2][k] = clamp(k * g_b + offset_b, 0., 255.);
+            vecMapLut[0][k] = clamp(k * gR + offsetR, 0., 255.);
+            vecMapLut[1][k] = clamp(k * gG + offsetG, 0., 255.);
+            vecMapLut[2][k] = clamp(k * gB + offsetB, 0., 255.);
         }
 
-        Image<RGBColor> image_c;
-        readImage(_fileNames[imaNum], image_c, image::EImageColorSpace::LINEAR);
+        Image<RGBColor> imageC;
+        readImage(_fileNames[imaNum], imageC, image::EImageColorSpace::LINEAR);
 
 #pragma omp parallel for
-        for (int j = 0; j < image_c.height(); ++j)
+        for (int j = 0; j < imageC.height(); ++j)
         {
-            for (int i = 0; i < image_c.width(); ++i)
+            for (int i = 0; i < imageC.width(); ++i)
             {
-                image_c(j, i)[0] = clamp(vec_map_lut[0][image_c(j, i)[0]], 0., 255.);
-                image_c(j, i)[1] = clamp(vec_map_lut[1][image_c(j, i)[1]], 0., 255.);
-                image_c(j, i)[2] = clamp(vec_map_lut[2][image_c(j, i)[2]], 0., 255.);
+                imageC(j, i)[0] = clamp(vecMapLut[0][imageC(j, i)[0]], 0., 255.);
+                imageC(j, i)[1] = clamp(vecMapLut[1][imageC(j, i)[1]], 0., 255.);
+                imageC(j, i)[2] = clamp(vecMapLut[2][imageC(j, i)[2]], 0., 255.);
             }
         }
 
-        const std::string out_folder =
-          (fs::path(_outputDirectory) / (EHistogramSelectionMethod_enumToString(_selectionMethod) + "_" + vec_harmonizeMethod[harmonizeMethod]))
+        const std::string outFolder =
+          (fs::path(_outputDirectory) / (EHistogramSelectionMethod_enumToString(_selectionMethod) + "_" + vecHarmonizeMethod[harmonizeMethod]))
             .string();
-        if (!utils::exists(out_folder))
-            fs::create_directory(out_folder);
-        const std::string out_filename = (fs::path(out_folder) / fs::path(_fileNames[imaNum]).filename()).string();
+        if (!utils::exists(outFolder))
+            fs::create_directory(outFolder);
+        const std::string outFilename = (fs::path(outFolder) / fs::path(_fileNames[imaNum]).filename()).string();
 
-        writeImage(out_filename, image_c, image::ImageWriteOptions());
+        writeImage(outFilename, imageC, image::ImageWriteOptions());
     }
     return true;
 }
 
-bool ColorHarmonizationEngineGlobal::ReadInputData()
+bool ColorHarmonizationEngineGlobal::readInputData()
 {
     if (!fs::is_directory(_outputDirectory))
     {
@@ -488,7 +486,7 @@ bool ColorHarmonizationEngineGlobal::ReadInputData()
     return true;
 }
 
-bool ColorHarmonizationEngineGlobal::CleanGraph()
+bool ColorHarmonizationEngineGlobal::cleanGraph()
 {
     // Create a graph from pairwise correspondences:
     // - keep the largest connected component.

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -10,6 +10,8 @@
 
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/system/Timer.hpp>
+#include <aliceVision/utils/filesIO.hpp>
+
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/sfm.hpp>
@@ -101,7 +103,7 @@ ColorHarmonizationEngineGlobal::ColorHarmonizationEngineGlobal(const std::string
     _selectionMethod(selectionMethod),
     _imgRef(imgRef)
 {
-    if (!fs::exists(outputDirectory))
+    if (!utils::exists(outputDirectory))
         fs::create_directory(outputDirectory);
 }
 
@@ -206,7 +208,6 @@ bool ColorHarmonizationEngineGlobal::Process()
         const size_t viewI = iter->first.first;
         const size_t viewJ = iter->first.second;
 
-        //
         const MatchesPerDescType& matchesPerDesc = iter->second;
 
         //-- Edges names:
@@ -270,7 +271,7 @@ bool ColorHarmonizationEngineGlobal::Process()
             std::string sEdge = _fileNames[viewI] + "_" + _fileNames[viewJ];
             sEdge = (fs::path(_outputDirectory) / sEdge).string();
 
-            if (!fs::exists(sEdge))
+            if (!utils::exists(sEdge))
                 fs::create_directory(sEdge);
 
             std::string out_filename_I = "00_mask_I.png";
@@ -426,7 +427,7 @@ bool ColorHarmonizationEngineGlobal::Process()
         const std::string out_folder =
           (fs::path(_outputDirectory) / (EHistogramSelectionMethod_enumToString(_selectionMethod) + "_" + vec_harmonizeMethod[harmonizeMethod]))
             .string();
-        if (!fs::exists(out_folder))
+        if (!utils::exists(out_folder))
             fs::create_directory(out_folder);
         const std::string out_filename = (fs::path(out_folder) / fs::path(_fileNames[imaNum]).filename()).string();
 

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.hpp
@@ -57,7 +57,7 @@ class ColorHarmonizationEngineGlobal
 
     ~ColorHarmonizationEngineGlobal();
 
-    virtual bool Process();
+    virtual bool process();
 
   private:
     EHistogramSelectionMethod _selectionMethod;
@@ -84,10 +84,10 @@ class ColorHarmonizationEngineGlobal
     std::string _outputDirectory;
 
     /// Clean graph
-    bool CleanGraph();
+    bool cleanGraph();
 
     /// Read input data (point correspondences)
-    bool ReadInputData();
+    bool readInputData();
 };
 
 }  // namespace aliceVision


### PR DESCRIPTION
## Description

This PR mirrors what has been done in QtAliceVision in alicevision/QtAliceVision#70 and catches the error code thrown by `std::filesystem::exists` to ensure that there is no unhandled thrown exception (for example if a file exists but the user does not have the correct access rights) that might cause the program to crash. 

Additionally, some functions and variables were renamed to respect the camelBack case.