### PR TITLE
Clarify check-cpu.sh documentation

### DIFF
--- a/docker/check-cpu.sh
+++ b/docker/check-cpu.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # This script is used to check the amount of available memory to ensure 2 GB of memory per process.
-# If the number of processes is greater than the amount of available memory (considering 2 GB per core) we restrict the number of cores to use.
+# If the number of processes is greater than the amount of available memory (considering 2 GB per core) we restrict the number of parallel make jobs to avoid resource contention. 
 #
 # Sample usage:
 # CPU_CORES=`check-cpu.sh`


### PR DESCRIPTION
The original comment in the script incorrectly stated that it limits the number of cores used during the build process. In reality, the script calculates and limits the number of parallel jobs (`make -j`) based on available memory, which indirectly affects core usage. While limiting the number of jobs may reduce the number of cores utilized—if each job corresponds to one thread or core—this is not always guaranteed.

This change clarifies the purpose of the script, communicating that it restricts the number of parallel build jobs to prevent resource contention, rather than directly controlling core usage.
