### PR TITLE
[sfmData] fix relative to absolute path conversion for features/matches folders

### DIFF
--- a/pyTests/sfmData/test_sfmdata.py
+++ b/pyTests/sfmData/test_sfmdata.py
@@ -316,7 +316,8 @@ def test_sfmdata_get_set_folders():
 
     # Set absolute path
     filename = "internal_folders.sfm"
-    abs_filename = os.path.abspath(os.path.dirname(__file__)) + "/" + filename
+    projectFolder = os.path.abspath(os.path.dirname(__file__))
+    abs_filename = os.path.join(projectFolder, filename)
     data.setAbsolutePath(abs_filename)
 
     # Check that the folders were kept and are now absolute paths
@@ -324,13 +325,13 @@ def test_sfmdata_get_set_folders():
         "The previously added features folder should have remained in the list"
     assert os.path.isabs(data.getFeaturesFolders()[0]), \
         "The absolute path has been set: the features folder's path should be absolute as well"
-    assert os.path.relpath(data.getFeaturesFolders()[0]) == relative_folder, \
+    assert os.path.relpath(data.getFeaturesFolders()[0], projectFolder) == relative_folder, \
         "The absolute path for the features folder should correspond to the provided relative one"
     assert len(data.getMatchesFolders()) == 1, \
         "The previously added matches folder should have remained in the list"
     assert os.path.isabs(data.getMatchesFolders()[0]), \
         "The absolute path has been set: the matches folder's path should be absolute as well"
-    assert os.path.relpath(data.getMatchesFolders()[0]) == relative_folder, \
+    assert os.path.relpath(data.getMatchesFolders()[0], projectFolder) == relative_folder, \
         "The absolute path for the matches folder should correspond to the provided relative one"
 
     # Check that relative folders are still valid
@@ -348,10 +349,10 @@ def test_sfmdata_get_set_folders():
     assert len(data.getMatchesFolders()) == 2, \
         "A second matches folder should have been addded to the list"
 
-    assert os.path.relpath(data.getFeaturesFolders()[0]) == relative_folder
-    assert os.path.relpath(data.getFeaturesFolders()[1]) == other_folder
-    assert os.path.relpath(data.getMatchesFolders()[0]) == relative_folder
-    assert os.path.relpath(data.getMatchesFolders()[1]) == other_folder
+    assert os.path.relpath(data.getFeaturesFolders()[0], projectFolder) == relative_folder
+    assert os.path.relpath(data.getFeaturesFolders()[1], projectFolder) == other_folder
+    assert os.path.relpath(data.getMatchesFolders()[0], projectFolder) == relative_folder
+    assert os.path.relpath(data.getMatchesFolders()[1], projectFolder) == other_folder
 
     # Reset features and matches folders and add new ones
     new_folder1 = "../new"
@@ -365,5 +366,5 @@ def test_sfmdata_get_set_folders():
     assert len(data.getFeaturesFolders()) == 3
     assert len(data.getMatchesFolders()) == 3
     for i in range(len(data.getFeaturesFolders())):
-        assert os.path.relpath(data.getFeaturesFolders()[i]) == new_folders[i]
-        assert os.path.relpath(data.getMatchesFolders()[i]) == new_folders[i]
+        assert os.path.relpath(data.getFeaturesFolders()[i], projectFolder) == new_folders[i]
+        assert os.path.relpath(data.getMatchesFolders()[i], projectFolder) == new_folders[i]

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -108,9 +108,10 @@ void LocalBundleAdjustmentGraph::saveIntrinsicsToHistory(const sfmData::SfMData&
 
 void LocalBundleAdjustmentGraph::exportIntrinsicsHistory(const std::string& folder, const std::string& filename)
 {
-    ALICEVISION_LOG_DEBUG("Exporting intrinsics history...");
+    const std::string filepath = (fs::path(folder) / filename).string();
+    ALICEVISION_LOG_DEBUG("Exporting intrinsics history: " << filepath);
     std::ofstream os;
-    os.open((fs::path(folder) / filename).string(), std::ios::app);
+    os.open(filepath, std::ios::app);
     os.seekp(0, std::ios::end);  // put the cursor at the end
 
     for (const auto& intrinsicHistoryPair : _intrinsicsHistory)

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -148,21 +148,26 @@ std::vector<std::string> toAbsoluteFolders(const std::vector<std::string>& folde
     // If absolute path is not set, return input folders
     if (absolutePath.empty())
         return folders;
+    // project folder from project filepath
+    const fs::path projectFolder = fs::path(absolutePath).parent_path();
     // Else, convert relative paths to absolute paths
     std::vector<std::string> absolutePaths;
     absolutePaths.reserve(folders.size());
     for (const auto& folder : folders)
     {
-        const fs::path f = fs::absolute(folder);
-        if (utils::exists(f))
+        fs::path f(folder);
+        if(f.is_relative())
         {
+            // convert to absolute path
+            f = projectFolder / folder;
+        }
+        if (fs::exists(f))
+        {
+            // simplify the path to avoid things like "../.."
             // fs::canonical can only be used if the path exists
-            absolutePaths.push_back(fs::canonical(f).string());
+            f = fs::canonical(f);
         }
-        else
-        {
-            absolutePaths.push_back(f.string());
-        }
+        absolutePaths.push_back(f.string());
     }
     return absolutePaths;
 }


### PR DESCRIPTION
Fix a bug introduced here:
https://github.com/alicevision/AliceVision/pull/1642/files#diff-f64b65d73de3bc8923c999e3186f55d07357ced340de2a8e0d70cae60bc48877L128

Features/matches paths are relative to the project folder (not the "current" folder).

