### PR TITLE
PLY loader to SfMData landmarks

### DIFF
--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -41,6 +41,7 @@ alicevision_add_library(aliceVision_sfmDataIO
     aliceVision_sfmData
     aliceVision_camera
   PRIVATE_LINKS
+    assimp::assimp
     aliceVision_image
     Boost::regex
     Boost::boost

--- a/src/aliceVision/sfmDataIO/plyIO.hpp
+++ b/src/aliceVision/sfmDataIO/plyIO.hpp
@@ -23,5 +23,13 @@ namespace sfmDataIO {
  */
 bool savePLY(const sfmData::SfMData& sfmData, const std::string& filename, ESfMData partFlag);
 
+/**
+ * @brief Load the structure from a PLY file
+ * @param[in] sfmData The output SfMData
+ * @param[in] filename The filename
+ * @return true if completed
+ */
+bool loadPLY(sfmData::SfMData& sfmData, const std::string& filename);
+
 }  // namespace sfmDataIO
 }  // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/sfmDataIO.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIO.cpp
@@ -124,6 +124,10 @@ bool load(aliceVision::sfmData::SfMData& sfmData, const std::string& filename, E
         ALICEVISION_THROW_ERROR("Cannot load the ABC file: \"" << filename << "\", AliceVision is built without Alembic support.");
 #endif
     }
+    else if (extension == ".ply")
+    {
+        status = loadPLY(sfmData, filename);
+    }
     else if (fs::is_directory(filename))
     {
         status = readGt(filename, sfmData);


### PR DESCRIPTION
Load PLY as sfmData (fill only landmarks)

Relates to https://github.com/alicevision/Meshroom/pull/2346.