### PR TITLE
Versatile image exporting

### DIFF
--- a/src/aliceVision/camera/IntrinsicBase.hpp
+++ b/src/aliceVision/camera/IntrinsicBase.hpp
@@ -27,6 +27,10 @@ namespace camera {
 class IntrinsicBase
 {
   public:
+    using sptr = std::shared_ptr<IntrinsicBase>;
+    using ptr = IntrinsicBase*;
+    
+  public:
     explicit IntrinsicBase(unsigned int width, unsigned int height, const std::string& serialNumber = "")
       : _w(width),
         _h(height),
@@ -375,7 +379,7 @@ class IntrinsicBase
     /**
      * @brief Return true if this ray should be visible in the image
      * @param ray input ray to check for visibility
-     * @return True if this ray is visible theoretically
+     * @return True if this ray is visible theorically
      */
     virtual bool isVisibleRay(const Vec3& ray) const = 0;
 
@@ -482,7 +486,7 @@ class IntrinsicBase
  * @brief Apply intrinsic and extrinsic parameters to unit vector
  * from the cameras focus to a point on the camera plane
  * @param[in] pose Extrinsic pose
- * @param[in] intrinsic Intrinsic camera parameters
+ * @param[in] intrinsic Intrinsic camera paremeters
  * @param[in] x Point in image
  * @return The unit vector in 3D space pointing out from the camera to the point
  */

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -21,17 +21,59 @@ using namespace aliceVision::image;
 
 namespace fs = std::filesystem;
 
-SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eigen::Vector3d & bbMax)
+SfMData::SfMData(const SfMData & other, bool unused)
 {
-    _views = other._views;
-    _intrinsics  = other._intrinsics;
-    constraints2d = other.constraints2d;
-    rotationpriors = other.rotationpriors;
+    //First copy all the non pointers
+    _landmarks = other._landmarks;
+    _constraints2d = other._constraints2d;
+    _constraintsPoint = other._constraintsPoint;
+    _rotationpriors = other._rotationpriors;
     _absolutePath = other._absolutePath;
     _featuresFolders = other._featuresFolders;
     _matchesFolders = other._matchesFolders;
     _poses = other._poses;
     _rigs = other._rigs;
+    _posesUncertainty = other._posesUncertainty;
+    _landmarksUncertainty = other._landmarksUncertainty;
+
+    for (const auto & [idView, pView]: other._views)
+    {
+        sfmData::View::sptr pOutView(pView->clone());
+        _views[idView] = pOutView;
+    }
+
+    for (const auto & [idIntrinsic, pIntrinsic]: other._intrinsics)
+    {
+        camera::IntrinsicBase::sptr pOutIntrinsic(pIntrinsic->clone());
+        _intrinsics[idIntrinsic] = pOutIntrinsic;
+    }
+}
+
+SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eigen::Vector3d & bbMax)
+{
+    //First copy all the non pointers
+    _constraints2d = other._constraints2d;
+    _constraintsPoint = other._constraintsPoint;
+    _rotationpriors = other._rotationpriors;
+    _absolutePath = other._absolutePath;
+    _featuresFolders = other._featuresFolders;
+    _matchesFolders = other._matchesFolders;
+    _poses = other._poses;
+    _rigs = other._rigs;
+    _posesUncertainty = other._posesUncertainty;
+    _landmarksUncertainty = other._landmarksUncertainty;
+
+    for (const auto & [idView, pView]: other._views)
+    {
+        sfmData::View::sptr pOutView(pView->clone());
+        _views[idView] = pOutView;
+    }
+
+    for (const auto & [idIntrinsic, pIntrinsic]: other._intrinsics)
+    {
+        camera::IntrinsicBase::sptr pOutIntrinsic(pIntrinsic->clone());
+        _intrinsics[idIntrinsic] = pOutIntrinsic;
+    }
 
     for (const auto & pl : other._landmarks)
     {
@@ -52,23 +94,31 @@ bool SfMData::operator==(const SfMData& other) const
 {
     // Views
     if (_views.size() != other._views.size())
+    {
         return false;
+    }
 
     for (Views::const_iterator it = _views.begin(); it != _views.end(); ++it)
     {
         const View& view1 = *(it->second.get());
         const View& view2 = *(other._views.at(it->first).get());
         if (view1 != view2)
+        {
             return false;
+        }
 
         // Image paths
         if (view1.getImage().getImagePath() != view2.getImage().getImagePath())
+        {
             return false;
+        }
     }
 
     // Ancestors
     if (_ancestors.size() != other._ancestors.size())
+    {
         return false;
+    }
 
     for (ImageInfos::const_iterator it = _ancestors.begin(); it != _ancestors.end(); ++it)
     {
@@ -76,20 +126,28 @@ bool SfMData::operator==(const SfMData& other) const
         const ImageInfo& ancestor2 = *(other._ancestors.at(it->first));
 
         if (ancestor1 != ancestor2)
+        {
             return false;
+        }
     }
 
     // Poses
     if ((_poses != other._poses))
+    {
         return false;
+    }
 
     // Rigs
     if (_rigs != other._rigs)
+    {
         return false;
+    }
 
     // Intrinsics
     if (_intrinsics.size() != other._intrinsics.size())
+    {
         return false;
+    }
 
     Intrinsics::const_iterator it = _intrinsics.begin();
     Intrinsics::const_iterator otherIt = other._intrinsics.begin();
@@ -97,18 +155,24 @@ bool SfMData::operator==(const SfMData& other) const
     {
         // Index
         if (it->first != otherIt->first)
+        {
             return false;
+        }
 
         // Intrinsic
         camera::IntrinsicBase& intrinsic1 = *(it->second.get());
         camera::IntrinsicBase& intrinsic2 = *(otherIt->second.get());
         if (intrinsic1 != intrinsic2)
+        {
             return false;
+        }
     }
 
     // Points IDs are not preserved
     if (_landmarks.size() != other._landmarks.size())
+    {
         return false;
+    }
 
     Landmarks::const_iterator landMarkIt = _landmarks.begin();
     Landmarks::const_iterator otherLandmarkIt = other._landmarks.begin();
@@ -119,21 +183,42 @@ bool SfMData::operator==(const SfMData& other) const
         const Landmark& landmark1 = landMarkIt->second;
         const Landmark& landmark2 = otherLandmarkIt->second;
         if (landmark1 != landmark2)
+        {
             return false;
+        }
     }
 
-    if (constraints2d.size() != other.constraints2d.size())
+    if (_constraints2d.size() != other._constraints2d.size())
+    {
         return false;
+    }
 
-    Constraints2D::const_iterator constraint2dIt = constraints2d.begin();
-    Constraints2D::const_iterator otherconstraint2dIt = other.constraints2d.begin();
-    for (; constraint2dIt != constraints2d.end() && otherconstraint2dIt != other.constraints2d.end(); ++constraint2dIt, ++otherconstraint2dIt)
+    Constraints2D::const_iterator constraint2dIt = _constraints2d.begin();
+    Constraints2D::const_iterator otherconstraint2dIt = other._constraints2d.begin();
+    for (; constraint2dIt != _constraints2d.end() && otherconstraint2dIt != other._constraints2d.end(); ++constraint2dIt, ++otherconstraint2dIt)
     {
         if (*constraint2dIt != *otherconstraint2dIt)
+        {
             return false;
+        }
     }
 
-    // Root path can be reset during exports
+    if (_constraintsPoint.size() != other._constraintsPoint.size())
+    {
+        return false;
+    }
+
+    ConstraintsPoint::const_iterator constraintPointIt = _constraintsPoint.begin();
+    ConstraintsPoint::const_iterator otherconstraintPointIt = other._constraintsPoint.begin();
+    for (; constraintPointIt != _constraintsPoint.end() && otherconstraintPointIt != other._constraintsPoint.end(); ++constraintPointIt, ++otherconstraintPointIt)
+    {
+        if (*constraintPointIt != *otherconstraintPointIt)
+        {
+            return false;
+        }
+    }
+
+    // Root path can be reseted during exports
     return true;
 }
 
@@ -250,7 +335,7 @@ void SfMData::setPose(const View& view, const CameraPose& absolutePose)
     // const bool knownPose = existsPose(view);
     CameraPose& viewPose = _poses[view.getPoseId()];
 
-    // Pose dedicated for this view (independent from rig, even if it is potentially part of a rig)
+    // Pose dedicated for this view (independant from rig, even if it is potentially part of a rig)
     if (view.isPoseIndependant())
     {
         viewPose = absolutePose;
@@ -303,7 +388,10 @@ void SfMData::combine(const SfMData& sfmData)
     _landmarks.insert(sfmData._landmarks.begin(), sfmData._landmarks.end());
 
     // constraints
-    constraints2d.insert(constraints2d.end(), sfmData.constraints2d.begin(), sfmData.constraints2d.end());
+    _constraints2d.insert(_constraints2d.end(), sfmData._constraints2d.begin(), sfmData._constraints2d.end());
+
+    // constraints
+    _constraintsPoint.insert(sfmData._constraintsPoint.begin(), sfmData._constraintsPoint.end());
 }
 
 void SfMData::clear()
@@ -313,9 +401,9 @@ void SfMData::clear()
     _landmarks.clear();
     _posesUncertainty.clear();
     _landmarksUncertainty.clear();
-    constraints2d.clear();
-    rotationpriors.clear();
-
+    _constraints2d.clear();
+    _constraintsPoint.clear();
+    _rotationpriors.clear();
     _absolutePath.clear();
     _featuresFolders.clear();
     _matchesFolders.clear();

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -68,23 +68,24 @@ class SfMData
     PosesUncertainty _posesUncertainty;
     /// Uncertainty per landmark
     LandmarksUncertainty _landmarksUncertainty;
-    /// 2D Constraints
-    Constraints2D constraints2d;
-    /// Point constraints
-    ConstraintsPoint constraintsPoint;
-    /// Rotation priors
-    RotationPriors rotationpriors;
 
     SfMData() = default;
+    
+    /**
+     * @brief Copy constructor 
+     * @param other the copied sfmData
+     * @param unused a parameter to make sure we explicitely want this copy (for legacy)
+     * 
+    */
+    SfMData(const SfMData & other, bool unused);
 
     /**
-     * Copy constructor 
+     * @brief Copy constructor 
      * Use a bounding box to restrict the copied landmarks to the selected region
     */
     SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eigen::Vector3d & bbMax);
 
     // Operators
