### PR TITLE
Fix crash on convert distortion

### DIFF
--- a/src/software/convert/main_convertDistortion.cpp
+++ b/src/software/convert/main_convertDistortion.cpp
@@ -176,6 +176,12 @@ int aliceVision_main(int argc, char** argv)
             {
                 std::shared_ptr<camera::Distortion> distortion = isod->getDistortion();
                 std::shared_ptr<camera::Undistortion> undistortion;
+
+                if (!distortion)
+                {
+                   ALICEVISION_LOG_ERROR("No distortion object found for intrinsic " << pairIntrinsic.first);
+                   break;
+                }
                 
                 switch (distortion->getType())
                 {


### PR DESCRIPTION
Using convert distortion in a pipeline where the intrinsic contains an empty distortion object led to a crash. I checked for pointer nullity.