### PR TITLE
[docker] Update CUDA minor version to 12.1.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container: ["alicevision/alicevision-deps:2024.12.03-ubuntu22.04-cuda12.1.0", "alicevision/alicevision-deps:2024.12.09-rocky9-cuda12.1.0"]
+        container: ["alicevision/alicevision-deps:2025.01.06-ubuntu22.04-cuda12.1.1", "alicevision/alicevision-deps:2025.01.06-rocky9-cuda12.1.1"]
     container:
       image: ${{ matrix.container }}
     env:
@@ -33,7 +33,7 @@ jobs:
       ALICEVISION_ROOT: ${{ github.workspace }}/../AV_install
       ALICEVISION_SENSOR_DB: ${{ github.workspace }}/../AV_install/share/aliceVision/cameraSensors.db
       ALICEVISION_LENS_PROFILE_INFO: ""
-      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2024.12.03-ubuntu22.04-cuda12.1.0' && 'ON' || 'OFF' }}"
+      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2025.01.06-ubuntu22.04-cuda12.1.1' && 'ON' || 'OFF' }}"
     steps:
       - uses: actions/checkout@v1
 

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -9,5 +9,5 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-CUDA_VERSION=12.1.0 UBUNTU_VERSION=22.04 docker/build-ubuntu.sh
-CUDA_VERSION=12.1.0 ROCKY_VERSION=9 docker/build-rocky.sh
+CUDA_VERSION=12.1.1 UBUNTU_VERSION=22.04 docker/build-ubuntu.sh
+CUDA_VERSION=12.1.1 ROCKY_VERSION=9 docker/build-rocky.sh

--- a/docker/build-rocky.sh
+++ b/docker/build-rocky.sh
@@ -6,9 +6,9 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2024.12.09
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.01.06
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
-test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.0
+test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$ROCKY_VERSION" && ROCKY_VERSION=9
 test -z "$REPO_OWNER" && REPO_OWNER=alicevision
 test -z "$DOCKER_REGISTRY" && DOCKER_REGISTRY=docker.io

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,9 +6,9 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2024.12.03
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.01.06
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
-test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.0
+test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=22.04
 test -z "$REPO_OWNER" && REPO_OWNER=alicevision
 test -z "$DOCKER_REGISTRY" && DOCKER_REGISTRY=docker.io


### PR DESCRIPTION
## Description

This PR udpates the CUDA version for the dependencies images from 12.1.0 to 12.1.1. This fixes the deprecation notice that is prompted when running the images with 12.1.0, as pointed out in https://github.com/alicevision/AliceVision/issues/1792.