### PR TITLE
Add locks for intrinsics

### DIFF
--- a/src/aliceVision/camera/Distortion.hpp
+++ b/src/aliceVision/camera/Distortion.hpp
@@ -67,10 +67,16 @@ class Distortion
 
     virtual Eigen::MatrixXd getDerivativeRemoveDistoWrtDisto(const Vec2& p) const { return Eigen::MatrixXd(0, 0); }
 
+    inline void setLocked(bool lock) { _isLocked = lock; }
+
+    inline bool isLocked() const { return _isLocked; }
+
     virtual ~Distortion() = default;
+
 
   protected:
     std::vector<double> _distortionParams{};
+    bool _isLocked{false};
 };
 
 }  // namespace camera

--- a/src/aliceVision/camera/IntrinsicScaleOffset.hpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffset.hpp
@@ -106,6 +106,22 @@ class IntrinsicScaleOffset : public IntrinsicBase
     inline bool isRatioLocked() const { return _ratioLocked; }
 
     /**
+     * @brief Lock the offset
+     * @param lock True if the offset is locked, false otherwise
+     */
+    inline void setOffsetLocked(bool lock) { _offsetLocked = lock; }
+
+    inline bool isOffsetLocked() const { return _offsetLocked; }
+
+    /**
+     * @brief Lock the scale
+     * @param lock True if the scale is locked, false otherwise
+     */
+    inline void setScaleLocked(bool lock) { _scaleLocked = lock; }
+
+    inline bool isScaleLocked() const { return _scaleLocked; }
+
+    /**
      * @brief get focal length in mm
      * @return focal length in mm
     */
@@ -123,6 +139,8 @@ class IntrinsicScaleOffset : public IntrinsicBase
     Vec2 _offset{0.0, 0.0};
     Vec2 _initialScale{-1.0, -1.0};
     bool _ratioLocked{true};
+    bool _offsetLocked{false};
+    bool _scaleLocked{false};
 };
 
 }  // namespace camera

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -228,6 +228,8 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
         ODoubleProperty(userProps, "mvg_initialFocalLength").set(initialFocalLength);
         OBoolProperty(userProps, "mvg_intrinsicLocked").set(intrinsicCasted->isLocked());
         OBoolProperty(userProps, "mvg_intrinsicPixelRatioLocked").set(intrinsicCasted->isRatioLocked());
+        OBoolProperty(userProps, "mvg_intrinsicOffsetLocked").set(intrinsicCasted->isOffsetLocked());
+        OBoolProperty(userProps, "mvg_intrinsicScaleLocked").set(intrinsicCasted->isOffsetLocked());
         OStringProperty(userProps, "mvg_intrinsicDistortionInitializationMode")
           .set(camera::EInitMode_enumToString(intrinsicCasted->getDistortionInitializationMode()));
 
@@ -246,6 +248,7 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
         {
             distortionType = distortion->getType();
             ODoubleArrayProperty(userProps, "mvg_distortionParams").set(distortion->getParameters());
+            OBoolProperty(userProps, "mvg_distortionLocked").set(distortion->isLocked());
         }
 
         // Undistortion parameters and offset

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -174,6 +174,9 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
 
         intrinsicTree.put("pixelRatio", pixelRatio);
         intrinsicTree.put("pixelRatioLocked", intrinsicScaleOffset->isRatioLocked());
+        intrinsicTree.put("offsetLocked", intrinsicScaleOffset->isOffsetLocked());
+        intrinsicTree.put("scaleLocked", intrinsicScaleOffset->isScaleLocked());
+
 
         saveMatrix("principalPoint", intrinsicScaleOffset->getOffset(), intrinsicTree);
     }
@@ -197,7 +200,10 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
                 paramTree.put("", param);
                 distParamsTree.push_back(std::make_pair("", paramTree));
             }
+
+            intrinsicTree.put("distortionLocked", distortionObject->isLocked());
         }
+
         intrinsicTree.put("distortionInitializationMode",
                           camera::EInitMode_enumToString(intrinsicScaleOffsetDisto->getDistortionInitializationMode()));
 
@@ -360,6 +366,12 @@ void loadIntrinsic(const Version& version, IndexT& intrinsicId, std::shared_ptr<
             intrinsicWithScale->setInitialScale(initialFocalLengthPx);
             intrinsicWithScale->setRatioLocked(intrinsicTree.get<bool>("pixelRatioLocked"));
         }
+
+        if (version >= Version(1, 2, 10))
+        {
+            intrinsicWithScale->setOffsetLocked(intrinsicTree.get<bool>("offsetLocked"));
+            intrinsicWithScale->setScaleLocked(intrinsicTree.get<bool>("scaleLocked"));
+        }
     }
 
     // Load distortion
@@ -415,6 +427,11 @@ void loadIntrinsic(const Version& version, IndexT& intrinsicId, std::shared_ptr<
             if (distortionParams.size() == distortionObject->getParameters().size())
             {
                 distortionObject->setParameters(distortionParams);
+            }
+
+            if (version >= Version(1, 2, 10))
+            {
+                distortionObject->setLocked(intrinsicTree.get<bool>("distortionLocked"));
             }
         }
     }

--- a/src/aliceVision/sfmDataIO/sfmDataIO.hpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIO.hpp
@@ -12,7 +12,7 @@
 
 #define ALICEVISION_SFMDATAIO_VERSION_MAJOR 1
 #define ALICEVISION_SFMDATAIO_VERSION_MINOR 2
-#define ALICEVISION_SFMDATAIO_VERSION_REVISION 9
+#define ALICEVISION_SFMDATAIO_VERSION_REVISION 10
 
 // AliceVision version as a string; for example "0.9.0".
 #define ALICEVISION_SFMDATAIO_VERSION_STRING                                                                                                         \


### PR DESCRIPTION
- add a lock for optical center (offset) in sfmData per intrinsic
- add a lock for focal length (scale) in sfmData per intrinsic
- add a lock for distortion objects in sfmData
- Use these locks in Bundle Adjustment
