### PR TITLE
Fix typos in README and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
  - I have read the [contribution guidelines](../CONTRIBUTING.md).
  - I have updated the documentation, if applicable.
  - I have ensured that the change is tested somewhere.
- - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).
+ - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).
 
 -->
 ## Description

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can also contact the core team privately on: [alicevision-team@googlegroups.
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2995/badge)](https://bestpractices.coreinfrastructure.org/projects/2995)
 
 Beyond open source interest to foster developments, open source is a way of life. The project has started as a collaborative project and aims to continue. We love to exchange ideas, improve ourselves while making improvements for other people and discover new collaboration opportunities to expand everybody’s horizon.
-Contributions are welcome. We integrate all contributions as soon as it is useful for someone, don't create troubles for others and the code quality is good enough for maintainance.
+Contributions are welcome. We integrate all contributions as soon as it is useful for someone, don't create troubles for others and the code quality is good enough for maintenance.
 
 Please have a look at the [project code of conduct](CODE_OF_CONDUCT.md) to provide a friendly, motivating and welcoming environment for all.
 Please have a look at the [project contributing guide](CONTRIBUTING.md) to provide an efficient workflow that minimize waste of time for contributors and maintainers as well as maximizing the project quality and efficiency.


### PR DESCRIPTION
Found via `codespell -q 3 -L abl,ahd,finaly,indext,inout,iterm,optio,trackin,valide`

## Description

Trivial typo fix that are user-facing.  
Closes #1820

## Features list

n/a


## Implementation remarks

n/a
