### PR TITLE
[segmentation] Image segmentation CPU bugfix and ONNX output update

### DIFF
--- a/src/aliceVision/segmentation/segmentation.cpp
+++ b/src/aliceVision/segmentation/segmentation.cpp
@@ -72,7 +72,6 @@ bool Segmentation::initialize()
 
         _output.resize(_parameters.classes.size() * _parameters.modelHeight * _parameters.modelWidth);
         _cudaInput = cudaAllocator.Alloc(_output.size() * sizeof(float));
-        _cudaOutput = cudaAllocator.Alloc(_output.size() * sizeof(float));
 #endif
     }
     else
@@ -94,7 +93,6 @@ bool Segmentation::terminate()
     Ort::MemoryInfo mem_info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemType::OrtMemTypeDefault);
     Ort::Allocator cudaAllocator(*_ortSession, mem_info_cuda);
     cudaAllocator.Free(_cudaInput);
-    cudaAllocator.Free(_cudaOutput);
 #endif
 
     return true;

--- a/src/aliceVision/segmentation/segmentation.cpp
+++ b/src/aliceVision/segmentation/segmentation.cpp
@@ -89,11 +89,14 @@ bool Segmentation::initialize()
 
 bool Segmentation::terminate()
 {
+    if (_parameters.useGpu)
+    {
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_ONNX_GPU)
-    Ort::MemoryInfo mem_info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemType::OrtMemTypeDefault);
-    Ort::Allocator cudaAllocator(*_ortSession, mem_info_cuda);
-    cudaAllocator.Free(_cudaInput);
+        Ort::MemoryInfo mem_info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemType::OrtMemTypeDefault);
+        Ort::Allocator cudaAllocator(*_ortSession, mem_info_cuda);
+        cudaAllocator.Free(_cudaInput);
 #endif
+    }
 
     return true;
 }

--- a/src/aliceVision/segmentation/segmentation.cpp
+++ b/src/aliceVision/segmentation/segmentation.cpp
@@ -67,11 +67,7 @@ bool Segmentation::initialize()
         _ortSession = std::make_unique<Ort::Session>(*_ortEnvironment, _parameters.modelWeights.c_str(), ortSessionOptions);
     #endif
 
-        Ort::MemoryInfo memInfoCuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemType::OrtMemTypeDefault);
-        Ort::Allocator cudaAllocator(*_ortSession, memInfoCuda);
-
         _output.resize(_parameters.classes.size() * _parameters.modelHeight * _parameters.modelWidth);
-        _cudaInput = cudaAllocator.Alloc(_output.size() * sizeof(float));
 #endif
     }
     else
@@ -81,20 +77,6 @@ bool Segmentation::initialize()
         _ortSession = std::make_unique<Ort::Session>(*_ortEnvironment, modelWeights.c_str(), ortSessionOptions);
 #else
         _ortSession = std::make_unique<Ort::Session>(*_ortEnvironment, _parameters.modelWeights.c_str(), ortSessionOptions);
-#endif
-    }
-
-    return true;
-}
-
-bool Segmentation::terminate()
-{
-    if (_parameters.useGpu)
-    {
-#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_ONNX_GPU)
-        Ort::MemoryInfo mem_info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemType::OrtMemTypeDefault);
-        Ort::Allocator cudaAllocator(*_ortSession, mem_info_cuda);
-        cudaAllocator.Free(_cudaInput);
 #endif
     }
 
@@ -299,24 +281,14 @@ bool Segmentation::processTile(image::Image<ScoredLabel>& labels, const image::I
         return false;
     }
 
-    std::vector<float> output(_parameters.classes.size() * _parameters.modelHeight * _parameters.modelWidth);
-    int idx = 0;
-    for (int ch = 0; ch < _parameters.classes.size(); ch++)
-    {
-        for (int i = 0; i < _parameters.modelHeight; i++)
-        {
-            for (int j = 0; j < _parameters.modelWidth; j++)
-            {
-                const std::vector<int64_t> coords = {0, ch, i, j};
-                output[idx++] = outTensor[0].At<float>(coords);
-            }
-        }
-    }
-
     if (!labelsFromOutputTensor(labels, outTensor[0]))
     {
         return false;
     }
+
+    std::vector<float> output(_parameters.classes.size() * _parameters.modelHeight * _parameters.modelWidth);
+    auto *outTData = outTensor.front().GetTensorMutableData<float>();
+    output.assign(outTData, outTData + _parameters.classes.size() * _parameters.modelHeight * _parameters.modelWidth);
 
     return true;
 }
