### PR TITLE
[FuseCut] Fix: Check cam vertex validity in meshing

### DIFF
--- a/src/aliceVision/fuseCut/GraphFiller.cpp
+++ b/src/aliceVision/fuseCut/GraphFiller.cpp
@@ -121,14 +121,17 @@ void GraphFiller::rayMarchingGraphEmpty(int vertexIndex,
 
     assert(cam >= 0);
     assert(cam < _mp.ncams);
+    
+    if (_camsVertexes[cam] < 0)
+    {
+        return;
+    }
 
     // Initialisation
     GeometryIntersection geometry(vertexIndex);  // Starting on global vertex index
     Point3d intersectPt = originPt;
     // toTheCam
     const double pointCamDistance = (_mp.CArr[cam] - originPt).size();
-
-
 
     TetrahedronsRayMarching marching(_tetrahedralization, vertexIndex, _camsVertexes[cam], false);
 
@@ -200,6 +203,14 @@ void GraphFiller::rayMarchingGraphFull(int vertexIndex,
                                          float fullWeight,
                                          double nPixelSizeBehind)
 {
+    assert(cam >= 0);
+    assert(cam < _mp.ncams);
+    
+    if (_camsVertexes[cam] < 0)
+    {
+        return;
+    }
+
     const int maxint = std::numeric_limits<int>::max();
     const Point3d& originPt = _verticesCoords[vertexIndex];
     const double pixSize = _verticesAttr[vertexIndex].pixSize;
@@ -295,7 +306,11 @@ void GraphFiller::forceTedgesByGradientIJCV(float nPixelSizeBehind)
                 GeometryIntersection geometry(vertexIndex);  // Starting on global vertex index
                 Point3d intersectPt = originPt;
                 // toTheCam
-            
+
+                if (_camsVertexes[cam] < 0)
+                {
+                    continue;
+                }
 
                 TetrahedronsRayMarching marching(_tetrahedralization, vertexIndex, _camsVertexes[cam], false);
 


### PR DESCRIPTION
When a camera's frustum is not intersecting the estimated bouding box, the associated camera vertex id is set to -1 (invalid). 

This fix is simply checking for the validity of the camera vertex id when used.