### PR TITLE
[ci] Windows: Only install necessary components from the CUDA Toolkit

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -223,7 +223,7 @@ jobs:
                              -DALICEVISION_USE_POPSIFT=OFF
                              -DALICEVISION_USE_ALEMBIC=ON
                              -DALICEVISION_USE_OPENGV=OFF
-                             -DALICEVISION_BUILD_STEREOPHOTOMETRY=OFF
+                             -DALICEVISION_BUILD_PHOTOMETRICSTEREO=OFF
                              -DALICEVISION_BUILD_SEGMENTATION=OFF
                              -DBOOST_NO_CXX11=ON
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -189,11 +189,13 @@ jobs:
         id: cuda-toolkit
         with:
           cuda: '12.5.0'
+          sub-packages: '["nvcc", "cudart", "cublas", "cusparse"]'
 
       - name: Display CUDA information
         run: echo "Installed cuda version is "${{steps.cuda-toolkit.outputs.cuda}}
              echo "Cuda install location "${{steps.cuda-toolkit.outputs.CUDA_PATH}}
              nvcc -V
+             echo ${{ env.CUDA_PATH }}
 
       # Install latest CMake.
       - uses: lukka/get-cmake@latest

--- a/src/aliceVision/depthMap/CMakeLists.txt
+++ b/src/aliceVision/depthMap/CMakeLists.txt
@@ -129,8 +129,6 @@ alicevision_add_library(aliceVision_depthMap
     aliceVision_mvsUtils
     aliceVision_system
     assimp::assimp
-    ${CUDA_CUDADEVRT_LIBRARY}
-    ${CUDA_CUBLAS_LIBRARIES} #TODO shouldn't be here, but required to build on some machines
   PRIVATE_LINKS
     aliceVision_gpu
     aliceVision_sfmData

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -420,21 +420,22 @@ if (ALICEVISION_BUILD_PANORAMA)
 endif()
 
 if(ALICEVISION_BUILD_MVS)
-
-    # Lighting estimation from picture, albedo and geometry
-    alicevision_add_software(aliceVision_lightingEstimation
-        SOURCE main_lightingEstimation.cpp
-        FOLDER ${FOLDER_SOFTWARE_UTILS}
-        LINKS aliceVision_system
-              aliceVision_cmdline
-              aliceVision_numeric
-              aliceVision_sfmData
-              aliceVision_sfmDataIO
-              aliceVision_mvsUtils
-              aliceVision_image
-              aliceVision_lightingEstimation
-              ${Boost_LIBRARIES}
-    )
+    if(ALICEVISION_BUILD_PHOTOMETRICSTEREO)
+        # Lighting estimation from picture, albedo and geometry
+        alicevision_add_software(aliceVision_lightingEstimation
+            SOURCE main_lightingEstimation.cpp
+            FOLDER ${FOLDER_SOFTWARE_UTILS}
+            LINKS aliceVision_system
+                  aliceVision_cmdline
+                  aliceVision_numeric
+                  aliceVision_sfmData
+                  aliceVision_sfmDataIO
+                  aliceVision_mvsUtils
+                  aliceVision_image
+                  aliceVision_lightingEstimation
+                  ${Boost_LIBRARIES}
+        )
+    endif()
 
 
     # Lighting estimation from picture, albedo and geometry


### PR DESCRIPTION
## Description

This PR fixes an issue that appeared following the update of the Visual Studio version in the GitHub runner for Windows (cf https://github.com/Jimver/cuda-toolkit/issues/382) and that caused the installation of CUDA to hang forever.

To fix this, instead of installing the whole CUDA toolkit, we only install the components that are needed (and that do not cause the issue): nvcc, cublas, cudart, cusparse.

Additionally, the flag to disable the build of the photometric stereo components is updated, as it was erroneous since https://github.com/alicevision/AliceVision/pull/1590.
