### PR TITLE
Reduce intrication of distortion with intrinsics

### DIFF
--- a/pyTests/camera/test_equidistant.py
+++ b/pyTests/camera/test_equidistant.py
@@ -77,8 +77,8 @@ from pyalicevision import numeric as avnum
 # - void setDistortionParams(vector<double>& distortionParams)
 # - template<class F> void setDistortionParamsFn(F&& callback) / not binded
 # - template<class F> void setDistortionParamsFn(size_t count, F&& callback) / not binded
-# - vector<double> getParams() => DONE
-# - size_t getParamsSize() => DONE
+# - vector<double> getParameters() => DONE
+# - size_t getParametersSize() => DONE
 # - updateFromParams(vector<double>& params) => DONE
 # - float getMaximalDistortion(double min_radius, double max_radius)
 # - Eigen::Matrix<double, 2, 2> getDerivativeAddDistoWrtPt(Vec2& pt) / Matrix and Vec2 not binded
@@ -285,16 +285,16 @@ def test_equidistant_get_set_params():
     """ Test creating an Equidistant object, getting and setting its parameters with the
     parent's class getters and setters. """
     intrinsic = av.Equidistant()
-    params = intrinsic.getParams()
+    params = intrinsic.getParameters()
 
-    assert len(params) == intrinsic.getParamsSize()
+    assert len(params) == intrinsic.getParametersSize()
     assert params == DEFAUT_PARAMETERS
 
     params = (2.0, 2.0, 1.0, 1.0)
 
-    assert params != intrinsic.getParams()
+    assert params != intrinsic.getParameters()
     intrinsic.updateFromParams(params)
-    assert params == intrinsic.getParams()
+    assert params == intrinsic.getParameters()
 
 
 def test_equidistant_lock_unlock():

--- a/pyTests/camera/test_pinhole.py
+++ b/pyTests/camera/test_pinhole.py
@@ -67,8 +67,8 @@ from pyalicevision import numeric as avnum
 # - void setDistortionParams(vector<double>& distortionParams)
 # - template<class F> void setDistortionParamsFn(F&& callback) / not binded
 # - template<class F> void setDistortionParamsFn(size_t count, F&& callback) / not binded
-# - vector<double> getParams() => DONE
-# - size_t getParamsSize() => DONE
+# - vector<double> getParameters() => DONE
+# - size_t getParametersSize() => DONE
 # - updateFromParams(vector<double>& params) => DONE
 # - float getMaximalDistortion(double min_radius, double max_radius)
 # - Eigen::Matrix<double, 2, 2> getDerivativeAddDistoWrtPt(Vec2& pt) / Matrix and Vec2 not binded
@@ -243,16 +243,16 @@ def test_pinhole_get_set_params():
     """ Test creating a Pinhole object, getting and setting its parameters with the
     parent's class getters and setters. """
     intrinsic = av.Pinhole()
-    params = intrinsic.getParams()
+    params = intrinsic.getParameters()
 
-    assert len(params) == intrinsic.getParamsSize()
+    assert len(params) == intrinsic.getParametersSize()
     assert params == DEFAUT_PARAMETERS
 
     params = (2.0, 2.0, 1.0, 1.0)
 
-    assert params != intrinsic.getParams()
+    assert params != intrinsic.getParameters()
     intrinsic.updateFromParams(params)
-    assert params == intrinsic.getParams()
+    assert params == intrinsic.getParameters()
 
 
 def test_pinhole_lock_unlock():

--- a/src/aliceVision/camera/Equidistant.cpp
+++ b/src/aliceVision/camera/Equidistant.cpp
@@ -116,7 +116,7 @@ Eigen::Matrix<double, 2, 3> Equidistant::getDerivativeTransformProjectWrtPoint3(
     return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtPt(P) * d_P_d_angles * d_angles_d_X * d_X_d_pt;
 }
 
-Eigen::Matrix<double, 2, 3> Equidistant::getDerivativeTransformProjectWrtDisto(const Eigen::Matrix4d& pose, const Vec4& pt) const
+Eigen::Matrix<double, 2, Eigen::Dynamic> Equidistant::getDerivativeTransformProjectWrtDistortion(const Eigen::Matrix4d& pose, const Vec4& pt) const
 {
     Eigen::Matrix4d T = pose;
     const Vec4 X = T * pt;  // apply pose
@@ -272,6 +272,20 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Equidistant::getDerivativeBackProjectUn
 
     J.block<3, 2>(0, 0) = getDerivativetoUnitSphereWrtScale(ptUndist);
     J.block<3, 2>(0, 2) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtPrincipalPoint();
+
+    return J;
+}
+
+Eigen::Matrix<double, 3, Eigen::Dynamic> Equidistant::getDerivativeBackProjectUnitWrtDistortion(const Vec2& pt2D) const
+{
+    size_t disto_size = getDistortionParamsSize();
+
+    const Vec2 ptMeters = ima2cam(pt2D);
+    const Vec2 ptUndist = removeDistortion(ptMeters);
+    const Vec3 ptSphere = toUnitSphere(ptUndist);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> J(3, disto_size);
+    J = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtDisto(ptMeters);
 
     return J;
 }

--- a/src/aliceVision/camera/Equidistant.cpp
+++ b/src/aliceVision/camera/Equidistant.cpp
@@ -187,12 +187,6 @@ Eigen::Matrix<double, 2, Eigen::Dynamic> Equidistant::getDerivativeTransformProj
     ret.block<2, 2>(0, 0) = getDerivativeTransformProjectWrtScale(pose, pt3D);
     ret.block<2, 2>(0, 2) = getDerivativeTransformProjectWrtPrincipalPoint(pose, pt3D);
 
-    if (_pDistortion != nullptr)
-    {
-        const size_t distortionSize = _pDistortion->getDistortionParametersCount();
-        ret.block(0, 4, 2, distortionSize) = getDerivativeTransformProjectWrtDisto(pose, pt3D);
-    }
-
     return ret;
 }
 