-
     bool operator==(const SfMData& other) const;
 
     inline bool operator!=(const SfMData& other) const { return !(*this == other); }
@@ -137,22 +138,22 @@ class SfMData
      * @brief Get Constraints2D
      * @return Constraints2D
      */
-    const Constraints2D& getConstraints2D() const { return constraints2d; }
-    Constraints2D& getConstraints2D() { return constraints2d; }
+    const Constraints2D& getConstraints2D() const { return _constraints2d; }
+    Constraints2D& getConstraints2D() { return _constraints2d; }
 
     /**
      * @brief Get ConstraintsPoints
      * @return ConstraintsPoints
      */
-    const ConstraintsPoint& getConstraintsPoint() const { return constraintsPoint; }
-    ConstraintsPoint& getConstraintsPoint() { return constraintsPoint; }
+    const ConstraintsPoint& getConstraintsPoint() const { return _constraintsPoint; }
+    ConstraintsPoint& getConstraintsPoint() { return _constraintsPoint; }
 
     /**
      * @brief Get RotationPriors
      * @return RotationPriors
      */
-    const RotationPriors& getRotationPriors() const { return rotationpriors; }
-    RotationPriors& getRotationPriors() { return rotationpriors; }
+    const RotationPriors& getRotationPriors() const { return _rotationpriors; }
+    RotationPriors& getRotationPriors() { return _rotationpriors; }
 
     /**
      * @brief Get relative features folder paths
@@ -584,7 +585,7 @@ class SfMData
     void setAbsolutePose(IndexT poseId, const CameraPose& pose) { _poses[poseId] = pose; }
 
     /**
-     * @brief Erase the pose for the given poseId
+     * @brief Erase yhe pose for the given poseId
      * @param[in] poseId The given poseId
      * @param[in] noThrow If false, throw exception if no pose found
      */
