### PR TITLE
Use focal length from json and fix typos in parameters

### DIFF
--- a/src/aliceVision/camera/IntrinsicScaleOffset.cpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffset.cpp
@@ -161,5 +161,12 @@ double IntrinsicScaleOffset::getFocalLengthMM() const
     return _scale(0) * sensorWidth() / static_cast<double>(std::max(w(), h()));
 }
 
+void IntrinsicScaleOffset::setFocalLength(double focalLengthMM, double pixelAspectRatio)
+{
+    const double focalRatio = 1.0 / pixelAspectRatio;
+    _scale(0) = (focalLengthMM / sensorWidth()) * double(w());
+    _scale(1) = _scale(0) / focalRatio;
+}
+
 }  // namespace camera
 }  // namespace aliceVision

--- a/src/aliceVision/camera/IntrinsicScaleOffset.hpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffset.hpp
@@ -111,6 +111,13 @@ class IntrinsicScaleOffset : public IntrinsicBase
     */
     double getFocalLengthMM() const;
 
+    /**
+     * @Brief set scale given focal length and pixelaspectratio
+     * @param focalLengthMM focal length in mm
+     * @param pixelAspectRatio pixel aspect ratio (image with = pixelAspectRatio * realwith)
+    */
+    void setFocalLength(double focalLengthMM, double pixelAspectRatio);
+
   protected:
     Vec2 _scale{1.0, 1.0};
     Vec2 _offset{0.0, 0.0};

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -171,6 +171,7 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
         
         intrinsicTree.put("initialFocalLength", initialFocalLengthMM);
         intrinsicTree.put("focalLength", focalLengthMM);
+
         intrinsicTree.put("pixelRatio", pixelRatio);
         intrinsicTree.put("pixelRatioLocked", intrinsicScaleOffset->isRatioLocked());
 

--- a/src/software/utils/main_applyCalibration.cpp
+++ b/src/software/utils/main_applyCalibration.cpp
@@ -294,21 +294,22 @@ bool applyJson(sfmData::SfMData & sfmData, boost::json::value & input)
     intrinsic->setSensorWidth(filmbackWidth);
     intrinsic->setSensorHeight((isDesqueezed)?filmbackHeight:filmbackHeight*pixelAspect);
     intrinsic->setDistortionObject(nullptr);
+    intrinsic->setFocalLength(focalLength, pixelAspect);
 
     if (model == "anamorphic4")
     {        
         std::vector<double> params = 
         {
-            boost::json::value_to<double>(obj.at("Cx02Degree2")),
-            boost::json::value_to<double>(obj.at("Cy02Degree2")),
-            boost::json::value_to<double>(obj.at("Cx22Degree2")),
-            boost::json::value_to<double>(obj.at("Cy22Degree2")),
-            boost::json::value_to<double>(obj.at("Cx04Degree4")),
-            boost::json::value_to<double>(obj.at("Cy04Degree4")),
-            boost::json::value_to<double>(obj.at("Cx24Degree4")),
-            boost::json::value_to<double>(obj.at("Cy24Degree4")),
-            boost::json::value_to<double>(obj.at("Cx44Degree4")),
-            boost::json::value_to<double>(obj.at("Cy44Degree4")),
+            boost::json::value_to<double>(obj.at("cx02Degree2")),
+            boost::json::value_to<double>(obj.at("cy02Degree2")),
+            boost::json::value_to<double>(obj.at("cx22Degree2")),
+            boost::json::value_to<double>(obj.at("cy22Degree2")),
+            boost::json::value_to<double>(obj.at("cx04Degree4")),
+            boost::json::value_to<double>(obj.at("cy04Degree4")),
+            boost::json::value_to<double>(obj.at("cx24Degree4")),
+            boost::json::value_to<double>(obj.at("cy24Degree4")),
+            boost::json::value_to<double>(obj.at("cx44Degree4")),
+            boost::json::value_to<double>(obj.at("cy44Degree4")),
             degreeToRadian(boost::json::value_to<double>(obj.at("lensRotation"))),
             boost::json::value_to<double>(obj.at("squeezeX")),
             boost::json::value_to<double>(obj.at("squeezeY")),


### PR DESCRIPTION
- Consider focal length in json file
- using camelCase for all parameters