### PR TITLE
[mesh] visibility from mesh itself: check point is in camera frustum

### DIFF
--- a/src/aliceVision/mesh/meshVisibility.cpp
+++ b/src/aliceVision/mesh/meshVisibility.cpp
@@ -178,6 +178,13 @@ void remapMeshVisibilities_meshItself(const mvsUtils::MultiViewParams& mp, Mesh&
         {
             const Point3d& c = mp.CArr[camIndex];
 
+            // Check if the point is in the camera's frutum.
+            // Project in image space and check that the pixel coordinates are in the image.
+            Pixel pix;
+            mp.getPixelFor3DPoint(&pix, v, camIndex);
+            if (!mp.isPixelInImage(pix, camIndex, 1))
+                continue;
+
             // check vertex normal (another solution would be to check each neighboring triangle)
             const double angle = angleBetwV1andV2((c - v).normalize(), normalsPerVertex[vi]);
             if (angle > 90.0)

--- a/src/software/utils/main_selectConnectedViews.cpp
+++ b/src/software/utils/main_selectConnectedViews.cpp
@@ -37,7 +37,10 @@ void saveTCameras(std::ostream& stream, const MapTCamsPerView& tcamsPerView)
     for (auto it = tcamsPerView.begin(); it != tcamsPerView.end(); ++it)
     {
         if(it->second.empty())
+        {
+            ALICEVISION_LOG_WARNING("The camera " << it->first << " is reconstructed but is not linked to any other camera.");
             continue;
+        }
         // RC camera
         stream << it->first << " ";
         // List of TC cameras


### PR DESCRIPTION

Minor other fix:
- [software] SelectConnectedViews: add warning when a view has zero connected camera