### PR TITLE
Option to Remove absolute paths to linked libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,10 +79,11 @@ option(ALICEVISION_USE_MESHSDFILTER "Use MeshSDFilter library (enable MeshDenois
 option(ALICEVISION_REQUIRE_CERES_WITH_SUITESPARSE "Require Ceres with SuiteSparse (ensure best performances)" ON)
 
 option(ALICEVISION_USE_RPATH "Add RPATH on software with relative paths to libraries" ON)
-
+option(ALICEVISION_REMOVE_ABSOLUTE "Remove absolute paths in dependencies" OFF)
 option(ALICEVISION_BUILD_TESTS "Build AliceVision tests" OFF)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 
 # Default build is in Release mode
 if(NOT CMAKE_BUILD_TYPE AND NOT MSVC)

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -45,18 +45,29 @@ function(alicevision_add_library library_name)
     cuda_add_library(${library_name} ${LIBRARY_SOURCES})
   endif()
 
+  
+  if (ALICEVISION_REMOVE_ABSOLUTE)
+    foreach (item ${LIBRARY_PUBLIC_LINKS})
+        get_filename_component(nameItem ${item} NAME)
+        list(APPEND TRANSFORMED_LIBRARY_PUBLIC_LINKS ${nameItem})
+    endforeach()
+  else()
+    set(TRANSFORMED_LIBRARY_PUBLIC_LINKS ${LIBRARY_PUBLIC_LINKS})
+  endif()
+
   # FindCUDA.cmake implicit	target_link_libraries() can not be mixed with new signature (CMake < 3.9.0)
   if(NOT LIBRARY_USE_CUDA)
     target_link_libraries(${library_name}
-      PUBLIC ${LIBRARY_PUBLIC_LINKS}
+      PUBLIC ${TRANSFORMED_LIBRARY_PUBLIC_LINKS}
       PRIVATE ${LIBRARY_PRIVATE_LINKS}
     )
   else()
     target_link_libraries(${library_name}
-       ${LIBRARY_PUBLIC_LINKS}
+       ${TRANSFORMED_LIBRARY_PUBLIC_LINKS}
        ${LIBRARY_PRIVATE_LINKS}
     )
   endif()
+
 
   target_include_directories(${library_name}
     PUBLIC $<BUILD_INTERFACE:${ALICEVISION_INCLUDE_DIR}>


### PR DESCRIPTION
Option to remove absolute paths to linked libraries, just keeping the library name. It is up to the build system to handle the paths. Disabled by default