### PR TITLE
Export radial3 distortion to nuke

### DIFF
--- a/pyTests/camera/test_undistortion_radial.py
+++ b/pyTests/camera/test_undistortion_radial.py
@@ -1,5 +1,5 @@
 """
-Collection of unit tests for the 3DE Undistortion model.
+Collection of unit tests for the Radial K3 Undistortion model.
 """
 
 import pytest
@@ -8,7 +8,7 @@ from pyalicevision import camera as av
 
 ##################
 ### List of functions:
-# - Undistortion3DEAnamorphic4(int width, int height) => DONE
+# - UndistortionRadialK3(int width, int height) => DONE
 # - EUNDISTORTION getType() => DONE
 # - Undistortion* clone() => DONE
 # - Vec2 undistortNormalized(Vec2& p) / Vec2 not binded
@@ -35,21 +35,21 @@ from pyalicevision import camera as av
 # - Vec2 inverse(Vec2& p) / Vec2 not binded
 ##################
 
-DEFAULT_PARAMETERS = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
-NON_DEFAULT_PARAMETERS = (0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+DEFAULT_PARAMETERS = (0.0, 0.0, 0.0)
+NON_DEFAULT_PARAMETERS = (0.1, 0.0, 0.2)
 WIDTH = 1000
 HEIGHT = 800
 
-def test_undistortion_3de_constructor():
-    """ Test creating an Undistortion3DEAnamorphic4 object and checking its set
+def test_undistortion_radial_constructor():
+    """ Test creating an UndistortionRadialK3 object and checking its set
     values are correct. """
-    undistortion = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
+    undistortion = av.UndistortionRadialK3(WIDTH, HEIGHT)
 
     size = undistortion.getSize()
     # TODO: uncomment when Vec2 is binded
     # assert size[0] == WIDTH and size[1] == HEIGHT
 
-    assert undistortion.getType() == av.UNDISTORTION_3DEANAMORPHIC4
+    assert undistortion.getType() == av.UNDISTORTION_RADIALK3
 
     parameters = undistortion.getParameters()
     assert parameters == DEFAULT_PARAMETERS
@@ -58,10 +58,10 @@ def test_undistortion_3de_constructor():
     assert undistortion.getUndistortionParametersCount() == len(DEFAULT_PARAMETERS)
 
 
-def test_undistortion_3de_get_set_parameters():
-    """ Test creating an Undistortion3DEAnamorphic4 object and manipulating its
+def test_undistortion_radial_get_set_parameters():
+    """ Test creating an UndistortionRadialK3 object and manipulating its
     undistortion parameters. """
-    undistortion = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
+    undistortion = av.UndistortionRadialK3(WIDTH, HEIGHT)
     parameters = undistortion.getParameters()
     assert parameters == DEFAULT_PARAMETERS
 
@@ -83,15 +83,15 @@ def test_undistortion_3de_get_set_parameters():
     assert parameters == undistortion.getParameters()
 
 
-def test_undistortion_3de_compare():
-    """ Test creating different Undistortion3DEAnamorphic4 objects and comparing them
+def test_undistortion_radial_compare():
+    """ Test creating different UndistortionRadialK3 objects and comparing them
     with the '==' operator. """
-    undistortion1 = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
-    undistortion2 = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
+    undistortion1 = av.UndistortionRadialK3(WIDTH, HEIGHT)
+    undistortion2 = av.UndistortionRadialK3(WIDTH, HEIGHT)
     assert undistortion1 == undistortion2
 
     # The '==' operator only compares the undistortion parameters and ignores the size
-    undistortion3 = av.Undistortion3DEAnamorphic4(HEIGHT, WIDTH)
+    undistortion3 = av.UndistortionRadialK3(HEIGHT, WIDTH)
     assert undistortion1 == undistortion3
 
     # Update the undistortion parameters before comparing again
@@ -99,10 +99,10 @@ def test_undistortion_3de_compare():
     assert not undistortion1 == undistortion3
 
 
-def test_undistortion_3de_clone():
-    """ Test creating an Undistortion3DEAnamorphic4 object, cloning it, and checking
+def test_undistortion_radial_clone():
+    """ Test creating an UndistortionRadialK3 object, cloning it, and checking
     the values of the cloned object are correct. """
-    undistortion1 = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
+    undistortion1 = av.UndistortionRadialK3(WIDTH, HEIGHT)
     undistortion2 = undistortion1.clone()
     assert undistortion1 == undistortion2
 
@@ -112,10 +112,10 @@ def test_undistortion_3de_clone():
     assert undistortion2.getParameters() == DEFAULT_PARAMETERS
 
 
-def test_undistortion_3de_get_set_size():
-    """ Test creating an Undistortion3DEAnamorphic4 object and getting/setting its
+def test_undistortion_radial_get_set_size():
+    """ Test creating an UndistortionRadialK3 object and getting/setting its
     size. """
-    undistortion = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
+    undistortion = av.UndistortionRadialK3(WIDTH, HEIGHT)
     size = undistortion.getSize()
     # TODO: uncomment when Vec2 is binded
     # assert size[0] == WIDTH and size[1] == HEIGHT
@@ -128,6 +128,6 @@ def test_undistortion_3de_get_set_size():
 
 
 @pytest.mark.skip(reason="Vec2 not binded")
-def test_undistortion_3de_get_set_offset():
-    """ Test creating an Undistortion3DEAnamorphic4 object and manipulating its offset. """
+def test_undistortion_radial_get_set_offset():
+    """ Test creating an UndistortionRadialK3 object and manipulating its offset. """
     assert True

--- a/src/aliceVision/calibration/distortionEstimation.cpp
+++ b/src/aliceVision/calibration/distortionEstimation.cpp
@@ -108,6 +108,83 @@ class CostLine : public ceres::CostFunction
     Vec2 _pt;
 };
 
+class CostPoint : public ceres::CostFunction
+{
+public:
+    CostPoint(std::shared_ptr<camera::Undistortion> & undistortion, const Vec2& ptUndistorted, const Vec2 &ptDistorted)
+        : _ptUndistorted(ptUndistorted)
+        , _ptDistorted(ptDistorted)
+        , _undistortion(undistortion)
+    {
+        set_num_residuals(2);
+        mutable_parameter_block_sizes()->push_back(2);
+        mutable_parameter_block_sizes()->push_back(undistortion->getUndistortionParametersCount());
+    }
+
+    bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
+    {
+        const double* parameter_center = parameters[0];
+        const double* parameter_disto = parameters[1];
+
+        const int undistortionSize = _undistortion->getUndistortionParametersCount();
+
+        //Read parameters and update camera
+        std::vector<double> undistortionParams(undistortionSize);
+
+        for (int idParam = 0; idParam < undistortionSize; idParam++)
+        {
+            undistortionParams[idParam] = parameter_disto[idParam];
+        }
+        _undistortion->setParameters(undistortionParams);
+
+        Vec2 offset;
+        offset.x() = parameter_center[0];
+        offset.y() = parameter_center[1];
+        _undistortion->setOffset(offset);
+
+        //Estimate measure
+        const Vec2 ipt = _undistortion->undistort(_ptDistorted);
+
+        const Vec2 hsize = (_undistortion->getSize() * 0.5);
+        Vec2 npt = (_ptDistorted - hsize);
+        npt.x() = npt.x() / hsize.x();
+        npt.y() = npt.y() / hsize.y();
+
+        const double w1 = std::max(std::abs(npt.x()), std::abs(npt.y()));
+        const double w = w1 * w1;
+
+        residuals[0] = w * (ipt.x() - _ptUndistorted.x());
+        residuals[1] = w * (ipt.y() - _ptUndistorted.y());
+
+        if(jacobians == nullptr)
+        {
+            return true;
+        }
+
+
+        if(jacobians[0] != nullptr)
+        {
+            Eigen::Map<Eigen::Matrix<double, 2, 2, Eigen::RowMajor>> J(jacobians[0]);
+
+            J = w * _undistortion->getDerivativeUndistortWrtOffset(_ptDistorted);
+        }
+
+        if(jacobians[1] != nullptr)
+        {
+            Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobians[1], 2, undistortionSize);
+
+            J = w * _undistortion->getDerivativeUndistortWrtParameters(_ptDistorted);
+        }
+
+        return true;
+    }
+
+private:
+    std::shared_ptr<camera::Undistortion> _undistortion;
+    Vec2 _ptUndistorted;
+    Vec2 _ptDistorted;
+};
+
 bool estimate(std::shared_ptr<camera::Undistortion> undistortionToEstimate,
               Statistics& statistics,
               std::vector<LineWithPoints>& lines,
@@ -233,12 +310,141 @@ bool estimate(std::shared_ptr<camera::Undistortion> undistortionToEstimate,
     const double mean = std::accumulate(errors.begin(), errors.end(), 0.0) / static_cast<double>(errors.size());
     const double sqSum = std::inner_product(errors.begin(), errors.end(), errors.begin(), 0.0);
     const double stddev = std::sqrt(sqSum / errors.size() - mean * mean);
-    std::nth_element(errors.begin(), errors.begin() + errors.size() / 2, errors.end());
+    std::sort(errors.begin(), errors.end());
     const double median = errors[errors.size() / 2];
+    const double max = errors[errors.size() - 1];
 
     statistics.mean = mean;
     statistics.stddev = stddev;
     statistics.median = median;
+    statistics.max = max;
+
+    return true;
+}
+
+bool estimate(std::shared_ptr<camera::Undistortion> undistortionToEstimate,
+              Statistics& statistics,
+              const std::vector<PointPair>& pointpairs,
+              bool lockCenter,
+              const std::vector<bool>& lockDistortions)
+{
+    if (!undistortionToEstimate)
+    {
+        return false;
+    }
+
+    if (pointpairs.empty())
+    {
+        return false;
+    }
+
+    ceres::Problem problem;
+    ceres::LossFunction* lossFunction =  new ceres::HuberLoss(2.0);
+
+    std::vector<double> undistortionParameters = undistortionToEstimate->getParameters();
+    Vec2 undistortionOffset = undistortionToEstimate->getOffset();
+
+    const std::size_t countUndistortionParams = undistortionParameters.size();
+
+    if (lockDistortions.size() != countUndistortionParams)
+    {
+        ALICEVISION_LOG_ERROR("Invalid number of distortion parameters (lockDistortions=" << lockDistortions.size() << ", countDistortionParams="
+                                                                                          << countUndistortionParams << ").");
+        return false;
+    }
+
+    double* ptrUndistortionParameters = &undistortionParameters[0];
+    double* center = &undistortionOffset.x();
+
+    // Add off center parameter
+    problem.AddParameterBlock(center, 2);
+    if (lockCenter)
+    {
+        problem.SetParameterBlockConstant(center);
+    }
+
+    // Add distortion parameter
+    problem.AddParameterBlock(ptrUndistortionParameters, countUndistortionParams);
+
+    // Check if all distortions are locked
+    bool allLocked = true;
+    for (bool lock : lockDistortions)
+    {
+        if (!lock)
+        {
+            allLocked = false;
+        }
+    }
+
+    if (allLocked)
+    {
+        problem.SetParameterBlockConstant(ptrUndistortionParameters);
+    }
+    else
+    {
+        // At least one parameter is not locked
+
+        std::vector<int> constantDistortions;
+        for (int idParamDistortion = 0; idParamDistortion < lockDistortions.size(); ++idParamDistortion)
+        {
+            if (lockDistortions[idParamDistortion])
+            {
+                constantDistortions.push_back(idParamDistortion);
+            }
+        }
+
+        if (!constantDistortions.empty())
+        {
+            ceres::SubsetManifold* subsetManifold = new ceres::SubsetManifold(countUndistortionParams, constantDistortions);
+            problem.SetManifold(ptrUndistortionParameters, subsetManifold);
+        }
+    }
+
+    for (auto& ppt : pointpairs)
+    {
+        ceres::CostFunction* costFunction = new CostPoint(undistortionToEstimate, ppt.undistortedPoint, ppt.distortedPoint);
+        problem.AddResidualBlock(costFunction, lossFunction, center, ptrUndistortionParameters);
+    }
+
+    ceres::Solver::Options options;
+    options.use_inner_iterations = true;
+    options.max_num_iterations = 100;
+    options.logging_type = ceres::SILENT;
+
+    ceres::Solver::Summary summary;
+    ceres::Solve(options, &problem, &summary);
+
+    ALICEVISION_LOG_TRACE(summary.FullReport());
+
+    if (!summary.IsSolutionUsable())
+    {
+        ALICEVISION_LOG_ERROR("Lens calibration estimation failed.");
+        return false;
+    }
+
+    undistortionToEstimate->setOffset(undistortionOffset);
+    undistortionToEstimate->setParameters(undistortionParameters);
+    std::vector<double> errors;
+
+    for (auto& ppt : pointpairs)
+    {
+        const Vec2 ipt = undistortionToEstimate->undistort(ppt.distortedPoint);
+        const double res = (ipt - ppt.undistortedPoint).norm();
+        errors.push_back(res);
+    }
+
+    const double mean = std::accumulate(errors.begin(), errors.end(), 0.0) / static_cast<double>(errors.size());
+    const double sqSum = std::inner_product(errors.begin(), errors.end(), errors.begin(), 0.0);
+    const double stddev = std::sqrt(sqSum / errors.size() - mean * mean);
+    std::sort(errors.begin(), errors.end());
+    const double median = errors[errors.size() / 2];
+    const double max = errors[errors.size() - 1];
+
+
+    statistics.mean = mean;
+    statistics.stddev = stddev;
+    statistics.median = median;
+    statistics.max = max;
 
     return true;
 }

--- a/src/aliceVision/calibration/distortionEstimation.hpp
+++ b/src/aliceVision/calibration/distortionEstimation.hpp
@@ -33,6 +33,18 @@ struct LineWithPoints
 };
 
 /**
+ * @brief a pair of points coordinates
+ * 
+ * One vector for the distorted coordinates
+ * One vector from the undistorted coordinates
+*/
+struct PointPair
+{
+    Vec2 distortedPoint;
+    Vec2 undistortedPoint;
+};
+
+/**
  * @brief Statistics on distortion parameters estimation error.
  */
 struct Statistics
@@ -40,6 +52,7 @@ struct Statistics
     double mean;
     double stddev;
     double median;
+    double max;
 };
 
 /**
@@ -57,6 +70,25 @@ struct Statistics
 bool estimate(std::shared_ptr<camera::Undistortion> undistortionToEstimate,
               Statistics& statistics,
               std::vector<LineWithPoints>& lines,
+              bool lockCenter,
+              const std::vector<bool>& lockDistortions);
+
+
+/**
+ * @brief Estimate the undistortion parameters of a camera using a set of pair of undistorted/distorted points.
+ *
+ * This algorithms minimizes a distance between points and points using distortion.
+ *
+ * @param[out] undistortionToEstimate Undistortion object with the parameters to estimate.
+ * @param[out] statistics Statistics on the estimation error.
+ * @param[in] pointpairs Set of pair of points used to estimate distortion.
+ * @param[in] lockCenter Lock the distortion offset during optimization.
+ * @param[in] lockDistortions Distortion parameters to lock during optimization.
+ * @return False if the estimation failed, otherwise true.
+ */
+bool estimate(std::shared_ptr<camera::Undistortion> undistortionToEstimate,
+              Statistics& statistics,
+              const std::vector<PointPair>& pointpairs,
               bool lockCenter,
               const std::vector<bool>& lockDistortions);
 

--- a/src/aliceVision/camera/CMakeLists.txt
+++ b/src/aliceVision/camera/CMakeLists.txt
@@ -11,6 +11,7 @@ set(camera_files_headers
 	DistortionRadial.hpp
 	Undistortion.hpp
 	Undistortion3DE.hpp
+    UndistortionRadial.hpp
 	Equidistant.hpp
 	IntrinsicBase.hpp
 	IntrinsicInitMode.hpp
@@ -25,6 +26,7 @@ set(camera_files_sources
     DistortionFisheye.cpp
     DistortionFisheye1.cpp
     DistortionRadial.cpp
+    UndistortionRadial.cpp
     Equidistant.cpp
     IntrinsicBase.cpp
     IntrinsicScaleOffset.cpp

--- a/src/aliceVision/camera/Camera.i
+++ b/src/aliceVision/camera/Camera.i
@@ -26,6 +26,7 @@ using namespace aliceVision::camera;
 %include <aliceVision/camera/DistortionFisheye1.i>
 %include <aliceVision/camera/DistortionRadial.i>
 %include <aliceVision/camera/Undistortion3DE.i>
+%include <aliceVision/camera/UndistortionRadial.i>
 
 %include <aliceVision/camera/IntrinsicInitMode.i>
 %include <aliceVision/camera/Equidistant.i>

--- a/src/aliceVision/camera/Undistortion.hpp
+++ b/src/aliceVision/camera/Undistortion.hpp
@@ -59,6 +59,8 @@ class Undistortion
 
     inline Vec2 getOffset() const { return _offset; }
 
+    inline Vec2 getScaledOffset() const { return _offset / _diagonal; }
+
     Vec2 getSize() const { return _size; }
 
     inline double getDiagonal() const { return _diagonal; }

--- a/src/aliceVision/camera/UndistortionRadial.cpp
+++ b/src/aliceVision/camera/UndistortionRadial.cpp
@@ -1,0 +1,100 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "UndistortionRadial.hpp"
+
+namespace aliceVision {
+namespace camera {
+
+Vec2 UndistortionRadialK3::undistortNormalized(const Vec2& p) const
+{
+    const double& k1 = _undistortionParams[0];
+    const double& k2 = _undistortionParams[1];
+    const double& k3 = _undistortionParams[2];
+
+    const double r = sqrt(p(0) * p(0) + p(1) * p(1));
+
+    const double r2 = r * r;
+    const double r4 = r2 * r2;
+    const double r6 = r4 * r2;
+    const double r_coeff = (1. + k1 * r2 + k2 * r4 + k3 * r6);
+
+    return p * r_coeff;
+}
+
+Eigen::Matrix<double, 2, 2> UndistortionRadialK3::getDerivativeUndistortNormalizedwrtPoint(const Vec2& p) const
+{
+    const double& k1 = _undistortionParams[0];
+    const double& k2 = _undistortionParams[1];
+    const double& k3 = _undistortionParams[2];
+
+    const double r2 = p(0) * p(0) + p(1) * p(1);
+    const double eps = 1e-21;
+    if (r2 < eps)
+    {
+        return Eigen::Matrix2d::Identity();
+    }
+
+    const double r4 = r2 * r2;
+    const double r6 = r4 * r2;
+
+    const double r_coeff = 1.0 + k1 * r2 + k2 * r4 + k3 * r6;
+    const double d_coeff = 2.0 * k1 + 4.0 * k2 * r2 + 6.0 * k3 * r4;
+
+    Eigen::Matrix2d ret;
+    ret(0, 0) = r_coeff + p(0) * d_coeff * p(0);
+    ret(0, 1) = p(0) * d_coeff * p(1);
+    ret(1, 0) = p(1) * d_coeff * p(0);
+    ret(1, 1) = r_coeff + p(1) * d_coeff * p(1);
+
+    return ret;
+}
+
+Eigen::Matrix<double, 2, Eigen::Dynamic> UndistortionRadialK3::getDerivativeUndistortNormalizedwrtParameters(const Vec2& p) const
+{
+    const double r2 = p(0) * p(0) + p(1) * p(1);
+    const double eps = 1e-21;
+    if (r2 < eps)
+    {
+        return Eigen::Matrix<double, 2, 3>::Zero();
+    }
+
+    const double r4 = r2 * r2;
+    const double r6 = r4 * r2;
+
+    Eigen::Matrix<double, 2, 3> ret;
+    ret(0, 0) = p(0) * r2;
+    ret(0, 1) = p(0) * r4;
+    ret(0, 2) = p(0) * r6;
+    ret(1, 0) = p(1) * r2;
+    ret(1, 1) = p(1) * r4;
+    ret(1, 2) = p(1) * r6;
+
+    return ret;
+}
+
+Vec2 UndistortionRadialK3::inverseNormalized(const Vec2& p) const
+{
+    const double epsilon = 1e-8;
+    Vec2 distorted_value = p;
+
+    Vec2 diff = undistortNormalized(distorted_value) - p;
+
+    int iter = 0;
+    while (diff.norm() > epsilon)
+    {
+        distorted_value = distorted_value - getDerivativeUndistortNormalizedwrtPoint(distorted_value).inverse() * diff;
+        diff = undistortNormalized(distorted_value) - p;
+        iter++;
+        if (iter > 100)
+            break;
+    }
+
+    return distorted_value;
+}
+
+}  // namespace camera
+}  // namespace aliceVision

--- a/src/aliceVision/camera/UndistortionRadial.hpp
+++ b/src/aliceVision/camera/UndistortionRadial.hpp
@@ -1,0 +1,47 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/camera/Undistortion.hpp>
+#include <aliceVision/numeric/numeric.hpp>
+
+#include <vector>
+#include <cmath>
+
+namespace aliceVision {
+namespace camera {
+
+class UndistortionRadialK3 : public Undistortion
+{
+  public:
+    /**
+     * @brief Default constructor, no distortion.
+     */
+    UndistortionRadialK3(int width, int height)
+      : Undistortion(width, height)
+    {
+        _undistortionParams = {0.0, 0.0, 0.0};
+    }
+
+    EUNDISTORTION getType() const override { return EUNDISTORTION::UNDISTORTION_RADIALK3; }
+
+    Undistortion* clone() const override { return new UndistortionRadialK3(*this); }
+
+    Vec2 undistortNormalized(const Vec2& p) const override;
+
+    Eigen::Matrix<double, 2, 2> getDerivativeUndistortNormalizedwrtPoint(const Vec2& p) const override;
+
+    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeUndistortNormalizedwrtParameters(const Vec2& p) const override;
+
+    /// add distortion (return p' such that undisto(p') = p)
+    Vec2 inverseNormalized(const Vec2& p) const override;
+
+    virtual ~UndistortionRadialK3() = default;
+};
+
+}  // namespace camera
+}  // namespace aliceVision

--- a/src/aliceVision/camera/UndistortionRadial.i
+++ b/src/aliceVision/camera/UndistortionRadial.i
@@ -1,0 +1,14 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%include <aliceVision/camera/Undistortion.i>
+%include <aliceVision/camera/UndistortionRadial.hpp>
+
+%{
+#include <aliceVision/camera/UndistortionRadial.hpp>
+using namespace aliceVision;
+using namespace aliceVision::camera;
+%}

--- a/src/aliceVision/camera/camera.hpp
+++ b/src/aliceVision/camera/camera.hpp
@@ -16,6 +16,7 @@
 #include <aliceVision/camera/DistortionRadial.hpp>
 #include <aliceVision/camera/Undistortion.hpp>
 #include <aliceVision/camera/Undistortion3DE.hpp>
+#include <aliceVision/camera/UndistortionRadial.hpp>
 #include <aliceVision/camera/IntrinsicBase.hpp>
 #include <aliceVision/camera/Pinhole.hpp>
 #include <aliceVision/camera/Equidistant.hpp>
@@ -98,6 +99,9 @@ inline std::shared_ptr<Undistortion> createUndistortion(EUNDISTORTION undistorti
 
     switch (undistortionType)
     {
+        case EUNDISTORTION::UNDISTORTION_RADIALK3:
+            undistortion = std::make_shared<UndistortionRadialK3>(w, h);
+            break;
         case EUNDISTORTION::UNDISTORTION_3DEANAMORPHIC4:
             undistortion = std::make_shared<Undistortion3DEAnamorphic4>(w, h);
             break;

--- a/src/aliceVision/camera/cameraCommon.hpp
+++ b/src/aliceVision/camera/cameraCommon.hpp
@@ -36,6 +36,7 @@ enum EDISTORTION
 enum EUNDISTORTION
 {
     UNDISTORTION_NONE,
+    UNDISTORTION_RADIALK3,
     UNDISTORTION_3DEANAMORPHIC4
 };
 
@@ -183,6 +184,10 @@ inline EUNDISTORTION EUNDISTORTION_stringToEnum(const std::string& undistortion)
     {
         return EUNDISTORTION::UNDISTORTION_3DEANAMORPHIC4;
     }
+    else if (type == "radialk3")
+    {
+        return EUNDISTORTION::UNDISTORTION_RADIALK3;
+    }
     else if (type == "none")
     {
         return EUNDISTORTION::UNDISTORTION_NONE;
@@ -197,6 +202,8 @@ inline std::string EUNDISTORTION_enumToString(EUNDISTORTION undistortion)
     {
         case EUNDISTORTION::UNDISTORTION_3DEANAMORPHIC4:
             return "3deanamorphic4";
+        case EUNDISTORTION::UNDISTORTION_RADIALK3:
+            return "radialk3";
         case EUNDISTORTION::UNDISTORTION_NONE:
             return "none";
     }

--- a/src/software/convert/CMakeLists.txt
+++ b/src/software/convert/CMakeLists.txt
@@ -49,6 +49,21 @@ if(ALICEVISION_BUILD_SFM)
                 nanoflann
         )
     endif()
+
+    # Convert Distortion format (from one to another)
+    alicevision_add_software(aliceVision_convertDistortion
+        SOURCE main_convertDistortion.cpp
+        FOLDER ${FOLDER_SOFTWARE_CONVERT}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_feature
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              aliceVision_calibration
+              Boost::program_options
+              Boost::system
+    )
+    
 endif() # ALICEVISION_BUILD_SFM
 
 

--- a/src/software/convert/main_convertDistortion.cpp
+++ b/src/software/convert/main_convertDistortion.cpp
@@ -1,0 +1,211 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+
+#include <aliceVision/calibration/distortionEstimation.hpp>
+#include <aliceVision/camera/UndistortionRadial.hpp>
+
+#include <boost/program_options.hpp>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+bool estimateDistortionMultiStep(std::shared_ptr<camera::Undistortion> undistortion,
+                                 calibration::Statistics& statistics,
+                                 const std::vector<calibration::PointPair>& ppts,
+                                 const std::vector<double> & initialParams,
+                                 const std::vector<std::vector<bool>> & lockSteps)
+{
+    undistortion->setParameters(initialParams);
+
+    for (std::size_t i = 0; i < lockSteps.size(); ++i)
+    {
+        if (!calibration::estimate(undistortion, statistics, ppts, false, lockSteps[i]))
+        {
+            ALICEVISION_LOG_ERROR("Failed to calibrate at step " << i);
+            return false;
+        }
+
+        ALICEVISION_LOG_INFO("Result quality of calibration: ");
+        ALICEVISION_LOG_INFO("Mean of error (stddev): " << statistics.mean << "(" << statistics.stddev << ")");
+        ALICEVISION_LOG_INFO("Median of error: " << statistics.median);
+        ALICEVISION_LOG_INFO("Max of error: " << statistics.max);
+    }
+
+    if (statistics.median > 1.0)
+    {
+        ALICEVISION_LOG_ERROR("Median is too high for a correct result");
+        return false;
+    }
+
+    return true;
+}
+
+bool convert(std::shared_ptr<camera::Undistortion> & undistortion, const camera::IntrinsicBase & intrinsic, const sfmData::Landmarks & landmarks)
+{
+    std::vector<calibration::PointPair> ppts;
+    for (const auto & pland : landmarks)
+    {
+        for (const auto pobs : pland.second.getObservations())
+        {
+            calibration::PointPair ppt;
+            ppt.distortedPoint = pobs.second.getCoordinates();
+            ppt.undistortedPoint = intrinsic.getUndistortedPixel(ppt.distortedPoint);
+
+            Vec2 check = intrinsic.getDistortedPixel(ppt.undistortedPoint);
+            if ((check - ppt.distortedPoint).norm() > 1e-2)
+            {
+                ALICEVISION_LOG_ERROR("error undistorting point");
+                continue;
+            }
+
+            ppts.push_back(ppt);
+        }
+    }
+
+    std::vector<double> initialParams;
+    std::vector<std::vector<bool>> lockSteps;
+
+    switch (undistortion->getType())
+    {
+    case camera::EUNDISTORTION::UNDISTORTION_RADIALK3:
+        initialParams = {0.0, 0.0, 0.0};
+        lockSteps = {
+                        {false, false, false},
+                    };
+        break;
+    default:
+        ALICEVISION_LOG_ERROR("Unsupported camera model for convertion.");
+        return false;
+    };
+
+
+    calibration::Statistics statistics;
+    if (!estimateDistortionMultiStep(undistortion, statistics, ppts, initialParams, lockSteps))
+    {
+        ALICEVISION_LOG_ERROR("Error estimating distortion");
+        return false;
+    }
+
+    return true;
+}
+
+// convert from a SfMData format to another
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string outputSfMDataFilename;
+
+    // user optional parameters
+    std::string from = "distortion";
+    std::string to = "undistortion";
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(),
+         "SfMData file.")
+        ("output,o", po::value<std::string>(&outputSfMDataFilename)->required(),
+         "Path to the output Alembic file.")
+        ("from,f", po::value<std::string>(&from)->required(),
+         "distortion model to convert from.")
+        ("to,t", po::value<std::string>(&to)->required(),
+         "distortion model to convert to.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision convertSfMFormat");
+    cmdline.add(requiredParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    
+    // load input SfMData scene
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    for (auto & pairIntrinsic : sfmData.getIntrinsics())
+    {
+        auto & intrinsic = pairIntrinsic.second;
+        if (intrinsic == nullptr)
+        {
+            continue;
+        }
+
+        //We're only interested in intrinsics with distortion
+        std::shared_ptr<camera::IntrinsicScaleOffsetDisto> isod = std::dynamic_pointer_cast<camera::IntrinsicScaleOffsetDisto>(intrinsic);
+        if (isod == nullptr)
+        {
+            continue;
+        }
+
+        if (from == "distortion")
+        {
+            if (to == "undistortion")
+            {
+                std::shared_ptr<camera::Distortion> distortion = isod->getDistortion();
+                std::shared_ptr<camera::Undistortion> undistortion;
+                
+                switch (distortion->getType())
+                {
+                case camera::EDISTORTION::DISTORTION_RADIALK3:
+                    undistortion = std::make_shared<camera::UndistortionRadialK3>(isod->w(), isod->h());
+                    break;
+                default:
+                    ALICEVISION_LOG_ERROR("Can't convert from" << distortion->getType());
+                    break;
+                };
+
+                if (convert(undistortion, *intrinsic, sfmData.getLandmarks()))
+                {
+                    isod->setDistortionObject(nullptr);
+                    isod->setUndistortionObject(undistortion);
+                }
+                else
+                {
+                    ALICEVISION_LOG_ERROR("Error converting distortion in intrinsic " << pairIntrinsic.first);
+                }
+            }
+            else 
+            {
+                ALICEVISION_LOG_ERROR("Invalid 'to' parameter");
+                return EXIT_FAILURE;
+            }
+        }
+        else
+        {
+            ALICEVISION_LOG_ERROR("Invalid 'from' parameter");
+            return EXIT_FAILURE;
+        }
+    }
+   
+    // export the SfMData scene in the expected format
+    if (!sfmDataIO::save(sfmData, outputSfMDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("An error occured while trying to save '" << outputSfMDataFilename << "'");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- New undistortion model using radial3 equations
- New node to convert distortions to undistortions (only for radial3 for now)
- New model in the exportDistortion Node to support radial3