### PR TITLE
Fix typos in src/software

### DIFF
--- a/src/software/convert/CMakeLists.txt
+++ b/src/software/convert/CMakeLists.txt
@@ -1,5 +1,5 @@
 ## AliceVision
-## Convertion software
+## Conversion software
 
 # Software PROPERTY FOLDER is 'Software/Convert'
 set(FOLDER_SOFTWARE_CONVERT "Software/Convert")

--- a/src/software/convert/main_convertDistortion.cpp
+++ b/src/software/convert/main_convertDistortion.cpp
@@ -101,7 +101,7 @@ bool convert(std::shared_ptr<camera::Undistortion> & undistortion, const camera:
                     };
         break;
     default:
-        ALICEVISION_LOG_ERROR("Unsupported camera model for convertion.");
+        ALICEVISION_LOG_ERROR("Unsupported camera model for conversion.");
         return false;
     };
 
@@ -222,7 +222,7 @@ int aliceVision_main(int argc, char** argv)
     // export the SfMData scene in the expected format
     if (!sfmDataIO::save(sfmData, outputSfMDataFilename, sfmDataIO::ESfMData::ALL))
     {
-        ALICEVISION_LOG_ERROR("An error occured while trying to save '" << outputSfMDataFilename << "'");
+        ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outputSfMDataFilename << "'");
         return EXIT_FAILURE;
     }
 

--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -185,7 +185,7 @@ int aliceVision_main(int argc, char** argv)
     // export the SfMData scene in the expected format
     if (!sfmDataIO::save(sfmData, outputSfMDataFilename, sfmDataIO::ESfMData(flags)))
     {
-        ALICEVISION_LOG_ERROR("An error occured while trying to save '" << outputSfMDataFilename << "'");
+        ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outputSfMDataFilename << "'");
         return EXIT_FAILURE;
     }
 

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -240,7 +240,7 @@ int aliceVision_main(int argc, char** argv)
         {
             bool found = true;
 
-            // Check if the point is close to the sensor enough to be theorically close to a neighboor
+            // Check if the point is close to the sensor enough to be theoretically close to a neighbor
             double length = (vertices[vIndex].coords - sensorPosition).norm();
             if (length < maxLength)
             {

--- a/src/software/convert/main_importKnownPoses.cpp
+++ b/src/software/convert/main_importKnownPoses.cpp
@@ -494,7 +494,7 @@ int aliceVision_main(int argc, char** argv)
     // export the SfMData scene in the expected format
     if (!sfmDataIO::save(sfmData, outputFilename, sfmDataIO::ESfMData::ALL))
     {
-        ALICEVISION_LOG_ERROR("An error occured while trying to save '" << outputFilename << "'");
+        ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << outputFilename << "'");
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -179,7 +179,7 @@ int aliceVision_main(int argc, char** argv)
     }
     system::Timer timer;
 
-    // Decide the views and instrinsics to export
+    // Decide the views and intrinsics to export
     sfmData::SfMData sfmDataExport;
     for (auto& viewPair : sfmData.getViews())
     {

--- a/src/software/export/main_exportMVSTexturing.cpp
+++ b/src/software/export/main_exportMVSTexturing.cpp
@@ -108,7 +108,7 @@ int aliceVision_main(int argc, char** argv)
     }
 
     const std::string sUndistMsg = bOneHaveDisto ? "undistorded" : "";
-    const std::string sQuitMsg = std::string("Your SfMData file was succesfully converted!\n") + "Now you can copy your " + sUndistMsg +
+    const std::string sQuitMsg = std::string("Your SfMData file was successfully converted!\n") + "Now you can copy your " + sUndistMsg +
                                  " images in the \"" + outDirectory + "\" folder and run MVS Texturing";
     std::cout << sQuitMsg << std::endl;
     return EXIT_SUCCESS;

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -1,5 +1,5 @@
 ## AliceVision
-## Pipeline softwares
+## Pipeline software
 
 # Software PROPERTY FOLDER is 'Software/Pipeline'
 set(FOLDER_SOFTWARE_PIPELINE "Software/Pipeline")
@@ -118,7 +118,7 @@ if(ALICEVISION_BUILD_SFM)
               Boost::json
     )
 
