### PR TITLE
Use ENV for environment variable persistence 

### DIFF
--- a/docker/Dockerfile_centos
+++ b/docker/Dockerfile_centos
@@ -40,10 +40,10 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release \
       -DSWIG_DIR="${AV_INSTALL}/share/swig/4.3.0" -DSWIG_EXECUTABLE="${AV_INSTALL}/bin-deps/swig" \
       "${AV_DEV}" || (cat "${AV_BUILD}/CMakeFiles/CMakeOutput.log" "${AV_BUILD}/CMakeFiles/CMakeError.log" && false)
 
-RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`; \
-    make -j"${CPU_CORES}" && \
+ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`      
+RUN make -j"${CPU_CORES}" && \
     make install && \
     make bundle && \
-    rm -rf "${AV_DEV}" "${AV_BUILD}" && \
-    echo "export ALICEVISION_SENSOR_DB=${AV_BUNDLE}/share/aliceVision/cameraSensors.db" >> /etc/profile.d/alicevision.sh && \
-	echo "export ALICEVISION_ROOT=${AV_BUNDLE}" >> /etc/profile.d/alicevision.sh
+    rm -rf "${AV_DEV}" "${AV_BUILD}"
+ENV ALICEVISION_SENSOR_DB=${AV_BUNDLE}/share/aliceVision/cameraSensors.db
+ENV ALICEVISION_ROOT=${AV_BUNDLE}

--- a/docker/Dockerfile_centos
+++ b/docker/Dockerfile_centos
@@ -39,9 +39,9 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release \
       -DALICEVISION_USE_POPSIFT=ON -DALICEVISION_USE_CUDA=ON -DALICEVISION_USE_ONNX_GPU=OFF -DALICEVISION_BUILD_DOC=OFF \
       -DSWIG_DIR="${AV_INSTALL}/share/swig/4.3.0" -DSWIG_EXECUTABLE="${AV_INSTALL}/bin-deps/swig" \
       "${AV_DEV}" || (cat "${AV_BUILD}/CMakeFiles/CMakeOutput.log" "${AV_BUILD}/CMakeFiles/CMakeError.log" && false)
-
-ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`      
-RUN make -j"${CPU_CORES}" && \
+      
+RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`; \
+    make -j"${CPU_CORES}" && \
     make install && \
     make bundle && \
     rm -rf "${AV_DEV}" "${AV_BUILD}"

--- a/docker/Dockerfile_centos_deps
+++ b/docker/Dockerfile_centos_deps
@@ -77,16 +77,17 @@ ENV PATH="/opt/rh/devtoolset-10/root/usr/bin:${PATH}" \
     CMAKE_VERSION=3.26.0
 
 COPY dl/vlfeat_K80L3.SIFT.tree ${AV_INSTALL}/share/aliceVision/
-RUN echo "export ALICEVISION_VOCTREE=${AV_INSTALL}/share/aliceVision/vlfeat_K80L3.SIFT.tree" > /etc/profile.d/alicevision.sh
+ENV ALICEVISION_VOCTREE=${AV_INSTALL}/share/aliceVision/vlfeat_K80L3.SIFT.tree
 
 COPY dl/sphereDetection_Mask-RCNN.onnx ${AV_INSTALL}/share/aliceVision/
-RUN echo "export ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVision/sphereDetection_Mask-RCNN.onnx" > /etc/profile.d/alicevision.sh
+ENV ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVision/sphereDetection_Mask-RCNN.onnx
 
 COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
-RUN echo "export ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx" > /etc/profile.d/alicevision.sh
+ENV ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx
 
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
-RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && echo "Build multithreading number of cores: ${CPU_CORES}"
+ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` 
+RUN echo "Build multithreading number of cores: ${CPU_CORES}"
 
 # Manually install cmake
 WORKDIR /opt

--- a/docker/Dockerfile_centos_deps
+++ b/docker/Dockerfile_centos_deps
@@ -86,8 +86,7 @@ COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
 ENV ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx
 
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
-ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` 
-RUN echo "Build multithreading number of cores: ${CPU_CORES}"
+RUN echo "Build multithreading number of cores: `${AV_DEV}/docker/check-cpu.sh`"
 
 # Manually install cmake
 WORKDIR /opt
@@ -145,6 +144,7 @@ RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib64/libcublas.so 
 # RUN make -j ${CPU_CORES} cctag
 # RUN make -j ${CPU_CORES} popsift
 
-RUN cmake --build . -j ${CPU_CORES} && \
+RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && \
+    cmake --build . -j ${CPU_CORES} && \
     mv "${AV_INSTALL}/bin" "${AV_INSTALL}/bin-deps" && \
     rm -rf "${AV_BUILD}"

