### PR TITLE
Inverted flag check in intrinsics

### DIFF
--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -569,7 +569,7 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
         lockFocal = (!refineIntrinsicsFocalLength) || intrinsicScaleOffset->isScaleLocked();
 
         // refine the focal length
-        if (lockFocal)
+        if (!lockFocal)
         {
             if (intrinsicScaleOffset->getInitialScale().x() > 0 && intrinsicScaleOffset->getInitialScale().y() > 0)
             {


### PR DESCRIPTION
lock Focal check was inverted, leading to erroneous bundle adjustment