### PR TITLE
[src] Comply with nanoflann >= 1.6.0 changes

### DIFF
--- a/src/aliceVision/fuseCut/Kdtree.hpp
+++ b/src/aliceVision/fuseCut/Kdtree.hpp
@@ -47,10 +47,12 @@ struct PointVectorAdaptator
 typedef nanoflann::L2_Simple_Adaptor<double, PointVectorAdaptator> KdTreeDist;
 typedef nanoflann::KDTreeSingleIndexAdaptor<KdTreeDist, PointVectorAdaptator, 3> KdTree;
 
-template<typename DistanceType, typename IndexType = size_t>
+template<typename _DistanceType, typename IndexType = size_t>
 class SmallerPixSizeInRadius
 {
   public:
+    // Necessary since nanoflann 1.7.0: https://github.com/jlblancoc/nanoflann/commit/9c84c4c32c2bfa7077cc8873dd3b5bcbb557da90
+    using DistanceType = _DistanceType;
     const DistanceType radius;
 
     const std::vector<double>& m_pixSizePrepare;

--- a/src/aliceVision/fuseCut/Kdtree.hpp
+++ b/src/aliceVision/fuseCut/Kdtree.hpp
@@ -95,6 +95,9 @@ class SmallerPixSizeInRadius
     }
 
     inline DistanceType worstDist() const { return radius; }
+
+    // Necessary since nanoflann 1.6.0: https://github.com/jlblancoc/nanoflann/commit/a74fc3b5b359c941d9a00eb9d92c2202c22eca3a
+    inline void sort() {}
 };
 
 class Tree

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -122,6 +122,9 @@ class BestPointInRadius
 
     // Upper bound on distance
     inline DistanceType worstDist() const { return m_radius; }
+
+    // Necessary since nanoflann 1.6.0: https://github.com/jlblancoc/nanoflann/commit/a74fc3b5b359c941d9a00eb9d92c2202c22eca3a
+    inline void sort() {}
 };
 
 // convert from a SfMData format to another

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -59,10 +59,12 @@ struct PointInfoVectorAdaptator
 using PointInfoKdTree =
   nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, PointInfoVectorAdaptator>, PointInfoVectorAdaptator, 3>;
 
-template<typename DistanceType, typename IndexType = size_t>
+template<typename _DistanceType, typename IndexType = size_t>
 class BestPointInRadius
 {
   public:
+    // Necessary since nanoflann 1.7.0: https://github.com/jlblancoc/nanoflann/commit/9c84c4c32c2bfa7077cc8873dd3b5bcbb557da90
+    using DistanceType = _DistanceType;
     const DistanceType m_radius;
     const std::vector<dataio::E57Reader::PointInfo>& m_points;
     const std::map<int, Eigen::Vector3d>& m_cameras;


### PR DESCRIPTION
## Description

This PR adds implements the necessary changes for AliceVision to keep compiling with nanoflann 1.6.0 and over. Although AliceVision currently uses an older version of nanoflann that does not require these changes to compile, including them now does not cause any change in the behaviour and will allow a smoother upgrade.

Changes were flagged by @dkogan in #1813 and #1833.


