### PR TITLE
New tool to import external Alembic files with an animated camera

### DIFF
--- a/meshroom/aliceVision/ImportAlembic.py
+++ b/meshroom/aliceVision/ImportAlembic.py
@@ -1,0 +1,51 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class ImportAlembic(desc.AVCommandLineNode):
+    commandLine = "aliceVision_importAlembic {allParams}"
+
+    category = "Utils"
+    documentation = """
+Import an external Alembic file that does not follow the SfMData convention, and populates a valid SfMData with its camera poses.
+"""
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Alembic File",
+            description="The external Alembic file to import.",
+            value="",
+        ),
+        desc.File(
+            name="imagesDir",
+            label="Images Directory",
+            description="Directory containing the images.",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="extension",
+            label="Images Extension",
+            description="File extension for the images in the directory to be taken into account.",
+            value="exr",
+            values=["exr", "jpg", "png"],
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            value="info",
+            values=VERBOSE_LEVEL,
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfMData",
+            description="SfMData file populated with the camera poses from the external Alembic file.",
+            value="{nodeCacheFolder}/importedAbc.sfm",
+        ),
+    ]

--- a/src/aliceVision/sfmDataIO/CMakeLists.txt
+++ b/src/aliceVision/sfmDataIO/CMakeLists.txt
@@ -28,10 +28,12 @@ if (ALICEVISION_HAVE_ALEMBIC)
     list(APPEND sfmDataIO_files_headers
         AlembicExporter.hpp
         AlembicImporter.hpp
+        ExternalAlembicImporter.hpp
     )
     list(APPEND sfmDataIO_files_sources
         AlembicExporter.cpp
         AlembicImporter.cpp
+        ExternalAlembicImporter.cpp
     )
 endif()
 