--- a/docker/Dockerfile_ubuntu
+++ b/docker/Dockerfile_ubuntu
@@ -40,8 +40,8 @@ WORKDIR "${AV_BUILD}"
 
 COPY docker ${AV_DEV}/docker
 
-ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`
-RUN cmake -DCMAKE_BUILD_TYPE=Release \
+RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`; \
+         cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS:BOOL=ON \
         -DTARGET_ARCHITECTURE=${TARGET_ARCHITECTURE} \
         -DALICEVISION_BUILD_DEPENDENCIES:BOOL=OFF \

--- a/docker/Dockerfile_ubuntu
+++ b/docker/Dockerfile_ubuntu
@@ -40,8 +40,8 @@ WORKDIR "${AV_BUILD}"
 
 COPY docker ${AV_DEV}/docker
 
-RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`; \
-         cmake -DCMAKE_BUILD_TYPE=Release \
+ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`
+RUN cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS:BOOL=ON \
         -DTARGET_ARCHITECTURE=${TARGET_ARCHITECTURE} \
         -DALICEVISION_BUILD_DEPENDENCIES:BOOL=OFF \
@@ -62,6 +62,7 @@ RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`; \
         "${AV_DEV}" && \
     make install -j${CPU_CORES} && \
     make bundle && \
-    rm -rf "${AV_BUILD}" "${AV_DEV}" && \
-    echo "export ALICEVISION_SENSOR_DB=${AV_BUNDLE}/share/aliceVision/cameraSensors.db" >> /etc/profile.d/alicevision.sh && \
-    echo "export ALICEVISION_ROOT=${AV_BUNDLE}" >> /etc/profile.d/alicevision.sh
+    rm -rf "${AV_BUILD}" "${AV_DEV}"
+
+ENV ALICEVISION_SENSOR_DB=${AV_BUNDLE}/share/aliceVision/cameraSensors.db
+ENV ALICEVISION_ROOT=${AV_BUNDLE}

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -71,8 +71,7 @@ COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
 ENV ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx
 
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
-ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` 
-RUN echo "Build multithreading number of cores: ${CPU_CORES}"
+RUN echo "Build multithreading number of cores: `${AV_DEV}/docker/check-cpu.sh`"
 
 COPY CMakeLists.txt ${AV_DEV}/
 COPY src/cmake/Dependencies.cmake ${AV_DEV}/src/cmake/
@@ -120,6 +119,7 @@ RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gn
 # RUN make -j ${CPU_CORES} popsift
 # RUN make -j ${CPU_CORES} cctag
 
-RUN cmake --build . -j ${CPU_CORES} && \
+RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && \
+    cmake --build . -j ${CPU_CORES} && \
     mv "${AV_INSTALL}/bin" "${AV_INSTALL}/bin-deps" && \
     rm -rf "${AV_BUILD}"

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -62,16 +62,17 @@ ENV AV_DEV=/opt/AliceVision_git \
     PATH="${PATH}:${AV_BUNDLE}"
 
 COPY dl/vlfeat_K80L3.SIFT.tree ${AV_INSTALL}/share/aliceVision/
-RUN echo "export ALICEVISION_VOCTREE=${AV_INSTALL}/share/aliceVision/vlfeat_K80L3.SIFT.tree" > /etc/profile.d/alicevision.sh
+ENV ALICEVISION_VOCTREE=${AV_INSTALL}/share/aliceVision/vlfeat_K80L3.SIFT.tree
 
 COPY dl/sphereDetection_Mask-RCNN.onnx ${AV_INSTALL}/share/aliceVision/
-RUN echo "export ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVision/sphereDetection_Mask-RCNN.onnx" > /etc/profile.d/alicevision.sh
+ENV ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVision/sphereDetection_Mask-RCNN.onnx
 
 COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
-RUN echo "export ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx" > /etc/profile.d/alicevision.sh
+ENV ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx
 
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
-RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && echo "Build multithreading number of cores: ${CPU_CORES}"
+ENV CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` 
+RUN echo "Build multithreading number of cores: ${CPU_CORES}"
 
 COPY CMakeLists.txt ${AV_DEV}/
 COPY src/cmake/Dependencies.cmake ${AV_DEV}/src/cmake/


### PR DESCRIPTION
## Description
As per #1789, this PR changes the usage of `/etc/profile.d/alicevision.sh` as a login script to set environment variables to the docker `ENV` directive. 


## Features list

- [x] Fix #1789

## Implementation remarks

This implementation relies on `alicevision.sh` not being used elsewhere. It does not appear to ever be copied out of the container/image.

