### PR TITLE
Added insta360 x3 sensor to db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -201,6 +201,7 @@ Apple;iPhone XR;5.60;dpreview
 Apple;iPhone XS;5.60;dpreview
 Apple;iPhone XS Max;5.60;dpreview
 Arashi Vision;Insta360 ONE X;6.16;usercontribution
+Arashi Vision;Insta360 X3;6.4;usercontribution
 Archos;Archos 101e Neon;1.6;devicespecifications
 Archos;Archos 50 Cobalt;2.9;devicespecifications
 Archos;Archos 50d Oxygen;4.69;devicespecifications


### PR DESCRIPTION
Added Insta360 X3 camera to cameraSensors.db

It's 1/2" sensor with 48MP resolution. so either IMX582 or IMX586, which has 0.8um pixel size.
`8k pixels_width* 0.8um size = 6.4 mm width`
On Amazon they advertise it's 48MP / 1/2" sensor: https://www.amazon.com/insta360-Waterproof-Single-Lens-Stabilization-Touchscreen/dp/B0B9H572LC?th=1

And for maker/model name:
![image](https://github.com/user-attachments/assets/03986ee8-10db-42b0-b01c-c23443367476)
