### PR TITLE
[ci] Windows: Update vcpkg archive with SWIG support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -168,7 +168,7 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.3.0
         id: vcpkgDownload
         with:
-          url: "https://gitlab.com/alicevision/vcpkgArchive/-/raw/main/aliceVisionDeps-2025.03.06.zip?ref_type=heads&inline=false"
+          url: "https://github.com/alicevision/vcpkg/releases/download/2025.03.11/aliceVisionDeps-2025.03.11.zip"
           target: "${{ env.vcpkgDir }}"
           filename: installed.zip
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,10 +68,10 @@ AliceVision's required dependencies can be built with it.
 Vcpkg evolved from being a Windows-only project to becoming cross-platform.
 In the scope of AliceVision, vcpkg has only been tested on Windows.
 
-1. Install vcpkg itself
+1. Install vcpkg
 
 See the reference [installation guide](https://github.com/alicevision/vcpkg/blob/alicevision_master/README.md#quick-start-windows) to setup vcpkg.
-We recommend to use our vcpkg fork, where dependencies have been validated by the AliceVision development team but it should work with the latest version.
+We recommend to use our vcpkg fork, where dependencies have been validated by the AliceVision development team and where some ports may have some custom changes.
 ```bash
 git clone https://github.com/alicevision/vcpkg --branch alicevision_master
 cd vcpkg
@@ -107,7 +107,11 @@ vcpkg install ^
           pcl ^
           clp ^
           libe57format ^
+          vcpkg-tool-swig ^
           --triplet x64-windows
+
+%VCPKG_ROOT%/installed/x64-windows/tools/python3/python -m ensurepip --upgrade
+%VCPKG_ROOT%/installed/x64-windows/tools/python3/python -m pip install numpy
 ```
 
 3. Build AliceVision
@@ -256,6 +260,9 @@ CMake Options
 
 * `ALICEVISION_BUILD_COVERAGE` (default `OFF`)
   Enable code coverage generation (gcc only)
+
+* `ALICEVISION_BUILD_SWIG_BINDING` (default `OFF`)
+  Build AliceVision's Python binding with SWIG
 
 
 Linux compilation

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Get the source code: `git clone --recursive git://github.com/alicevision/AliceVi
 
 See [**INSTALL.md**](INSTALL.md) to build the project.
 
-Continuous integration status: [![Build Status](https://travis-ci.org/alicevision/AliceVision.png?branch=develop)](https://travis-ci.org/alicevision/AliceVision) [![Coverage Status](https://coveralls.io/repos/github/alicevision/AliceVision/badge.png?branch=develop)](https://coveralls.io/github/alicevision/AliceVision?branch=develop).
+Continuous integration status: [![Build Status](https://github.com/alicevision/AliceVision/actions/workflows/continuous-integration.yml/badge.svg?branch=develop)](https://github.com/alicevision/AliceVision/actions/workflows/continuous-integration.yml)
 
 
 ## Launch 3D reconstructions
 
-Use [Meshroom](https://github.com/alicevision/meshroom) to launch the AliceVision pipeline.
+Use [Meshroom](https://github.com/alicevision/Meshroom) to launch the AliceVision pipeline.
  - Meshroom provides a User Interface to create 3D reconstructions.
  - Meshroom provides a command line to launch all the steps of the pipeline.
  - Meshroom is written in python and can be used to create your own python scripts to customize the pipeline or create custom automation.


### PR DESCRIPTION
## Description

This PR updates the link to the vcpkg archive containing the dependencies for Windows, which now includes SWIG and numpy to allow building the Python binding of AliceVision.

`INSTALL.md` is updated to explicitly include the instructions allowing to build the binding.