@@ -654,6 +655,12 @@ class SfMData
     Poses _poses;
     /// Considered rigs
     Rigs _rigs;
+    /// 2D Constraints
+    Constraints2D _constraints2d;
+    /// Point constraints
+    ConstraintsPoint _constraintsPoint;
+    /// Rotation priors
+    RotationPriors _rotationpriors;
 
     /**
      * @brief Get Rig pose of a given camera view

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -75,7 +75,7 @@ class View
      * @brief Deep View Copy
      * return a pointer to a new View
      */
-    View* clone()
+    View* clone() const
     {
         View* v = new View(*this);
         v->_image = std::make_shared<ImageInfo>(*this->_image);

--- a/src/aliceVision/track/TracksHandler.hpp
+++ b/src/aliceVision/track/TracksHandler.hpp
@@ -21,6 +21,11 @@ public:
         return _mapTracks;
     }
 
+    track::TracksMap & getAllTracksMutable()
+    {
+        return _mapTracks;
+    }
+
     const track::TracksPerView & getTracksPerView() const
     {
         return _mapTracksPerView;

--- a/src/aliceVision/utils/filesIO.hpp
+++ b/src/aliceVision/utils/filesIO.hpp
@@ -121,5 +121,25 @@ inline std::time_t getLastWriteTime(const std::string& path)
     return fs::exists(path, ec);
 }
 
+/**
+ * @brief cast a int to a string and pad the string with 0
+ * to_string_with_zero_padding(17, 5) -> "00017"
+ * @param value the initial value
+ * @param total_length the string required length 
+ * (will be exceeded if the number number of digits is greater 
+ * to_string_with_zero_padding(17, 1) -> "17")
+ * @return a string with the value
+*/
+inline std::string to_string_with_zero_padding(const int value, std::size_t total_length)
+{
+    auto str = std::to_string(value);
+    if (str.length() < total_length)
+    {
+        str.insert(str.front() == '-' ? 1 : 0, total_length - str.length(), '0');
+    }
+
+    return str;
+}
+
 }  // namespace utils
 }  // namespace aliceVision

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -147,6 +147,32 @@ if(ALICEVISION_BUILD_SFM)
                   aliceVision_cmdline
                   Boost::program_options
         )
+
+        # Output intrinsics transformed images
+        alicevision_add_software(aliceVision_exportImages
+        SOURCE main_exportImages.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+            aliceVision_cmdline
+            aliceVision_image
+            aliceVision_sfmData
+            aliceVision_sfmDataIO
+            Boost::program_options
+            Boost::boost
+        )
+
+        # Output intrinsics transformed sfmdata
+        alicevision_add_software(aliceVision_intrinsicsTransforming
+        SOURCE main_intrinsicsTransforming.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+            aliceVision_cmdline
+            aliceVision_sfmData
+            aliceVision_sfmDataIO
+            aliceVision_track
+            Boost::program_options
+            Boost::boost
+        )
     endif()
 
     # SfM quality evaluation

