### PR TITLE
[image] Fix erroneous color space detection for images that contain "raw" in their filepath

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -88,7 +88,10 @@ std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::strin
     std::string colorSpaceFromFileName = "";
     if (!imagePath.empty())
     {
-        colorSpaceFromFileName = getGlobalColorConfigOCIO().getColorSpaceFromFilepath(imagePath);
+        // Use only filename for color space infering
+        const std::string filename = fs::path(imagePath).filename().string(); 
+        colorSpaceFromFileName = getGlobalColorConfigOCIO().getColorSpaceFromFilepath(filename);
+        boost::algorithm::to_lower(colorSpaceFromFileName);
     }
 
     std::map<std::string, std::string> mapColorSpaces;
@@ -121,7 +124,7 @@ std::string getImageColorSpace(const OIIO::ImageSpec& oiioSpec, const std::strin
     {
         colorSpace = mapColorSpaces.at("workPlateColourSpace");
     }
-    else if (!colorSpaceFromFileName.empty())
+    else if (!colorSpaceFromFileName.empty() && colorSpaceFromFileName != "raw")
     {
         colorSpace = colorSpaceFromFileName;
     }


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

This PR fixes the following bug:
For non raw images (for instance jpeg format), without any color space indication in the metadata, if the image filepath contains "raw" then the Raw color space is detected by the ocio function using the filepath as a hint to guess the color space.
Because no conversion is defined in the ocio.config file from the raw color space the image reading fails.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->
- Use only the filename instead of the full filepath to guess the image color space in order to limit misinterpretation for all color spaces.
- Do not consider the Raw color space when it is returned by the ocio function.

## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

