### PR TITLE
Solve a set of bugs on cameraInit

### DIFF
--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -1486,7 +1486,13 @@ std::shared_ptr<camera::IntrinsicBase> KeyframeSelector::createIntrinsic(const s
                                                                          const double imageRatio,
                                                                          const std::size_t mediaIndex)
 {
-    auto intrinsic = sfmDataIO::getViewIntrinsic(view, focalLength, sensorWidth);
+    camera::EInitMode mode = camera::EInitMode::ESTIMATED;
+    if (sensorWidth <= 0)
+    {
+        mode = camera::EInitMode::UNKNOWN;
+    }
+    
+    auto intrinsic = sfmDataIO::getViewIntrinsic(view, mode, focalLength, sensorWidth);
     if (imageRatio > 1.0 && sensorWidth > -1.0)
     {
         intrinsic->setSensorWidth(sensorWidth);

--- a/src/aliceVision/sfmData/ImageInfo.cpp
+++ b/src/aliceVision/sfmData/ImageInfo.cpp
@@ -384,9 +384,10 @@ int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatab
             ALICEVISION_LOG_WARNING("Use default sensor size (24x36 mm)");
         }
         sensorWidth = 36.0;
-        sensorHeight = 24.0;
+        sensorHeight = -1.0;
     }
-    else if (sensorHeight == -1.0)  // If the sensor height has already been set with the effective height, don't overwrite it
+
+    if (sensorHeight == -1.0)  // If the sensor height has already been set with the effective height, don't overwrite it
     {
         sensorHeight = (imageRatio > 1.0) ? sensorWidth / imageRatio : sensorWidth * imageRatio;
     }

--- a/src/aliceVision/sfmDataIO/viewIO.hpp
+++ b/src/aliceVision/sfmDataIO/viewIO.hpp
@@ -66,6 +66,7 @@ void updateIncompleteView(sfmData::View& view, EViewIdMethod viewIdMethod = EVie
 /**
  * @brief create an intrinsic for the given View
  * @param[in] view The given view
+ * @param[in] intrinsicInitMode validity flags
  * @param[in] mmFocalLength (-1 if unknown)
  * @param[in] sensorWidth (-1 if unknown)
  * @param[in] defaultFocalLength (-1 if unknown)
@@ -78,6 +79,7 @@ void updateIncompleteView(sfmData::View& view, EViewIdMethod viewIdMethod = EVie
  * @return shared_ptr IntrinsicBase
  */
 std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& view,
+                                                        const camera::EInitMode intrinsicInitMode,
                                                         double mmFocalLength = -1.0,
                                                         double sensorWidth = -1,
                                                         double defaultFocalLength = -1,

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -642,6 +642,7 @@ int aliceVision_main(int argc, char** argv)
 
         // build intrinsic
         std::shared_ptr<camera::IntrinsicBase> intrinsicBase = getViewIntrinsic(view,
+                                                                                intrinsicInitMode,
                                                                                 focalLengthmm,
                                                                                 sensorWidth,
                                                                                 defaultFocalLength,

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1750,6 +1750,7 @@ int aliceVision_main(int argc, char* argv[])
                         const double defaultOffsetX = 0.0;
                         const double defaultOffsetY = 0.0;
                         intrinsicBase = sfmDataIO::getViewIntrinsic(view,
+                                                                    intrinsicInitMode,
                                                                     focalLengthmm,
                                                                     sensorWidth,
                                                                     defaultFocalLength,


### PR DESCRIPTION
Updates to camera init :

- when no information available, sensorwidth was set to 36 and sensorHeight was set to 24 not considering the image ratio
- The effect of pixel aspect ratio on "focal length" (scale) is updated
- The default offset is assigned even if no valid focal length is known
- Initial focal length was enforced during sfm even if the sensor width was only guessed