### PR TITLE
[sfmDataIO] Fix Alembic dependency requirement for unit test

### DIFF
--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -1,71 +1,71 @@
 # Headers
 set(sfmDataIO_files_headers
-  sfmDataIO.hpp
-  bafIO.hpp
-  colmap.hpp
-  gtIO.hpp
-  jsonIO.hpp
-  middlebury.hpp
-  plyIO.hpp
-  viewIO.hpp
-  sceneSample.hpp
+    sfmDataIO.hpp
+    bafIO.hpp
+    colmap.hpp
+    gtIO.hpp
+    jsonIO.hpp
+    middlebury.hpp
+    plyIO.hpp
+    viewIO.hpp
+    sceneSample.hpp
 )
 
 # Sources
 set(sfmDataIO_files_sources
-  sfmDataIO.cpp
-  bafIO.cpp
-  colmap.cpp
-  gtIO.cpp
-  jsonIO.cpp
-  middlebury.cpp
-  plyIO.cpp
-  viewIO.cpp
-  sceneSample.cpp
+    sfmDataIO.cpp
+    bafIO.cpp
+    colmap.cpp
+    gtIO.cpp
+    jsonIO.cpp
+    middlebury.cpp
+    plyIO.cpp
+    viewIO.cpp
+    sceneSample.cpp
 )
 
-if(ALICEVISION_HAVE_ALEMBIC)
-  list(APPEND sfmDataIO_files_headers
-    AlembicExporter.hpp
-    AlembicImporter.hpp
-  )
-  list(APPEND sfmDataIO_files_sources
-    AlembicExporter.cpp
-    AlembicImporter.cpp
-  )
+if (ALICEVISION_HAVE_ALEMBIC)
+    list(APPEND sfmDataIO_files_headers
+        AlembicExporter.hpp
+        AlembicImporter.hpp
+    )
+    list(APPEND sfmDataIO_files_sources
+        AlembicExporter.cpp
+        AlembicImporter.cpp
+    )
 endif()
 
 alicevision_add_library(aliceVision_sfmDataIO
-  SOURCES ${sfmDataIO_files_headers} ${sfmDataIO_files_sources}
-  PUBLIC_LINKS
-    aliceVision_sfmData
-    aliceVision_camera
-  PRIVATE_LINKS
-    assimp::assimp
-    aliceVision_image
-    Boost::regex
-    Boost::boost
+    SOURCES ${sfmDataIO_files_headers} ${sfmDataIO_files_sources}
+    PUBLIC_LINKS
+        aliceVision_sfmData
+        aliceVision_camera
+    PRIVATE_LINKS
+        assimp::assimp
+        aliceVision_image
+        Boost::regex
+        Boost::boost
 )
 
 
-if(ALICEVISION_HAVE_ALEMBIC)
-  target_link_libraries(aliceVision_sfmDataIO
-    PRIVATE Alembic::Alembic
-  )
-  # There is a missing include dependency in Alembic cmake export.
-  target_include_directories(aliceVision_sfmDataIO
-    PRIVATE "${ILMBASE_INCLUDE_DIR}"
-  )
+if (ALICEVISION_HAVE_ALEMBIC)
+    target_link_libraries(aliceVision_sfmDataIO
+        PRIVATE Alembic::Alembic
+    )
+    # There is a missing include dependency in Alembic cmake export.
+    target_include_directories(aliceVision_sfmDataIO
+        PRIVATE "${ILMBASE_INCLUDE_DIR}"
+    )
 endif()
 
 # Unit tests
 
 alicevision_add_test(sfmDataIO_test.cpp
-  NAME "sfmDataIO"
-  LINKS aliceVision_sfmData
-        aliceVision_sfmDataIO
-        aliceVision_feature
-        aliceVision_system
+    NAME "sfmDataIO"
+    LINKS aliceVision_sfmData
+          aliceVision_sfmDataIO
+          aliceVision_feature
+          aliceVision_system
 )
 
 alicevision_add_test(sfmDataIOCompatibilityJson_test.cpp
@@ -76,35 +76,36 @@ alicevision_add_test(sfmDataIOCompatibilityJson_test.cpp
           aliceVision_system
 )
 
-if(ALICEVISION_HAVE_ALEMBIC)
+if (ALICEVISION_HAVE_ALEMBIC)
     alicevision_add_test(sfmDataIOCompatibilityAbc_test.cpp
         NAME "sfmDataIOCompatibilityAbc"
         LINKS aliceVision_sfmData
               aliceVision_sfmDataIO
               aliceVision_feature
               aliceVision_system
-)
+    )
     alicevision_add_test(alembicIO_test.cpp
         NAME "sfmDataIO_alembic"
         LINKS aliceVision_sfmDataIO
               aliceVision_sfm
-              Alembic::Alembic)
+              Alembic::Alembic
+    )
 endif()
 
 
 alicevision_add_test(middlebury_test.cpp
-        NAME "sfmDataIO_middlebury"
-        LINKS aliceVision_sfmData
-        aliceVision_numeric
-        aliceVision_sfmDataIO
-        )
+    NAME "sfmDataIO_middlebury"
+    LINKS aliceVision_sfmData
+          aliceVision_numeric
+          aliceVision_sfmDataIO
+)
 
 alicevision_add_test(colmap_test.cpp
-        NAME "sfmDataIO_colmap"
-        LINKS aliceVision_sfmData
-        aliceVision_numeric
-        aliceVision_sfmDataIO
-        )
+    NAME "sfmDataIO_colmap"
+    LINKS aliceVision_sfmData
+          aliceVision_numeric
+          aliceVision_sfmDataIO
+)
 
 
 # SWIG Binding
