### PR TITLE
change threshold for sfm validity

### DIFF
--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -227,7 +227,16 @@ bool ReconstructionEngine_sequentialSfM::process()
 
     exportStatistics(elapsedTime);
 
-    return !_sfmData.getPoses().empty();
+    const size_t nbviews = _sfmData.getViews().size();
+    const size_t nbposes = _sfmData.getPoses().size();
+
+    size_t minPoses = 1;
+    if (nbviews > _params.smallDatasetLimit)
+    {
+        minPoses = 3;
+    }
+
+    return (nbposes >= minPoses);
 }
 
 void ReconstructionEngine_sequentialSfM::initializePyramidScoring()

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.hpp
@@ -47,6 +47,9 @@ class ReconstructionEngine_sequentialSfM : public ReconstructionEngine
         bool useLocalBundleAdjustment = false;
         int localBundelAdjustementGraphDistanceLimit = 1;
 
+        //Number of views under which a dataset is considered small
+        size_t smallDatasetLimit = 5;
+
         /// Dump current status of the scene every 3 resections
         bool logIntermediateSteps = false;
 


### PR DESCRIPTION
Actually, sfm returns an error only if there is no reconstructed views.
We want to return an error if there is only the initial reconstructed pair and no other valid views.
If the number of views is small, we still keep 1 view as the minimal size, but for any other size, we also return an error if only 2 views are reconstructed.