@@ -270,8 +264,6 @@ Eigen::Matrix<double, 3, 2> Equidistant::getDerivativetoUnitSphereWrtScale(const
 
 Eigen::Matrix<double, 3, Eigen::Dynamic> Equidistant::getDerivativeBackProjectUnitWrtParams(const Vec2& pt2D) const 
 {
-    size_t disto_size = getDistortionParamsSize();
-
     const Vec2 ptMeters = ima2cam(pt2D);
     const Vec2 ptUndist = removeDistortion(ptMeters);
     const Vec3 ptSphere = toUnitSphere(ptUndist);
@@ -280,11 +272,6 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Equidistant::getDerivativeBackProjectUn
 
     J.block<3, 2>(0, 0) = getDerivativetoUnitSphereWrtScale(ptUndist);
     J.block<3, 2>(0, 2) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtPrincipalPoint();
-
-    if (disto_size > 0)
-    {
-        J.block(0, 4, 3, disto_size) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtDisto(ptMeters);
-    }
 
     return J;
 }

--- a/src/aliceVision/camera/Equidistant.cpp
+++ b/src/aliceVision/camera/Equidistant.cpp
@@ -182,7 +182,7 @@ Eigen::Matrix<double, 2, 2> Equidistant::getDerivativeTransformProjectWrtPrincip
 
 Eigen::Matrix<double, 2, Eigen::Dynamic> Equidistant::getDerivativeTransformProjectWrtParams(const Eigen::Matrix4d& pose, const Vec4& pt3D) const
 {
-    Eigen::Matrix<double, 2, Eigen::Dynamic> ret(2, getParams().size());
+    Eigen::Matrix<double, 2, Eigen::Dynamic> ret(2, getParameters().size());
 
     ret.block<2, 2>(0, 0) = getDerivativeTransformProjectWrtScale(pose, pt3D);
     ret.block<2, 2>(0, 2) = getDerivativeTransformProjectWrtPrincipalPoint(pose, pt3D);
@@ -276,7 +276,7 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Equidistant::getDerivativeBackProjectUn
     const Vec2 ptUndist = removeDistortion(ptMeters);
     const Vec3 ptSphere = toUnitSphere(ptUndist);
 
-    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> J(3, getParams().size());
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> J(3, getParameters().size());
 
     J.block<3, 2>(0, 0) = getDerivativetoUnitSphereWrtScale(ptUndist);
     J.block<3, 2>(0, 2) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtPrincipalPoint();

--- a/src/aliceVision/camera/Equidistant.hpp
+++ b/src/aliceVision/camera/Equidistant.hpp
@@ -77,9 +77,7 @@ class Equidistant : public IntrinsicScaleOffsetDisto
     Vec2 project(const Vec4& pt, bool applyDistortion = true) const override;
 
     Eigen::Matrix<double, 2, 3> getDerivativeTransformProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4& pt) const override;
-
-    Eigen::Matrix<double, 2, 3> getDerivativeTransformProjectWrtDisto(const Eigen::Matrix4d& pose, const Vec4& pt) const;
-
+    
     Eigen::Matrix<double, 2, 2> getDerivativeTransformProjectWrtScale(const Eigen::Matrix4d& pose, const Vec4& pt) const;
 
     Eigen::Matrix<double, 2, 2> getDerivativeTransformProjectWrtPrincipalPoint(const Eigen::Matrix4d& pose, const Vec4& pt) const;
@@ -98,6 +96,10 @@ class Equidistant : public IntrinsicScaleOffsetDisto
      * @return The backproject jacobian with respect to the pose
      */
     Eigen::Matrix<double, 3, Eigen::Dynamic> getDerivativeBackProjectUnitWrtParams(const Vec2& pt2D) const override;
+
+    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeTransformProjectWrtDistortion(const Eigen::Matrix4d& pose, const Vec4& pt) const override;
+
+    Eigen::Matrix<double, 3, Eigen::Dynamic> getDerivativeBackProjectUnitWrtDistortion(const Vec2& pt2D) const override;
 
     double imagePlaneToCameraPlaneError(double value) const override;
 

--- a/src/aliceVision/camera/Equirectangular.cpp
+++ b/src/aliceVision/camera/Equirectangular.cpp
@@ -107,7 +107,7 @@ Eigen::Matrix<double, 2, 2> Equirectangular::getDerivativeTransformProjectWrtPri
 
 Eigen::Matrix<double, 2, Eigen::Dynamic> Equirectangular::getDerivativeTransformProjectWrtParams(const Eigen::Matrix4d& pose, const Vec4& pt3D) const
 {
-    Eigen::Matrix<double, 2, Eigen::Dynamic> ret(2, getParams().size());
+    Eigen::Matrix<double, 2, Eigen::Dynamic> ret(2, getParameters().size());
 
     ret.block<2, 2>(0, 0) = getDerivativeTransformProjectWrtScale(pose, pt3D);
     ret.block<2, 2>(0, 2) = getDerivativeTransformProjectWrtPrincipalPoint(pose, pt3D);

--- a/src/aliceVision/camera/Equirectangular.cpp
+++ b/src/aliceVision/camera/Equirectangular.cpp
@@ -164,6 +164,16 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Equirectangular::getDerivativeBackProje
     return ret;
 }
 
+Eigen::Matrix<double, 2, Eigen::Dynamic> Equirectangular::getDerivativeTransformProjectWrtDistortion(const Eigen::Matrix4d& pose, const Vec4& pt) const
+{
+    return Eigen::Matrix<double, 2, 1>::Zero();
+}
+
+Eigen::Matrix<double, 3, Eigen::Dynamic> Equirectangular::getDerivativeBackProjectUnitWrtDistortion(const Vec2& pt2D) const
+{
+    return Eigen::Matrix<double, 3, 1>::Zero();
+}
+
 double Equirectangular::imagePlaneToCameraPlaneError(double value) const { return 0.0; }
 
 bool Equirectangular::isVisibleRay(const Vec3& ray) const

--- a/src/aliceVision/camera/Equirectangular.hpp
+++ b/src/aliceVision/camera/Equirectangular.hpp
@@ -73,6 +73,10 @@ class Equirectangular : public IntrinsicScaleOffsetDisto
 
     Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeTransformProjectWrtParams(const Eigen::Matrix4d& pose, const Vec4& pt3D) const override;
 
+    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeTransformProjectWrtDistortion(const Eigen::Matrix4d& pose, const Vec4& pt) const override;
+
+    Eigen::Matrix<double, 3, Eigen::Dynamic> getDerivativeBackProjectUnitWrtDistortion(const Vec2& pt2D) const override;
+
     Vec3 toUnitSphere(const Vec2& pt) const override;
 
     Eigen::Matrix<double, 3, 2> getDerivativetoUnitSphereWrtPoint(const Vec2& pt) const;

--- a/src/aliceVision/camera/IntrinsicBase.cpp
+++ b/src/aliceVision/camera/IntrinsicBase.cpp
@@ -93,7 +93,7 @@ std::size_t IntrinsicBase::hashValue() const
     stl::hash_combine(seed, _sensorWidth);
     stl::hash_combine(seed, _sensorHeight);
     stl::hash_combine(seed, _serialNumber);
-    const std::vector<double> params = this->getParams();
+    const std::vector<double> params = this->getParameters();
     for (double param : params)
     {
         stl::hash_combine(seed, param);

--- a/src/aliceVision/camera/IntrinsicBase.cpp
+++ b/src/aliceVision/camera/IntrinsicBase.cpp
@@ -93,11 +93,13 @@ std::size_t IntrinsicBase::hashValue() const
     stl::hash_combine(seed, _sensorWidth);
     stl::hash_combine(seed, _sensorHeight);
     stl::hash_combine(seed, _serialNumber);
+    
     const std::vector<double> params = this->getParameters();
     for (double param : params)
     {
         stl::hash_combine(seed, param);
     }
+
     return seed;
 }
 

--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -270,13 +270,13 @@ class IntrinsicBase
      * @brief Get the intrinsic parameters
      * @return Intrinsic parameters as a vector
      */
-    virtual std::vector<double> getParams() const = 0;
+    virtual std::vector<double> getParameters() const = 0;
 
     /**
      * @brief Get the count of intrinsic parameters
      * @return The number of intrinsic parameters
      */
-    virtual std::size_t getParamsSize() const = 0;
+    virtual std::size_t getParametersSize() const = 0;
 
     /**
      * @brief Update intrinsic parameters

--- a/src/aliceVision/camera/IntrinsicScaleOffsetDisto.cpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffsetDisto.cpp
@@ -91,6 +91,11 @@ bool IntrinsicScaleOffsetDisto::updateFromParams(const std::vector<double>& para
         return false;
     }
 
+    if (_pDistortion && params.size() == 4 + _pDistortion->getParameters().size())
+    {
+        setDistortionParams({params.begin() + 4, params.end()});
+    }
+
     return true;
 }
 

--- a/src/aliceVision/camera/IntrinsicScaleOffsetDisto.cpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffsetDisto.cpp
@@ -91,11 +91,6 @@ bool IntrinsicScaleOffsetDisto::updateFromParams(const std::vector<double>& para
         return false;
     }
 
-    if (_pDistortion && params.size() == 4 + _pDistortion->getParameters().size())
-    {
-        setDistortionParams({params.begin() + 4, params.end()});
-    }
-
     return true;
 }
 

--- a/src/aliceVision/camera/IntrinsicScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffsetDisto.hpp
@@ -190,22 +190,12 @@ class IntrinsicScaleOffsetDisto : public IntrinsicScaleOffset
     {
         std::vector<double> params = {_scale(0), _scale(1), _offset(0), _offset(1)};
 
-        if (_pDistortion)
-        {
-            params.insert(params.end(), _pDistortion->getParameters().begin(), _pDistortion->getParameters().end());
-        }
-
         return params;
     }
 
     std::size_t getParametersSize() const override
     {
-        std::size_t size = 4;
-        if (_pDistortion)
-        {
-            size += _pDistortion->getParameters().size();
-        }
-        return size;
+        return 4;
     }
 
     // Data wrapper for non linear optimization (update from data)
@@ -259,6 +249,10 @@ class IntrinsicScaleOffsetDisto : public IntrinsicScaleOffset
 
         return this->_pDistortion->getDerivativeRemoveDistoWrtDisto(pt);
     }
+
+    virtual Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeTransformProjectWrtDistortion(const Eigen::Matrix4d& pose, const Vec4& pt) const = 0;
+
+    virtual Eigen::Matrix<double, 3, Eigen::Dynamic> getDerivativeBackProjectUnitWrtDistortion(const Vec2& pt2D) const = 0;
 
     /**
      * @brief Set The intrinsic disto initialization mode

--- a/src/aliceVision/camera/IntrinsicScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffsetDisto.hpp
@@ -186,7 +186,7 @@ class IntrinsicScaleOffsetDisto : public IntrinsicScaleOffset
     }
 
     // Data wrapper for non linear optimization (get data)
-    std::vector<double> getParams() const override
+    std::vector<double> getParameters() const override
     {
         std::vector<double> params = {_scale(0), _scale(1), _offset(0), _offset(1)};
 
@@ -198,7 +198,7 @@ class IntrinsicScaleOffsetDisto : public IntrinsicScaleOffset
         return params;
     }
 
-    std::size_t getParamsSize() const override
+    std::size_t getParametersSize() const override
     {
         std::size_t size = 4;
         if (_pDistortion)

--- a/src/aliceVision/camera/Pinhole.cpp
+++ b/src/aliceVision/camera/Pinhole.cpp
@@ -128,12 +128,6 @@ Eigen::Matrix<double, 2, Eigen::Dynamic> Pinhole::getDerivativeTransformProjectW
     ret.block<2, 2>(0, 0) = getDerivativeTransformProjectWrtScale(pose, pt3D);
     ret.block<2, 2>(0, 2) = getDerivativeTransformProjectWrtPrincipalPoint(pose, pt3D);
 
-    if (_pDistortion != nullptr)
-    {
-        const size_t distortionSize = _pDistortion->getDistortionParametersCount();
-        ret.block(0, 4, 2, distortionSize) = getDerivativeTransformProjectWrtDisto(pose, pt3D);
-    }
-
     return ret;
 }
 
@@ -174,12 +168,6 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Pinhole::getDerivativeBackProjectUnitWr
 
     J.block<3, 2>(0, 0) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtScale(pt2D);
     J.block<3, 2>(0, 2) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtPrincipalPoint();
-
-    if (disto_size > 0)
-    {
-        J.block(0, 4, 3, disto_size) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtDisto(ptMeters);
-    }
-
 
     return J;
 }

--- a/src/aliceVision/camera/Pinhole.cpp
+++ b/src/aliceVision/camera/Pinhole.cpp
@@ -98,7 +98,7 @@ Eigen::Matrix<double, 2, 3> Pinhole::getDerivativeTransformProjectWrtPoint3(cons
     return getDerivativeCam2ImaWrtPoint() * getDerivativeAddDistoWrtPt(P) * d_P_d_Pt;
 }
 
-Eigen::Matrix<double, 2, Eigen::Dynamic> Pinhole::getDerivativeTransformProjectWrtDisto(const Eigen::Matrix4d& pose, const Vec4& pt) const
+Eigen::Matrix<double, 2, Eigen::Dynamic> Pinhole::getDerivativeTransformProjectWrtDistortion(const Eigen::Matrix4d& pose, const Vec4& pt) const
 {
     const Vec4 X = pose * pt;  // apply pose
     const Vec2 P = X.head<2>() / X(2);
@@ -168,6 +168,28 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Pinhole::getDerivativeBackProjectUnitWr
 
     J.block<3, 2>(0, 0) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtScale(pt2D);
     J.block<3, 2>(0, 2) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtPrincipalPoint();
+
+    /*if (disto_size > 0)
+    {
+        J.block(0, 4, 3, disto_size) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtDisto(ptMeters);
+    }*/
+
+
+    return J;
+}
+
+Eigen::Matrix<double, 3, Eigen::Dynamic> Pinhole::getDerivativeBackProjectUnitWrtDistortion(const Vec2& pt2D) const
+{
+    size_t disto_size = getDistortionParamsSize();
+
+    const Vec2 ptMeters = ima2cam(pt2D);
+    const Vec2 ptUndist = removeDistortion(ptMeters);
+    const Vec3 ptSphere = toUnitSphere(ptUndist);
+
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> J(3, disto_size);
+    J = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtDisto(ptMeters);
+
 
     return J;
 }

--- a/src/aliceVision/camera/Pinhole.cpp
+++ b/src/aliceVision/camera/Pinhole.cpp
@@ -123,7 +123,7 @@ Eigen::Matrix<double, 2, 2> Pinhole::getDerivativeTransformProjectWrtScale(const
 
 Eigen::Matrix<double, 2, Eigen::Dynamic> Pinhole::getDerivativeTransformProjectWrtParams(const Eigen::Matrix4d& pose, const Vec4& pt3D) const
 {
-    Eigen::Matrix<double, 2, Eigen::Dynamic> ret(2, getParams().size());
+    Eigen::Matrix<double, 2, Eigen::Dynamic> ret(2, getParameters().size());
 
     ret.block<2, 2>(0, 0) = getDerivativeTransformProjectWrtScale(pose, pt3D);
     ret.block<2, 2>(0, 2) = getDerivativeTransformProjectWrtPrincipalPoint(pose, pt3D);
@@ -170,7 +170,7 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Pinhole::getDerivativeBackProjectUnitWr
     const Vec3 ptSphere = toUnitSphere(ptUndist);
 
 
-    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> J(3, getParams().size());
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> J(3, getParameters().size());
 
     J.block<3, 2>(0, 0) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtScale(pt2D);
     J.block<3, 2>(0, 2) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtPrincipalPoint();

--- a/src/aliceVision/camera/Pinhole.cpp
+++ b/src/aliceVision/camera/Pinhole.cpp
@@ -169,12 +169,6 @@ Eigen::Matrix<double, 3, Eigen::Dynamic> Pinhole::getDerivativeBackProjectUnitWr
     J.block<3, 2>(0, 0) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtScale(pt2D);
     J.block<3, 2>(0, 2) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtPt(ptMeters) * getDerivativeIma2CamWrtPrincipalPoint();
 
-    /*if (disto_size > 0)
-    {
-        J.block(0, 4, 3, disto_size) = getDerivativetoUnitSphereWrtPoint(ptUndist) * getDerivativeRemoveDistoWrtDisto(ptMeters);
-    }*/
-
-
     return J;
 }
 

--- a/src/aliceVision/camera/Pinhole.hpp
+++ b/src/aliceVision/camera/Pinhole.hpp
@@ -77,13 +77,15 @@ class Pinhole : public IntrinsicScaleOffsetDisto
 
     Eigen::Matrix<double, 2, 3> getDerivativeTransformProjectWrtPoint3(const Eigen::Matrix4d& pose, const Vec4& pt) const override;
 
-    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeTransformProjectWrtDisto(const Eigen::Matrix4d& pose, const Vec4& pt) const;
-
     Eigen::Matrix<double, 2, 2> getDerivativeTransformProjectWrtPrincipalPoint(const Eigen::Matrix4d& pose, const Vec4& pt) const;
 
     Eigen::Matrix<double, 2, 2> getDerivativeTransformProjectWrtScale(const Eigen::Matrix4d& pose, const Vec4& pt) const;
 
     Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeTransformProjectWrtParams(const Eigen::Matrix4d& pose, const Vec4& pt3D) const override;
+
+    Eigen::Matrix<double, 2, Eigen::Dynamic> getDerivativeTransformProjectWrtDistortion(const Eigen::Matrix4d& pose, const Vec4& pt) const override;
+
+    Eigen::Matrix<double, 3, Eigen::Dynamic> getDerivativeBackProjectUnitWrtDistortion(const Vec2& pt2D) const override;
 
     Vec3 toUnitSphere(const Vec2& pt) const override;
 

--- a/src/aliceVision/camera/Undistortion.hpp
+++ b/src/aliceVision/camera/Undistortion.hpp
@@ -33,6 +33,7 @@ class Undistortion
     {
         _pixelAspectRatio = 1.0;
         _isDesqueezed = false;
+        _isLocked = false;
         
         setSize(width, height);
         setOffset({0.0, 0.0});
@@ -61,6 +62,16 @@ class Undistortion
     bool isDesqueezed() const
     {
         return _isDesqueezed;
+    }
+
+    bool isLocked() const
+    {
+        return _isLocked;
+    }
+
+    void setLocked(bool lock) 
+    {
+        _isLocked = lock;
     }
 
     void setOffset(const Vec2& offset) { _offset = offset; }
@@ -151,6 +162,7 @@ class Undistortion
     double _pixelAspectRatio;
     bool _isDesqueezed;
     std::vector<double> _undistortionParams{};
+    bool _isLocked;
 };
 
 }  // namespace camera

