### PR TITLE
[software] PanoramaSeams: Check that the input is not empty

### DIFF
--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -246,6 +246,11 @@ int aliceVision_main(int argc, char** argv)
             continue;
         }
 
+        if (fs::file_size(iter.path()) == 0)
+        {
+            continue;
+        }
+
         std::smatch m;
         const std::string text = iter.path().string();
         if (!std::regex_search(text, m, pattern))


### PR DESCRIPTION
Adding a check that the given input image is not empty (Edge cases of panoramaWarping) to prevent errors.