### PR TITLE
Split LDR image set using capturing time

### DIFF
--- a/src/aliceVision/hdr/brackets.cpp
+++ b/src/aliceVision/hdr/brackets.cpp
@@ -38,8 +38,9 @@ bool estimateBracketsFromSfmData(std::vector<std::vector<std::shared_ptr<sfmData
         fnumbers.insert(view->getImage().getMetadataFNumber());
         double exp = view->getImage().getCameraExposureSetting().getExposure();
         std::string path = view->getImage().getImagePath();
+        int64_t timestamp = view->getImage().getMetadataDateTimestamp();
 
-        LuminanceInfo li(viewIt.first, path, exp);
+        LuminanceInfo li(viewIt.first, path, exp, timestamp);
         luminances.push_back(li);
     }
 
@@ -303,6 +304,97 @@ std::vector<std::vector<LuminanceInfo>> splitMonotonics(const std::vector<Lumina
     return splitted;
 }
 
+std::vector<std::vector<LuminanceInfo>> splitTimes(const std::vector<LuminanceInfo> & luminanceInfos, int maxDeltaInABurst = 2)
+{
+    std::vector<std::vector<LuminanceInfo>> splitted;
+
+    if (luminanceInfos.size() == 0)
+    {
+        return splitted;
+    }
+
+    // Split the luminanceInfos into groups which have close capture time (burst detection) 
+    std::vector<LuminanceInfo> normedTimes(luminanceInfos);
+    // Sort luminanceinfos by timestamp
+    std::sort(normedTimes.begin(),
+              normedTimes.end(),
+              [](const LuminanceInfo& a, const LuminanceInfo& b) -> bool {
+                return (a.mtimestamp < b.mtimestamp);
+              });
+
+    const int histoSize = maxDeltaInABurst + 2;
+    std::vector<int> histo(histoSize, 0);
+    for (int i = normedTimes.size() - 1; i >= 1; i--)
+    {
+        normedTimes[i].mtimestamp -= normedTimes[i - 1].mtimestamp;
+        histo[std::min(maxDeltaInABurst + 1, (int)normedTimes[i].mtimestamp)]++;
+    }
+    normedTimes[0].mtimestamp = 0;
+
+    // Check for outliers at both sides of the sequence.
+    // At the beginning an item is an outlier if the next one has been captured more than maxDeltaInABurst seconds after.
+    // At the end an item is an outlier if the previous one has been captured more than maxDeltaInABurst seconds before.
+    int firstIndexValid = 0;
+    while (normedTimes[firstIndexValid + 1].mtimestamp > maxDeltaInABurst && firstIndexValid < normedTimes.size() - 1)
+    {
+        firstIndexValid++;
+    }
+    if (firstIndexValid == normedTimes.size() - 1)
+    {
+        return splitted;
+    }
+    int LastIndexValid = normedTimes.size() - 1;
+    while (normedTimes[LastIndexValid].mtimestamp > maxDeltaInABurst && LastIndexValid > firstIndexValid)
+    {
+        LastIndexValid--;
+    }
+    if (LastIndexValid == firstIndexValid)
+    {
+        return splitted;
+    }
+
+    int outlierNumber = firstIndexValid + (normedTimes.size() - 1 - LastIndexValid);
+
+   int nbItemLow = 0;
+    for (int i = 0; i <= maxDeltaInABurst ; i++)
+    {
+        nbItemLow += histo[i];
+    }
+    const int nbItemHigh = histo.back();
+ 
+    int nbGroup;
+    int groupSize;
+    if (nbItemLow % (nbItemHigh + 1 - outlierNumber) == 0)
+    {
+        nbGroup = nbItemHigh + 1 - outlierNumber;
+        groupSize = (luminanceInfos.size() - outlierNumber) / nbGroup;
+        std::vector<LuminanceInfo> group;
+        std::map<float, int> mexposure;
+        for (int i = firstIndexValid; i <= LastIndexValid ; i++)
+        {
+            group.push_back(normedTimes[i]);
+            mexposure[normedTimes[i].mexposure] = 0;
+            if (i % groupSize == groupSize - 1)
+            {
+                if (mexposure.size() == groupSize)
+                {
+                    // All group's exposures are different from each others
+                    splitted.push_back(group);
+                    group.clear();
+                    mexposure.clear();
+                }
+                else
+                {
+                    splitted.clear();
+                    break;
+                }
+            }
+        }
+    }
+
+    return splitted;
+}
+
 /**
 * @brief assume ref is smaller than larger
 * Try to find a subpart of larger which has the same set of exposures that smaller
@@ -349,11 +441,15 @@ std::vector<std::vector<IndexT>> estimateGroups(const std::vector<LuminanceInfo>
 
     //Split and order the items using path
     std::vector<std::vector<LuminanceInfo>> splitted = splitBasedir(luminanceInfos);
-    //Create monotonic groups
+    //Create groups
     std::vector<std::vector<LuminanceInfo>> monotonics;
     for (const auto & luminanceInfoOneDir : splitted)
     {
-        std::vector<std::vector<LuminanceInfo>> lmonotonics = splitMonotonics(luminanceInfoOneDir);
+        std::vector<std::vector<LuminanceInfo>> lmonotonics = splitTimes(luminanceInfoOneDir);
+        if (lmonotonics.empty())
+        {
+            lmonotonics = splitMonotonics(luminanceInfoOneDir);
+        }
         monotonics.insert(monotonics.end(), lmonotonics.begin(), lmonotonics.end());
     }
 
@@ -426,7 +522,6 @@ std::vector<std::vector<IndexT>> estimateGroups(const std::vector<LuminanceInfo>
             continue;
         }
         
-
         //Compare with all valid monotonics
         int offset = -1;
         for (const auto& monotonic : monotonics)
@@ -484,7 +579,9 @@ std::vector<std::vector<IndexT>> estimateGroups(const std::vector<LuminanceInfo>
         groups.push_back(group);
     }
 
-    ALICEVISION_LOG_INFO("Groups found : "  << monotonics.size());
+    const int groupNumber = monotonics.size();
+    const int outlierNumber = luminanceInfos.size() - groupNumber * bestBracketCount;
+    ALICEVISION_LOG_INFO(groupNumber << " group(s) of " << bestBracketCount << " bracket(s) and " << outlierNumber << " outlier(s) found.");
 
     return groups;
 }

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -102,6 +102,14 @@ inline std::istream& operator>>(std::istream& in, ECalibrationMethod& calibratio
 
 /**
  * @brief Estimate the brackets information from the SfM data
+ * The bracket groups are estimated using the capturing time metadata of each picture.
+ * if the duration between 2 consecutive pictures is less than 2.5 seconds the 2 pictures are considered to be part of the
+ * same brackecting group.In case several single pictures, located at the beginning or at the end of the image set after
+ * it has been sorted, they are considered as outliers and they won't be added to any returned group.
+ * With the remaining pictures, a check is done to be sure that every groups contain the same number of pictures. If this
+ * is not the case, this first tentative of splitting aborts. A second method is then applied. It consists to group pictures
+ * with monotonic exposure variation after sorting them in the alphabetic order. Outliers can be removed at the beginiing
+ * and at the end of the sorted pictures or between 2 groups.
  * @param[out] groups the estimated groups
  * @param[in] sfmData SfM data to estimate the brackets from
  * @param[in] countBrackets the number of brackets (optional, 0 means that it will be guessed)

--- a/src/aliceVision/hdr/brackets.hpp
+++ b/src/aliceVision/hdr/brackets.hpp
@@ -17,13 +17,15 @@ struct LuminanceInfo
     aliceVision::IndexT mviewId;
     std::string mpath;
     float mexposure;
+    int64_t mtimestamp;
 
     LuminanceInfo() = default;
 
-    LuminanceInfo(aliceVision::IndexT vid, const std::string & path, float exposure):
+    LuminanceInfo(aliceVision::IndexT vid, const std::string & path, float exposure, int64_t timestamp):
         mviewId(vid),
         mpath(path),
-        mexposure(exposure)
+        mexposure(exposure),
+        mtimestamp(timestamp)
     {
 
     }


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description

This PR aims at splitting a set of raw LDR images into subsets using the capturing time in order to build as many HDR images as LDR image subsets.

That makes the splitting independent from the exposure pattern. The pattern is given by the set of image exposures when the LDR image set is sorted according to the alphabetic order.

Up to now, only monotonic patterns was supported. However, it appears that in some cases the middle exposure is delivered at the first position, followed by the darker images in the increasing order and by the brighter images also in the increasing order. For a set of 7 LDR images here is this pattern's exposures: 0, -3, -2, -1, 1, 2, 3. Currently, the HDR image is built without using the reference exposure which appears at the first position, focusing only on the monotonic part of the image set and considering the middle exposition as an outlier.

In this PR, the timestamp corresponding to the capturing date and time is added to the structure containing information about the exposure parameters and the LDR image set is sorted with respect to this timestamp. For that timestamp, second is the unit.
We consider as a parameter (non exposed), with a default value set to 2s, the maximum duration between two consecutive captures inside a group of LDR images corresponding to a single HDR image.

From the time sorted set of LDR images, All durations between two consecutive images are computed. and a histogram is built from them. From that histogram we compute the number _Nlow_ of durations lower than or equal to the parameter value and the number _Nhigh_ of durations higher than the parameter value.

At both extremities of the sorted image set, all single images separated with a higher duration than the one defined by the parameter are considered as outliers. _Nout_ is the number of outliers.

The number of LDR groups is given by _Ng_ = _Nhigh_ + 1 - _Nout_ if and only if _Nlow_ % _Ng_ = 0

In case of a reliable number of groups cannot be estimated by using the capturing time, the former method based on file naming and monotonic exposure pattern is applied as a fallback.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

By setting to 2 seconds the parameter for the maximum duration between 2 consecutive images within a HDR burst, due to the rounding occurring at the timestamp creation, the maximum duration allowed is 2.5 seconds.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