--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -1,0 +1,321 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
+#include <boost/program_options.hpp>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+using NameFunction = std::function<std::string(const sfmData::View &)>;
+
+template<typename T>
+std::string to_string_with_zero_padding(const T& value, std::size_t total_length)
+{
+    auto str = std::to_string(value);
+    if (str.length() < total_length)
+    {
+        str.insert(str.front() == '-' ? 1 : 0, total_length - str.length(), '0');
+    }
+
+    return str;
+}
+
+template<typename T>
+void ImageIntrinsicsTransform(const image::Image<T>& imageIn,
+                    const camera::IntrinsicBase & intrinsicSource,
+                    const camera::IntrinsicBase & intrinsicOutput,
+                    image::Image<T>& image_ud,
+                    T fillcolor,
+                    const oiio::ROI& roi = oiio::ROI())
+{
+    // There is distortion
+    const Vec2 center(imageIn.width() * 0.5, imageIn.height() * 0.5);
+
+    int widthRoi = intrinsicOutput.w();
+    int heightRoi = intrinsicOutput.h();
+    int xOffset = 0;
+    int yOffset = 0;
+    if (roi.defined())
+    {
+        widthRoi = roi.width();
+        heightRoi = roi.height();
+        xOffset = roi.xbegin;
+        yOffset = roi.ybegin;
+    }
+
+    image_ud.resize(widthRoi, heightRoi, true, fillcolor);
+    const image::Sampler2d<image::SamplerLinear> sampler;
+
+#pragma omp parallel for
+    for (int y = 0; y < heightRoi; ++y)
+    {
+        for (int x = 0; x < widthRoi; ++x)
+        {
+            const Vec2 undisto_pix(x + xOffset, y + yOffset);
+
+            // compute coordinates with distortion
+            const Vec3 intermediate = intrinsicOutput.backProjectUnit(undisto_pix);
+            if (intermediate.z() < -0.2) continue;
+            const Vec2 disto_pix = intrinsicSource.project(intermediate.homogeneous(), true);
+
+            // pick pixel if it is in the image domain
+            if (imageIn.contains(disto_pix(1), disto_pix(0)))
+            {
+                image_ud(y, x) = sampler(imageIn, disto_pix(1), disto_pix(0));
+            }
+        }
+    }
+}
+
+void processImage(const std::string& dstFileName,
+             const camera::IntrinsicBase & outputIntrinsic,
+             const camera::IntrinsicBase & sourceIntrinsic,
+             const oiio::ParamValueList& metadata,
+             const std::string& srcFileName,
+             bool evCorrection,
+             float exposureCompensation)
+{
+    image::Image<image::RGBAfColor> image;
+    image::Image<image::RGBAfColor> image_ud;
+
+    readImage(srcFileName, image, image::EImageColorSpace::LINEAR);
+
+    // exposure correction
+    if (evCorrection)
+    {
+        for (int pix = 0; pix < image.width() * image.height(); ++pix)
+        {
+            image(pix)[0] *= exposureCompensation;
+            image(pix)[1] *= exposureCompensation;
+            image(pix)[2] *= exposureCompensation;
+        }
+    }
+    
+    // undistort the image and save it
+    ImageIntrinsicsTransform(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0));
+
+    //Write the result
+    writeImage(dstFileName, image_ud, image::ImageWriteOptions(), metadata);
+}
+
+bool process(const sfmData::SfMData & input, 
+             const sfmData::SfMData & target, 
+             const NameFunction & namingFunction,
+             bool evCorrection,
+             size_t rangeStart,
+             size_t rangeEnd)
+{
+    rangeEnd = std::min(input.getViews().size(), rangeEnd);
+
+    // for exposure correction
+    const double medianCameraExposure = input.getMedianCameraExposureSetting().getExposure(); 
+
+    for (int posImage = rangeStart; posImage < rangeEnd; posImage++)
+    {
+        auto viewsIt = input.getViews().begin();
+        std::advance(viewsIt, posImage);
+
+        //Retrieve view
+        IndexT viewId = viewsIt->first;
+        const sfmData::View & view = *viewsIt->second;
+
+        //Retrieve intrinsic
+        IndexT intrinsicId = view.getIntrinsicId();
+        const auto & intrinsic = input.getIntrinsic(intrinsicId);
+
+        //Make sure the target sfm contains the same thing
+        const auto & targetIntrinsics = target.getIntrinsics();
+        if (targetIntrinsics.find(intrinsicId) == targetIntrinsics.end())
+        {
+            continue;
+        }
+
+        const auto & targetIntrinsic = target.getIntrinsic(intrinsicId);
+
+        //Retrieve image
+        std::string srcFileName = view.getImage().getImagePath();
+        oiio::ParamValueList metadata = image::readImageMetadata(srcFileName);
+        
+
+        // add exposure values to images metadata
+        const double cameraExposure = view.getImage().getCameraExposureSetting().getExposure();
+        const double ev = std::log2(1.0 / cameraExposure);
+        const float exposureCompensation = float(medianCameraExposure / cameraExposure);
+        metadata.push_back(oiio::ParamValue("AliceVision:EV", float(ev)));
+        metadata.push_back(oiio::ParamValue("AliceVision:EVComp", exposureCompensation));
+
+        //Process Image
+        std::string outFileName = namingFunction(view);
+
+        ALICEVISION_LOG_INFO("Process image " << srcFileName);
+        processImage(outFileName,
+                    targetIntrinsic,
+                    intrinsic,
+                    metadata,
+                    srcFileName,
+                    evCorrection,
+                    exposureCompensation);
+    }
+
+    return true;
+}
+
+int aliceVision_main(int argc, char* argv[])
+{
+    // command-line parameters
+    std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+    std::string inputSfmDataFilename;
+    std::string targetSfmDataFilename;
+    std::string outFolder;
+    std::string outImageFileTypeName = image::EImageFileType_enumToString(image::EImageFileType::EXR);
+    std::string namingMode = "frameid";
+    int rangeStart = -1;
+    int rangeSize = 1;
+    bool evCorrection = false;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&inputSfmDataFilename)->required(),
+         "Input SfMData file.")
+        ("target,t", po::value<std::string>(&targetSfmDataFilename)->required(),
+         "Target SfMData file.")
+        ("output,o", po::value<std::string>(&outFolder)->required(),
+         "Output folder.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("outputFileType", po::value<std::string>(&outImageFileTypeName)->default_value(outImageFileTypeName),
+         image::EImageFileType_informations().c_str())
+        ("rangeStart", po::value<int>(&rangeStart)->default_value(rangeStart),
+         "Range image index start.")
+        ("rangeSize", po::value<int>(&rangeSize)->default_value(rangeSize),
+         "Range size.")
+        ("evCorrection", po::value<bool>(&evCorrection)->default_value(evCorrection),
+         "Correct exposure value.")
+        ("namingMode", po::value<std::string>(&namingMode)->default_value(namingMode),
+         "naming mode.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision prepareDenseScene");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // set output file type
+    image::EImageFileType outputFileType = image::EImageFileType_stringToEnum(outImageFileTypeName);
+
+    // Create output dir
+    if (!utils::exists(outFolder))
+    {
+        fs::create_directory(outFolder);
+    }
+
+    sfmDataIO::ESfMData flagsPart = sfmDataIO::ESfMData(
+                sfmDataIO::ESfMData::VIEWS | 
+                sfmDataIO::ESfMData::INTRINSICS | 
+                sfmDataIO::ESfMData::EXTRINSICS
+            );
+
+    // Read the input SfM scene
+    sfmData::SfMData inputSfmData;
+    if (!sfmDataIO::load(inputSfmData, inputSfmDataFilename, flagsPart))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << inputSfmDataFilename << "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    // Read the target SfM scene
+    sfmData::SfMData targetSfmData;
+    if (!sfmDataIO::load(targetSfmData, targetSfmDataFilename, flagsPart))
+    {
+        ALICEVISION_LOG_ERROR("The target SfMData file '" << targetSfmDataFilename << "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    int rangeEnd = inputSfmData.getViews().size();
+
+    // set range
+    if (rangeStart != -1)
+    {
+        if (rangeStart < 0 || rangeSize < 0)
+        {
+            ALICEVISION_LOG_ERROR("Range is incorrect");
+            return EXIT_FAILURE;
+        }
+
+        if (rangeStart + rangeSize > inputSfmData.getViews().size())
+        {
+            rangeSize = inputSfmData.getViews().size() - rangeStart;
+        }
+
+        rangeEnd = rangeStart + rangeSize;
+
+        if (rangeSize <= 0)
+        {
+            ALICEVISION_LOG_WARNING("Nothing to compute.");
+            return EXIT_SUCCESS;
+        }
+    }
+    else
+    {
+        rangeStart = 0;
+    }
+
+    NameFunction namingFunction;
+    
+    if (namingMode == "frameid")
+    {
+        namingFunction = [&outputFileType, outFolder](const sfmData::View & view) 
+        {
+            const std::string baseFilename = to_string_with_zero_padding(view.getFrameId(), 10);
+            const std::string ext = image::EImageFileType_enumToString(outputFileType);
+            return (fs::path(outFolder) / (baseFilename + "." + ext)).string();    
+        };
+    }
+    else if (namingMode == "viewid")
+    {
+        namingFunction = [&outputFileType, outFolder](const sfmData::View & view) 
+        {
+            const std::string baseFilename = std::to_string(view.getViewId());
+            const std::string ext = image::EImageFileType_enumToString(outputFileType);
+            return (fs::path(outFolder) / (baseFilename + "." + ext)).string();    
+        };
+    }
+    else 
+    {
+        namingFunction = [&outputFileType, outFolder](const sfmData::View & view) 
+        {
+            const fs::path imagePath = fs::path(view.getImage().getImagePath());
+            const std::string baseFilename = imagePath.stem().string();
+            const std::string ext = image::EImageFileType_enumToString(outputFileType);
+            return (fs::path(outFolder) / (baseFilename + "." + ext)).string();    
+        };
+    }
+
+    if (!process(inputSfmData, targetSfmData, namingFunction, evCorrection, rangeStart, rangeEnd))
+    {
+        ALICEVISION_LOG_ERROR("Process failed");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -23,17 +23,6 @@ namespace fs = std::filesystem;
 
 using NameFunction = std::function<std::string(const sfmData::View &)>;
 
-template<typename T>
-std::string to_string_with_zero_padding(const T& value, std::size_t total_length)
-{
-    auto str = std::to_string(value);
-    if (str.length() < total_length)
-    {
-        str.insert(str.front() == '-' ? 1 : 0, total_length - str.length(), '0');
-    }
-
-    return str;
-}
 
 template<typename T>
 void ImageIntrinsicsTransform(const image::Image<T>& imageIn,
@@ -70,7 +59,6 @@ void ImageIntrinsicsTransform(const image::Image<T>& imageIn,
 
             // compute coordinates with distortion
             const Vec3 intermediate = intrinsicOutput.backProjectUnit(undisto_pix);
-            if (intermediate.z() < -0.2) continue;
             const Vec2 disto_pix = intrinsicSource.project(intermediate.homogeneous(), true);
 
             // pick pixel if it is in the image domain
@@ -82,18 +70,57 @@ void ImageIntrinsicsTransform(const image::Image<T>& imageIn,
     }
 }
 
-void processImage(const std::string& dstFileName,
+/**
+ * @Brief process an image such that they appear captured by a new virtual intrinsic
+ * @param dstFileName the image output file name
+ * @param outputIntrinsic the virtual camera intrinsic
+ * @param sourceIntrinsic read image real intrinsic
+ * @param srcFileName the initial image file path
+ * @param evCorrection do we apply exposure compensation
+ * @param cameraExposure current image camera exposure
+ * @param medianCameraExposure median camera exposure for the sfmData
+ * @return false on error
+*/
+bool processImage(const std::string& dstFileName,
              const camera::IntrinsicBase & outputIntrinsic,
              const camera::IntrinsicBase & sourceIntrinsic,
-             const oiio::ParamValueList& metadata,
              const std::string& srcFileName,
              bool evCorrection,
-             float exposureCompensation)
+             double cameraExposure,
+             double medianCameraExposure)
 {
     image::Image<image::RGBAfColor> image;
     image::Image<image::RGBAfColor> image_ud;
 
-    readImage(srcFileName, image, image::EImageColorSpace::LINEAR);
+    oiio::ParamValueList metadata;
+    try 
+    {
+        metadata = image::readImageMetadata(srcFileName);
+    }
+    catch (...)
+    {
+        ALICEVISION_LOG_ERROR("Impossible to read image metadata");
+        return false;
+    }
+    
+    //Compute exposure compensation
+    const double ev = std::log2(1.0 / cameraExposure);
+    const float exposureCompensation = float(medianCameraExposure / cameraExposure);
+
+    // add exposure values to images metadata
+    metadata.push_back(oiio::ParamValue("AliceVision:EV", float(ev)));
+    metadata.push_back(oiio::ParamValue("AliceVision:EVComp", exposureCompensation));
+
+    try
+    {
+        readImage(srcFileName, image, image::EImageColorSpace::LINEAR);
+    }
+    catch (...)
+    {
+        ALICEVISION_LOG_ERROR("Impossible to read image");
+        return false;
+    }
+    
 
     // exposure correction
     if (evCorrection)
@@ -110,9 +137,28 @@ void processImage(const std::string& dstFileName,
     ImageIntrinsicsTransform(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0));
 
     //Write the result
-    writeImage(dstFileName, image_ud, image::ImageWriteOptions(), metadata);
+    try
+    {
+        writeImage(dstFileName, image_ud, image::ImageWriteOptions(), metadata);
+    }
+    catch (...)
+    {
+        ALICEVISION_LOG_ERROR("Impossible to write image");
+        return false;
+    }
+
+    return true;
 }
 
+/**
+ * @Brief process a set of images such that they appear captured by a new virtual intrinsic
+ * @param input the original sfmData to parse
+ * @param target the transformed sfmData which will be used for intrinsics properties
+ * @param namingFunction function which defines how is the image named given the view object
+ * @param evCorrection do we correct the exposure
+ * @param rangeStart the initial view index to process (range selection)
+ * @param rangeEnd the last view index to process (range selection)
+*/
 bool process(const sfmData::SfMData & input, 
              const sfmData::SfMData & target, 
              const NameFunction & namingFunction,
@@ -132,7 +178,7 @@ bool process(const sfmData::SfMData & input,
 
         //Retrieve view
         IndexT viewId = viewsIt->first;
-        const sfmData::View & view = *viewsIt->second;
+        sfmData::View & view = *viewsIt->second;
 
         //Retrieve intrinsic
         IndexT intrinsicId = view.getIntrinsicId();
@@ -147,17 +193,8 @@ bool process(const sfmData::SfMData & input,
 
         const auto & targetIntrinsic = target.getIntrinsic(intrinsicId);
 
-        //Retrieve image
+        //Retrieve image name
         std::string srcFileName = view.getImage().getImagePath();
-        oiio::ParamValueList metadata = image::readImageMetadata(srcFileName);
-        
-
-        // add exposure values to images metadata
-        const double cameraExposure = view.getImage().getCameraExposureSetting().getExposure();
-        const double ev = std::log2(1.0 / cameraExposure);
-        const float exposureCompensation = float(medianCameraExposure / cameraExposure);
-        metadata.push_back(oiio::ParamValue("AliceVision:EV", float(ev)));
-        metadata.push_back(oiio::ParamValue("AliceVision:EVComp", exposureCompensation));
 
         //Process Image
         std::string outFileName = namingFunction(view);
@@ -166,10 +203,10 @@ bool process(const sfmData::SfMData & input,
         processImage(outFileName,
                     targetIntrinsic,
                     intrinsic,
-                    metadata,
                     srcFileName,
                     evCorrection,
-                    exposureCompensation);
+                    view.getImage().getCameraExposureSetting().getExposure(),
+                    medianCameraExposure);
     }
 
     return true;
@@ -286,7 +323,7 @@ int aliceVision_main(int argc, char* argv[])
     {
         namingFunction = [&outputFileType, outFolder](const sfmData::View & view) 
         {
-            const std::string baseFilename = to_string_with_zero_padding(view.getFrameId(), 10);
+            const std::string baseFilename = utils::to_string_with_zero_padding(view.getFrameId(), 10);
             const std::string ext = image::EImageFileType_enumToString(outputFileType);
             return (fs::path(outFolder) / (baseFilename + "." + ext)).string();    
         };

--- a/src/software/utils/main_intrinsicsTransforming.cpp
+++ b/src/software/utils/main_intrinsicsTransforming.cpp
@@ -1,0 +1,318 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/utils/filesIO.hpp>
+#include <boost/program_options.hpp>
+#include <aliceVision/track/tracksUtils.hpp>
+#include <aliceVision/track/trackIO.hpp>
+#include <aliceVision/track/TracksHandler.hpp>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+/**
+ * @brief create a new SfmData where all the non pinhole stuff are removed
+ * For example, distortion/undistortion are removed
+ * @param sfmData the original sfmData
+ * @param outputSfmData the result sfmData
+ * @param fakeFov if one intrinsic is non pinhole, what is the required fov for the "fake" camera
+ * @return true if everything worked
+*/
+bool convertToPinhole(const sfmData::SfMData & sfmData, 
+                    sfmData::SfMData & outputSfmData,
+                    double fakeFov)
+{
+    outputSfmData.getIntrinsics().clear();
+
+    // Loop over all input intrinsics
+    for (const auto & [intrinsicId, intrinsicPtr] : sfmData.getIntrinsics())
+    {
+        const auto & originalIntrinsic = *intrinsicPtr;
+
+        bool isPinhole = camera::isPinhole(originalIntrinsic.getType());
+
+        //BY default, create a fake camera with a given fov
+        double hw = double(originalIntrinsic.w()) * 0.5;
+        double fx = hw / std::tan(fakeFov * 0.5);
+        double fy = fx;
+        double cx = 0.0;
+        double cy = 0.0;
+
+        if (isPinhole)
+        {
+            //IF pinhone, recreate without distortion
+            const auto & pinhole = dynamic_cast<const camera::Pinhole &>(originalIntrinsic);
+            fx = pinhole.getScale().x();
+            fy = pinhole.getScale().y();
+            cx = pinhole.getOffset().x();
+            cy = pinhole.getOffset().y();
+        }
+
+        std::shared_ptr<camera::IntrinsicBase> fakecam = camera::createIntrinsic(
+                                                camera::EINTRINSIC::PINHOLE_CAMERA, 
+                                                camera::DISTORTION_NONE, 
+                                                camera::UNDISTORTION_NONE, 
+                                                intrinsicPtr->w(), 
+                                                intrinsicPtr->h(),
+                                                fx, fy, cx, cy
+                                                );
+        
+        outputSfmData.getIntrinsics().insert({intrinsicId, fakecam});
+    }
+
+    return true;
+}
+
+/**
+ * @brief create a new SfmData where all the intrinsics are converted to equirectangular
+ * For example, distortion/undistortion are removed
+ * @param sfmData the original sfmData
+ * @param outputSfmData the result sfmData
+ * @return true if everything worked
+*/
+bool convertToEquirectangular(const sfmData::SfMData & sfmData, 
+                            sfmData::SfMData & outputSfmData)
+{
+    outputSfmData.getIntrinsics().clear();
+
+    // Loop over all input intrinsics
+    for (const auto & [intrinsicId, intrinsicPtr] : sfmData.getIntrinsics())
+    {
+        const auto & originalIntrinsic = *intrinsicPtr;
+
+        size_t minSize = std::min(originalIntrinsic.w(), originalIntrinsic.h());
+        double fx = double(minSize) / M_PI;
+        double fy = fx;
+
+        std::shared_ptr<camera::IntrinsicBase> fakecam = camera::createIntrinsic(
+                                                camera::EINTRINSIC::EQUIRECTANGULAR_CAMERA, 
+                                                camera::DISTORTION_NONE, 
+                                                camera::UNDISTORTION_NONE, 
+                                                minSize * 2, minSize,
+                                                fx, fy, 0, 0
+                                                );
+
+        outputSfmData.getIntrinsics().insert({intrinsicId, fakecam});
+    }
+
+    return true;
+}
+
+/**
+ * @brief Convert all obsrvation to simulate that they were observed using the new intrinsics
+ * @param sfmData the original sfmData
+ * @param outputSfmData the result sfmData
+ * @return true if everything worked
+*/
+bool convertObservations(const sfmData::SfMData & sfmData, 
+                        sfmData::SfMData & outputSfmData)
+{
+    for (auto & [idLandmark, landmark] : outputSfmData.getLandmarks())
+    {
+        //Copy observations and erase
+        const auto observationsCopy = landmark.getObservations();
+        landmark.getObservations().clear();
+
+        for (const auto & [idView, obs] : observationsCopy)
+        {
+            //Ignore non reconstructed views
+            const auto & view = sfmData.getView(idView);
+
+            //Undistort observation
+            IndexT intrinsicId = view.getIntrinsicId();
+            if (intrinsicId == UndefinedIndexT)
+            {
+                continue;
+            }
+
+            const auto & inputIntrinsic = sfmData.getIntrinsic(intrinsicId);
+            const auto & outputIntrinsic = outputSfmData.getIntrinsic(intrinsicId);
+
+            const Vec3 intermediate = inputIntrinsic.backProjectUnit(obs.getCoordinates());
+            const Vec2 undistorted = outputIntrinsic.project(intermediate.homogeneous(), false);
+
+            if (undistorted.x() < 0 || undistorted.y() < 0)
+            {
+                continue;
+            }
+
+            if (undistorted.x() >= outputIntrinsic.w() || undistorted.y() >= outputIntrinsic.h())
+            {
+                continue;
+            }
+
+            sfmData::Observation outputObservation = obs;
+            outputObservation.setCoordinates(undistorted);
+            landmark.getObservations()[idView] = outputObservation;
+        }
+    }
+    return true;
+}
+
+/**
+ * @brief Convert all tracks to simulate that they were observed using the new intrinsics
+ * @param inputSfmData the original sfmData
+ * @param outputSfmData the  sfmData with updated intrinsics
+ * @return true if everything worked
+*/
+bool convertTracks(const sfmData::SfMData & inputSfmData, 
+                  const sfmData::SfMData & outputSfmData,
+                  track::TracksHandler& tracksHandler)
+{
+    track::TracksMap & tracksMap = tracksHandler.getAllTracksMutable();
+    const track::TracksPerView tpv = tracksHandler.getTracksPerView();
+
+    for (const auto & [viewId, trackids]: tpv)
+    {
+        const auto & view = inputSfmData.getView(viewId);
+        IndexT intrinsicId = view.getIntrinsicId();
+        if (intrinsicId == UndefinedIndexT)
+        {
+            continue;
+        }
+
+        const auto & inputIntrinsic = inputSfmData.getIntrinsic(intrinsicId);
+        const auto & outputIntrinsic = outputSfmData.getIntrinsic(intrinsicId);
+
+        for (const auto & trackId : trackids)
+        {
+            auto & track = tracksMap.at(trackId);
+            auto & item = track.featPerView[viewId];
+
+            const Vec3 intermediate = inputIntrinsic.backProjectUnit(item.coords);
+            const Vec2 undistorted = outputIntrinsic.project(intermediate.homogeneous(), false);
+
+            item.coords = undistorted;
+        }
+    }
+
+    return true;
+}
+
+int aliceVision_main(int argc, char* argv[])
+{
+    // command-line parameters
+    std::string verboseLevel = system::EVerboseLevel_enumToString(system::Logger::getDefaultVerboseLevel());
+    std::string inputSfmDataFilename;
+    std::string outputSfmDataFilename;
+    std::string inputTracksFilename;
+    std::string outputTracksFilename;
+    std::string cameraTypeStr;
+    double fakeFov = 90.0;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&inputSfmDataFilename)->required(),
+         "Input SfMData file.")
+        ("output,o", po::value<std::string>(&outputSfmDataFilename)->required(),
+         "Output folder.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("fakeFov", po::value<double>(&fakeFov)->default_value(fakeFov),
+         "Virtual FOV if output is pinhole and input is not.")
+        ("type", po::value<std::string>(&cameraTypeStr)->default_value(cameraTypeStr),
+         "Default camera model type (pinhole, equidistant, equirectangular).")
+        ("inputTracks", po::value<std::string>(&inputTracksFilename)->required(),
+         "Input Tracks file.")
+        ("outputTracks", po::value<std::string>(&outputTracksFilename)->required(),
+         "Output Tracks file.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision prepareDenseScene");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    camera::EINTRINSIC cameraType = camera::EINTRINSIC::PINHOLE_CAMERA;
+    if (!cameraTypeStr.empty())
+    {
+        cameraType = camera::EINTRINSIC_stringToEnum(cameraTypeStr);
+    }
+
+    sfmDataIO::ESfMData flagsPart = sfmDataIO::ESfMData(
+                sfmDataIO::ESfMData::ALL
+            );
+
+    // Read the input SfM scene
+    sfmData::SfMData inputSfmData;
+    if (!sfmDataIO::load(inputSfmData, inputSfmDataFilename, flagsPart))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << inputSfmDataFilename << "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    sfmData::SfMData outputSfmData(inputSfmData);
+    if (cameraType == camera::EINTRINSIC::PINHOLE_CAMERA)
+    {
+        if (!convertToPinhole(inputSfmData, outputSfmData, fakeFov))
+        {
+            ALICEVISION_LOG_ERROR("There was an error converting intrinsics");
+            return EXIT_FAILURE;
+        }
+    }
+    else if (cameraType == camera::EINTRINSIC::EQUIRECTANGULAR_CAMERA)
+    {
+        if (!convertToEquirectangular(inputSfmData, outputSfmData))
+        {
+            ALICEVISION_LOG_ERROR("There was an error converting intrinsics");
+            return EXIT_FAILURE;
+        }
+    }
+    else 
+    {
+        ALICEVISION_LOG_ERROR("Invalid camera model");
+        return EXIT_FAILURE;
+    }
+
+    if (!convertObservations(inputSfmData, outputSfmData))
+    {
+        ALICEVISION_LOG_ERROR("There was an error converting observations");
+        return EXIT_FAILURE;
+    }
+
+    if (!inputTracksFilename.empty())
+    {
+        // Load tracks
+        ALICEVISION_LOG_INFO("Load tracks");
+        track::TracksHandler tracksHandler;
+        if (!tracksHandler.load(inputTracksFilename, inputSfmData.getViewsKeys()))
+        {
+            ALICEVISION_LOG_ERROR("The input tracks file '" + inputTracksFilename + "' cannot be read.");
+            return EXIT_FAILURE;
+        }
+
+        if (!convertTracks(inputSfmData, outputSfmData, tracksHandler))
+        {
+            ALICEVISION_LOG_ERROR("There was an error converting tracks");
+            return EXIT_FAILURE;
+        }
+    }
+
+    ALICEVISION_LOG_INFO("Export SfM: " << outputSfmDataFilename);
+    if (!sfmDataIO::save(outputSfmData, outputSfmDataFilename, flagsPart))
+    {
+        ALICEVISION_LOG_ERROR("The output SfMData file '" << outputSfmDataFilename << "' cannot be written.");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
1) 
- A node aimed to replace intrinsics of a given sfmData with a defined camera type without distortion (Could be pinhole or equirectangular at th emoment).
- Transform tracks and observations to match the new virtual camera

2)
- A node to export images
- Images are transformed so that the source image was taken using the original intrinsics and now appears as if taken using the newly defined virtual camera.

This is meant to replace both export Animated Camera and prepare dense scene when other nodes will be ready.