--- a/src/aliceVision/lightingEstimation/lightingCalibration.cpp
+++ b/src/aliceVision/lightingEstimation/lightingCalibration.cpp
@@ -97,13 +97,13 @@ void lightCalibration(const sfmData::SfMData& sfmData,
                 allSpheresParams.push_back(currentSphereParams);
 
                 IndexT intrinsicId = currentView.getIntrinsicId();
-                focals.push_back(sfmData.getIntrinsics().at(intrinsicId)->getParams().at(0));
+                focals.push_back(sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(0));
 
-                float focalPx = sfmData.getIntrinsics().at(intrinsicId)->getParams().at(0);
+                float focalPx = sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(0);
                 nbCols = sfmData.getIntrinsics().at(intrinsicId)->w();
                 nbRows = sfmData.getIntrinsics().at(intrinsicId)->h();
-                float x_p = (nbCols) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParams().at(2);
-                float y_p = (nbRows) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParams().at(3);
+                float x_p = (nbCols) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(2);
+                float y_p = (nbRows) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(3);
 
                 Eigen::MatrixXf currentK = Eigen::MatrixXf::Zero(3, 3);
                 // Create K matrix

--- a/src/aliceVision/localization/optimization.cpp
+++ b/src/aliceVision/localization/optimization.cpp
@@ -236,7 +236,7 @@ bool refineSequence(std::vector<LocalizationResult>& vec_localizationResult,
         // just debugging stuff
         if (allTheSameIntrinsics)
         {
-            std::vector<double> params = tinyScene.getIntrinsics().at(0).get()->getParams();
+            std::vector<double> params = tinyScene.getIntrinsics().at(0).get()->getParameters();
             ALICEVISION_LOG_DEBUG("K before bundle: " << params[0] << " " << params[1] << " " << params[2]);
             if (params.size() == 6)
                 ALICEVISION_LOG_DEBUG("Distortion before bundle: " << params[3] << " " << params[4] << " " << params[5]);
@@ -303,7 +303,7 @@ bool refineSequence(std::vector<LocalizationResult>& vec_localizationResult,
         // update the intrinsics of each localization result
 
         // get its optimized parameters
-        std::vector<double> params = tinyScene.getIntrinsics().at(0).get()->getParams();
+        std::vector<double> params = tinyScene.getIntrinsics().at(0).get()->getParameters();
         ALICEVISION_LOG_DEBUG("Type of intrinsics " << tinyScene.getIntrinsics().at(0).get()->getType());
         if (params.size() == 4)
         {

--- a/src/aliceVision/localization/optimization.cpp
+++ b/src/aliceVision/localization/optimization.cpp
@@ -301,11 +301,11 @@ bool refineSequence(std::vector<LocalizationResult>& vec_localizationResult,
         // update the intrinsics of each localization result
 
         auto intrinsic = tinyScene.getIntrinsics().at(0);
-        auto casted = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+        auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
         std::shared_ptr<camera::Distortion> distortion;
-        if (casted)
+        if (isod)
         {
-            distortion = casted->getDistortion();
+            distortion = isod->getDistortion();
         }
 
         // get its optimized parameters
@@ -324,10 +324,10 @@ bool refineSequence(std::vector<LocalizationResult>& vec_localizationResult,
             }
             currResult.updateIntrinsics(params);
 
-            auto curDistortion = currResult.getIntrinsics().getDistortion();
-            if (distortion && curDistortion)
+            auto currDistortion = currResult.getIntrinsics().getDistortion();
+            if (distortion && currDistortion)
             {
-                curDistortion->setParameters(distortion->getParameters());
+                currDistortion->setParameters(distortion->getParameters());
             }
             
 

--- a/src/aliceVision/localization/optimization.cpp
+++ b/src/aliceVision/localization/optimization.cpp
@@ -236,10 +236,8 @@ bool refineSequence(std::vector<LocalizationResult>& vec_localizationResult,
         // just debugging stuff
         if (allTheSameIntrinsics)
         {
-            std::vector<double> params = tinyScene.getIntrinsics().at(0).get()->getParameters();
+            std::vector<double> params = tinyScene.getIntrinsics().at(0)->getParameters();
             ALICEVISION_LOG_DEBUG("K before bundle: " << params[0] << " " << params[1] << " " << params[2]);
-            if (params.size() == 6)
-                ALICEVISION_LOG_DEBUG("Distortion before bundle: " << params[3] << " " << params[4] << " " << params[5]);
         }
     }
 
@@ -302,20 +300,19 @@ bool refineSequence(std::vector<LocalizationResult>& vec_localizationResult,
         // if we used the same intrinsics for all the localization results we need to
         // update the intrinsics of each localization result
 
-        // get its optimized parameters
-        std::vector<double> params = tinyScene.getIntrinsics().at(0).get()->getParameters();
-        ALICEVISION_LOG_DEBUG("Type of intrinsics " << tinyScene.getIntrinsics().at(0).get()->getType());
-        if (params.size() == 4)
+        auto intrinsic = tinyScene.getIntrinsics().at(0);
+        auto casted = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+        std::shared_ptr<camera::Distortion> distortion;
+        if (casted)
         {
-            // this means that the b_no_distortion has been passed
-            // set distortion to 0
-            params.push_back(0);
-            params.push_back(0);
-            params.push_back(0);
+            distortion = casted->getDistortion();
         }
-        assert(params.size() == 6);
+
+        // get its optimized parameters
+        std::vector<double> params = intrinsic->getParameters();
+
+        ALICEVISION_LOG_DEBUG("Type of intrinsics " << intrinsic->getType());
         ALICEVISION_LOG_DEBUG("K after bundle: " << params[0] << " " << params[1] << " " << params[2] << " " << params[3]);
-        ALICEVISION_LOG_DEBUG("Distortion after bundle " << params[4] << " " << params[5] << " " << params[6]);
 
         // update the intrinsics of the each localization result
         for (size_t viewID = 0; viewID < numViews; ++viewID)
@@ -326,6 +323,13 @@ bool refineSequence(std::vector<LocalizationResult>& vec_localizationResult,
                 continue;
             }
             currResult.updateIntrinsics(params);
+
+            auto curDistortion = currResult.getIntrinsics().getDistortion();
+            if (distortion && curDistortion)
+            {
+                curDistortion->setParameters(distortion->getParameters());
+            }
+            
 
             // just debugging -- print reprojection errors
             const Mat2X residuals = currResult.computeInliersResiduals();

--- a/src/aliceVision/photometricStereo/normalIntegration.cpp
+++ b/src/aliceVision/photometricStereo/normalIntegration.cpp
@@ -112,9 +112,9 @@ void normalIntegration(const sfmData::SfMData& sfmData,
                     viewId = viewIt.first;
                     // Get intrinsics associated with this view :
                     intrinsicId = viewIt.second->getIntrinsicId();
-                    const float focalPx = sfmData.getIntrinsics().at(intrinsicId)->getParams().at(0);
-                    const float x_p = (nbCols) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParams().at(2);
-                    const float y_p = (nbRows) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParams().at(3);
+                    const float focalPx = sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(0);
+                    const float x_p = (nbCols) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(2);
+                    const float y_p = (nbRows) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(3);
 
                     // Create K matrix
                     K(0, 0) = focalPx;
@@ -219,9 +219,9 @@ void normalIntegration(const sfmData::SfMData& sfmData,
         {
             intrinsicId = sfmData.getViews().begin()->second->getIntrinsicId();
             // Get intrinsics associated with this view :
-            const float focalPx = sfmData.getIntrinsics().at(intrinsicId)->getParams().at(0);
-            const float x_p = (nbCols) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParams().at(2);
-            const float y_p = (nbRows) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParams().at(3);
+            const float focalPx = sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(0);
+            const float x_p = (nbCols) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(2);
+            const float y_p = (nbRows) / 2 + sfmData.getIntrinsics().at(intrinsicId)->getParameters().at(3);
 
             // Create K matrix
             K(0, 0) = focalPx;

--- a/src/aliceVision/rig/ResidualError.hpp
+++ b/src/aliceVision/rig/ResidualError.hpp
@@ -25,9 +25,9 @@ class ResidualErrorMainCameraFunctor
         _K = intrinsics.K();
 
         _params.reserve(4);
-        _params.push_back(intrinsics.getParams()[4]);
-        _params.push_back(intrinsics.getParams()[5]);
-        _params.push_back(intrinsics.getParams()[6]);
+        _params.push_back(intrinsics.getParameters()[4]);
+        _params.push_back(intrinsics.getParameters()[5]);
+        _params.push_back(intrinsics.getParameters()[6]);
 
         // Set the observation
         _observation[0] = pt2d[0];
@@ -133,9 +133,9 @@ class ResidualErrorSecondaryCameraFunctor
         _K = intrinsics.K();
 
         _params.reserve(3);
-        _params.push_back(intrinsics.getParams()[3]);
-        _params.push_back(intrinsics.getParams()[4]);
-        _params.push_back(intrinsics.getParams()[5]);
+        _params.push_back(intrinsics.getParameters()[3]);
+        _params.push_back(intrinsics.getParameters()[4]);
+        _params.push_back(intrinsics.getParameters()[5]);
 
         // Set the observation
         _observation[0] = pt2d[0];
@@ -260,9 +260,9 @@ class ResidualErrorSecondaryCameraFixedRelativeFunctor
         _K = intrinsics.K();
 
         _params.reserve(3);
-        _params.push_back(intrinsics.getParams()[3]);
-        _params.push_back(intrinsics.getParams()[4]);
-        _params.push_back(intrinsics.getParams()[5]);
+        _params.push_back(intrinsics.getParameters()[3]);
+        _params.push_back(intrinsics.getParameters()[4]);
+        _params.push_back(intrinsics.getParameters()[5]);
 
         // Set the observation
         _observation[0] = pt2d[0];

--- a/src/aliceVision/rig/ResidualError.hpp
+++ b/src/aliceVision/rig/ResidualError.hpp
@@ -260,9 +260,9 @@ class ResidualErrorSecondaryCameraFixedRelativeFunctor
         _K = intrinsics.K();
 
         _params.reserve(3);
-        _params.push_back(intrinsics.getParameters()[3]);
-        _params.push_back(intrinsics.getParameters()[4]);
-        _params.push_back(intrinsics.getParameters()[5]);
+        _params.push_back(intrinsics.getDistortion()->getParameters()[0]);
+        _params.push_back(intrinsics.getDistortion()->getParameters()[1]);
+        _params.push_back(intrinsics.getDistortion()->getParameters()[2]);
 
         // Set the observation
         _observation[0] = pt2d[0];

--- a/src/aliceVision/rig/Rig.cpp
+++ b/src/aliceVision/rig/Rig.cpp
@@ -328,7 +328,7 @@ bool Rig::optimizeCalibration()
     //         {
     //           case PINHOLE_CAMERA:
     //           {
-    //             std::vector<double> vec_params = localizationResult.getIntrinsics().getParams();
+    //             std::vector<double> vec_params = localizationResult.getIntrinsics().getParameters();
     //             intrinsics.reserve(3);
     //             intrinsics.push_back(vec_params[0]);
     //             intrinsics.push_back(vec_params[1]);
@@ -344,7 +344,7 @@ bool Rig::optimizeCalibration()
     //           }
     //           case PINHOLE_CAMERA_RADIAL3
     //           {
-    //             std::vector<double> vec_params = localizationResult.getIntrinsics().getParams();
+    //             std::vector<double> vec_params = localizationResult.getIntrinsics().getParameters();
     //             intrinsics.reserve(6);
     //             intrinsics.push_back(vec_params[0]);
     //             intrinsics.push_back(vec_params[1]);

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -29,7 +29,7 @@ LocalBundleAdjustmentGraph::LocalBundleAdjustmentGraph(const sfmData::SfMData& s
 
         IntrinsicHistory intrinsicHistory;
         intrinsicHistory.nbPoses = 0;
-        intrinsicHistory.focalLength = intrinsicPtr->getParams().at(0);
+        intrinsicHistory.focalLength = intrinsicPtr->getParameters().at(0);
         intrinsicHistory.isConstant = intrinsicPtr->isLocked();
 
         _intrinsicsHistory[intrinsicId].push_back(intrinsicHistory);
@@ -99,7 +99,7 @@ void LocalBundleAdjustmentGraph::saveIntrinsicsToHistory(const sfmData::SfMData&
 
         IntrinsicHistory intrinsicHistory;
         intrinsicHistory.nbPoses = intrinsicUsage[intrinsicId];
-        intrinsicHistory.focalLength = intrinsicPtr->getParams().at(0);
+        intrinsicHistory.focalLength = intrinsicPtr->getParameters().at(0);
         intrinsicHistory.isConstant = isFocalLengthConstant(intrinsicId);
 
         _intrinsicsHistory.at(intrinsicId).push_back(intrinsicHistory);

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -1021,7 +1021,7 @@ bool BundleAdjustmentCeres::adjust(sfmData::SfMData& sfmData, ERefineOptions ref
     ceres::Solve(options, &problem, &summary);
 
     // print summary
-    //if (_ceresOptions.summary)
+    if (_ceresOptions.summary)
         ALICEVISION_LOG_INFO(summary.FullReport());
 
     // solution is not usable

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -40,7 +40,7 @@ ceres::CostFunction* createCostFunctionFromIntrinsics(const std::shared_ptr<Intr
 {
     auto costFunction = new ceres::DynamicAutoDiffCostFunction<ProjectionSimpleErrorFunctor>(new ProjectionSimpleErrorFunctor(observation, intrinsic));
 
-    costFunction->AddParameterBlock(intrinsic->getParams().size());
+    costFunction->AddParameterBlock(intrinsic->getParameters().size());
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(3);
     costFunction->SetNumResiduals(2);
@@ -58,7 +58,7 @@ ceres::CostFunction* createRigCostFunctionFromIntrinsics(std::shared_ptr<Intrins
 {
     auto costFunction = new ceres::DynamicAutoDiffCostFunction<ProjectionErrorFunctor>(new ProjectionErrorFunctor(observation, intrinsic));
 
-    costFunction->AddParameterBlock(intrinsic->getParams().size());
+    costFunction->AddParameterBlock(intrinsic->getParameters().size());
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(3);
@@ -79,7 +79,7 @@ ceres::CostFunction* createConstraintsCostFunctionFromIntrinsics(std::shared_ptr
 {       
     auto costFunction = new ceres::DynamicAutoDiffCostFunction<Constraint2dErrorFunctor>(new Constraint2dErrorFunctor(observation_first, observation_second, intrinsic));
 
-    costFunction->AddParameterBlock(intrinsic->getParams().size()); 
+    costFunction->AddParameterBlock(intrinsic->getParameters().size()); 
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(6);
     costFunction->SetNumResiduals(2);
@@ -431,7 +431,7 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
         _intrinsicObjects[intrinsicId].reset(intrinsicPtr->clone());
 
         std::vector<double>& intrinsicBlock = _intrinsicsBlocks[intrinsicId];
-        intrinsicBlock = intrinsicPtr->getParams();
+        intrinsicBlock = intrinsicPtr->getParameters();
 
         double* intrinsicBlockPtr = intrinsicBlock.data();
 

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -40,7 +40,19 @@ ceres::CostFunction* createCostFunctionFromIntrinsics(const std::shared_ptr<Intr
 {
     auto costFunction = new ceres::DynamicAutoDiffCostFunction<ProjectionSimpleErrorFunctor>(new ProjectionSimpleErrorFunctor(observation, intrinsic));
 
+    int distortionSize = 1;
+    auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+    if (isod)
+    {
+        auto distortion = isod->getDistortion();
+        if (distortion)
+        {
+            distortionSize = distortion->getParameters().size();
+        }
+    }
+
     costFunction->AddParameterBlock(intrinsic->getParameters().size());
+    costFunction->AddParameterBlock(distortionSize);
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(3);
     costFunction->SetNumResiduals(2);
@@ -58,7 +70,19 @@ ceres::CostFunction* createRigCostFunctionFromIntrinsics(std::shared_ptr<Intrins
 {
     auto costFunction = new ceres::DynamicAutoDiffCostFunction<ProjectionErrorFunctor>(new ProjectionErrorFunctor(observation, intrinsic));
 
+    int distortionSize = 1;
+    auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+    if (isod)
+    {
+        auto distortion = isod->getDistortion();
+        if (distortion)
+        {
+            distortionSize = distortion->getParameters().size();
+        }
+    }
+
     costFunction->AddParameterBlock(intrinsic->getParameters().size());
+    costFunction->AddParameterBlock(distortionSize);
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(3);
@@ -79,7 +103,20 @@ ceres::CostFunction* createConstraintsCostFunctionFromIntrinsics(std::shared_ptr
 {       
     auto costFunction = new ceres::DynamicAutoDiffCostFunction<Constraint2dErrorFunctor>(new Constraint2dErrorFunctor(observation_first, observation_second, intrinsic));
 
+    int distortionSize = 1;
+    auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+    if (isod)
+    {
+        auto distortion = isod->getDistortion();
+        if (distortion)
+        {
+            distortionSize = distortion->getParameters().size();
+        }
+    }
+
+
     costFunction->AddParameterBlock(intrinsic->getParameters().size()); 
+    costFunction->AddParameterBlock(distortionSize);
     costFunction->AddParameterBlock(6);
     costFunction->AddParameterBlock(6);
     costFunction->SetNumResiduals(2);
@@ -172,11 +209,15 @@ bool BundleAdjustmentCeres::Statistics::exportToFile(const std::string& folder, 
             posesWithDistUpperThanTen += it.second;
 
     os << time << ";" << states[EParameter::POSE][EEstimatorParameterState::REFINED] << ";"
-       << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";" << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";"
-       << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT]
-       << ";" << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
-       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT]
-       << ";" << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
+       << states[EParameter::POSE][EEstimatorParameterState::CONSTANT] << ";" 
+       << states[EParameter::POSE][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::LANDMARK][EEstimatorParameterState::REFINED] << ";" 
+       << states[EParameter::LANDMARK][EEstimatorParameterState::CONSTANT] << ";" 
+       << states[EParameter::LANDMARK][EEstimatorParameterState::IGNORED] << ";"
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::REFINED] << ";" 
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::CONSTANT] << ";" 
+       << states[EParameter::INTRINSIC][EEstimatorParameterState::IGNORED] << ";" 
+       << nbResidualBlocks << ";" << nbSuccessfullIterations << ";"
        << nbUnsuccessfullIterations << ";" << RMSEinitial << ";" << RMSEfinal << ";";
 
     for (int i = -1; i < 10; ++i)
@@ -383,12 +424,20 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
                                                    ceres::Problem& problem)
 {
     const bool refineIntrinsicsOpticalCenter =
-      (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS) || (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_IF_ENOUGH_DATA);
+      (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS) 
+      || (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_IF_ENOUGH_DATA);
     const bool refineIntrinsicsFocalLength = refineOptions & REFINE_INTRINSICS_FOCAL;
     const bool refineIntrinsicsDistortion = refineOptions & REFINE_INTRINSICS_DISTORTION;
     const bool refineIntrinsics = refineIntrinsicsDistortion || refineIntrinsicsFocalLength || refineIntrinsicsOpticalCenter;
 
     std::map<IndexT, std::size_t> intrinsicsUsage;
+
+
+    //Create a fake distortion block which is always constant
+    //This is to trick ceres limitations
+    _fakeDistortionBlock = {0.0};
+    problem.AddParameterBlock(_fakeDistortionBlock.data(), 1);
+    problem.SetParameterBlockConstant(_fakeDistortionBlock.data());
 
     // count the number of reconstructed views per intrinsic
     for (const auto& viewPair : sfmData.getViews())
@@ -396,20 +445,25 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
         const sfmData::View& view = *(viewPair.second);
 
         if (intrinsicsUsage.find(view.getIntrinsicId()) == intrinsicsUsage.end())
+        {
             intrinsicsUsage[view.getIntrinsicId()] = 0;
+        }
 
         if (sfmData.isPoseAndIntrinsicDefined(view))
+        {
             ++intrinsicsUsage.at(view.getIntrinsicId());
+        }
     }
 
-    for (const auto& intrinsicPair : sfmData.getIntrinsics())
+    for (const auto& [intrinsicId, intrinsicPtr] : sfmData.getIntrinsics())
     {
-        const IndexT intrinsicId = intrinsicPair.first;
-        const auto& intrinsicPtr = intrinsicPair.second;
         const auto usageIt = intrinsicsUsage.find(intrinsicId);
         if (usageIt == intrinsicsUsage.end())
+        {
             // if the intrinsic is never referenced by any view, skip it
             continue;
+        }
+
         const std::size_t usageCount = usageIt->second;
 
         // do not refine an intrinsic does not used by any reconstructed view
@@ -419,22 +473,20 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
             continue;
         }
 
-        std::shared_ptr<camera::IntrinsicScaleOffset> intrinsicScaleOffset =
-              std::dynamic_pointer_cast<camera::IntrinsicScaleOffset>(intrinsicPtr);
+        //Ignore camera which are not scale offset derived
+        auto intrinsicScaleOffset = camera::IntrinsicScaleOffset::cast(intrinsicPtr);
         if (!intrinsicScaleOffset)
         {
             continue;
         }
 
-        assert(isValid(intrinsicPtr->getType()));
-
+        //Create a copy of the intrinsics to enable rollback
         _intrinsicObjects[intrinsicId].reset(intrinsicPtr->clone());
 
+        //Create data block for intrinsics inside ceres
         std::vector<double>& intrinsicBlock = _intrinsicsBlocks[intrinsicId];
         intrinsicBlock = intrinsicPtr->getParameters();
-
         double* intrinsicBlockPtr = intrinsicBlock.data();
-
         problem.AddParameterBlock(intrinsicBlockPtr, intrinsicBlock.size());
 
         // add intrinsic parameter to the all parameters blocks pointers list
@@ -446,104 +498,119 @@ void BundleAdjustmentCeres::addIntrinsicsToProblem(const sfmData::SfMData& sfmDa
             // set the whole parameter block as constant.
             _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::CONSTANT);
             problem.SetParameterBlockConstant(intrinsicBlockPtr);
-            continue;
         }
+        else 
+        {   
+            // constant parameters
+            bool lockCenter = false;
+            bool lockFocal = false;
+            bool lockRatio = true;
+            double focalRatio = 1.0;
 
-        // constant parameters
-        bool lockCenter = false;
-        bool lockFocal = false;
-        bool lockRatio = true;
-        bool lockDistortion = false;
-        double focalRatio = 1.0;
+            lockFocal = (!refineIntrinsicsFocalLength) || intrinsicScaleOffset->isScaleLocked();
 
-        lockFocal = (!refineIntrinsicsFocalLength) || intrinsicScaleOffset->isScaleLocked();
-
-        // refine the focal length
-        if (!lockFocal)
-        {
-            if (intrinsicScaleOffset->getInitialScale().x() > 0 && intrinsicScaleOffset->getInitialScale().y() > 0 && _ceresOptions.useFocalPrior)
+            // refine the focal length
+            if (!lockFocal)
             {
-                
-                // if we have an initial guess, we only authorize a margin around this value.
-                assert(intrinsicBlock.size() >= 1);
-                const double maxFocalError = 0.2 * std::max(intrinsicPtr->w(), intrinsicPtr->h());
+                if (intrinsicScaleOffset->getInitialScale().x() > 0 
+                    && intrinsicScaleOffset->getInitialScale().y() > 0 
+                    && _ceresOptions.useFocalPrior)
+                {
+                    const double maxFocalError = 0.2 * std::max(intrinsicPtr->w(), intrinsicPtr->h());
 
-                const double fx = intrinsicScaleOffset->getInitialScale().x();
-                const double fy = intrinsicScaleOffset->getInitialScale().y();
+                    const double fx = intrinsicScaleOffset->getInitialScale().x();
+                    const double fy = intrinsicScaleOffset->getInitialScale().y();
 
-                const double lboundY = std::max(0.0, fy - maxFocalError);
-                const double uboundY = std::max(0.0, fy + maxFocalError);
-                const double lboundX = std::max(0.0, lboundY * fx/fy);
-                const double uboundX = std::max(0.0, uboundY * fx/fy);
+                    const double lboundY = std::max(0.0, fy - maxFocalError);
+                    const double uboundY = std::max(0.0, fy + maxFocalError);
+                    const double lboundX = std::max(0.0, lboundY * fx/fy);
+                    const double uboundX = std::max(0.0, uboundY * fx/fy);
 
-                problem.SetParameterLowerBound(intrinsicBlockPtr, 0, lboundX);
-                problem.SetParameterUpperBound(intrinsicBlockPtr, 0, uboundX);
-                problem.SetParameterLowerBound(intrinsicBlockPtr, 1, lboundY);
-                problem.SetParameterUpperBound(intrinsicBlockPtr, 1, uboundY);
+                    problem.SetParameterLowerBound(intrinsicBlockPtr, 0, lboundX);
+                    problem.SetParameterUpperBound(intrinsicBlockPtr, 0, uboundX);
+                    problem.SetParameterLowerBound(intrinsicBlockPtr, 1, lboundY);
+                    problem.SetParameterUpperBound(intrinsicBlockPtr, 1, uboundY);
+                }
+                else
+                {
+                    // we don't have an initial guess, but we assume that we use
+                    // a converging lens, so the focal length should be positive.
+                    problem.SetParameterLowerBound(intrinsicBlockPtr, 0, 0.0);
+                    problem.SetParameterLowerBound(intrinsicBlockPtr, 1, 0.0);
+                }
+
+                focalRatio = intrinsicBlockPtr[0] / intrinsicBlockPtr[1];
+                lockRatio = intrinsicScaleOffset->isRatioLocked();
             }
-            else  // no initial guess
+
+            // optical center
+            lockCenter = intrinsicScaleOffset->isOffsetLocked();
+            
+            bool validRefineCenter = (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS) 
+                            || (
+                                (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_IF_ENOUGH_DATA) 
+                                && _minNbImagesToRefineOpticalCenter > 0 
+                                && usageCount >= _minNbImagesToRefineOpticalCenter
+                            );
+
+            if (!validRefineCenter)
             {
-                // we don't have an initial guess, but we assume that we use
-                // a converging lens, so the focal length should be positive.
-                problem.SetParameterLowerBound(intrinsicBlockPtr, 0, 0.0);
-                problem.SetParameterLowerBound(intrinsicBlockPtr, 1, 0.0);
+                lockCenter = true;
             }
 
-            focalRatio = intrinsicBlockPtr[0] / intrinsicBlockPtr[1];
-            lockRatio = intrinsicScaleOffset->isRatioLocked();
+            if (!lockCenter)
+            {
+                // refine optical center within 10% of the image size.
+                assert(intrinsicBlock.size() >= 3);
+
+                const double opticalCenterMinPercent = -0.05;
+                const double opticalCenterMaxPercent = 0.05;
+
+                // add bounds to the principal point
+                problem.SetParameterLowerBound(intrinsicBlockPtr, 2, opticalCenterMinPercent * intrinsicPtr->w());
+                problem.SetParameterUpperBound(intrinsicBlockPtr, 2, opticalCenterMaxPercent * intrinsicPtr->w());
+                problem.SetParameterLowerBound(intrinsicBlockPtr, 3, opticalCenterMinPercent * intrinsicPtr->h());
+                problem.SetParameterUpperBound(intrinsicBlockPtr, 3, opticalCenterMaxPercent * intrinsicPtr->h());
+            }
+            
+            auto * subsetManifold = new IntrinsicsManifold(
+                                        intrinsicBlock.size(), 
+                                        focalRatio, 
+                                        lockFocal, 
+                                        lockRatio, 
+                                        lockCenter
+                                    );
+
+            problem.SetManifold(intrinsicBlockPtr, subsetManifold);
         }
 
-        // optical center
-        lockCenter = intrinsicScaleOffset->isOffsetLocked();
-        
-        bool validRefineCenter = (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS) ||
-                        ((refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_IF_ENOUGH_DATA) 
-                        && _minNbImagesToRefineOpticalCenter > 0 
-                        && usageCount >= _minNbImagesToRefineOpticalCenter);
-        if (!validRefineCenter)
-        {
-            lockCenter = true;
-        }
-
-        if (!lockCenter)
-        {
-            // refine optical center within 10% of the image size.
-            assert(intrinsicBlock.size() >= 3);
-
-            const double opticalCenterMinPercent = -0.05;
-            const double opticalCenterMaxPercent = 0.05;
-
-            // add bounds to the principal point
-            problem.SetParameterLowerBound(intrinsicBlockPtr, 2, opticalCenterMinPercent * intrinsicPtr->w());
-            problem.SetParameterUpperBound(intrinsicBlockPtr, 2, opticalCenterMaxPercent * intrinsicPtr->w());
-            problem.SetParameterLowerBound(intrinsicBlockPtr, 3, opticalCenterMinPercent * intrinsicPtr->h());
-            problem.SetParameterUpperBound(intrinsicBlockPtr, 3, opticalCenterMaxPercent * intrinsicPtr->h());
-        }
-
-        // lens distortion
-        if (!refineIntrinsicsDistortion || intrinsicPtr->getDistortionInitializationMode() == camera::EInitMode::CALIBRATED)
-        {
-            lockDistortion = true;
-        }
 
         //Check if this particular distortion is locked
-        std::shared_ptr<camera::IntrinsicScaleOffsetDisto> intrinsicScaleOffsetDisto =
-              std::dynamic_pointer_cast<camera::IntrinsicScaleOffsetDisto>(intrinsicPtr);
-        if (intrinsicScaleOffsetDisto)
+        auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsicPtr);
+        if (isod)
         {
-            if (intrinsicScaleOffsetDisto->getDistortion())
+            auto distortion = isod->getDistortion();
+            if (distortion)
             {
-                if (intrinsicScaleOffsetDisto->getDistortion()->isLocked())
+                //Create data block for intrinsics inside ceres
+                std::vector<double>& distortionBlock = _distortionsBlocks[intrinsicId];
+                distortionBlock = distortion->getParameters();
+                double* distortionBlockPtr = distortionBlock.data();
+                problem.AddParameterBlock(distortionBlockPtr, distortionBlock.size());
+                
+                if (!refineIntrinsicsDistortion 
+                    || isod->getDistortionInitializationMode() == camera::EInitMode::CALIBRATED
+                    || distortion->isLocked()
+                    || !refineIntrinsics 
+                    || intrinsicPtr->getState() == EEstimatorParameterState::CONSTANT
+                    )
                 {
-                    lockDistortion = true;
+                    problem.SetParameterBlockConstant(distortionBlockPtr);
                 }
             }
         }
 
-        IntrinsicsManifold* subsetManifold =
-          new IntrinsicsManifold(intrinsicBlock.size(), focalRatio, lockFocal, lockRatio, lockCenter, lockDistortion);
-        problem.SetManifold(intrinsicBlockPtr, subsetManifold);
-
+       
         _statistics.addState(EParameter::INTRINSIC, EEstimatorParameterState::REFINED);
     }
 }
@@ -575,15 +642,18 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
             landmarkBlock.at(i) = landmark.X(Eigen::Index(i));
 
         double* landmarkBlockPtr = landmarkBlock.data();
+        problem.AddParameterBlock(landmarkBlockPtr, 3);
+
+        double* fakeDistortionBlockPtr = _fakeDistortionBlock.data();
 
         // add landmark parameter to the all parameters blocks pointers list
         _allParametersBlocks.push_back(landmarkBlockPtr);
 
         // iterate over 2D observation associated to the 3D landmark
-        for (const auto& observationPair : landmark.getObservations())
+        for (const auto& [viewId, observation] : landmark.getObservations())
         {
-            const sfmData::View& view = sfmData.getView(observationPair.first);
-            const sfmData::Observation& observation = observationPair.second;
+            const sfmData::View& view = sfmData.getView(viewId);
+            const IndexT intrinsicId = view.getIntrinsicId();
 
             // each residual block takes a point and a camera as input and outputs a 2
             // dimensional residual. Internally, the cost function stores the observed
@@ -592,8 +662,14 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
 
             // needed parameters to create a residual block (K, pose)
             double* poseBlockPtr = _posesBlocks.at(view.getPoseId()).data();
-            double* intrinsicBlockPtr = _intrinsicsBlocks.at(view.getIntrinsicId()).data();
-            const std::shared_ptr<IntrinsicBase> intrinsic = _intrinsicObjects[view.getIntrinsicId()];
+            double* intrinsicBlockPtr = _intrinsicsBlocks.at(intrinsicId).data();
+            const std::shared_ptr<IntrinsicBase> intrinsic = _intrinsicObjects[intrinsicId];
+
+            double * distortionBlockPtr = fakeDistortionBlockPtr;
+            if (_distortionsBlocks.find(intrinsicId) != _distortionsBlocks.end())
+            {
+                distortionBlockPtr = _distortionsBlocks.at(intrinsicId).data();
+            }
 
             // apply a specific parameter ordering:
             if (_ceresOptions.useParametersOrdering)
@@ -601,6 +677,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                 _linearSolverOrdering.AddElementToGroup(landmarkBlockPtr, 0);
                 _linearSolverOrdering.AddElementToGroup(poseBlockPtr, 1);
                 _linearSolverOrdering.AddElementToGroup(intrinsicBlockPtr, 2);
+                _linearSolverOrdering.AddElementToGroup(distortionBlockPtr, 2);
             }
 
             if (view.isPartOfRig() && !view.isPoseIndependant())
@@ -610,22 +687,26 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                 double* rigBlockPtr = _rigBlocks.at(view.getRigId()).at(view.getSubPoseId()).data();
                 _linearSolverOrdering.AddElementToGroup(rigBlockPtr, 1);
 
-                problem.AddResidualBlock(costFunction,
-                                         lossFunction,
-                                         intrinsicBlockPtr,
-                                         poseBlockPtr,
-                                         rigBlockPtr,        // subpose of the cameras rig
-                                         landmarkBlockPtr);  // do we need to copy 3D point to avoid false motion, if failure ?
+                std::vector<double*> params;
+                params.push_back(intrinsicBlockPtr);
+                params.push_back(distortionBlockPtr);
+                params.push_back(poseBlockPtr);
+                params.push_back(rigBlockPtr);
+                params.push_back(landmarkBlockPtr);
+
+                problem.AddResidualBlock(costFunction, lossFunction, params);
             }
             else
             {
                 ceres::CostFunction* costFunction = createCostFunctionFromIntrinsics(intrinsic, observation);
+ 
+                std::vector<double*> params;
+                params.push_back(intrinsicBlockPtr);
+                params.push_back(distortionBlockPtr);
+                params.push_back(poseBlockPtr);
+                params.push_back(landmarkBlockPtr);
 
-                problem.AddResidualBlock(costFunction,
-                                         lossFunction,
-                                         intrinsicBlockPtr,
-                                         poseBlockPtr,
-                                         landmarkBlockPtr);  // do we need to copy 3D point to avoid false motion, if failure ?
+                problem.AddResidualBlock(costFunction, lossFunction, params);
             }
 
             if (!refineStructure || landmark.state == EEstimatorParameterState::CONSTANT)
@@ -647,7 +728,8 @@ void BundleAdjustmentCeres::addConstraints2DToProblem(const sfmData::SfMData& sf
     // set a LossFunction to be less penalized by false measurements.
     // note: set it to NULL if you don't want use a lossFunction.
     ceres::LossFunction* lossFunction = _ceresOptions.lossFunction.get();
-
+    double* fakeDistortionBlockPtr = _fakeDistortionBlock.data();
+    
     for (const auto& constraint : sfmData.getConstraints2D())
     {
         const sfmData::View& view_1 = sfmData.getView(constraint.ViewFirst);
@@ -666,20 +748,29 @@ void BundleAdjustmentCeres::addConstraints2DToProblem(const sfmData::SfMData& sf
         double* poseBlockPtr_1 = _posesBlocks.at(view_1.getPoseId()).data();
         double* poseBlockPtr_2 = _posesBlocks.at(view_2.getPoseId()).data();
 
-        double* intrinsicBlockPtr_1 = _intrinsicsBlocks.at(view_1.getIntrinsicId()).data();
-        double* intrinsicBlockPtr_2 = _intrinsicsBlocks.at(view_2.getIntrinsicId()).data();
+        IndexT intrinsicId_1 = view_1.getIntrinsicId();
+        IndexT intrinsicId_2 = view_2.getIntrinsicId();
 
-        const std::shared_ptr<IntrinsicBase> intrinsicObject1 = _intrinsicObjects[view_1.getIntrinsicId()];
-        const std::shared_ptr<IntrinsicBase> intrinsicObject2 = _intrinsicObjects[view_2.getIntrinsicId()];
+        double* intrinsicBlockPtr_1 = _intrinsicsBlocks.at(intrinsicId_1).data();
+        double* intrinsicBlockPtr_2 = _intrinsicsBlocks.at(intrinsicId_2).data();
+
+        const std::shared_ptr<IntrinsicBase> intrinsicObject1 = _intrinsicObjects[intrinsicId_1];
+        const std::shared_ptr<IntrinsicBase> intrinsicObject2 = _intrinsicObjects[intrinsicId_2];
 
         // For the moment assume a unique camera
         assert(intrinsicBlockPtr_1 == intrinsicBlockPtr_2);
+
+        double * distortionBlockPtr_1 = fakeDistortionBlockPtr;
+        if (_distortionsBlocks.find(intrinsicId_1) != _distortionsBlocks.end())
+        {
+            distortionBlockPtr_1 = _distortionsBlocks.at(intrinsicId_1).data();
+        }
 
         ceres::CostFunction* costFunction = createConstraintsCostFunctionFromIntrinsics(intrinsicObject1,
                                                                                         constraint.ObservationFirst,
                                                                                         constraint.ObservationSecond);
         
-        problem.AddResidualBlock(costFunction, lossFunction, intrinsicBlockPtr_1, poseBlockPtr_1, poseBlockPtr_2);
+        problem.AddResidualBlock(costFunction, lossFunction, intrinsicBlockPtr_1, distortionBlockPtr_1, poseBlockPtr_1, poseBlockPtr_2);
     }
 }
 
@@ -845,6 +936,27 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
 
             sfmData.getIntrinsics().at(intrinsicId)->updateFromParams(intrinsicBlockPair.second);
         }
+
+        for (const auto& [idIntrinsic, distortionBlock]: _distortionsBlocks)
+        {
+            auto intrinsic = sfmData.getIntrinsicSharedPtr(idIntrinsic);
+
+            // do not update a camera pose set as Ignored or Constant in the Local strategy
+            if (intrinsic->getState() != EEstimatorParameterState::REFINED)
+            {
+                continue;
+            }
+
+            auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+            if (isod)
+            {
+                auto distortion = isod->getDistortion();
+                if (distortion)
+                {
+                    distortion->setParameters(distortionBlock);
+                }
+            }
+        }
     }
 
     // update landmarks
@@ -909,7 +1021,7 @@ bool BundleAdjustmentCeres::adjust(sfmData::SfMData& sfmData, ERefineOptions ref
     ceres::Solve(options, &problem, &summary);
 
     // print summary
-    if (_ceresOptions.summary)
+    //if (_ceresOptions.summary)
         ALICEVISION_LOG_INFO(summary.FullReport());
 
     // solution is not usable
@@ -939,9 +1051,24 @@ void BundleAdjustmentCeres::PrepareForEvaluation(bool evaluate_jacobians, bool n
 {
     if (new_evaluation_point)
     {
-        for (const auto& pair : _intrinsicsBlocks)
+        for (const auto& [idIntrinsic, intrinsicBlock] : _intrinsicsBlocks)
         {
-            _intrinsicObjects[pair.first]->updateFromParams(pair.second);
+            _intrinsicObjects[idIntrinsic]->updateFromParams(intrinsicBlock);
+        }
+
+        for (const auto& [idIntrinsic, distortionBlock] : _distortionsBlocks)
+        {
+            auto intrinsic = _intrinsicObjects[idIntrinsic];
+
+            auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+            if (isod)
+            {
+                auto distortion = isod->getDistortion();
+                if (distortion)
+                {
+                    distortion->setParameters(distortionBlock);
+                }
+            }
         }
     }
 }

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
@@ -244,7 +244,10 @@ class BundleAdjustmentCeres : public BundleAdjustment, ceres::EvaluationCallback
     /// intrinsics blocks wrapper
     /// block: intrinsics params
     std::map<IndexT, std::vector<double>> _intrinsicsBlocks;
+    std::map<IndexT, std::vector<double>> _distortionsBlocks;
     std::map<IndexT, std::shared_ptr<camera::IntrinsicBase>> _intrinsicObjects;
+
+    std::vector<double> _fakeDistortionBlock;
     /// landmarks blocks wrapper
     /// block: 3d position(3)
     std::map<IndexT, std::array<double, 3>> _landmarksBlocks;

--- a/src/aliceVision/sfm/bundle/costfunctions/constraint2d.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/constraint2d.hpp
@@ -30,8 +30,9 @@ struct Constraint2dErrorFunctor
     bool operator()(T const* const* parameters, T* residuals) const
     {       
         const T* parameter_intrinsics = parameters[0];
-        const T* parameter_pose1 = parameters[1];
-        const T* parameter_pose2 = parameters[2];
+        const T* parameter_distortion = parameters[1];
+        const T* parameter_pose1 = parameters[2];
+        const T* parameter_pose2 = parameters[3];
 
         
         Eigen::Matrix<T, 3, 3> oneRo, twoRo, twoRone;
@@ -40,14 +41,16 @@ struct Constraint2dErrorFunctor
         twoRone = twoRo * oneRo.transpose();
 
         Eigen::Vector<T, 3> lifted;
-        const T * liftParameters[1];
+        const T * liftParameters[2];
         liftParameters[0] = parameter_intrinsics;
+        liftParameters[1] = parameter_distortion;
         _intrinsicLiftFunctor(liftParameters, lifted.data());
         Eigen::Vector<T, 3> transformed = twoRone * lifted;
 
-        const T * projectParameters[2];
+        const T * projectParameters[3];
         projectParameters[0] = parameter_intrinsics;
-        projectParameters[1] = transformed.data();
+        projectParameters[1] = parameter_distortion;
+        projectParameters[2] = transformed.data();
         return _intrinsicProjectFunctor(projectParameters, residuals);
     }
 

--- a/src/aliceVision/sfm/bundle/costfunctions/intrinsicsLift.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/intrinsicsLift.hpp
@@ -21,7 +21,7 @@ class CostIntrinsicsLift : public ceres::CostFunction
     {
         set_num_residuals(3);
         
-        mutable_parameter_block_sizes()->push_back(intrinsics->getParamsSize());
+        mutable_parameter_block_sizes()->push_back(intrinsics->getParametersSize());
     }
 
     bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
@@ -44,7 +44,7 @@ class CostIntrinsicsLift : public ceres::CostFunction
 
         if (jacobians[0] != nullptr)
         {
-            Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobians[0], 3, _intrinsics->getParamsSize());
+            Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobians[0], 3, _intrinsics->getParametersSize());
 
             J = _intrinsics->getDerivativeBackProjectUnitWrtParams(_pt2d);
         }

--- a/src/aliceVision/sfm/bundle/costfunctions/intrinsicsLift.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/intrinsicsLift.hpp
@@ -20,13 +20,26 @@ class CostIntrinsicsLift : public ceres::CostFunction
         _intrinsics(intrinsics)
     {
         set_num_residuals(3);
+
+        size_t size_disto = 1;
+        auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsics);
+        if (isod)
+        {
+            _distortion = isod->getDistortion();
+            if (_distortion)
+            {
+                size_disto = _distortion->getParameters().size();
+            }
+        }
         
         mutable_parameter_block_sizes()->push_back(intrinsics->getParametersSize());
+        mutable_parameter_block_sizes()->push_back(size_disto);
     }
 
     bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
     {
         const double* parameter_intrinsics = parameters[0];
+        const double* parameter_distortion = parameters[1];
 
         const Eigen::Matrix4d T = Eigen::Matrix4d::Identity();
 
@@ -49,11 +62,20 @@ class CostIntrinsicsLift : public ceres::CostFunction
             J = _intrinsics->getDerivativeBackProjectUnitWrtParams(_pt2d);
         }
 
+        if (jacobians[1] != nullptr && _distortion)
+        {
+            Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobians[1], 3,  _distortion->getParameters().size());
+
+            auto isod = camera::IntrinsicScaleOffsetDisto::cast(_intrinsics);
+            J = isod->getDerivativeBackProjectUnitWrtDistortion(_pt2d);
+        }
+
         return true;
     }
 
   private:
     const std::shared_ptr<camera::IntrinsicBase> _intrinsics;
+    std::shared_ptr<camera::Distortion> _distortion;
     const Vec2 _pt2d;
 };
 

--- a/src/aliceVision/sfm/bundle/costfunctions/intrinsicsProject.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/intrinsicsProject.hpp
@@ -20,15 +20,28 @@ class CostIntrinsicsProject : public ceres::CostFunction
         _intrinsics(intrinsics)
     {
         set_num_residuals(2);
+
+        size_t size_disto = 1;
+        auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsics);
+        if (isod)
+        {
+            _distortion = isod->getDistortion();
+            if (_distortion)
+            {
+                size_disto = _distortion->getParameters().size();
+            }
+        }
         
-        mutable_parameter_block_sizes()->push_back(intrinsics->getParameters().size());
+        mutable_parameter_block_sizes()->push_back(intrinsics->getParametersSize());
+        mutable_parameter_block_sizes()->push_back(size_disto);
         mutable_parameter_block_sizes()->push_back(3);
     }
 
     bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
     {
         const double* parameter_intrinsics = parameters[0];
-        const double* parameter_point = parameters[1];
+        const double* parameter_distortion = parameters[1];
+        const double* parameter_point = parameters[2];
 
         const Eigen::Map<const Vec3> pt(parameter_point);
         const Vec4 pth = pt.homogeneous();
@@ -49,7 +62,7 @@ class CostIntrinsicsProject : public ceres::CostFunction
             return true;
         }
 
-        size_t params_size = _intrinsics->getParameters().size();
+        size_t params_size = _intrinsics->getParametersSize();
         double d_res_d_pt_est = 1.0 / scale;
 
         if (jacobians[0] != nullptr)
@@ -58,10 +71,18 @@ class CostIntrinsicsProject : public ceres::CostFunction
 
             J = d_res_d_pt_est * _intrinsics->getDerivativeTransformProjectWrtParams(T, pth);
         }
-
-        if (jacobians[1] != nullptr)
+        
+        if (jacobians[1] != nullptr && _distortion)
         {
-            Eigen::Map<Eigen::Matrix<double, 2, 3, Eigen::RowMajor>> J(jacobians[1]);
+            Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> J(jacobians[1], 2, _distortion->getParameters().size());
+
+            auto isod = camera::IntrinsicScaleOffsetDisto::cast(_intrinsics);
+            J = d_res_d_pt_est * isod->getDerivativeTransformProjectWrtDistortion(T, pth);
+        }
+
+        if (jacobians[2] != nullptr)
+        {
+            Eigen::Map<Eigen::Matrix<double, 2, 3, Eigen::RowMajor>> J(jacobians[2]);
 
             J = d_res_d_pt_est * _intrinsics->getDerivativeTransformProjectWrtPoint3(T, pth);
         }
@@ -72,6 +93,7 @@ class CostIntrinsicsProject : public ceres::CostFunction
   private:
     const sfmData::Observation _measured;
     const std::shared_ptr<camera::IntrinsicBase> _intrinsics;
+    std::shared_ptr<camera::Distortion> _distortion;
 };
 
 }  // namespace sfm

--- a/src/aliceVision/sfm/bundle/costfunctions/intrinsicsProject.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/intrinsicsProject.hpp
@@ -21,19 +21,19 @@ class CostIntrinsicsProject : public ceres::CostFunction
     {
         set_num_residuals(2);
 
-        size_t size_disto = 1;
+        size_t sizeDisto = 1;
         auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsics);
         if (isod)
         {
             _distortion = isod->getDistortion();
             if (_distortion)
             {
-                size_disto = _distortion->getParameters().size();
+                sizeDisto = _distortion->getParameters().size();
             }
         }
         
         mutable_parameter_block_sizes()->push_back(intrinsics->getParametersSize());
-        mutable_parameter_block_sizes()->push_back(size_disto);
+        mutable_parameter_block_sizes()->push_back(sizeDisto);
         mutable_parameter_block_sizes()->push_back(3);
     }
 

--- a/src/aliceVision/sfm/bundle/costfunctions/intrinsicsProject.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/intrinsicsProject.hpp
@@ -21,7 +21,7 @@ class CostIntrinsicsProject : public ceres::CostFunction
     {
         set_num_residuals(2);
         
-        mutable_parameter_block_sizes()->push_back(intrinsics->getParams().size());
+        mutable_parameter_block_sizes()->push_back(intrinsics->getParameters().size());
         mutable_parameter_block_sizes()->push_back(3);
     }
 
@@ -49,7 +49,7 @@ class CostIntrinsicsProject : public ceres::CostFunction
             return true;
         }
 
-        size_t params_size = _intrinsics->getParams().size();
+        size_t params_size = _intrinsics->getParameters().size();
         double d_res_d_pt_est = 1.0 / scale;
 
         if (jacobians[0] != nullptr)

--- a/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
@@ -105,7 +105,7 @@ struct ProjectionErrorFunctor
             transformedPoint[2] += cam_t[2];
         }
 
-        const T * innerParameters[2];
+        const T * innerParameters[3];
         innerParameters[0] = parameter_intrinsics;
         innerParameters[1] = parameter_distortion;
         innerParameters[2] = transformedPoint;

--- a/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
@@ -31,8 +31,9 @@ struct ProjectionSimpleErrorFunctor
     bool operator()(T const* const* parameters, T* residuals) const
     {       
         const T* parameter_intrinsics = parameters[0];
-        const T* parameter_pose = parameters[1];
-        const T* parameter_point = parameters[2];
+        const T* parameter_distortion = parameters[1];
+        const T* parameter_pose = parameters[2];
+        const T* parameter_point = parameters[3];
 
         //--
         // Apply external parameters (Pose)
@@ -49,9 +50,10 @@ struct ProjectionSimpleErrorFunctor
         transformedPoint[1] += cam_t[1];
         transformedPoint[2] += cam_t[2];
 
-        const T * innerParameters[2];
+        const T * innerParameters[3];
         innerParameters[0] = parameter_intrinsics;
-        innerParameters[1] = transformedPoint;
+        innerParameters[1] = parameter_distortion;
+        innerParameters[2] = transformedPoint;
 
         return _intrinsicFunctor(innerParameters, residuals);
     }
@@ -70,9 +72,10 @@ struct ProjectionErrorFunctor
     bool operator()(T const* const* parameters, T* residuals) const
     {       
         const T* parameter_intrinsics = parameters[0];
-        const T* parameter_pose = parameters[1];
-        const T* parameter_subpose = parameters[2];
-        const T* parameter_point = parameters[3];
+        const T* parameter_distortion = parameters[1];
+        const T* parameter_pose = parameters[2];
+        const T* parameter_subpose = parameters[3];
+        const T* parameter_point = parameters[4];
 
         T transformedPoint[3];
         {
@@ -104,7 +107,8 @@ struct ProjectionErrorFunctor
 
         const T * innerParameters[2];
         innerParameters[0] = parameter_intrinsics;
-        innerParameters[1] = transformedPoint;
+        innerParameters[1] = parameter_distortion;
+        innerParameters[2] = transformedPoint;
 
         return _intrinsicFunctor(innerParameters, residuals);
     }

--- a/src/aliceVision/sfm/bundle/manifolds/intrinsics.hpp
+++ b/src/aliceVision/sfm/bundle/manifolds/intrinsics.hpp
@@ -21,16 +21,13 @@ class IntrinsicsManifold : public ceres::Manifold
                                 double focalRatio,
                                 bool lockFocal,
                                 bool lockFocalRatio,
-                                bool lockCenter,
-                                bool lockDistortion)
+                                bool lockCenter)
       : _ambientSize(parametersSize),
         _focalRatio(focalRatio),
         _lockFocal(lockFocal),
         _lockFocalRatio(lockFocalRatio),
-        _lockCenter(lockCenter),
-        _lockDistortion(lockDistortion)
+        _lockCenter(lockCenter)
     {
-        _distortionSize = _ambientSize - 4;
         _tangentSize = 0;
 
         if (!_lockFocal)
@@ -48,11 +45,6 @@ class IntrinsicsManifold : public ceres::Manifold
         if (!_lockCenter)
         {
             _tangentSize += 2;
-        }
-
-        if (!_lockDistortion)
-        {
-            _tangentSize += _distortionSize;
         }
     }
 
@@ -92,15 +84,6 @@ class IntrinsicsManifold : public ceres::Manifold
             ++posDelta;
         }
 
-        if (!_lockDistortion)
-        {
-            for (int i = 0; i < _distortionSize; i++)
-            {
-                x_plus_delta[4 + i] = x[4 + i] + delta[posDelta];
-                ++posDelta;
-            }
-        }
-
         return true;
     }
 
@@ -137,15 +120,6 @@ class IntrinsicsManifold : public ceres::Manifold
             ++posDelta;
         }
 
-        if (!_lockDistortion)
-        {
-            for (int i = 0; i < _distortionSize; i++)
-            {
-                J(4 + i, posDelta) = 1.0;
-                ++posDelta;
-            }
-        }
-
         return true;
     }
 
