### PR TITLE
CI: Move from CentOS to Ubuntu for Linux

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: alicevision/alicevision-deps:2024.10.22-ubuntu20.04-cuda11.3.1
+      image: alicevision/alicevision-deps:2024.11.25-ubuntu22.04-cuda12.1.0
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release
@@ -45,26 +45,23 @@ jobs:
         run: |
           cmake .. \
            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-           -DBUILD_SHARED_LIBS:BOOL=ON \
+           -DBUILD_SHARED_LIBS=ON \
            -DCMAKE_PREFIX_PATH="${DEPS_INSTALL_DIR}" \
-           -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../../AV_install \
+           -DCMAKE_INSTALL_PREFIX="${ALICEVISION_ROOT}" \
            -DTARGET_ARCHITECTURE=core \
-           -DALICEVISION_BUILD_TESTS:BOOL=ON \
-           -DALICEVISION_BUILD_SWIG_BINDING:BOOL=ON \
-           -DALICEVISION_USE_OPENCV:BOOL=ON \
-           -DALICEVISION_USE_CUDA:BOOL=ON \
-           -DALICEVISION_USE_CCTAG:BOOL=ON \
-           -DALICEVISION_USE_POPSIFT:BOOL=ON \
-           -DALICEVISION_USE_ALEMBIC:BOOL=ON  \
-           -DOpenCV_DIR:PATH="${DEPS_INSTALL_DIR}/share/OpenCV" \
-           -DALICEVISION_USE_OPENGV:BOOL=ON \
-           -DOPENGV_DIR:PATH="${DEPS_INSTALL_DIR}" \
-           -DBOOST_NO_CXX11:BOOL=ON \
-           -DCeres_DIR:PATH="${DEPS_INSTALL_DIR}/share/Ceres" \
-           -DEIGEN_INCLUDE_DIR_HINTS:PATH="${DEPS_INSTALL_DIR}" \
-           -DAlembic_DIR:PATH="${DEPS_INSTALL_DIR}/lib/cmake/Alembic" \
-           -DSWIG_DIR:PATH="${DEPS_INSTALL_DIR}/share/swig/4.3.0" \
-           -DSWIG_EXECUTABLE:PATH="${DEPS_INSTALL_DIR}/bin-deps/swig"
+           -DALICEVISION_BUILD_TESTS=ON \
+           -DALICEVISION_BUILD_SWIG_BINDING=ON \
+           -DALICEVISION_USE_OPENCV=ON \
+           -DALICEVISION_USE_CUDA=ON \
+           -DALICEVISION_USE_CCTAG=ON \
+           -DALICEVISION_USE_POPSIFT=ON \
+           -DALICEVISION_USE_ALEMBIC=ON  \
+           -DOpenCV_DIR="${DEPS_INSTALL_DIR}/share/OpenCV" \
+           -DALICEVISION_USE_OPENGV=ON \
+           -DCeres_DIR="${DEPS_INSTALL_DIR}/share/Ceres" \
+           -DAlembic_DIR="${DEPS_INSTALL_DIR}/lib/cmake/Alembic" \
+           -DSWIG_DIR="${DEPS_INSTALL_DIR}/share/swig/4.3.0" \
+           -DSWIG_EXECUTABLE="${DEPS_INSTALL_DIR}/bin-deps/swig"
 
       - name: Build
         working-directory: ./build
@@ -79,6 +76,7 @@ jobs:
       - name: Unit Tests
         working-directory: ./build
         run: |
+          export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
           make test
 
       - name: Build As Third Party
@@ -123,8 +121,8 @@ jobs:
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
           echo "ldd aliceVision_cameraInit"
           ldd ${ALICEVISION_ROOT}/bin/aliceVision_cameraInit
-          python --version
-          python EvaluationLauncher.py -s ${ALICEVISION_ROOT}/bin -i $PWD/Benchmarking_Camera_Calibration_2008/ -o $PWD/reconstructions/ -r $PWD/results.json -v
+          python3 --version
+          python3 EvaluationLauncher.py -s ${ALICEVISION_ROOT}/bin -i $PWD/Benchmarking_Camera_Calibration_2008/ -o $PWD/reconstructions/ -r $PWD/results.json -v
 
       - name: Python Binding - Unit Tests
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,7 +39,6 @@ jobs:
           mkdir ./build_as_3rdparty
           mkdir ./functional_tests
           mkdir ../AV_install
-          git submodule update -i
 
       - name: Configure CMake
         working-directory: ./build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: alicevision/alicevision-deps:2024.10.22-centos7-cuda11.3.1
+      image: alicevision/alicevision-deps:2024.10.22-ubuntu20.04-cuda11.3.1
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -8,8 +8,8 @@ test -e docker/fetch.sh || {
 
 test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2024.10.22
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
-test -z "$CUDA_VERSION" && CUDA_VERSION=11.3.1
-test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=20.04
+test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.0
+test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=22.04
 test -z "$REPO_OWNER" && REPO_OWNER=alicevision
 test -z "$DOCKER_REGISTRY" && DOCKER_REGISTRY=docker.io
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,15 +176,6 @@ macro(add_target_properties _target _name)
 endmacro(add_target_properties)
 
 # ==============================================================================
-# Check that submodule have been initialized and updated
-# ==============================================================================
-if(ALICEVISION_USE_MESHSDFILTER AND NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/MeshSDFilter/CMakeLists.txt)
-  message(FATAL_ERROR
-    "\n submodule(s) are missing, please update your repository:\n"
-    "  > git submodule update -i\n")
-endif()
-
-# ==============================================================================
 # Additional cmake find modules
 # ==============================================================================
 set(CMAKE_MODULE_PATH

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -1047,7 +1047,7 @@ if(AV_BUILD_CCTAG)
 
     ExternalProject_Add(${CCTAG_TARGET}
         GIT_REPOSITORY https://github.com/alicevision/CCTag
-        GIT_TAG v1.0.3
+        GIT_TAG v1.0.4
         PREFIX ${BUILD_DIR}
         BUILD_IN_SOURCE 0
         BUILD_ALWAYS 0

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -266,8 +266,6 @@ function(alicevision_add_test test_file)
   if(UNIX)
     # setup LD_LIBRARY_PATH for running tests
     get_property(TEST_LINK_DIRS TARGET ${TEST_EXECUTABLE_NAME} PROPERTY LINK_DIRECTORIES)
-
-    set_property(TEST test_${TEST_EXECUTABLE_NAME} PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}:${TEST_LINK_DIRS}:$ENV{LD_LIBRARY_PATH}")
   endif()
   
   if (WIN32)


### PR DESCRIPTION
To get a more recent version of python-3.

The Ubuntu image is now based on Ubuntu 22 and uses CUDA 12.1 (instead of 11.3).
