### PR TITLE
Distortion export for pipelines without lens grids

### DIFF
--- a/src/aliceVision/camera/Undistortion.hpp
+++ b/src/aliceVision/camera/Undistortion.hpp
@@ -31,10 +31,11 @@ class Undistortion
   public:
     Undistortion(int width, int height)
     {
-        setSize(width, height);
-        setOffset({0.0, 0.0});
         _pixelAspectRatio = 1.0;
         _isDesqueezed = false;
+        
+        setSize(width, height);
+        setOffset({0.0, 0.0});
     }
 
     virtual EUNDISTORTION getType() const = 0;

--- a/src/software/convert/main_convertDistortion.cpp
+++ b/src/software/convert/main_convertDistortion.cpp
@@ -170,6 +170,8 @@ int aliceVision_main(int argc, char** argv)
             continue;
         }
 
+        ALICEVISION_LOG_INFO("Processing intrinsic " << pairIntrinsic.first);
+
         if (from == "distortion")
         {
             if (to == "undistortion")

--- a/src/software/convert/main_convertDistortion.cpp
+++ b/src/software/convert/main_convertDistortion.cpp
@@ -67,9 +67,10 @@ bool convert(std::shared_ptr<camera::Undistortion> & undistortion, const camera:
             calibration::PointPair ppt;
             ppt.distortedPoint = pobs.second.getCoordinates();
             ppt.undistortedPoint = intrinsic.getUndistortedPixel(ppt.distortedPoint);
+            ppt.scale = pobs.second.getScale();
 
             Vec2 check = intrinsic.getDistortedPixel(ppt.undistortedPoint);
-            if ((check - ppt.distortedPoint).norm() > 1e-2)
+            if ((check - ppt.distortedPoint).norm() > 1e-3)
             {
                 countErrors++;
                 continue;

--- a/src/software/export/main_exportDistortion.cpp
+++ b/src/software/export/main_exportDistortion.cpp
@@ -235,11 +235,17 @@ int aliceVision_main(int argc, char* argv[])
 
         const auto intrinsicDisto = std::dynamic_pointer_cast<IntrinsicScaleOffsetDisto>(intrinsicPtr);
         if (!intrinsicDisto)
+        {
+            ALICEVISION_LOG_INFO("Intrinsic " << intrinsicId << " has incorrect format");
             continue;
+        }
 
         const auto undistortion = intrinsicDisto->getUndistortion();
         if (!undistortion)
+        {
+            ALICEVISION_LOG_INFO("Intrinsic " << intrinsicId << " is not exported as it has no undistortion object.");
             continue;
+        }
 
         if (exportNukeNode)
         {


### PR DESCRIPTION
- Make sure distortion export is more verbose if no undistortion are available.
- Convert Distortion is now working properly.