-    # Bootstraping SfM
+    # Bootstrapping SfM
     alicevision_add_software(aliceVision_sfmBootstraping
         SOURCE main_sfmBootstraping.cpp
         FOLDER ${FOLDER_SOFTWARE_PIPELINE}

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -362,7 +362,7 @@ int aliceVision_main(int argc, char** argv)
     // number of views with LCP data used to add chromatic aberration params in metadata
     std::size_t lcpChromaticViewCount = 0;
 
-    // load known informations
+    // load known information
     if (imageFolder.empty())
     {
         // fill SfMData from the JSON file

--- a/src/software/pipeline/main_depthMapEstimation.cpp
+++ b/src/software/pipeline/main_depthMapEstimation.cpp
@@ -247,7 +247,7 @@ int aliceVision_main(int argc, char* argv[])
     // print GPU Information
     ALICEVISION_LOG_INFO(gpu::gpuInformationCUDA());
 
-    // check if the gpu suppport CUDA compute capability 2.0
+    // check if the gpu support CUDA compute capability 2.0
     if (!gpu::gpuSupportCUDA(2, 0))
     {
         ALICEVISION_LOG_ERROR("This program needs a CUDA-Enabled GPU (with at least compute capability 2.0).");

--- a/src/software/pipeline/main_featureExtraction.cpp
+++ b/src/software/pipeline/main_featureExtraction.cpp
@@ -84,7 +84,7 @@ int aliceVision_main(int argc, char** argv)
         ("contrastFiltering", po::value<feature::EFeatureConstrastFiltering>(&featDescConfig.contrastFiltering)->default_value(featDescConfig.contrastFiltering),
          feature::EFeatureConstrastFiltering_information().c_str())
         ("relativePeakThreshold", po::value<float>(&featDescConfig.relativePeakThreshold)->default_value(featDescConfig.relativePeakThreshold),
-         "Peak Threshold relative to median of gradiants.")
+         "Peak Threshold relative to median of gradients.")
         ("workingColorSpace", po::value<image::EImageColorSpace>(&workingColorSpace)->default_value(workingColorSpace),
          ("Working color space: " + image::EImageColorSpace_informations()).c_str())
         ("forceCpuExtraction", po::value<bool>(&forceCpuExtraction)->default_value(forceCpuExtraction),

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -165,7 +165,7 @@ int aliceVision_main(int argc, char** argv)
         ("guidedMatching", po::value<bool>(&guidedMatching)->default_value(guidedMatching),
          "Use the found model to improve the pairwise correspondences.")
         ("crossMatching", po::value<bool>(&crossMatching)->default_value(crossMatching),
-         "Make sure that the matching process is symmetric (same matches for I->J than fo J->I).")
+         "Make sure that the matching process is symmetric (same matches for I->J than for J->I).")
         ("matchFilePerImage", po::value<bool>(&matchFilePerImage)->default_value(matchFilePerImage),
          "Save matches in a separate file per image.")
         ("distanceRatio", po::value<float>(&distRatio)->default_value(distRatio),

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -256,7 +256,7 @@ int aliceVision_main(int argc, char** argv)
                 throw std::runtime_error("No camera with valid pose and intrinsic.");
             }
             // For all cameras with valid extrinsic/intrinsic, we select the camera with common visibilities based on cameras' frustum.
-            // We use an epsilon near value for the frustum, to ensure that mulitple images with a pure rotation will not intersect at the nodal
+            // We use an epsilon near value for the frustum, to ensure that multiple images with a pure rotation will not intersect at the nodal
             // point.
             PairSet pairs = sfm::FrustumFilter(sfmDataA, 0.01).getFrustumIntersectionPairs();
             for (const auto& p : pairs)

--- a/src/software/pipeline/main_meshFiltering.cpp
+++ b/src/software/pipeline/main_meshFiltering.cpp
@@ -34,7 +34,7 @@ enum class ESubsetType : unsigned char
 };
 
 /**
- * @brief get informations about each subset type
+ * @brief get information about each subset type
  * @return String
  */
 std::string ESubsetType_informations()
@@ -137,7 +137,7 @@ int aliceVision_main(int argc, char* argv[])
         ("smoothingSubset",po::value<std::string>(&smoothingSubsetTypeName)->default_value(smoothingSubsetTypeName),
          ESubsetType_informations().c_str())
         ("smoothingBoundariesNeighbours", po::value<int>(&smoothingBoundariesNeighbours)->default_value(smoothingBoundariesNeighbours),
-         "Neighbours of the boudaries to consider.")
+         "Neighbours of the boundaries to consider.")
         ("smoothingIterations", po::value<int>(&smoothNIter)->default_value(smoothNIter),
          "Number of smoothing iterations.")
         ("smoothingLambda", po::value<float>(&lambda)->default_value(lambda),

--- a/src/software/pipeline/main_meshMasking.cpp
+++ b/src/software/pipeline/main_meshMasking.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 /**
  * @brief Basic cache system to manage masks.
  *
- * It keeps the latest "maxSize" (defaut = 16) masks in memory.
+ * It keeps the latest "maxSize" (default = 16) masks in memory.
  */
 struct MaskCache
 {

--- a/src/software/pipeline/main_nodalSfM.cpp
+++ b/src/software/pipeline/main_nodalSfM.cpp
@@ -434,7 +434,7 @@ int aliceVision_main(int argc, char** argv)
     // Using two views, create an initial map and pair of cameras
     buildInitialWorld(sfmData, reconstructedPairs[0], mapTracksPerView, mapTracks);
 
-    // Loop until termination of the process using the current boostrapped map
+    // Loop until termination of the process using the current bootstrapped map
     std::set<IndexT> visited;
     while (1)
     {
@@ -458,7 +458,7 @@ int aliceVision_main(int argc, char** argv)
         }
     }
 
-    // Refinment options
+    // Refinement options
     sfm::BundleAdjustmentCeres::CeresOptions options;
     sfm::BundleAdjustment::ERefineOptions refineOptions =
       sfm::BundleAdjustment::REFINE_ROTATION | sfm::BundleAdjustment::REFINE_STRUCTURE | sfm::BundleAdjustment::REFINE_INTRINSICS_FOCAL |

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -167,7 +167,7 @@ bool processImage(const PanoramaMap& panoramaMap,
         needWeights = false;
         needSeams = true;
 
-        // Enlarge the panorama boundingbox to allow consider neighboor pixels even at small scale
+        // Enlarge the panorama boundingbox to allow consider neighbor pixels even at small scale
         panoramaBoundingBox =
           referenceBoundingBox.divide(panoramaMap.getScale()).dilate(panoramaMap.getBorderSize()).multiply(panoramaMap.getScale());
 
@@ -194,7 +194,7 @@ bool processImage(const PanoramaMap& panoramaMap,
     std::vector<IndexT> overlappingViews;
     if (!panoramaMap.getOverlaps(overlappingViews, referenceBoundingBox))
     {
-        ALICEVISION_LOG_ERROR("Problem analyzing neighboorhood");
+        ALICEVISION_LOG_ERROR("Problem analyzing neighborhood");
         return false;
     }
 

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -875,7 +875,7 @@ int main(int argc, char* argv[])
         ("initializeCameras", po::value<std::string>(&initializeCameras),
          "Initialization type for the cameras poses.")
         ("nbViewsPerLine", po::value<std::string>(&nbViewsPerLineString),
-         "Number of views per line splitted by comma. For instance, \"2,4,*,4,2\".")
+         "Number of views per line split by commas. For instance, \"2,4,*,4,2\".")
         ("buildContactSheet", po::value<bool>(&buildContactSheet)->default_value(buildContactSheet),
          "Build a contact sheet");
 
@@ -1074,7 +1074,7 @@ int main(int argc, char* argv[])
         {
             if (nbViewsPerLineString.empty())
             {
-                ALICEVISION_LOG_ERROR("Init cameras from Sperical, but 'nbViewsPerLine' is not set.");
+                ALICEVISION_LOG_ERROR("Init cameras from Spherical, but 'nbViewsPerLine' is not set.");
                 return EXIT_FAILURE;
             }
 

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -44,7 +44,7 @@ bool computeOptimalPanoramaSize(std::pair<int, int>& optimalSize, const sfmData:
     std::vector<double> scales;
     for (auto& viewIt : sfmData.getViews())
     {
-        // Ignore non positionned views
+        // Ignore non positioned views
         const sfmData::View& view = *viewIt.second.get();
         if (!sfmData.isPoseAndIntrinsicDefined(view))
         {
@@ -235,7 +235,7 @@ int aliceVision_main(int argc, char** argv)
     }
 
     panoramaSize.second = panoramaSize.first / 2;
-    ALICEVISION_LOG_INFO("Choosen panorama size : " << panoramaSize.first << "x" << panoramaSize.second);
+    ALICEVISION_LOG_INFO("Chosen panorama size : " << panoramaSize.first << "x" << panoramaSize.second);
 
     // Define empty tiles data
     std::unique_ptr<float> empty_float(new float[tileSize * tileSize * 3]);
@@ -308,7 +308,7 @@ int aliceVision_main(int argc, char** argv)
             snappedCoarseBbox = coarseBbox;
             snappedCoarseBbox.snapToGrid(tileSize);
 
-            // Initialize bouding box for image
+            // Initialize bounding box for image
             BoundingBox globalBbox;
 
             {

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -119,7 +119,7 @@ bool prepareDenseScene(const SfMData& sfmData,
     }
 
     if ((outputFileType != image::EImageFileType::EXR) && saveMetadata)
-        ALICEVISION_LOG_WARNING("Cannot save informations in images metadata.\n"
+        ALICEVISION_LOG_WARNING("Cannot save information in images metadata.\n"
                                 "Choose '.exr' file type if you want AliceVision custom metadata");
 
     // export data
@@ -192,7 +192,7 @@ bool prepareDenseScene(const SfMData& sfmData,
 
             if (saveMetadata)
             {
-                // convert to 44 matix
+                // convert to 44 matrix
                 Mat4 projectionMatrix;
                 projectionMatrix << P(0, 0), P(0, 1), P(0, 2), P(0, 3), P(1, 0), P(1, 1), P(1, 2), P(1, 3), P(2, 0), P(2, 1), P(2, 2), P(2, 3), 0, 0,
                   0, 1;

--- a/src/software/pipeline/main_sfmBootstraping.cpp
+++ b/src/software/pipeline/main_sfmBootstraping.cpp
@@ -137,7 +137,7 @@ int aliceVision_main(int argc, char** argv)
     ("initialPairA", po::value<std::string>(&initialPairString.first)->default_value(initialPairString.first), "UID or filepath or filename of the first image.")
     ("initialPairB", po::value<std::string>(&initialPairString.second)->default_value(initialPairString.second), "UID or filepath or filename of the second image.");
 
-    CmdLine cmdline("AliceVision SfM Bootstraping");
+    CmdLine cmdline("AliceVision SfM Bootstrapping");
 
     cmdline.add(requiredParams);
     cmdline.add(optionalParams);

--- a/src/software/pipeline/main_texturing.cpp
+++ b/src/software/pipeline/main_texturing.cpp
@@ -130,7 +130,7 @@ int aliceVision_main(int argc, char* argv[])
         ("correctEV", po::value<bool>(&correctEV)->default_value(correctEV),
          "Option to uniformize images exposure.")
         ("forceVisibleByAllVertices", po::value<bool>(&texParams.forceVisibleByAllVertices)->default_value(texParams.forceVisibleByAllVertices),
-         "Triangle visibility is based on the union of vertices visiblity.")
+         "Triangle visibility is based on the union of vertices visibility.")
         ("flipNormals", po::value<bool>(&flipNormals)->default_value(flipNormals),
          "Option to flip face normals. It can be needed as it depends on the vertices order in triangles and the "
          "convention changes from one software to another.")

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -119,7 +119,7 @@ if(ALICEVISION_BUILD_SFM)
               Boost::boost
     )
 
-    # Frustrum filtering
+    # Frustum filtering
     alicevision_add_software(aliceVision_frustumFiltering
         SOURCE main_frustumFiltering.cpp
         FOLDER ${FOLDER_SOFTWARE_UTILS}

--- a/src/software/utils/main_applyCalibration.cpp
+++ b/src/software/utils/main_applyCalibration.cpp
@@ -173,7 +173,7 @@ bool applySfmData(sfmData::SfMData & sfmData, const sfmData::SfMData & sfmDataCa
             const bool distortionOnly = (isDistortionCalibrated && !isIntrinsicCalibrated);
             const bool smaller = (width <= calibrationWidth && height <= calibrationHeight);
 
-            ALICEVISION_LOG_WARNING("Distorsion is calibrated: " << isDistortionCalibrated);
+            ALICEVISION_LOG_WARNING("Distortion is calibrated: " << isDistortionCalibrated);
             ALICEVISION_LOG_WARNING("Intrinsics are calibrated: " << isIntrinsicCalibrated);
             ALICEVISION_LOG_WARNING("Size is smaller than calibration: " << smaller);
             

--- a/src/software/utils/main_depthMapRendering.cpp
+++ b/src/software/utils/main_depthMapRendering.cpp
@@ -138,12 +138,12 @@ int aliceVision_main(int argc, char** argv)
 
         //Store depthmap
         auto path = (pathOutputDirectory / (std::to_string(index) + "_depthMap.exr"));
-        ALICEVISION_LOG_INFO("Ouput depthmap to " << path);
+        ALICEVISION_LOG_INFO("Output depthmap to " << path);
         image::writeImage(path.string(), image, image::ImageWriteOptions(), metadata);
 
         //Store mask
         path = (pathOutputDirectory / (std::to_string(index) + "_mask.exr"));
-        ALICEVISION_LOG_INFO("Ouput mask to " << path);
+        ALICEVISION_LOG_INFO("Output mask to " << path);
         image::writeImage(path.string(), mask, image::ImageWriteOptions(), metadata);
     }
 

--- a/src/software/utils/main_generateSampleScene.cpp
+++ b/src/software/utils/main_generateSampleScene.cpp
@@ -27,7 +27,7 @@ namespace po = boost::program_options;
 int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
-    std::string sfmOutputDataFilepath;  // output folder for splited images
+    std::string sfmOutputDataFilepath;  // output folder for split images
 
     // clang-format off
     po::options_description requiredParams("Required parameters");

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1043,7 +1043,7 @@ int aliceVision_main(int argc, char* argv[])
          "Use original image names instead of view names when saving.")
 
         ("reconstructedViewsOnly", po::value<bool>(&pParams.reconstructedViewsOnly)->default_value(pParams.reconstructedViewsOnly),
-         "Process only recontructed views or all views.")
+         "Process only reconstructed views or all views.")
 
         ("fixNonFinite", po::value<bool>(&pParams.fixNonFinite)->default_value(pParams.fixNonFinite),
          "Fill non-finite pixels.")

--- a/src/software/utils/main_importMiddlebury.cpp
+++ b/src/software/utils/main_importMiddlebury.cpp
@@ -59,7 +59,7 @@ int aliceVision_main(int argc, char** argv)
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
         ("uniqueIntrinsics", po::bool_switch(&uniqueIntrinsics),
-          "Consider all the camera having the same intrinsics (the first camera instrinsics will be used for all the others).")
+          "Consider all the camera having the same intrinsics (the first camera intrinsics will be used for all the others).")
         ("importPoses", po::value<bool>(&importPoses)->default_value(importPoses),
          "Import the poses, disable this if you want, e.g. test the sfm part and assess the camera pose estimation.")
         ("lockIntrinsics", po::value<bool>(&lockIntrinsics)->default_value(lockIntrinsics),

--- a/src/software/utils/main_lightingEstimation.cpp
+++ b/src/software/utils/main_lightingEstimation.cpp
@@ -42,7 +42,7 @@ enum class EAlbedoEstimation
 };
 
 /**
- * @brief get informations about each describer type
+ * @brief get information about each describer type
  * @return String
  */
 std::string EAlbedoEstimation_informations()

--- a/src/software/utils/main_mergeMeshes.cpp
+++ b/src/software/utils/main_mergeMeshes.cpp
@@ -46,7 +46,7 @@ enum class EOperationType : unsigned char
 };
 
 /**
- * @brief get informations about each operation type
+ * @brief get information about each operation type
  * @return String
  */
 std::string EOperationType_informations()

--- a/src/software/utils/main_normalMapRendering.cpp
+++ b/src/software/utils/main_normalMapRendering.cpp
@@ -124,7 +124,7 @@ int aliceVision_main(int argc, char** argv)
         }
         
         auto path = (pathOutputDirectory / (std::to_string(index) + "_normalMap.exr"));
-        ALICEVISION_LOG_INFO("Ouput to " << path);
+        ALICEVISION_LOG_INFO("Output to " << path);
         image::writeImage(path.string(), image, image::ImageWriteOptions(), metadata);
     }
 

--- a/src/software/utils/main_qualityEvaluation.cpp
+++ b/src/software/utils/main_qualityEvaluation.cpp
@@ -93,7 +93,7 @@ int aliceVision_main(int argc, char** argv)
     for (const auto& iter : sfmData.getViews())
     {
         const auto& view = iter.second;
-        // jump to next view if there is no correponding pose in reconstruction
+        // jump to next view if there is no corresponding pose in reconstruction
         if (sfmData.getPoses().find(view->getPoseId()) == sfmData.getPoses().end())
         {
             ALICEVISION_LOG_INFO("no pose in input for view " << view->getPoseId());

--- a/src/software/utils/main_sfmToRig.cpp
+++ b/src/software/utils/main_sfmToRig.cpp
@@ -100,7 +100,7 @@ int aliceVision_main(int argc, char** argv)
         const IndexT poseId = view->getPoseId();
         const int subPoseId = mapPoseToSubPose[poseId];
 
-        // New commmon pose id is the same than the rig id for convenience
+        // New common pose id is the same than the rig id for convenience
         view->setPoseId(indexRig);
         view->setRigAndSubPoseId(indexRig, subPoseId);
         view->setIndependantPose(false);

--- a/src/software/utils/main_sfmTransfer.cpp
+++ b/src/software/utils/main_sfmTransfer.cpp
@@ -286,7 +286,7 @@ int aliceVision_main(int argc, char** argv)
                                     throw std::runtime_error("Invalid RigId/PoseId (out of rig) for view: " + viewA.getImage().getImagePath());
                             }
                         }
-                        // copy the pose of the rig or the independant pose
+                        // copy the pose of the rig or the independent pose
                         sfmData.getPoses()[viewA.getPoseId()] = sfmDataRef.getPoses().at(viewB.getPoseId());
 
                         // warning: we copy the full rig (and not only the subpose corresponding to the view).
@@ -337,7 +337,7 @@ int aliceVision_main(int argc, char** argv)
                             for (const auto& obsIt : landIt.second.getObservations())
                             {
                                 const IndexT viewId = obsIt.first;
-                                // If the observation view has a correspondance in the other sfmData, we copy it :
+                                // If the observation view has a correspondence in the other sfmData, we copy it :
                                 if (commonViewsMap.find(viewId) != commonViewsMap.end())
                                 {
                                     newLandmark.getObservations().emplace(commonViewsMap.at(viewId), landIt.second.getObservations().at(viewId));

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -234,7 +234,7 @@ bool splitEquirectangular(sfmData::SfMData& outSfmData,
         // Override make and model in order to force camera model in SfM
         outMetadataSpec.attribute("Make", "Custom");
         outMetadataSpec.attribute("Model", "Pinhole");
-        const float focal_mm = focal_px * (36.0 / splitResolution);  // muliplied by sensorWidth (36mm by default)
+        const float focal_mm = focal_px * (36.0 / splitResolution);  // multiplied by sensorWidth (36mm by default)
         outMetadataSpec.attribute("Exif:FocalLength", focal_mm);
 
         // Make sure sub-folder exists for complete rig structure
@@ -352,7 +352,7 @@ int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
     std::string inputPath;                       // media file path list or SfMData file
-    std::string outputFolder;                    // output folder for splited images
+    std::string outputFolder;                    // output folder for split images
     std::string outSfmDataFilepath;              // output SfMData file
     std::string splitMode;                       // split mode (dualfisheye, equirectangular)
     std::string dualFisheyeOffsetPresetX;        // dual-fisheye offset preset on X axis

--- a/src/software/utils/main_voctreeCreation.cpp
+++ b/src/software/utils/main_voctreeCreation.cpp
@@ -76,7 +76,7 @@ int aliceVision_main(int argc, char** argv)
          "Number of levels of the tree.")
         ("sanitycheck,s", po::value<bool>(&sanityCheck)->default_value(sanityCheck),
          "Perform a sanity check at the end of the creation of the vocabulary tree. "
-         "The sanity check is a query to the database with the same documents/images useed to train the vocabulary tree.");
+         "The sanity check is a query to the database with the same documents/images used to train the vocabulary tree.");
     // clang-format on
 
     CmdLine cmdline(

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -168,7 +168,7 @@ bool ColorHarmonizationEngineGlobal::process()
     //-------------------
 
     std::map<size_t, size_t> mapCameraNodeToCameraIndex;  // graph node Id to 0->Ncam
-    std::map<size_t, size_t> mapCameraIndexTocameraNode;  // 0->Ncam correspondance to graph node Id
+    std::map<size_t, size_t> mapCameraIndexTocameraNode;  // 0->Ncam correspondence to graph node Id
     std::set<size_t> setIndexImage;
 
     for (size_t i = 0; i < _pairwiseMatches.size(); ++i)


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.ai,CHANGES.md,src/aliceVision/sensorDB/cameraSensors.db,./src/nonFree/sift/vl" -L abl,ahd,alledges,bailin,celll,classe,devicess,dum,finaly,htmp,ihs,indext,inout,ist,iterm,nin,numer,optio,splitted,tabl,trackin,valide`