### PR TITLE
Remove ceres from automatic public dependencies

### DIFF
--- a/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/sfm/sfm.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/multiview/NViewDataSet.hpp>
 #include <aliceVision/fuseCut/Fuser.hpp>
 #include <aliceVision/fuseCut/PointCloud.hpp>

--- a/src/aliceVision/localization/CMakeLists.txt
+++ b/src/aliceVision/localization/CMakeLists.txt
@@ -38,6 +38,7 @@ alicevision_add_library(aliceVision_localization
     aliceVision_matchingImageCollection
     Boost::boost
     ${FLANN_LIBRARIES}
+    ${CERES_LIBRARIES}
 )
 
 if(ALICEVISION_HAVE_CCTAG)

--- a/src/aliceVision/multiview/CMakeLists.txt
+++ b/src/aliceVision/multiview/CMakeLists.txt
@@ -76,10 +76,10 @@ alicevision_add_library(aliceVision_multiview
   PUBLIC_LINKS
     aliceVision_numeric
     aliceVision_robustEstimation
-    ${CERES_LIBRARIES}
   PRIVATE_LINKS
     aliceVision_system
     ${LEMON_LIBRARY}
+    ${CERES_LIBRARIES}
 )
 
 alicevision_add_library(aliceVision_multiview_test_data

--- a/src/aliceVision/multiview/translationAveraging/translationAveragingTest.hpp
+++ b/src/aliceVision/multiview/translationAveraging/translationAveragingTest.hpp
@@ -15,9 +15,6 @@
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
 
-#include "ceres/ceres.h"
-#include "ceres/rotation.h"
-
 #include <fstream>
 #include <map>
 #include <utility>

--- a/src/aliceVision/rig/CMakeLists.txt
+++ b/src/aliceVision/rig/CMakeLists.txt
@@ -16,8 +16,8 @@ alicevision_add_library(aliceVision_rig
     aliceVision_geometry
     aliceVision_localization
     aliceVision_numeric
-    ${CERES_LIBRARIES}
   PRIVATE_LINKS
     aliceVision_sfm
     aliceVision_system
+    ${CERES_LIBRARIES}
 )

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -75,9 +75,9 @@ alicevision_add_library(aliceVision_sfm
     aliceVision_sfmData
     aliceVision_sfmDataIO
     Boost::boost
-    ${CERES_LIBRARIES}
   PRIVATE_LINKS
     ${LEMON_LIBRARY}
+    ${CERES_LIBRARIES}
 )
 
 # Unit tests
@@ -90,6 +90,7 @@ alicevision_add_test(bundle/bundleAdjustment_test.cpp
         aliceVision_feature
         aliceVision_system
         ${LEMON_LIBRARY}
+        ${CERES_LIBRARIES}
 )
 
 alicevision_add_test(bundle/bundleAdjustment_Enhanced_test.cpp
@@ -100,6 +101,7 @@ alicevision_add_test(bundle/bundleAdjustment_Enhanced_test.cpp
         aliceVision_feature
         aliceVision_system
         ${LEMON_LIBRARY}
+        ${CERES_LIBRARIES}
 )
 
 alicevision_add_test(utils/alignment_test.cpp
@@ -109,6 +111,7 @@ alicevision_add_test(utils/alignment_test.cpp
         aliceVision_multiview
         aliceVision_multiview_test_data
         ${LEMON_LIBRARY}
+        ${CERES_LIBRARIES}
 )
 
 add_subdirectory(pipeline)

--- a/src/aliceVision/sfm/pipeline/global/CMakeLists.txt
+++ b/src/aliceVision/sfm/pipeline/global/CMakeLists.txt
@@ -5,4 +5,5 @@ alicevision_add_test(globalSfM_test.cpp
         aliceVision_multiview_test_data
         aliceVision_feature
         aliceVision_system
+        ${CERES_LIBRARIES}
 )

--- a/src/aliceVision/sfm/pipeline/panorama/CMakeLists.txt
+++ b/src/aliceVision/sfm/pipeline/panorama/CMakeLists.txt
@@ -8,6 +8,7 @@ alicevision_add_test(panoramaSfM_radial3_test.cpp
         aliceVision_feature
         aliceVision_matching
         aliceVision_system
+        ${CERES_LIBRARIES}
 )
 
 alicevision_add_test(panoramaSfM_radial3_outliers_test.cpp
@@ -16,6 +17,7 @@ alicevision_add_test(panoramaSfM_radial3_outliers_test.cpp
         aliceVision_feature
         aliceVision_matching
         aliceVision_system
+        ${CERES_LIBRARIES}
 )
 
 alicevision_add_test(panoramaSfM_equidistant_test.cpp
@@ -24,6 +26,7 @@ alicevision_add_test(panoramaSfM_equidistant_test.cpp
         aliceVision_feature
         aliceVision_matching
         aliceVision_system
+        ${CERES_LIBRARIES}
 )
 
 alicevision_add_test(panoramaSfM_equidistant_outliers_test.cpp
@@ -32,5 +35,6 @@ alicevision_add_test(panoramaSfM_equidistant_outliers_test.cpp
         aliceVision_feature
         aliceVision_matching
         aliceVision_system
+        ${CERES_LIBRARIES}
 )
 

--- a/src/aliceVision/sfm/pipeline/panorama/panoramaSfM_test_common.hpp
+++ b/src/aliceVision/sfm/pipeline/panorama/panoramaSfM_test_common.hpp
@@ -7,7 +7,7 @@
 
 #include <aliceVision/feature/imageDescriberCommon.hpp>
 #include <aliceVision/sfm/utils/statistics.hpp>
-#include <aliceVision/sfm/sfm.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.hpp>
 
 #include <cmath>

--- a/src/aliceVision/sfm/pipeline/sequential/CMakeLists.txt
+++ b/src/aliceVision/sfm/pipeline/sequential/CMakeLists.txt
@@ -5,4 +5,5 @@ alicevision_add_test(sequentialSfM_test.cpp
         aliceVision_multiview_test_data
         aliceVision_feature
         aliceVision_system
+        ${CERES_LIBRARIES}
 )

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -88,6 +88,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # Track builder
@@ -102,6 +103,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_track
               Boost::program_options
               Boost::json
+              ${CERES_LIBRARIES}
     )
 
     # Relative pose
@@ -116,6 +118,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_track
               Boost::program_options
               Boost::json
+              ${CERES_LIBRARIES}
     )
 
     # Bootstraping SfM
@@ -130,6 +133,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_track
               Boost::program_options
               Boost::json
+              ${CERES_LIBRARIES}
     )
 
     # Incremental / Sequential SfM
@@ -144,6 +148,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # Incremental SFM for pure rotation
@@ -158,6 +163,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # SfM Triangulation
@@ -172,6 +178,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # Global SfM
@@ -186,6 +193,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # Compute structure from known camera poses
@@ -199,6 +207,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # Calibrate a camera
@@ -244,6 +253,7 @@ if(ALICEVISION_BUILD_SFM)
               Boost::program_options
               Boost::json
               Boost::boost
+              ${CERES_LIBRARIES}
     )
 
     # Calibrate a rig
@@ -360,6 +370,7 @@ if(ALICEVISION_BUILD_PANORAMA)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               ${Boost_LIBRARIES}
+              ${CERES_LIBRARIES}
     )
     alicevision_add_software(aliceVision_panoramaWarping
         SOURCE main_panoramaWarping.cpp
@@ -373,6 +384,7 @@ if(ALICEVISION_BUILD_PANORAMA)
               aliceVision_sfmDataIO
               aliceVision_panorama
               ${Boost_LIBRARIES}
+              ${CERES_LIBRARIES}
     )
     alicevision_add_software(aliceVision_panoramaMerging
         SOURCE main_panoramaMerging.cpp
@@ -426,6 +438,7 @@ if(ALICEVISION_BUILD_PANORAMA)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               ${Boost_LIBRARIES}
+              ${CERES_LIBRARIES}
     )
 endif()
 

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -29,6 +29,7 @@ if(ALICEVISION_BUILD_SFM)
                   ${CUDA_CUBLAS_LIBRARIES}
                   ${CUDA_cusparse_LIBRARY}
                   ${UNCERTAINTYTE_LIBRARY}
+                  ${CERES_LIBRARIES}
                   Boost::program_options
             INCLUDE_DIRS ${UNCERTAINTYTE_INCLUDE_DIR}
         )