@@ -125,11 +126,11 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     )
 
     target_include_directories(sfmDataIO
-    PRIVATE
-        ../include
-        ${ALICEVISION_ROOT}/include
-        ${Python3_INCLUDE_DIRS}
-        ${Python3_NumPy_INCLUDE_DIRS}
+        PRIVATE
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
     )
     set_property(
         TARGET sfmDataIO
@@ -141,20 +142,20 @@ if (ALICEVISION_BUILD_SWIG_BINDING)
     )
 
     target_link_libraries(sfmDataIO
-    PUBLIC
-        aliceVision_sfmDataIO
+        PUBLIC
+            aliceVision_sfmDataIO
     )
 
     install(
-    TARGETS
-        sfmDataIO
-    DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        TARGETS
+            sfmDataIO
+        DESTINATION
+            ${CMAKE_INSTALL_PREFIX}
     )
     install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/sfmDataIO.py
-    DESTINATION
-        ${CMAKE_INSTALL_PREFIX}
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/sfmDataIO.py
+        DESTINATION
+            ${CMAKE_INSTALL_PREFIX}
     )
 endif()

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -68,16 +68,27 @@ alicevision_add_test(sfmDataIO_test.cpp
         aliceVision_system
 )
 
-alicevision_add_test(sfmDataIOCompatibility_test.cpp
-  NAME "sfmDataIOCompatibility"
-  LINKS aliceVision_sfmData
-        aliceVision_sfmDataIO
-        aliceVision_feature
-        aliceVision_system
+alicevision_add_test(sfmDataIOCompatibilityJson_test.cpp
+    NAME "sfmDataIOCompatibilityJson"
+    LINKS aliceVision_sfmData
+          aliceVision_sfmDataIO
+          aliceVision_feature
+          aliceVision_system
 )
 
 if(ALICEVISION_HAVE_ALEMBIC)
-  alicevision_add_test(alembicIO_test.cpp NAME "sfmDataIO_alembic" LINKS aliceVision_sfmDataIO aliceVision_sfm Alembic::Alembic)
+    alicevision_add_test(sfmDataIOCompatibilityAbc_test.cpp
+        NAME "sfmDataIOCompatibilityAbc"
+        LINKS aliceVision_sfmData
+              aliceVision_sfmDataIO
+              aliceVision_feature
+              aliceVision_system
+)
+    alicevision_add_test(alembicIO_test.cpp
+        NAME "sfmDataIO_alembic"
+        LINKS aliceVision_sfmDataIO
+              aliceVision_sfm
+              Alembic::Alembic)
 endif()
 
 

--- a/src/aliceVision/sfmDataIO/sfmDataIOCompatibilityAbc_test.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIOCompatibilityAbc_test.cpp
@@ -1,0 +1,169 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/system/Timer.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfmDataIO/sceneSample.hpp>
+
+#include <boost/preprocessor/stringize.hpp>
+
+#include <filesystem>
+#include <sstream>
+
+#define BOOST_TEST_MODULE sfmDataIO
+
+#include <boost/test/unit_test.hpp>
+
+using namespace aliceVision;
+using namespace aliceVision::sfmDataIO;
+
+namespace fs = std::filesystem;
+
+BOOST_AUTO_TEST_CASE(Compatibility_generate_abc_files_current_version)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    {
+        fs::path outputPath = pathSource.parent_path() / "compatibilityData" /
+                              "scene_v" BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_MAJOR) "." BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_MINOR) "." BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_REVISION) ".abc";
+        BOOST_CHECK(sfmDataIO::save(sfmData, outputPath.string(), ESfMData::ALL));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_0)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.0.abc";
+
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_1)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.1.abc";
+
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_2)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.2.abc";
+
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_3)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.3.abc";
+
+    // TODO when we will have files to compare
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_4)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.4.abc";
+
+    // TODO when we will have files to compare
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_5)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.5.abc";
+
+    // TODO when we will have files to compare
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_6)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.6.abc";
+
+    // TODO when we will have files to compare
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_8)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.8.abc";
+
+    // TODO when we will have files to compare
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}
+
+BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_11)
+{
+    sfmData::SfMData sfmData;
+    generateSampleScene(sfmData);
+
+    fs::path pathSource(__FILE__);
+    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.11.abc";
+
+    // TODO when we will have files to compare
+    sfmData::SfMData sfmDataLoad;
+    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
+
+    BOOST_CHECK(sfmData == sfmDataLoad);
+}

