### PR TITLE
Fix pipeline when LdrToHdrMerge is used on single brackets

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include <aliceVision/numeric/numeric.hpp>
+#include <cmath>
 
 #include <filesystem>
 
@@ -77,7 +78,7 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         {
             // Automatically determines the number of brackets
             double exp = view->getImage().getCameraExposureSetting().getExposure();
-            if (exp < lastExposure)
+            if (exp <= lastExposure)
             {
                 groups.push_back(group);
                 group.clear();

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -194,6 +194,22 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    //Let check that we don't have only groups of 1 images (LDR)
+    bool onlyOne = true;
+    for (const auto & item : groupedViews)
+    {
+        if (item.size() > 1)
+        {
+            onlyOne = false;
+        }
+    }
+
+    if (onlyOne)
+    {
+        ALICEVISION_LOG_INFO("Only groups of one bracket : Bypass processing.");
+        byPass = true;
+    }
+
     // Check groups
     std::size_t usedNbBrackets;
     {


### PR DESCRIPTION
Make sure we bypass processing when there is no multi bracketing