@@ -51,6 +52,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmDataIO
               aliceVision_lensCorrectionProfile
               ${Boost_LIBRARIES}
+              ${CERES_LIBRARIES}
     )
 
     if(ALICEVISION_HAVE_OPENCV)
@@ -95,6 +97,7 @@ if(ALICEVISION_BUILD_SFM)
               Boost::program_options
               Boost::boost
               Boost::timer
+              ${CERES_LIBRARIES}
     )
 
     # Voctree statistics
@@ -122,6 +125,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # Transform rig
@@ -164,6 +168,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # SfM transfer
@@ -177,6 +182,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # SfM transform
@@ -190,6 +196,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # SfM to rig
@@ -225,6 +232,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_sfmData
               aliceVision_sfmDataIO
               Boost::program_options
+              ${CERES_LIBRARIES}
     )
 
     # SfM split reconstructed
@@ -259,6 +267,7 @@ if(ALICEVISION_BUILD_SFM)
               Boost::boost
               Boost::timer
               ${LEMON_LIBRARY}
+              ${CERES_LIBRARIES}
     )
 
     # Keyframe selection
@@ -287,6 +296,7 @@ if(ALICEVISION_BUILD_SFM)
               aliceVision_system
               aliceVision_cmdline
               ${Boost_LIBRARIES}
+              ${CERES_LIBRARIES}
     )
 
     # Perform color chart detection


### PR DESCRIPTION
Previously ceres was added to the list of public dependencies of many alicevision libraries. This is convenient because dependency is automatically resolved. However this dependency is propagated also in AliceVisionConfig.cmake, which we don't want for many reasons. 

Currently, ceres is deeply rooted inside many part of alicevision for no reasons. Mostly because BundleAdjustmentCeres.hpp declares a lot of ceres objects in its interface. A more future proof workaround would be to make this more private but would take more time to do.
