### PR TITLE
Use same pose model for symbolic and autodiff

### DIFF
--- a/src/aliceVision/geometry/lie.hpp
+++ b/src/aliceVision/geometry/lie.hpp
@@ -118,6 +118,172 @@ inline Eigen::Vector3d logm(const Eigen::Matrix3d& R)
 
     return ret;
 }
+
+/**
+Compute the jacobian of the logarithm wrt changes in the rotation matrix values
+@param R the input rotation matrix
+@return the jacobian matrix (3*9 matrix)
+*/
+inline Eigen::Matrix<double, 3, 9, Eigen::RowMajor> dlogmdr(const Eigen::Matrix3d& R)
+{
+    double p1 = R(2, 1) - R(1, 2);
+    double p2 = R(0, 2) - R(2, 0);
+    double p3 = R(1, 0) - R(0, 1);
+
+    double costheta = (R.trace() - 1.0) / 2.0;
+    if (costheta > 1.0)
+        costheta = 1.0;
+    else if (costheta < -1.0)
+        costheta = -1.0;
+
+    double theta = acos(costheta);
+
+    if (fabs(theta) < std::numeric_limits<float>::epsilon())
+    {
+        Eigen::Matrix<double, 3, 9> J;
+        J.fill(0);
+        J(0, 5) = 1;
+        J(0, 7) = -1;
+        J(1, 2) = -1;
+        J(1, 6) = 1;
+        J(2, 1) = 1;
+        J(2, 3) = -1;
+        return J;
+    }
+
+    double scale = theta / (2.0 * sin(theta));
+
+    Eigen::Vector3d resnoscale;
+    resnoscale(0) = p1;
+    resnoscale(1) = p2;
+    resnoscale(2) = p3;
+
+    Eigen::Matrix<double, 3, 3> dresdp = Eigen::Matrix3d::Identity() * scale;
+    Eigen::Matrix<double, 3, 9> dpdmat;
+    dpdmat.fill(0);
+    dpdmat(0, 5) = 1;
+    dpdmat(0, 7) = -1;
+    dpdmat(1, 2) = -1;
+    dpdmat(1, 6) = 1;
+    dpdmat(2, 1) = 1;
+    dpdmat(2, 3) = -1;
+
+    double dscaledtheta = -0.5 * theta * cos(theta) / (sin(theta) * sin(theta)) + 0.5 / sin(theta);
+    double dthetadcostheta = -1.0 / sqrt(-costheta * costheta + 1.0);
+
+    Eigen::Matrix<double, 1, 9> dcosthetadmat;
+    dcosthetadmat << 0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5;
+    Eigen::Matrix<double, 1, 9> dscaledmat = dscaledtheta * dthetadcostheta * dcosthetadmat;
+
+    return dpdmat * scale + resnoscale * dscaledmat;
+}
+
+
+
+/**
+Compute the jacobian of the exponential wrt changes in the rotation vector values
+@param vecr the rotation vector
+@return the jacobian matrix (9*3 matrix)
+*/
+inline Eigen::Matrix<double, 9, 3, Eigen::RowMajor> dexpmdr(const Eigen::Vector3d & vecr)
+{
+    double angle = vecr.norm();  
+
+    if (angle < 1e-24)
+    {
+        Eigen::Matrix<double, 9, 3> d_K_d_vecr;
+        d_K_d_vecr.fill(0);
+        d_K_d_vecr(1, 2) = 1;
+        d_K_d_vecr(2, 1) = -1;
+        d_K_d_vecr(3, 2) = -1;
+        d_K_d_vecr(5, 0) = 1;
+        d_K_d_vecr(6, 1) = 1;
+        d_K_d_vecr(7, 0) = -1;
+        return d_K_d_vecr;
+    }
+
+    const double x = vecr(0);
+    const double y = vecr(1);
+    const double z = vecr(2);
+
+    double angle2 = angle * angle;
+    double angle3 = angle2 * angle;
+    double sina = sin(angle);
+    double cosa = cos(angle);
+    double mcosa = 1.0 - cosa;
+    double c = mcosa/ angle2;
+    double s = sina / angle;
+
+    double d_s_d_angle = cosa/angle - sina/angle2;
+    double d_c_d_angle = sina/angle2 - 2.0*mcosa/angle3;
+    
+    double d_angle_d_x = x / angle;
+    double d_angle_d_y = y / angle;
+    double d_angle_d_z = z / angle;
+
+    //Jacobian of s*K + c*K*K
+    Eigen::Matrix<double, 9, 5> J;
+    J(0,0)=0;
+    J(1,0)=c*y;
+    J(2,0)=c*z;
+    J(3,0)=c*y;
+    J(4,0)=-2*c*x;
+    J(5,0)=s;
+    J(6,0)=c*z;
+    J(7,0)=-s;
+    J(8,0)=-2*c*x;
+    J(0,1)=-2*c*y;
+    J(1,1)=c*x;
+    J(2,1)=-s;
+    J(3,1)=c*x;
+    J(4,1)=0;
+    J(5,1)=c*z;
+    J(6,1)=s;
+    J(7,1)=c*z;
+    J(8,1)=-2*c*y;
+    J(0,2)=-2*c*z;
+    J(1,2)=s;
+    J(2,2)=c*x;
+    J(3,2)=-s;
+    J(4,2)=-2*c*z;
+    J(5,2)=c*y;
+    J(6,2)=c*x;
+    J(7,2)=c*y;
+    J(8,2)=0;
+    J(0,3)=0;
+    J(1,3)=z;
+    J(2,3)=-y;
+    J(3,3)=-z;
+    J(4,3)=0;
+    J(5,3)=x;
+    J(6,3)=y;
+    J(7,3)=-x;
+    J(8,3)=0;
+    J(0,4)=-y*y - z*z;
+    J(1,4)=x*y;
+    J(2,4)=x*z;
+    J(3,4)=x*y;
+    J(4,4)=-x*x - z*z;
+    J(5,4)=y*z;
+    J(6,4)=x*z;
+    J(7,4)=y*z;
+    J(8,4)=-x*x - y*y;
+
+    //Jacobian of [x y z s c] wrt [x y z]
+    Eigen::Matrix<double, 5, 3> M = Eigen::Matrix<double, 5, 3>::Zero();
+    M(0, 0) = 1.0;
+    M(1, 1) = 1.0;
+    M(2, 2) = 1.0;
+    M(3, 0) = d_s_d_angle * d_angle_d_x;
+    M(3, 1) = d_s_d_angle * d_angle_d_y;
+    M(3, 2) = d_s_d_angle * d_angle_d_z;
+    M(4, 0) = d_c_d_angle * d_angle_d_x;
+    M(4, 1) = d_c_d_angle * d_angle_d_y;
+    M(4, 2) = d_c_d_angle * d_angle_d_z;
+
+    return J * M;
+}
+
 }  // namespace SO3
 
 namespace SE3 {

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentSymbolicCeres.hpp
@@ -150,12 +150,6 @@ class BundleAdjustmentSymbolicCeres : public BundleAdjustment, ceres::Evaluation
     virtual void PrepareForEvaluation(bool evaluate_jacobians, bool new_evaluation_point);
 
   private:
-    void addPose(const sfmData::CameraPose& cameraPose,
-                 bool isConstant,
-                 SE3::Matrix& poseBlock,
-                 ceres::Problem& problem,
-                 bool refineTranslation,
-                 bool refineRotation);
 
     /**
      * @brief Clear structures for a new problem
@@ -252,7 +246,7 @@ class BundleAdjustmentSymbolicCeres : public BundleAdjustment, ceres::Evaluation
     std::vector<double*> _allParametersBlocks;
     /// poses blocks wrapper
     /// block: ceres angleAxis(3) + translation(3)
-    std::map<IndexT, SE3::Matrix> _posesBlocks;  // TODO : maybe we can use boost::flat_map instead of std::map ?
+    std::map<IndexT, std::array<double, 6>> _posesBlocks;  // TODO : maybe we can use boost::flat_map instead of std::map ?
     /// intrinsics blocks wrapper
     /// block: intrinsics params
     std::map<IndexT, std::vector<double>> _intrinsicsBlocks;
@@ -262,7 +256,7 @@ class BundleAdjustmentSymbolicCeres : public BundleAdjustment, ceres::Evaluation
     std::map<IndexT, std::array<double, 3>> _landmarksBlocks;
     /// rig sub-poses blocks wrapper
     /// block: ceres angleAxis(3) + translation(3)
-    std::map<IndexT, std::map<IndexT, SE3::Matrix>> _rigBlocks;
+    std::map<IndexT, std::map<IndexT, std::array<double, 6>>> _rigBlocks;
     /// Rig pose to use when there is no rig
     SE3::Matrix _rigNull = SE3::Matrix::Identity();
 

--- a/src/aliceVision/sfm/bundle/costfunctions/panoramaPinhole.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/panoramaPinhole.hpp
@@ -21,8 +21,8 @@ class CostPanoramaPinHole : public ceres::CostFunction
     {
         set_num_residuals(2);
 
-        mutable_parameter_block_sizes()->push_back(16);
-        mutable_parameter_block_sizes()->push_back(16);
+        mutable_parameter_block_sizes()->push_back(6);
+        mutable_parameter_block_sizes()->push_back(6);
         mutable_parameter_block_sizes()->push_back(intrinsic->getParams().size());
     }
 
@@ -35,11 +35,11 @@ class CostPanoramaPinHole : public ceres::CostFunction
         const double* parameter_pose_j = parameters[1];
         const double* parameter_intrinsics = parameters[2];
 
-        const Eigen::Map<const Eigen::Matrix<double, 4, 4, Eigen::RowMajor>> iTo(parameter_pose_i);
-        const Eigen::Map<const Eigen::Matrix<double, 4, 4, Eigen::RowMajor>> jTo(parameter_pose_j);
+        const Eigen::Map<const Eigen::Vector3d> iro(parameter_pose_i);
+        const Eigen::Map<const Eigen::Vector3d> jro(parameter_pose_j);
 
-        Eigen::Matrix<double, 3, 3> iRo = iTo.block<3, 3>(0, 0);
-        Eigen::Matrix<double, 3, 3> jRo = jTo.block<3, 3>(0, 0);
+        Eigen::Matrix<double, 3, 3> iRo = SO3::expm(iro);
+        Eigen::Matrix<double, 3, 3> jRo = SO3::expm(jro);
 
         _intrinsic->setScale({parameter_intrinsics[0], parameter_intrinsics[1]});
         _intrinsic->setOffset({parameter_intrinsics[2], parameter_intrinsics[3]});
@@ -70,30 +70,26 @@ class CostPanoramaPinHole : public ceres::CostFunction
 
         if (jacobians[0] != nullptr)
         {
-            Eigen::Map<Eigen::Matrix<double, 2, 16, Eigen::RowMajor>> J(jacobians[0]);
+            Eigen::Map<Eigen::Matrix<double, 2, 6, Eigen::RowMajor>> J(jacobians[0]);
 
-            Eigen::Matrix<double, 2, 9> J9 = _intrinsic->getDerivativeProjectWrtRotation(T, pt_i_sphere) *
+            Eigen::Matrix<double, 2, 3> J3 = _intrinsic->getDerivativeProjectWrtRotation(T, pt_i_sphere) *
                                              getJacobian_AB_wrt_B<3, 3, 3>(jRo, iRo.transpose()) * getJacobian_At_wrt_A<3, 3>() *
-                                             getJacobian_AB_wrt_A<3, 3, 3>(Eigen::Matrix3d::Identity(), iRo);
+                                             SO3::dexpmdr(iro);
 
             J.fill(0);
-            J.block<2, 3>(0, 0) = J9.block<2, 3>(0, 0);
-            J.block<2, 3>(0, 4) = J9.block<2, 3>(0, 3);
-            J.block<2, 3>(0, 8) = J9.block<2, 3>(0, 6);
+            J.block<2, 3>(0, 0) = J3.block<2, 3>(0, 0);
         }
 
         if (jacobians[1] != nullptr)
         {
-            Eigen::Map<Eigen::Matrix<double, 2, 16, Eigen::RowMajor>> J(jacobians[1]);
+            Eigen::Map<Eigen::Matrix<double, 2, 6, Eigen::RowMajor>> J(jacobians[1]);
 
-            Eigen::Matrix<double, 2, 9> J9 = _intrinsic->getDerivativeProjectWrtRotation(T, pt_i_sphere) *
+            Eigen::Matrix<double, 2, 3> J3 = _intrinsic->getDerivativeProjectWrtRotation(T, pt_i_sphere) *
                                              getJacobian_AB_wrt_A<3, 3, 3>(jRo, iRo.transpose()) *
-                                             getJacobian_AB_wrt_A<3, 3, 3>(Eigen::Matrix3d::Identity(), jRo);
+                                             SO3::dexpmdr(jro);
 
             J.fill(0);
-            J.block<2, 3>(0, 0) = J9.block<2, 3>(0, 0);
-            J.block<2, 3>(0, 4) = J9.block<2, 3>(0, 3);
-            J.block<2, 3>(0, 8) = J9.block<2, 3>(0, 6);
+            J.block<2, 3>(0, 0) = J3.block<2, 3>(0, 0);
         }
 
         if (jacobians[2] != nullptr)

--- a/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
@@ -14,15 +14,14 @@ namespace sfm {
 class CostProjection : public ceres::CostFunction
 {
   public:
-    CostProjection(const sfmData::Observation& measured, const std::shared_ptr<camera::IntrinsicBase>& intrinsics, bool withRig)
+    CostProjection(const sfmData::Observation& measured, const std::shared_ptr<camera::IntrinsicBase>& intrinsics)
       : _measured(measured),
-        _intrinsics(intrinsics),
-        _withRig(withRig)
+        _intrinsics(intrinsics)
     {
         set_num_residuals(2);
 
-        mutable_parameter_block_sizes()->push_back(16);
-        mutable_parameter_block_sizes()->push_back(16);
+        mutable_parameter_block_sizes()->push_back(6);
+        mutable_parameter_block_sizes()->push_back(6);
         mutable_parameter_block_sizes()->push_back(intrinsics->getParams().size());
         mutable_parameter_block_sizes()->push_back(3);
     }
@@ -34,9 +33,19 @@ class CostProjection : public ceres::CostFunction
         const double* parameter_intrinsics = parameters[2];
         const double* parameter_landmark = parameters[3];
 
-        const Eigen::Map<const SE3::Matrix> rTo(parameter_pose);
-        const Eigen::Map<const SE3::Matrix> cTr(parameter_rig);
+        const Eigen::Map<const Eigen::Vector3d> rro(parameter_pose);
+        const Eigen::Map<const Eigen::Vector3d> rto(parameter_pose + 3);
+        const Eigen::Map<const Eigen::Vector3d> crr(parameter_rig);
+        const Eigen::Map<const Eigen::Vector3d> ctr(parameter_rig + 3);
         const Eigen::Map<const Vec3> pt(parameter_landmark);
+
+        Eigen::Matrix4d rTo = Eigen::Matrix4d::Identity();
+        rTo.block<3, 3>(0, 0) = SO3::expm(rro);
+        rTo.block<3, 1>(0, 3) = rto;
+
+        Eigen::Matrix4d cTr = Eigen::Matrix4d::Identity();
+        cTr.block<3, 3>(0, 0) = SO3::expm(crr);
+        cTr.block<3, 1>(0, 3) = ctr;
 
         /*Update intrinsics object with estimated parameters*/
         size_t params_size = _intrinsics->getParams().size();
@@ -67,18 +76,37 @@ class CostProjection : public ceres::CostFunction
 
         if (jacobians[0] != nullptr)
         {
-            Eigen::Map<Eigen::Matrix<double, 2, 16, Eigen::RowMajor>> J(jacobians[0]);
+            Eigen::Map<Eigen::Matrix<double, 2, 6, Eigen::RowMajor>> J(jacobians[0]);
 
-            J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPose(T, pth) * getJacobian_AB_wrt_B<4, 4, 4>(cTr, rTo) *
-                getJacobian_AB_wrt_A<4, 4, 4>(Eigen::Matrix4d::Identity(), rTo);
+            
+            Eigen::Matrix<double, 2, 16> Jpose;
+            Jpose = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPose(T, pth) * getJacobian_AB_wrt_B<4, 4, 4>(cTr, rTo);
+
+            Eigen::Matrix<double, 9, 3> Jbuf = SO3::dexpmdr(rro);
+
+            Eigen::Matrix<double, 16, 6> Jalg =  Eigen::Matrix<double, 16, 6>::Zero();
+            Jalg.block<3, 3>(0, 0) = Jbuf.block<3, 3>(0, 0);
+            Jalg.block<3, 3>(4, 0) = Jbuf.block<3, 3>(3, 0);
+            Jalg.block<3, 3>(8, 0) = Jbuf.block<3, 3>(6, 0);
+            Jalg.block<3, 3>(12, 3).setIdentity();
+
+            J = Jpose * Jalg;
         }
 
         if (jacobians[1] != nullptr)
         {
-            Eigen::Map<Eigen::Matrix<double, 2, 16, Eigen::RowMajor>> J(jacobians[1]);
+            Eigen::Map<Eigen::Matrix<double, 2, 6, Eigen::RowMajor>> J(jacobians[1]);
 
-            J = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPose(T, pth) * getJacobian_AB_wrt_A<4, 4, 4>(cTr, rTo) *
-                getJacobian_AB_wrt_A<4, 4, 4>(Eigen::Matrix4d::Identity(), cTr);
+            Eigen::Matrix<double, 2, 16> Jpose;
+            Jpose = d_res_d_pt_est * _intrinsics->getDerivativeProjectWrtPose(T, pth) * getJacobian_AB_wrt_A<4, 4, 4>(cTr, rTo);
+
+            Eigen::Matrix<double, 9, 3> Jbuf = SO3::dexpmdr(crr);
+
+            Eigen::Matrix<double, 16, 6> Jalg =  Eigen::Matrix<double, 16, 6>::Zero();
+            Jalg.block<3, 3>(0, 0) = Jbuf.block<3, 3>(0, 0);
+            Jalg.block<3, 3>(4, 0) = Jbuf.block<3, 3>(3, 0);
+            Jalg.block<3, 3>(8, 0) = Jbuf.block<3, 3>(6, 0);
+            Jalg.block<3, 3>(12, 3).setIdentity();
         }
 
         if (jacobians[2] != nullptr)
@@ -101,7 +129,6 @@ class CostProjection : public ceres::CostFunction
   private:
     const sfmData::Observation& _measured;
     const std::shared_ptr<camera::IntrinsicBase> _intrinsics;
-    bool _withRig;
 };
 
 }  // namespace sfm