--- a/src/aliceVision/sfmDataIO/ExternalAlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/ExternalAlembicImporter.cpp
@@ -1,0 +1,132 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmDataIO/ExternalAlembicImporter.hpp>
+
+#include <aliceVision/version.hpp>
+#include <aliceVision/system/Logger.hpp>
+
+#include <aliceVision/camera/camera.hpp>
+#include <aliceVision/image/io.hpp>
+
+namespace aliceVision {
+namespace sfmDataIO {
+
+ExternalAlembicImporter::ExternalAlembicImporter(const std::string& filename)
+{
+    Alembic::AbcCoreFactory::IFactory factory;
+    Alembic::AbcCoreFactory::IFactory::CoreType coreType;
+    Alembic::Abc::IArchive archive = factory.getArchive(filename, coreType);
+
+    if (!archive.valid())
+    {
+        throw std::runtime_error("Can't open '" + filename + "' : Alembic file is not valid.");
+    }
+
+    _rootEntity = archive.getTop();
+    _filename = filename;
+}
+
+void ExternalAlembicImporter::populateSfM(sfmData::SfMData& sfmdata, const std::vector<std::string> & files)
+{
+    Alembic::Abc::M44d identity;
+    visitObject(_rootEntity, identity, sfmdata, files);
+}
+
+void ExternalAlembicImporter::visitObject(Alembic::Abc::IObject iObj, const Alembic::Abc::M44d & mat, sfmData::SfMData& sfmdata, const std::vector<std::string> & files)
+{
+    
+    const Alembic::Abc::MetaData& md = iObj.getMetaData();
+    
+    if (Alembic::AbcGeom::IXform::matches(md))
+    {
+        Alembic::AbcGeom::IXform xform(iObj, Alembic::Abc::kWrapExisting);
+        Alembic::AbcGeom::IXformSchema schema = xform.getSchema();
+            
+        Alembic::AbcGeom::XformSample xsample;
+
+        if (schema.getNumSamples() == 1)
+        {
+            ALICEVISION_THROW_ERROR("Non implemented path.");
+        }
+        
+        if (schema.getNumSamples() != files.size())
+        {
+            ALICEVISION_THROW_ERROR("Incompatible number of files wrt abc samples.")
+        }
+
+        Mat4 M = Mat4::Identity();
+        M(1, 1) = -1.0;
+        M(2, 2) = -1.0;
+
+        for (Alembic::Abc::index_t frame = 0; frame < xform.getSchema().getNumSamples(); ++frame)
+        {
+            xform.getSchema().get(xsample,  Alembic::Abc::ISampleSelector(frame));
+            const auto & currentMat = xsample.getMatrix();
+            const auto newMat = mat * xsample.getMatrix();
+
+            Mat4 T = Mat4::Identity();
+            for (int i = 0; i < 4; i++)
+            {
+                for (int j = 0; j < 4; j++)
+                {
+                    T(i, j) = newMat[j][i];
+                }
+            }
+
+            Mat4 T2 = (M * T * M).inverse();
+            geometry::Pose3 pose(T2);
+
+            Alembic::AbcGeom::ICamera camera(xform.getChild(0),  Alembic::Abc::kWrapExisting);
+            Alembic::AbcGeom::ICameraSchema cs = camera.getSchema();
+            Alembic::AbcGeom::CameraSample camSample;
+            camSample = cs.getValue(Alembic::Abc::ISampleSelector(frame));
+
+            /*std::cout << " ---- " << std::endl;
+            std::cout << camSample.getFocalLength() << std::endl;
+            std::cout << camSample.getHorizontalAperture() << std::endl;
+            std::cout << camSample.getVerticalAperture() << std::endl;
+            std::cout << camSample.getLensSqueezeRatio() << std::endl;
+            std::cout << camSample.getHorizontalFilmOffset() << std::endl;
+            std::cout << camSample.getVerticalFilmOffset() << std::endl;*/
+
+            int w = 0;
+            int h = 0;
+            image::readImageMetadata(files[frame], w, h);
+
+            auto cam = camera::createPinhole(
+                                            camera::EDISTORTION::DISTORTION_NONE,
+                                            camera::EUNDISTORTION::UNDISTORTION_NONE,
+                                            w, h,
+                                            1.0, 1.0,
+                                            0.0, 0.0
+                                            );
+            
+            const double dw = static_cast<double>(w);
+            const double dh = static_cast<double>(h);
+            double happ = camSample.getHorizontalAperture();
+            double vapp = camSample.getVerticalAperture();
+            const double sensorWidthPix = std::max(dw, dh);
+
+            cam->setSensorWidth(happ / (dw * 0.1 / sensorWidthPix));
+            cam->setSensorHeight(vapp / (dh * 0.1 / sensorWidthPix));
+            cam->setFocalLength(camSample.getFocalLength(), 1.0, false);
+
+            sfmdata.getIntrinsics()[frame] = cam;
+            sfmdata.getPoses()[frame] = sfmData::CameraPose(pose);
+            sfmdata.getViews()[frame] = std::make_shared<sfmData::View>(files[frame], frame, frame, frame, w, h);
+        }
+    }
+
+    // Recurse
+    for (std::size_t i = 0; i < iObj.getNumChildren(); i++)
+    {
+        visitObject(iObj.getChild(i), mat, sfmdata, files);
+    }
+}
+
+}  // namespace sfmDataIO
+}  // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/ExternalAlembicImporter.hpp
+++ b/src/aliceVision/sfmDataIO/ExternalAlembicImporter.hpp
@@ -1,0 +1,39 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+
+#include <Alembic/AbcGeom/All.h>
+#include <Alembic/AbcCoreFactory/All.h>
+#include <Alembic/AbcCoreOgawa/All.h>
+
+
+namespace aliceVision {
+namespace sfmDataIO {
+
+class ExternalAlembicImporter
+{
+public:
+    explicit ExternalAlembicImporter(const std::string& filename);
+
+    /**
+     * @brief populate a SfMData from the alembic file
+     * @param[out] sfmData The output SfMData
+     * @param[in] files the input list of images files
+     */
+    void populateSfM(sfmData::SfMData& sfmdata, const std::vector<std::string> & files);
+
+    void visitObject(Alembic::Abc::IObject iObj, const Alembic::Abc::M44d & mat, sfmData::SfMData& sfmdata, const std::vector<std::string> & files);
+
+private: 
+    Alembic::Abc::IObject _rootEntity;
+    std::string _filename;
+};
+
+}  // namespace sfmDataIO
+}  // namespace aliceVision

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -133,8 +133,22 @@ if (ALICEVISION_BUILD_SFM)
               Boost::program_options
     )
 