@@ -164,14 +138,12 @@ class IntrinsicsManifold : public ceres::Manifold
     int TangentSize() const override { return _tangentSize; }
 
   private:
-    size_t _distortionSize;
     size_t _ambientSize;
     size_t _tangentSize;
     double _focalRatio;
     bool _lockFocal;
     bool _lockFocalRatio;
     bool _lockCenter;
-    bool _lockDistortion;
 };
 
 }  // namespace sfm

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -742,7 +742,7 @@ void AlembicExporter::addCameraKeyframe(const geometry::Pose3& pose,
     // Intrinsic type
     _dataImpl->_mvgIntrinsicType.set(cam->getTypeStr());
     // Intrinsic parameters
-    std::vector<double> intrinsicParams = cam->getParams();
+    std::vector<double> intrinsicParams = cam->getParameters();
     _dataImpl->_mvgIntrinsicParams.set(intrinsicParams);
 
     // Attach intrinsic parameters to camera object

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -263,6 +263,8 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
             ODoubleProperty(userProps, "mvg_undistortionOffsetY").set(undistortion->getOffset().y());
             ODoubleProperty(userProps, "mvg_undistortionDiagonal").set(undistortion->getDiagonal());
             ODoubleProperty(userProps, "mvg_undistortionPixelAspectRatio").set(undistortion->getPixelAspectRatio());
+            OBoolProperty(userProps, "mvg_undistortionDesqueezed").set(undistortion->isDesqueezed());
+            OBoolProperty(userProps, "mvg_undistortionLocked").set(undistortion->isLocked());
         }
         
         OStringProperty(userProps, "mvg_distortionType").set(EDISTORTION_enumToString(distortionType));

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -429,6 +429,7 @@ bool readCamera(const Version& abcVersion,
     double undistortionDiagonal = 0.0;
     double undistortionPixelAspectRatio = 1.0;
     bool undistortionDesqueezed = false;
+    bool undistortionLocked = false;
     std::string serialNumber = "";
 
     if (userProps)
@@ -628,7 +629,11 @@ bool readCamera(const Version& abcVersion,
                 }
                 if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_undistortionDesqueezed"))
                 {
-                    undistortionDesqueezed = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_undistortionPixelAspectRatio", sampleFrame);
+                    undistortionDesqueezed = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_undistortionDesqueezed", sampleFrame);
+                }
+                if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_undistortionLocked"))
+                {
+                    undistortionLocked = getAbcProp<Alembic::Abc::IBoolProperty>(userProps, *propHeader, "mvg_undistortionLocked", sampleFrame);
                 }
             }
         }