--- a/src/aliceVision/sfm/bundle/costfunctions/rotationPrior.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/rotationPrior.hpp
@@ -11,7 +11,7 @@
 namespace aliceVision {
 namespace sfm {
 
-class CostRotationPrior : public ceres::SizedCostFunction<3, 16, 16>
+class CostRotationPrior : public ceres::SizedCostFunction<3, 6, 6>
 {
   public:
     explicit CostRotationPrior(const Eigen::Matrix3d& two_R_one)
@@ -23,11 +23,11 @@ class CostRotationPrior : public ceres::SizedCostFunction<3, 16, 16>
         const double* parameter_pose_one = parameters[0];
         const double* parameter_pose_two = parameters[1];
 
-        const Eigen::Map<const Eigen::Matrix<double, 4, 4, Eigen::RowMajor>> oneTo(parameter_pose_one);
-        const Eigen::Map<const Eigen::Matrix<double, 4, 4, Eigen::RowMajor>> twoTo(parameter_pose_two);
+        const Eigen::Map<const Eigen::Vector3d> onero(parameter_pose_one);
+        const Eigen::Map<const Eigen::Vector3d> tworo(parameter_pose_two);
 
-        Eigen::Matrix<double, 3, 3> oneRo = oneTo.block<3, 3>(0, 0);
-        Eigen::Matrix<double, 3, 3> twoRo = twoTo.block<3, 3>(0, 0);
+        Eigen::Matrix<double, 3, 3> oneRo = SO3::expm(onero);
+        Eigen::Matrix<double, 3, 3> twoRo = SO3::expm(tworo);
 
         Eigen::Matrix3d two_R_one_est = twoRo * oneRo.transpose();
         Eigen::Matrix3d error_R = two_R_one_est * _two_R_one.transpose();
@@ -44,30 +44,26 @@ class CostRotationPrior : public ceres::SizedCostFunction<3, 16, 16>
 
         if (jacobians[0])
         {
-            Eigen::Map<Eigen::Matrix<double, 3, 16, Eigen::RowMajor>> J(jacobians[0]);
+            Eigen::Map<Eigen::Matrix<double, 3, 6, Eigen::RowMajor>> J(jacobians[0]);
 
-            Eigen::Matrix<double, 3, 9> J9 = SO3::dlogmdr(error_R) * getJacobian_AB_wrt_A<3, 3, 3>(two_R_one_est, _two_R_one.transpose()) *
+            Eigen::Matrix<double, 3, 3> J3 = SO3::dlogmdr(error_R) * getJacobian_AB_wrt_A<3, 3, 3>(two_R_one_est, _two_R_one.transpose()) *
                                              getJacobian_AB_wrt_B<3, 3, 3>(twoRo, oneRo.transpose()) * getJacobian_At_wrt_A<3, 3>() *
-                                             getJacobian_AB_wrt_A<3, 3, 3>(Eigen::Matrix3d::Identity(), oneRo);
+                                             SO3::dexpmdr(onero);
 
             J.fill(0);
-            J.block<3, 3>(0, 0) = J9.block<3, 3>(0, 0);
-            J.block<3, 3>(0, 4) = J9.block<3, 3>(0, 3);
-            J.block<3, 3>(0, 8) = J9.block<3, 3>(0, 6);
+            J.block<3, 3>(0, 0) = J3.block<3, 3>(0, 0);
         }
 
         if (jacobians[1])
         {
-            Eigen::Map<Eigen::Matrix<double, 3, 16, Eigen::RowMajor>> J(jacobians[1]);
+            Eigen::Map<Eigen::Matrix<double, 3, 6, Eigen::RowMajor>> J(jacobians[1]);
 
-            Eigen::Matrix<double, 3, 9> J9 = SO3::dlogmdr(error_R) * getJacobian_AB_wrt_A<3, 3, 3>(two_R_one_est, _two_R_one.transpose()) *
+            Eigen::Matrix<double, 3, 3> J3 = SO3::dlogmdr(error_R) * getJacobian_AB_wrt_A<3, 3, 3>(two_R_one_est, _two_R_one.transpose()) *
                                              getJacobian_AB_wrt_A<3, 3, 3>(twoRo, oneRo.transpose()) *
-                                             getJacobian_AB_wrt_A<3, 3, 3>(Eigen::Matrix3d::Identity(), twoRo);
+                                             SO3::dexpmdr(tworo);
 
             J.fill(0);
-            J.block<3, 3>(0, 0) = J9.block<3, 3>(0, 0);
-            J.block<3, 3>(0, 4) = J9.block<3, 3>(0, 3);
-            J.block<3, 3>(0, 8) = J9.block<3, 3>(0, 6);
+            J.block<3, 3>(0, 0) = J3.block<3, 3>(0, 0);
         }
 
         return true;

--- a/src/aliceVision/sfm/bundle/manifolds/so3.hpp
+++ b/src/aliceVision/sfm/bundle/manifolds/so3.hpp
@@ -12,68 +12,6 @@
 #include <ceres/ceres.h>
 
 namespace aliceVision {
-namespace SO3 {
-
-/**
-Compute the jacobian of the logarithm wrt changes in the rotation matrix values
-@param R the input rotation matrix
-@return the jacobian matrix (3*9 matrix)
-*/
-inline Eigen::Matrix<double, 3, 9, Eigen::RowMajor> dlogmdr(const Eigen::Matrix3d& R)
-{
-    double p1 = R(2, 1) - R(1, 2);
-    double p2 = R(0, 2) - R(2, 0);
-    double p3 = R(1, 0) - R(0, 1);
-
-    double costheta = (R.trace() - 1.0) / 2.0;
-    if (costheta > 1.0)
-        costheta = 1.0;
-    else if (costheta < -1.0)
-        costheta = -1.0;
-
-    double theta = acos(costheta);
-
-    if (fabs(theta) < std::numeric_limits<float>::epsilon())
-    {
-        Eigen::Matrix<double, 3, 9> J;
-        J.fill(0);
-        J(0, 5) = 1;
-        J(0, 7) = -1;
-        J(1, 2) = -1;
-        J(1, 6) = 1;
-        J(2, 1) = 1;
-        J(2, 3) = -1;
-        return J;
-    }
-
-    double scale = theta / (2.0 * sin(theta));
-
-    Eigen::Vector3d resnoscale;
-    resnoscale(0) = p1;
-    resnoscale(1) = p2;
-    resnoscale(2) = p3;
-
-    Eigen::Matrix<double, 3, 3> dresdp = Eigen::Matrix3d::Identity() * scale;
-    Eigen::Matrix<double, 3, 9> dpdmat;
-    dpdmat.fill(0);
-    dpdmat(0, 5) = 1;
-    dpdmat(0, 7) = -1;
-    dpdmat(1, 2) = -1;
-    dpdmat(1, 6) = 1;
-    dpdmat(2, 1) = 1;
-    dpdmat(2, 3) = -1;
-
-    double dscaledtheta = -0.5 * theta * cos(theta) / (sin(theta) * sin(theta)) + 0.5 / sin(theta);
-    double dthetadcostheta = -1.0 / sqrt(-costheta * costheta + 1.0);
-
-    Eigen::Matrix<double, 1, 9> dcosthetadmat;
-    dcosthetadmat << 0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5;
-    Eigen::Matrix<double, 1, 9> dscaledmat = dscaledtheta * dthetadcostheta * dcosthetadmat;
-
-    return dpdmat * scale + resnoscale * dscaledmat;
-}
-}  // namespace SO3
-
 namespace sfm {
 
 class SO3Manifold : public ceres::Manifold

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
@@ -391,7 +391,6 @@ bool ReconstructionEngine_panorama::adjust()
     BundleAdjustmentSymbolicCeres::CeresOptions options;
     options.summary = true;
     options.maxNumIterations = 300;
-    options.useFocalPrior = false;
     options.useParametersOrdering = false;
 
     // Start bundle with rotation only


### PR DESCRIPTION
Symbolic ceres solver was using SO(3) matrix as internal representation.
Autodiff ceres solver was using so(3) vector as internal representation.

Symbolic ceres solver is now using so(3) vector as internal representation.

Next step is to merge symbolic cost functions inside the same class than autodiff cost functions