### PR TITLE
Fix Sonx RX0 II camera model

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -6840,7 +6840,7 @@ Sony;Sony DSC-HX60V;6.16;usercontribution
 Sony;Sony DSC-HX7V;6.16;usercontribution
 Sony;Sony DSC-QX30U;6.16;usercontribution
 Sony;Sony DSC-RX0;13.2;dpreview,dxomark
-Sony;Sony DSC-RX0 II;13.2;dpreview
+Sony;Sony DSC-RX0M2;13.2;dpreview
 Sony;Sony DSC-RX10;13.2;usercontribution
 Sony;Sony DSC-RX100M5;13.2;usercontribution
 Sony;Sony DSC-T110;6.16;usercontribution


### PR DESCRIPTION
The camera identifies itself as DSC-RX0M2 in Exif.