@@ -705,6 +710,7 @@ bool readCamera(const Version& abcVersion,
             {
                 undistortion->setParameters(undistortionParams);
                 undistortion->setOffset(undistortionOffset);
+                undistortion->setLocked(undistortionLocked);
 
                 if (abcVersion >= Version(1, 2, 7))
                 {

--- a/src/aliceVision/sfmDataIO/bafIO.cpp
+++ b/src/aliceVision/sfmDataIO/bafIO.cpp
@@ -29,7 +29,7 @@ bool saveBAF(const sfmData::SfMData& sfmData, const std::string& filename, ESfMD
         for (sfmData::Intrinsics::const_iterator iterIntrinsic = intrinsics.begin(); iterIntrinsic != intrinsics.end(); ++iterIntrinsic)
         {
             // get params
-            const std::vector<double> intrinsicsParams = iterIntrinsic->second.get()->getParams();
+            const std::vector<double> intrinsicsParams = iterIntrinsic->second.get()->getParameters();
             std::copy(intrinsicsParams.begin(), intrinsicsParams.end(), std::ostream_iterator<double>(stream, " "));
             stream << '\n';
         }

--- a/src/aliceVision/sfmDataIO/colmap.cpp
+++ b/src/aliceVision/sfmDataIO/colmap.cpp
@@ -139,7 +139,7 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
                            << " " << pinhole_intrinsic_radial->w() << " " << pinhole_intrinsic_radial->h() << " "
                            << pinhole_intrinsic_radial->getFocalLengthPixX() << " " << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
                            << pinhole_intrinsic_radial->getPrincipalPoint().x() << " " << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
-                           << pinhole_intrinsic_radial->getParams().at(4)
+                           << pinhole_intrinsic_radial->getParameters().at(4)
                            << " "
                            // k2, p1, p2, k3, k4, k5, k6
                            << "0.0 0.0 0.0 0.0 0.0 0.0 0.0"
@@ -157,13 +157,13 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
                            << " " << pinhole_intrinsic_radial->w() << " " << pinhole_intrinsic_radial->h() << " "
                            << pinhole_intrinsic_radial->getFocalLengthPixX() << " " << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
                            << pinhole_intrinsic_radial->getPrincipalPoint().x() << " " << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
-                           << pinhole_intrinsic_radial->getParams().at(4) << " " << pinhole_intrinsic_radial->getParams().at(5)
+                           << pinhole_intrinsic_radial->getParameters().at(4) << " " << pinhole_intrinsic_radial->getParameters().at(5)
                            << " "
                            // tangential params p1 and p2
                            << 0.0 << " " << 0.0
                            << " "
                            // k3
-                           << pinhole_intrinsic_radial->getParams().at(6)
+                           << pinhole_intrinsic_radial->getParameters().at(6)
                            << " "
                            // remaining radial params k4-k6
                            << 0.0 << " " << 0.0 << " " << 0.0 << "\n";
@@ -180,13 +180,13 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
                            << " " << pinholeCameraBrownIntrinsics->w() << " " << pinholeCameraBrownIntrinsics->h() << " "
                            << pinholeCameraBrownIntrinsics->getFocalLengthPixX() << " " << pinholeCameraBrownIntrinsics->getFocalLengthPixY() << " "
                            << pinholeCameraBrownIntrinsics->getPrincipalPoint().x() << " " << pinholeCameraBrownIntrinsics->getPrincipalPoint().y()
-                           << " " << pinholeCameraBrownIntrinsics->getParams().at(4) << " " << pinholeCameraBrownIntrinsics->getParams().at(5)
+                           << " " << pinholeCameraBrownIntrinsics->getParameters().at(4) << " " << pinholeCameraBrownIntrinsics->getParameters().at(5)
                            << " "
                            // tangential params p1 and p2
-                           << pinholeCameraBrownIntrinsics->getParams().at(7) << " " << pinholeCameraBrownIntrinsics->getParams().at(8)
+                           << pinholeCameraBrownIntrinsics->getParameters().at(7) << " " << pinholeCameraBrownIntrinsics->getParameters().at(8)
                            << " "
                            // k3
-                           << pinholeCameraBrownIntrinsics->getParams().at(6)
+                           << pinholeCameraBrownIntrinsics->getParameters().at(6)
                            << " "
                            // remaining radial params k4-k6
                            << 0.0 << " " << 0.0 << " " << 0.0 << "\n";
@@ -203,8 +203,8 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
                            << " " << pinholeIntrinsicFisheye->w() << " " << pinholeIntrinsicFisheye->h() << " "
                            << pinholeIntrinsicFisheye->getFocalLengthPixX() << " " << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
                            << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " " << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
-                           << pinholeIntrinsicFisheye->getParams().at(4) << " " << pinholeIntrinsicFisheye->getParams().at(5) << " "
-                           << pinholeIntrinsicFisheye->getParams().at(6) << " " << pinholeIntrinsicFisheye->getParams().at(7) << "\n";
+                           << pinholeIntrinsicFisheye->getParameters().at(4) << " " << pinholeIntrinsicFisheye->getParameters().at(5) << " "
+                           << pinholeIntrinsicFisheye->getParameters().at(6) << " " << pinholeIntrinsicFisheye->getParameters().at(7) << "\n";
             }
             break;
         case camera::DISTORTION_FISHEYE1:
@@ -218,7 +218,7 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
                            << " " << pinholeIntrinsicFisheye->w() << " " << pinholeIntrinsicFisheye->h() << " "
                            << pinholeIntrinsicFisheye->getFocalLengthPixX() << " " << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
                            << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " " << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
-                           << pinholeIntrinsicFisheye->getParams().at(4) << "\n";
+                           << pinholeIntrinsicFisheye->getParameters().at(4) << "\n";
             }
             break;
         default:

--- a/src/aliceVision/sfmDataIO/colmap.cpp
+++ b/src/aliceVision/sfmDataIO/colmap.cpp
@@ -124,7 +124,8 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
                 intrString << intrinsicsID << " "
                            << "PINHOLE"
                            << " " << pinhole_intrinsic->w() << " " << pinhole_intrinsic->h() << " " << pinhole_intrinsic->getFocalLengthPixX() << " "
-                           << pinhole_intrinsic->getFocalLengthPixY() << " " << pinhole_intrinsic->getPrincipalPoint().x() << " "
+                           << pinhole_intrinsic->getFocalLengthPixY() << " " 
+                           << pinhole_intrinsic->getPrincipalPoint().x() << " "
                            << pinhole_intrinsic->getPrincipalPoint().y() << "\n";
             }
             break;
@@ -134,12 +135,17 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
             {
                 std::shared_ptr<camera::Pinhole> pinhole_intrinsic_radial = std::dynamic_pointer_cast<camera::Pinhole>(intrinsic);
 
+                auto distortion = pinhole_intrinsic_radial->getDistortion();
+
                 intrString << intrinsicsID << " "
                            << "FULL_OPENCV"
-                           << " " << pinhole_intrinsic_radial->w() << " " << pinhole_intrinsic_radial->h() << " "
-                           << pinhole_intrinsic_radial->getFocalLengthPixX() << " " << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
-                           << pinhole_intrinsic_radial->getPrincipalPoint().x() << " " << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
-                           << pinhole_intrinsic_radial->getParameters().at(4)
+                           << " " << pinhole_intrinsic_radial->w() << " " 
+                           << pinhole_intrinsic_radial->h() << " "
+                           << pinhole_intrinsic_radial->getFocalLengthPixX() << " " 
+                           << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
+                           << pinhole_intrinsic_radial->getPrincipalPoint().x() << " " 
+                           << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
+                           << distortion->getParameters().at(0)
                            << " "
                            // k2, p1, p2, k3, k4, k5, k6
                            << "0.0 0.0 0.0 0.0 0.0 0.0 0.0"
@@ -151,20 +157,23 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
             // Parameters: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
             {
                 std::shared_ptr<camera::Pinhole> pinhole_intrinsic_radial = std::dynamic_pointer_cast<camera::Pinhole>(intrinsic);
+                auto distortion = pinhole_intrinsic_radial->getDistortion();
 
                 intrString << intrinsicsID << " "
                            << "FULL_OPENCV"
-                           << " " << pinhole_intrinsic_radial->w() << " " << pinhole_intrinsic_radial->h() << " "
-                           << pinhole_intrinsic_radial->getFocalLengthPixX() << " " << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
-                           << pinhole_intrinsic_radial->getPrincipalPoint().x() << " " << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
-                           << pinhole_intrinsic_radial->getParameters().at(4) << " " << pinhole_intrinsic_radial->getParameters().at(5)
-                           << " "
+                           << " " << pinhole_intrinsic_radial->w() << " " 
+                           << pinhole_intrinsic_radial->h() << " "
+                           << pinhole_intrinsic_radial->getFocalLengthPixX() << " " 
+                           << pinhole_intrinsic_radial->getFocalLengthPixY() << " "
+                           << pinhole_intrinsic_radial->getPrincipalPoint().x() << " " 
+                           << pinhole_intrinsic_radial->getPrincipalPoint().y() << " "
+                           << distortion->getParameters().at(0) << " " 
+                           << distortion->getParameters().at(1) << " "
                            // tangential params p1 and p2
                            << 0.0 << " " << 0.0
                            << " "
                            // k3
-                           << pinhole_intrinsic_radial->getParameters().at(6)
-                           << " "
+                           << distortion->getParameters().at(2) << " "
                            // remaining radial params k4-k6
                            << 0.0 << " " << 0.0 << " " << 0.0 << "\n";
             }
@@ -174,20 +183,22 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
             // Parameters: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
             {
                 std::shared_ptr<camera::Pinhole> pinholeCameraBrownIntrinsics = std::dynamic_pointer_cast<camera::Pinhole>(intrinsic);
+                auto distortion = pinholeCameraBrownIntrinsics->getDistortion();
 
                 intrString << intrinsicsID << " "
                            << "FULL_OPENCV"
                            << " " << pinholeCameraBrownIntrinsics->w() << " " << pinholeCameraBrownIntrinsics->h() << " "
-                           << pinholeCameraBrownIntrinsics->getFocalLengthPixX() << " " << pinholeCameraBrownIntrinsics->getFocalLengthPixY() << " "
-                           << pinholeCameraBrownIntrinsics->getPrincipalPoint().x() << " " << pinholeCameraBrownIntrinsics->getPrincipalPoint().y()
-                           << " " << pinholeCameraBrownIntrinsics->getParameters().at(4) << " " << pinholeCameraBrownIntrinsics->getParameters().at(5)
-                           << " "
+                           << pinholeCameraBrownIntrinsics->getFocalLengthPixX() << " " 
+                           << pinholeCameraBrownIntrinsics->getFocalLengthPixY() << " "
+                           << pinholeCameraBrownIntrinsics->getPrincipalPoint().x() << " " 
+                           << pinholeCameraBrownIntrinsics->getPrincipalPoint().y() << " " 
+                           << distortion->getParameters().at(0) << " " 
+                           << distortion->getParameters().at(1) << " "
                            // tangential params p1 and p2
-                           << pinholeCameraBrownIntrinsics->getParameters().at(7) << " " << pinholeCameraBrownIntrinsics->getParameters().at(8)
-                           << " "
+                           << distortion->getParameters().at(3) << " " 
+                           << distortion->getParameters().at(4) << " "
                            // k3
-                           << pinholeCameraBrownIntrinsics->getParameters().at(6)
-                           << " "
+                           << distortion->getParameters().at(2) << " "
                            // remaining radial params k4-k6
                            << 0.0 << " " << 0.0 << " " << 0.0 << "\n";
             }
@@ -197,14 +208,19 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
             // Parameters: fx, fy, cx, cy, k1, k2, k3, k4
             {
                 std::shared_ptr<camera::Pinhole> pinholeIntrinsicFisheye = std::dynamic_pointer_cast<camera::Pinhole>(intrinsic);
+                auto distortion = pinholeIntrinsicFisheye->getDistortion();
 
                 intrString << intrinsicsID << " "
                            << "OPENCV_FISHEYE"
                            << " " << pinholeIntrinsicFisheye->w() << " " << pinholeIntrinsicFisheye->h() << " "
-                           << pinholeIntrinsicFisheye->getFocalLengthPixX() << " " << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
-                           << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " " << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
-                           << pinholeIntrinsicFisheye->getParameters().at(4) << " " << pinholeIntrinsicFisheye->getParameters().at(5) << " "
-                           << pinholeIntrinsicFisheye->getParameters().at(6) << " " << pinholeIntrinsicFisheye->getParameters().at(7) << "\n";
+                           << pinholeIntrinsicFisheye->getFocalLengthPixX() << " " 
+                           << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " " 
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
+                           << distortion->getParameters().at(0) << " " 
+                           << distortion->getParameters().at(1) << " "
+                           << distortion->getParameters().at(2) << " " 
+                           << distortion->getParameters().at(3) << "\n";
             }
             break;
         case camera::DISTORTION_FISHEYE1:
@@ -212,13 +228,16 @@ std::string convertIntrinsicsToColmapString(const IndexT intrinsicsID, std::shar
             // Parameters: fx, fy, cx, cy, k1, k2, k3, k4
             {
                 std::shared_ptr<camera::Pinhole> pinholeIntrinsicFisheye = std::dynamic_pointer_cast<camera::Pinhole>(intrinsic);
+                auto distortion = pinholeIntrinsicFisheye->getDistortion();
 
                 intrString << intrinsicsID << " "
                            << "FOV"
                            << " " << pinholeIntrinsicFisheye->w() << " " << pinholeIntrinsicFisheye->h() << " "
-                           << pinholeIntrinsicFisheye->getFocalLengthPixX() << " " << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
-                           << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " " << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
-                           << pinholeIntrinsicFisheye->getParameters().at(4) << "\n";
+                           << pinholeIntrinsicFisheye->getFocalLengthPixX() << " " 
+                           << pinholeIntrinsicFisheye->getFocalLengthPixY() << " "
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().x() << " " 
+                           << pinholeIntrinsicFisheye->getPrincipalPoint().y() << " "
+                           << distortion->getParameters().at(0) << "\n";
             }
             break;
         default:

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -209,6 +209,7 @@ void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::share
             intrinsicTree.put("undistortionDiagonal", undistortionObject->getDiagonal());
             intrinsicTree.put("pixelAspectRatio", undistortionObject->getPixelAspectRatio());
             intrinsicTree.put("isDesqueezed", undistortionObject->isDesqueezed());
+            intrinsicTree.put("isLocked", undistortionObject->isLocked());
 
             for (double param : undistortionObject->getParameters())
             {
@@ -400,6 +401,7 @@ void loadIntrinsic(const Version& version, IndexT& intrinsicId, std::shared_ptr<
                 Vec2 offset;
                 loadMatrix("undistortionOffset", offset, intrinsicTree);
                 undistortionObject->setOffset(offset);
+                undistortionObject->setLocked(intrinsicTree.get<bool>("isLocked", true));
 
                 if (version >= Version(1, 2, 7))
                 {

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -115,7 +115,7 @@ bool exportToMatlab(const SfMData& sfm_data, const std::string& outDirectory)
                 continue;
             const IntrinsicBase& intrinsics = *sfm_data.getIntrinsics().at(view.getIntrinsicId()).get();
             cameraIntrinsicsFile << view.getViewId() << " " << camera::EINTRINSIC_enumToString(intrinsics.getType());
-            for (double p : intrinsics.getParams())
+            for (double p : intrinsics.getParameters())
                 cameraIntrinsicsFile << " " << p;
             cameraIntrinsicsFile << "\n";
         }

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -112,11 +112,30 @@ bool exportToMatlab(const SfMData& sfm_data, const std::string& outDirectory)
         {
             const View& view = *v.second.get();
             if (!sfm_data.isPoseAndIntrinsicDefined(view))
+            {
                 continue;
-            const IntrinsicBase& intrinsics = *sfm_data.getIntrinsics().at(view.getIntrinsicId()).get();
-            cameraIntrinsicsFile << view.getViewId() << " " << camera::EINTRINSIC_enumToString(intrinsics.getType());
-            for (double p : intrinsics.getParameters())
+            }
+
+            const auto & intrinsics = sfm_data.getIntrinsicSharedPtr(view.getIntrinsicId());
+            cameraIntrinsicsFile << view.getViewId() << " " << camera::EINTRINSIC_enumToString(intrinsics->getType());
+            for (double p : intrinsics->getParameters())
+            {
                 cameraIntrinsicsFile << " " << p;
+            }
+
+            auto casted = camera::IntrinsicScaleOffsetDisto::cast(intrinsics);
+            if (casted)
+            {
+                auto disto = casted->getDistortion();
+                if (disto)
+                {
+                    for (double p : disto->getParameters())
+                    {
+                        cameraIntrinsicsFile << " " << p;
+                    }
+                }
+            }
+
             cameraIntrinsicsFile << "\n";
         }
         cameraIntrinsicsFile.close();

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1431,7 +1431,7 @@ int aliceVision_main(int argc, char* argv[])
 
             if (pParams.par.enabled)
             {
-                pParams.par.value = cam->getParams()[1] / cam->getParams()[0];
+                pParams.par.value = cam->getParameters()[1] / cam->getParameters()[0];
             }
 
             // Image processing

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1431,10 +1431,14 @@ int aliceVision_main(int argc, char* argv[])
 
             if (pParams.par.enabled)
             {
-                pParams.par.value = cam->getParameters()[1] / cam->getParameters()[0];
+                auto casted = camera::IntrinsicScaleOffset::cast(cam);
+                if (casted)
+                {
+                    pParams.par.value = casted->getScale().y() / casted->getScale().x();
+                }
             }
 
-            // Image processing
+            // Image processSing
             processImage(image, pParams, viewMetadata, cam);
 
             if (pParams.applyDcpMetadata)

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1431,14 +1431,14 @@ int aliceVision_main(int argc, char* argv[])
 
             if (pParams.par.enabled)
             {
-                auto casted = camera::IntrinsicScaleOffset::cast(cam);
-                if (casted)
+                auto iso = camera::IntrinsicScaleOffset::cast(cam);
+                if (iso)
                 {
-                    pParams.par.value = casted->getScale().y() / casted->getScale().x();
+                    pParams.par.value = iso->getScale().y() / iso->getScale().x();
                 }
             }
 
-            // Image processSing
+            // Image processing
             processImage(image, pParams, viewMetadata, cam);
 
             if (pParams.applyDcpMetadata)

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -208,7 +208,7 @@ int aliceVision_main(int argc, char** argv)
             {
                 if (intrinsic.first == intrinsicRef.first)
                 {
-                    intrinsic.second->updateFromParams(intrinsicRef.second->getParams());
+                    intrinsic.second->updateFromParams(intrinsicRef.second->getParameters());
                     break;
                 }
             }

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -202,13 +202,13 @@ int aliceVision_main(int argc, char** argv)
 
     if (matchingMethod == EMatchingMethod::FROM_INTRINSICID)
     {
-        for (auto intrinsic : sfmData.getIntrinsics())
+        for (auto & [idIntrinsic, intrinsic] : sfmData.getIntrinsics())
         {
-            for (const auto intrinsicRef : sfmDataRef.getIntrinsics())
+            for (const auto & [idIntrinsicRef, intrinsicRef] : sfmDataRef.getIntrinsics())
             {
-                if (intrinsic.first == intrinsicRef.first)
+                if (idIntrinsic == idIntrinsicRef)
                 {
-                    intrinsic.second->updateFromParams(intrinsicRef.second->getParameters());
+                    intrinsic.reset(intrinsicRef->clone());
                     break;
                 }
             }


### PR DESCRIPTION
Distortion parameters are no more integrated in the intrinsic's parameters list for easier class separations. This will help us adding undistortion parameters to the bundle in a similar fashion.