### PR TITLE
feat: DJI Mini 4 Pro camera (FC8482)

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -1465,6 +1465,7 @@ DJI;FC6520;17.3;usercontribution
 DJI;FC6540;23.5;usercontribution
 DJI;FC7203;6.16;usercontribution
 DJI;FC7303;6.16;usercontribution
+DJI;FC8482;13.4;usercontribution
 DJI;MAVIC2-ENTERPRISE-ADVANCED;4.8;
 DJI;Mavic3;17.3;dji
 DJI;Mini 2 SE;6.16;dji


### PR DESCRIPTION


## Description

Add the DJI Mini 4 Pro camera to the database.

1/1.3-inch CMOS -> approximately 13.4mm x 9.6mm