### PR TITLE
[meshroom] ExtractMetadata: Move `pyalicevision` import into the `processChunk` method

### DIFF
--- a/meshroom/aliceVision/ExtractMetadata.py
+++ b/meshroom/aliceVision/ExtractMetadata.py
@@ -4,8 +4,6 @@ from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 from pathlib import Path
 
-import pyalicevision as av
-
 import distutils.dir_util as du
 import shutil
 import glob
@@ -73,6 +71,7 @@ Using exifTool, this node extracts metadata of all images referenced in a sfmDat
     ]
 
     def processChunk(self, chunk):
+        import pyalicevision as av
         try:
             chunk.logManager.start(chunk.node.verboseLevel.value)
             


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description

This PR update the pure python meshroom node ExtractMetadata by moving the import of AliceVision from top level to the processing method.
This is in order to optimize the opening of meshroom.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