-    # Transform rig
-    if (ALICEVISION_HAVE_ALEMBIC)
+    if(ALICEVISION_HAVE_ALEMBIC)
+
+        # Import external Alembic files
+        alicevision_add_software(aliceVision_importAlembic
+            SOURCE main_importAlembic.cpp
+            FOLDER ${FOLDER_SOFTWARE_UTILS}
+            LINKS aliceVision_sfmData
+                  aliceVision_sfmDataIO
+                  aliceVision_system
+                  aliceVision_cmdline
+                  aliceVision_image
+                  Boost::program_options
+                  Alembic::Alembic
+        )
+
+        # Transform rig
         alicevision_add_software(aliceVision_rigTransform
             SOURCE main_rigTransform.cpp
             FOLDER ${FOLDER_SOFTWARE_UTILS}

--- a/src/software/utils/main_importAlembic.cpp
+++ b/src/software/utils/main_importAlembic.cpp
@@ -1,0 +1,104 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/types.hpp>
+#include <aliceVision/config.hpp>
+
+#include <aliceVision/system/Timer.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+
+#include <aliceVision/sfmDataIO/ExternalAlembicImporter.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include <fstream>
+#include <filesystem>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+namespace po = boost::program_options;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string abcFilename;
+    std::string sfmDataOutputFilename;
+    std::string imagesDir;
+    std::string extension;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&abcFilename)->required(), "Input Alembic file.")
+        ("imagesDir", po::value<std::string>(&imagesDir)->required(), "directory with images")
+        ("extension", po::value<std::string>(&extension)->required(), "images extension")
+        ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(), "SfMData output file.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision Alembic importer");
+
+    cmdline.add(requiredParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // Set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    if (!std::filesystem::exists(imagesDir))
+    {
+        ALICEVISION_LOG_ERROR("Images directory does not exist.");
+        return EXIT_FAILURE;
+    }
+
+    if (!std::filesystem::is_directory(imagesDir))
+    {
+        ALICEVISION_LOG_ERROR("Images directory value is not a directory.");
+        return EXIT_FAILURE;
+    }
+
+    std::vector<std::string> files;
+    for (const auto & item: std::filesystem::directory_iterator(imagesDir))
+    {
+        const std::string itemExtension = item.path().extension().string();
+        if (boost::algorithm::to_lower_copy(itemExtension) == extension)
+        {
+            files.push_back(std::filesystem::canonical(item.path()).string());
+        }
+    }
+    std::sort(files.begin(), files.end());
+    
+
+    std::unique_ptr<sfmDataIO::ExternalAlembicImporter> importer;
+
+    try
+    {
+        importer = std::make_unique<sfmDataIO::ExternalAlembicImporter>(abcFilename);
+    }
+    catch(...)
+    {
+        ALICEVISION_LOG_ERROR("Error during importer");
+        return EXIT_FAILURE;
+    }
+
+    sfmData::SfMData sfmData;
+    importer->populateSfM(sfmData, files);
+
+    if (!sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData(sfmDataIO::ALL)))
+    {
+        ALICEVISION_LOG_ERROR("The output SfMData file '" << sfmDataOutputFilename << "' cannot be write.");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull request adds a new feature that enables importing Alembic files without requiring the `AliceVision sfmData` convention, allowing for the import of an external animated camera.
The `ExternalAlembicImporter` class manages the import process and populates the `SfMData` with the corresponding camera poses.
Additionally, it introduces a new command-line tool: `aliceVision_importAlembic`.