--- a/src/aliceVision/sfmDataIO/sfmDataIOCompatibilityJson_test.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIOCompatibilityJson_test.cpp
@@ -1,5 +1,5 @@
 // This file is part of the AliceVision project.
-// Copyright (c) 2021 AliceVision contributors.
+// Copyright (c) 2025 AliceVision contributors.
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -23,7 +23,7 @@ using namespace aliceVision::sfmDataIO;
 
 namespace fs = std::filesystem;
 
-BOOST_AUTO_TEST_CASE(Compatibility_generate_files_current_version)
+BOOST_AUTO_TEST_CASE(Compatibility_generate_json_files_current_version)
 {
     sfmData::SfMData sfmData;
     generateSampleScene(sfmData);
@@ -34,25 +34,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_generate_files_current_version)
                               "scene_v" BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_MAJOR) "." BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_MINOR) "." BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_REVISION) ".json";
         BOOST_CHECK(sfmDataIO::save(sfmData, outputPath.string(), ESfMData::ALL));
     }
-    {
-        fs::path outputPath = pathSource.parent_path() / "compatibilityData" /
-                              "scene_v" BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_MAJOR) "." BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_MINOR) "." BOOST_PP_STRINGIZE(ALICEVISION_SFMDATAIO_VERSION_REVISION) ".abc";
-        BOOST_CHECK(sfmDataIO::save(sfmData, outputPath.string(), ESfMData::ALL));
-    }
-}
-
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_0)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.0.abc";
-
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
 }
 
 BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_0)
@@ -62,20 +43,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_0)
 
     fs::path pathSource(__FILE__);
     fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.0.json";
-
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_1)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.1.abc";
 
     sfmData::SfMData sfmDataLoad;
     BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
@@ -97,20 +64,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_1)
     BOOST_CHECK(sfmData == sfmDataLoad);
 }
 
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_2)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.2.abc";
-
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
 BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_2)
 {
     sfmData::SfMData sfmData;
@@ -125,21 +78,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_2)
     BOOST_CHECK(sfmData == sfmDataLoad);
 }
 
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_3)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.3.abc";
-
-    // TODO when we will have files to compare
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
 BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_3)
 {
     sfmData::SfMData sfmData;
@@ -147,21 +85,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_3)
 
     fs::path pathSource(__FILE__);
     fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.3.json";
-
-    // TODO when we will have files to compare
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_4)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.4.abc";
 
     // TODO when we will have files to compare
     sfmData::SfMData sfmDataLoad;
@@ -185,21 +108,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_4)
     BOOST_CHECK(sfmData == sfmDataLoad);
 }
 
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_5)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.5.abc";
-
-    // TODO when we will have files to compare
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
 BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_5)
 {
     sfmData::SfMData sfmData;
@@ -207,21 +115,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_5)
 
     fs::path pathSource(__FILE__);
     fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.5.json";
-
-    // TODO when we will have files to compare
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_6)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.6.abc";
 
     // TODO when we will have files to compare
     sfmData::SfMData sfmDataLoad;
@@ -245,21 +138,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_6)
     BOOST_CHECK(sfmData == sfmDataLoad);
 }
 
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_8)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.8.abc";
-
-    // TODO when we will have files to compare
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
 BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_8)
 {
     sfmData::SfMData sfmData;
@@ -267,21 +145,6 @@ BOOST_AUTO_TEST_CASE(Compatibility_json_1_2_8)
 
     fs::path pathSource(__FILE__);
     fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.8.json";
-
-    // TODO when we will have files to compare
-    sfmData::SfMData sfmDataLoad;
-    BOOST_CHECK(sfmDataIO::load(sfmDataLoad, toLoad.string(), ESfMData::ALL));
-
-    BOOST_CHECK(sfmData == sfmDataLoad);
-}
-
-BOOST_AUTO_TEST_CASE(Compatibility_abc_1_2_11)
-{
-    sfmData::SfMData sfmData;
-    generateSampleScene(sfmData);
-
-    fs::path pathSource(__FILE__);
-    fs::path toLoad = pathSource.parent_path() / "compatibilityData" / "scene_v1.2.11.abc";
 
     // TODO when we will have files to compare
     sfmData::SfMData sfmDataLoad;


### PR DESCRIPTION
## Description

This PR fixes https://github.com/alicevision/AliceVision/issues/1810 by splitting the "sfmDataIOCompatibility" unit test into two different test files:
- one that tests the compatibility for JSON files and that is always built
- one that tests the compatibility for ABC files and that is only built if AliceVision is built with Alembic support.

Additionally, the `CMakeLists.txt` is updated to use 4-space indentation across all the file.