### PR TITLE
[utils] Image Processing: Add simultaneous support for regex and input folders

### DIFF
--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -44,7 +44,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 3
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 4
 
 using namespace aliceVision;
 namespace po = boost::program_options;

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1028,7 +1028,8 @@ int aliceVision_main(int argc, char* argv[])
     requiredParams.add_options()
         ("input,i", po::value<std::string>(&inputExpression)->default_value(inputExpression),
          "SfMData file input, image filenames or regex(es) on the image file path (supported regex: '#' matches a "
-         "single digit, '@' one or more digits, '?' one character and '*' zero or more).")
+         "single digit, '@' one or more digits, '?' one character and '*' zero or more)."
+         "Argument must be between quotes if regex are used.")
         ("inputFolders", po::value<std::vector<std::string>>(&inputFolders)->multitoken(),
          "Use images from specific folder(s) instead of those specify in the SfMData file.")
         ("output,o", po::value<std::string>(&outputPath)->required(),

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1524,18 +1524,12 @@ int aliceVision_main(int argc, char* argv[])
         {
             filesStrPaths.push_back(inputPath.string());
         }
-        else if (inputFolders.empty())
-        {
-            ALICEVISION_LOG_INFO("Working directory Path '" + inputPath.parent_path().generic_string() + "'.");
-
-            const std::regex regex = utils::filterToRegex(inputExpression);
-            // Get supported files in inputPath directory which matches our regex filter
-            filesStrPaths = utils::getFilesPathsFromFolder(inputPath.parent_path().generic_string(), [&regex](const fs::path& path) {
-                return image::isSupported(path.extension().string()) && std::regex_match(path.generic_string(), regex);
-            });
-        }
         else
         {
+            if (inputFolders.empty())
+            {
+                inputFolders.push_back(inputPath.parent_path().generic_string());
+            }
             const std::regex regex = utils::filterToRegex(inputExpression);
             for (const auto& inputFolder : inputFolders)
             {

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1514,34 +1514,35 @@ int aliceVision_main(int argc, char* argv[])
         const fs::path inputPath(inputExpression);
         std::vector<std::string> filesStrPaths;
 
-        // If sfmInputDataFilename is empty use imageFolders instead
         if (inputExpression.empty())
         {
             // Get supported files
             filesStrPaths =
               utils::getFilesPathsFromFolders(inputFolders, [](const fs::path& path) { return image::isSupported(path.extension().string()); });
         }
+        else if (fs::is_regular_file(inputPath))
+        {
+            filesStrPaths.push_back(inputPath.string());
+        }
+        else if (inputFolders.empty())
+        {
+            ALICEVISION_LOG_INFO("Working directory Path '" + inputPath.parent_path().generic_string() + "'.");
+
+            const std::regex regex = utils::filterToRegex(inputExpression);
+            // Get supported files in inputPath directory which matches our regex filter
+            filesStrPaths = utils::getFilesPathsFromFolder(inputPath.parent_path().generic_string(), [&regex](const fs::path& path) {
+                return image::isSupported(path.extension().string()) && std::regex_match(path.generic_string(), regex);
+            });
+        }
         else
         {
-            // If you try to use both a regex-like filter expression and folders as input
-            if (!inputFolders.empty())
+            const std::regex regex = utils::filterToRegex(inputExpression);
+            for (const auto& inputFolder : inputFolders)
             {
-                ALICEVISION_LOG_WARNING("InputFolders and filter expression cannot be used at the same time, InputFolders are ignored here.");
-            }
-
-            if (fs::is_regular_file(inputPath))
-            {
-                filesStrPaths.push_back(inputPath.string());
-            }
-            else
-            {
-                ALICEVISION_LOG_INFO("Working directory Path '" + inputPath.parent_path().generic_string() + "'.");
-
-                const std::regex regex = utils::filterToRegex(inputExpression);
-                // Get supported files in inputPath directory which matches our regex filter
-                filesStrPaths = utils::getFilesPathsFromFolder(inputPath.parent_path().generic_string(), [&regex](const fs::path& path) {
+                std::vector<std::string> currFilesStrPaths = utils::getFilesPathsFromFolder(inputFolder, [&regex](const fs::path& path) {
                     return image::isSupported(path.extension().string()) && std::regex_match(path.generic_string(), regex);
                 });
+                filesStrPaths.insert(filesStrPaths.end(), currFilesStrPaths.begin(), currFilesStrPaths.end());
             }
         }
 

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1610,10 +1610,28 @@ int aliceVision_main(int argc, char* argv[])
                     outputFilePath = (fs::path(outputPath).parent_path() / (filename + outputExt)).generic_string();
                     ALICEVISION_LOG_WARNING("Extension " << userExt << " is not supported! Output image saved in " << outputFilePath);
                 }
+                // Create output directory if it does not exist
+                if (!fs::exists(fs::path(outputPath).parent_path()))
+                {
+                    if (!fs::create_directory(fs::path(outputPath).parent_path()))
+                    {
+                        ALICEVISION_LOG_ERROR("Unexisting directory " << fs::path(outputPath).parent_path().generic_string() << " cannot be created");
+                        return EXIT_FAILURE;
+                    }
+                }
             }
             else
             {
                 outputFilePath = (fs::path(outputPath) / (filename + outputExt)).generic_string();
+                // Create output directory if it does not exist
+                if (!fs::exists(fs::path(outputPath)))
+                {
+                    if (!fs::create_directory(fs::path(outputPath)))
+                    {
+                        ALICEVISION_LOG_ERROR("Unexisting directory " << outputPath << " cannot be created");
+                        return EXIT_FAILURE;
+                    }
+                }
             }
 
             image::DCPProfile dcpProf;


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR update the behavior of the imageProcessing executable when both input folder(s) and a regular input expression exist in the command line.

In the current version, input folders given in the command line are ignored if a regular expression is also given.
This PR applies the regular expression in all the input folders.
Nothing is changed if a the input is a sfmData file.

Additionally, if the output directory does not exist, it is created. If for some reason it cannot be created, an error is returned.

imageProcessing version is updated to 3.4

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