@@ -325,8 +297,7 @@ bool Segmentation::processTileGPU(image::Image<ScoredLabel>& labels, const image
 {
     ALICEVISION_LOG_TRACE("Process tile using gpu");
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CUDA)
-    Ort::MemoryInfo mem_info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemType::OrtMemTypeDefault);
-    Ort::Allocator cudaAllocator(*_ortSession, mem_info_cuda);
+    Ort::MemoryInfo memInfo = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator, OrtMemType::OrtMemTypeDefault);
 
     std::vector<const char*> inputNames{"input"};
     std::vector<const char*> outputNames{"output"};
@@ -335,16 +306,18 @@ bool Segmentation::processTileGPU(image::Image<ScoredLabel>& labels, const image
     std::vector<float> transformedInput;
     imageToPlanes(transformedInput, source);
 
-    cudaMemcpy(_cudaInput, transformedInput.data(), sizeof(float) * transformedInput.size(), cudaMemcpyHostToDevice);
-
-    Ort::Value inputTensors = Ort::Value::CreateTensor<float>(
-      mem_info_cuda, reinterpret_cast<float*>(_cudaInput), transformedInput.size(), inputDimensions.data(), inputDimensions.size());
+    std::vector<Ort::Value> inputTensors;
+    inputTensors.emplace_back(Ort::Value::CreateTensor<float>(memInfo,
+                                                              transformedInput.data(),
+                                                              transformedInput.size(),
+                                                              inputDimensions.data(),
+                                                              inputDimensions.size()));
 
     std::vector<Ort::Value> outTensor;
 
     try
     {
-        outTensor = _ortSession->Run(Ort::RunOptions{nullptr}, inputNames.data(), &inputTensors, 1, outputNames.data(), 1);
+        outTensor = _ortSession->Run(Ort::RunOptions{nullptr}, inputNames.data(), inputTensors.data(), 1, outputNames.data(), 1);
     }
     catch (const Ort::Exception& exception)
     {
@@ -352,23 +325,13 @@ bool Segmentation::processTileGPU(image::Image<ScoredLabel>& labels, const image
         return false;
     }
 
-    int idx = 0;
-    for (int ch = 0; ch < _parameters.classes.size(); ch++)
-    {
-        for (int i = 0; i < _parameters.modelHeight; i++)
-        {
-            for (int j = 0; j < _parameters.modelWidth; j++)
-            {
-                const std::vector<int64_t> coords = {0, ch, i, j};
-                _output[idx++] = outTensor[0].At<float>(coords);
-            }
-        }
-    }
-
     if (!labelsFromOutputTensor(labels, outTensor[0]))
     {
         return false;
     }
+
+    auto *outTData = outTensor.front().GetTensorMutableData<float>();
+    _output.assign(outTData, outTData + _parameters.classes.size() * _parameters.modelHeight * _parameters.modelWidth);
 
 #endif
 

--- a/src/aliceVision/segmentation/segmentation.hpp
+++ b/src/aliceVision/segmentation/segmentation.hpp
@@ -86,10 +86,17 @@ class Segmentation
 
     /**
      * Transform model output to a label image
-     * @param labels the output labels imaage
+     * @param labels the output labels image
      * @param modeloutput the model output vector
      */
     bool labelsFromModelOutput(image::Image<ScoredLabel>& labels, const std::vector<float>& modelOutput);
+
+    /**
+     * Transform model output to a label image
+     * @param labels the output labels image
+     * @param modeloutput the model output tensor
+     */
+    bool labelsFromOutputTensor(image::Image<ScoredLabel>& labels, Ort::Value& modelOutput);
 
     /**
      * Process effectively a buffer of the model input size

--- a/src/aliceVision/segmentation/segmentation.hpp
+++ b/src/aliceVision/segmentation/segmentation.hpp
@@ -57,7 +57,7 @@ class Segmentation
         }
     }
 
-    virtual ~Segmentation() { terminate(); }
+    virtual ~Segmentation() {}
 
     /**
      * Process an input image to estimate segmentation
@@ -73,23 +73,11 @@ class Segmentation
     bool initialize();
 
     /**
-     * Onnx destruction code
-     */
-    bool terminate();
-
-    /**
      * Assume the source image is the correct size
      * @param labels the output label image
      * @param source the input image to process
      */
     bool tiledProcess(image::Image<IndexT>& labels, const image::Image<image::RGBfColor>& source);
-
-    /**
-     * Transform model output to a label image
-     * @param labels the output labels image
-     * @param modeloutput the model output vector
-     */
-    bool labelsFromModelOutput(image::Image<ScoredLabel>& labels, const std::vector<float>& modelOutput);
 
     /**
      * Transform model output to a label image


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
This PR modifies the access to the output of the onnx model using the dedicated 'At' accessor in image segmentation. This is a safer method than accessing with a pointer because onnx does not guarantee that the allocated memory is contiguous.

It also fixes a bug when using the cpu mode by avoiding freeing cuda memory in this case.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

