### PR TITLE
Color checker detection and correction update

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container: ["alicevision/alicevision-deps:2025.02.21-ubuntu22.04-cuda12.1.1", "alicevision/alicevision-deps:2025.02.21-rocky9-cuda12.1.1"]
+        container: ["alicevision/alicevision-deps:2025.03.27-ubuntu22.04-cuda12.1.1", "alicevision/alicevision-deps:2025.03.27-rocky9-cuda12.1.1"]
     container:
       image: ${{ matrix.container }}
     env:
@@ -33,7 +33,7 @@ jobs:
       ALICEVISION_ROOT: ${{ github.workspace }}/../AV_install
       ALICEVISION_SENSOR_DB: ${{ github.workspace }}/../AV_install/share/aliceVision/cameraSensors.db
       ALICEVISION_LENS_PROFILE_INFO: ""
-      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2025.02.21-ubuntu22.04-cuda12.1.1' && 'ON' || 'OFF' }}"
+      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2025.03.27-ubuntu22.04-cuda12.1.1' && 'ON' || 'OFF' }}"
     steps:
       - uses: actions/checkout@v1
 

--- a/docker/Dockerfile_rocky_deps
+++ b/docker/Dockerfile_rocky_deps
@@ -54,6 +54,9 @@ RUN echo "export ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVis
 COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
 RUN echo "export ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx" >> /etc/profile.d/alicevision.sh
 
+COPY dl/ColorchartDetectionModel ${AV_INSTALL}/share/aliceVision
+RUN echo "export ALICEVISION_COLORCHARTDETECTION_MODEL_FOLDER=${AV_INSTALL}/share/aliceVision/ColorchartDetectionModel" >> /etc/profile.d/alicevision.sh
+
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
 RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && echo "Build multithreading number of cores: ${CPU_CORES}"
 

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -70,6 +70,9 @@ RUN echo "export ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVis
 COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
 RUN echo "export ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx" >> /etc/profile.d/alicevision.sh
 
+COPY dl/ColorchartDetectionModel ${AV_INSTALL}/share/aliceVision/ColorchartDetectionModel
+RUN echo "export ALICEVISION_COLORCHARTDETECTION_MODEL_FOLDER=${AV_INSTALL}/share/aliceVision/ColorchartDetectionModel" >> /etc/profile.d/alicevision.sh
+
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
 RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && echo "Build multithreading number of cores: ${CPU_CORES}"
 

--- a/docker/fetch.sh
+++ b/docker/fetch.sh
@@ -22,6 +22,8 @@ test -f dl/sphereDetection_Mask-RCNN.onnx || \
         wget https://gitlab.com/alicevision/SphereDetectionModel/-/raw/main/sphereDetection_Mask-RCNN.onnx -O dl/sphereDetection_Mask-RCNN.onnx
 test -f dl/fcn_resnet50.onnx || \
         wget https://gitlab.com/alicevision/semanticSegmentationModel/-/raw/main/fcn_resnet50.onnx -O dl/fcn_resnet50.onnx
+test -d dl/ColorchartDetectionModel || \
+        git clone https://gitlab.com/alicevision/ColorchartDetectionModel.git dl/ColorchartDetectionModel
 export CMAKE_VERSION=3.26.0
 export CMAKE_VERSION_MM=3.26
 test -f dl/cmake-${CMAKE_VERSION}.tar.gz || \

--- a/meshroom/aliceVision/ColorCheckerCorrection.py
+++ b/meshroom/aliceVision/ColorCheckerCorrection.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
@@ -33,9 +33,33 @@ If multiple color charts are submitted, only the first one will be taken in acco
             name="input",
             label="Input",
             description="Input SfMData file, image filenames or regex(es) on the image file path.\n"
-                        "Supported regex: '#' matches a single digit, '@' one or more digits, '?' one character and "
-                        "'*' zero or more.",
+                        "Supported regex: '#' matches a single digit, '@' one or more digits, '?' one character and '*' zero or more.",
             value="",
+        ),
+        desc.ChoiceParam(
+            name="correctionMethod",
+            label="Correction Level",
+            description="Level of correction:\n"
+                        " - luminance: Ajust luminance level only.\n"
+                        " - whiteBalance: Apply white balancing in addition to luminance adjustment.\n"
+                        " - full: Full color correction."
+                        " - bypass: Do nothing.",
+            value="luminance",
+            values=["luminance", "whiteBalance", "full", "bypass"],
+            exclusive=True,
+        ),
+        desc.BoolParam(
+            name="useBestColorCheckerOnly",
+            label="Use Best Color Chart Only",
+            description="If checked, use only the color chart with the best orientation and size to compute the color correction model.\n"
+                        "If unchecked, combine all detected color checkers.",
+            value=True,
+        ),
+        desc.BoolParam(
+            name="keepImageName",
+            label="Keep Image Name",
+            description="Keep image names if different from the view Ids.",
+            value=True,
         ),
         desc.ChoiceParam(
             name="extension",
@@ -43,6 +67,7 @@ If multiple color charts are submitted, only the first one will be taken in acco
             description="Output image file extension.",
             value="exr",
             values=["exr", ""],
+            exclusive=True,
         ),
         desc.ChoiceParam(
             name="storageDataType",

--- a/meshroom/aliceVision/ColorCheckerCorrection.py
+++ b/meshroom/aliceVision/ColorCheckerCorrection.py
@@ -40,7 +40,7 @@ If multiple color charts are submitted, only the first one will be taken in acco
             name="correctionMethod",
             label="Correction Level",
             description="Level of correction:\n"
-                        " - luminance: Ajust luminance level only.\n"
+                        " - luminance: Adjust luminance level only.\n"
                         " - whiteBalance: Apply white balancing in addition to luminance adjustment.\n"
                         " - full: Full color correction."
                         " - bypass: Do nothing.",

--- a/meshroom/aliceVision/ColorCheckerDetection.py
+++ b/meshroom/aliceVision/ColorCheckerDetection.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -16,10 +16,10 @@ Performs Macbeth color checker chart detection.
 
 Outputs:
 - the detected color charts position and colors
-- the associated transform matrix from "theoric" to "measured"
-assuming that the "theoric" Macbeth chart corners coordinates are:
+- the associated transform matrix from "theoric" to "measured" 
+assuming that the "theoric" Macbeth chart corners coordinates are: 
 (0, 0), (1675, 0), (1675, 1125), (0, 1125)
-
+  
 Dev notes:
 - Fisheye/pinhole is not handled
 - ColorCheckerViewer is unstable with multiple color chart within a same image
@@ -30,9 +30,25 @@ Dev notes:
             name="input",
             label="Input",
             description="SfMData file input, image filenames or regex(es) on the image file path.\n"
-                        "Supported regex: '#' matches a single digit, '@' one or more digits, '?' one character "
-                        "and '*' zero or more.",
+                        "Supported regex: '#' matches a single digit, '@' one or more digits, '?' one character and '*' zero or more.",
             value="",
+        ),
+        desc.ChoiceParam(
+            name="ccType",
+            label="Colorchart Type",
+            description="Colorchart type:\n"
+                        " - mcc24   classical macbeth 24 patches\n"
+                        " - sg140   Digital SG 140 patches\n"
+                        " - Vinyl18 DKK colorchart 12 patches + 6 rectangles)",
+            value="mcc24",
+            values=["mcc24", "sg140", "Vinyl18"],
+            exclusive=True,
+        ),
+        desc.File(
+            name="modelFolder",
+            label="Model Folder",
+            description="DNN model directory path.",
+            value="${ALICEVISION_COLORCHARTDETECTION_MODEL_FOLDER}",
         ),
         desc.IntParam(
             name="maxCount",
@@ -47,6 +63,20 @@ Dev notes:
             label="Debug",
             description="If checked, debug data will be generated.",
             value=False,
+        ),
+        desc.BoolParam(
+            name="processAllImages",
+            label="Process All Images",
+            description="If checked, detection will be launched on all images.\n"
+                        "If unchecked, only images with a name fitting a regular expression are considered.",
+            value=True,
+        ),
+        desc.File(
+            name="filter",
+            label="Filter",
+            description="Regex to select the images on which the colorchecker detection will be computed.",
+            value="*_macbeth.*",
+            enabled=lambda node: not node.processAllImages.value
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/aliceVision/ColorCheckerDetection.py
+++ b/meshroom/aliceVision/ColorCheckerDetection.py
@@ -19,7 +19,7 @@ Outputs:
 - the associated transform matrix from "theoric" to "measured" 
 assuming that the "theoric" Macbeth chart corners coordinates are: 
 (0, 0), (1675, 0), (1675, 1125), (0, 1125)
-  
+
 Dev notes:
 - Fisheye/pinhole is not handled
 - ColorCheckerViewer is unstable with multiple color chart within a same image
@@ -39,7 +39,7 @@ Dev notes:
             description="Colorchart type:\n"
                         " - mcc24   classical macbeth 24 patches\n"
                         " - sg140   Digital SG 140 patches\n"
-                        " - Vinyl18 DKK colorchart 12 patches + 6 rectangles)",
+                        " - Vinyl18 DKK colorchart 12 patches + 6 rectangles",
             value="mcc24",
             values=["mcc24", "sg140", "Vinyl18"],
             exclusive=True,

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -15,6 +15,7 @@
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>
 
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -24,7 +25,6 @@
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/mcc.hpp>
 
-#include <filesystem>
 #include <string>
 #include <fstream>
 #include <vector>
@@ -32,7 +32,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;
@@ -41,6 +41,82 @@ namespace fs = std::filesystem;
 namespace bpt = boost::property_tree;
 namespace po = boost::program_options;
 
+double srgbToLin(double c)
+{
+    return c <= 0.04045 ? c / 12.92 : powf((c + 0.055) / 1.055, 2.4);
+}
+cv::Vec3d srgbToLin(cv::Vec3d pix)
+{
+    cv::Vec3d pixOut(srgbToLin(pix[0]), srgbToLin(pix[1]), srgbToLin(pix[2]));
+    return pixOut;
+}
+double linToSrgb(double c)
+{
+    return c < 0.0031308 ? 12.92 * c : 1.055 * powf(c, 1.f / 2.4f) - 0.055;
+}
+cv::Vec3d linToSrgb(cv::Vec3d pix)
+{
+    cv::Vec3d pixOut(linToSrgb(pix[0]), linToSrgb(pix[1]), linToSrgb(pix[2]));
+    return pixOut;
+}
+
+double linToLum(cv::Vec3d pix)
+{
+    return 0.2126 * pix[0] + 0.7152 * pix[1] + 0.0722 * pix[2];
+}
+
+enum class ECorrectionMethod
+{
+    luminance,
+    whiteBalance,
+    full,
+    bypass
+};
+
+inline std::string ECorrectionMethod_enumToString(ECorrectionMethod correctionMethod)
+{
+    switch(correctionMethod)
+    {
+        case ECorrectionMethod::luminance:
+            return "luminance";
+        case ECorrectionMethod::whiteBalance:
+            return "whitebalance";
+        case ECorrectionMethod::full:
+            return "full";
+        case ECorrectionMethod::bypass:
+            return "bypass";
+    }
+    throw std::invalid_argument("Invalid ECorrectionMethod Enum");
+}
+
+inline ECorrectionMethod ECorrectionMethod_stringToEnum(std::string correctionMethod)
+{
+    boost::to_lower(correctionMethod);
+    if(correctionMethod == "luminance")
+        return ECorrectionMethod::luminance;
+    if(correctionMethod == "whitebalance")
+        return ECorrectionMethod::whiteBalance;
+    if(correctionMethod == "full")
+        return ECorrectionMethod::full;
+    if(correctionMethod == "bypass")
+        return ECorrectionMethod::bypass;
+
+    throw std::invalid_argument("Unrecognized correction method '" + correctionMethod + "'");
+}
+
+inline std::ostream& operator<<(std::ostream& os, ECorrectionMethod method)
+{
+    return os << ECorrectionMethod_enumToString(method);
+}
+
+inline std::istream& operator>>(std::istream& in, ECorrectionMethod& method)
+{
+    std::string token;
+    in >> token;
+    method = ECorrectionMethod_stringToEnum(token);
+    return in;
+}
+
 struct CChecker
 {
     std::string _bodySerialNumber;
@@ -48,6 +124,7 @@ struct CChecker
     std::string _imagePath;
     std::string _viewId;
     cv::Mat _colorData;
+    double _weight; // In the range [0,1]. 1.0 corresponds to a Macbeth frontal view occupying the full image.
 
     explicit CChecker(const bpt::ptree::value_type& ccheckerPTree)
     {
@@ -58,40 +135,109 @@ struct CChecker
         _colorData = cv::Mat::zeros(24, 1, CV_64FC3);
 
         int i = 0;
-        for (const bpt::ptree::value_type& row : ccheckerPTree.second.get_child("colors"))
+        for(const bpt::ptree::value_type& row : ccheckerPTree.second.get_child("colors"))
         {
             cv::Vec3d* rowPtr = _colorData.ptr<cv::Vec3d>(i);
             cv::Vec3d& matPixel = rowPtr[0];
 
-            matPixel[0] = row.second.get_child("r").get_value<double>();
-            matPixel[1] = row.second.get_child("g").get_value<double>();
-            matPixel[2] = row.second.get_child("b").get_value<double>();
+            matPixel[0] = row.second.get_child("r").get_value<double>(0.f);
+            matPixel[1] = row.second.get_child("g").get_value<double>(0.f);
+            matPixel[2] = row.second.get_child("b").get_value<double>(0.f);
+
+            matPixel = srgbToLin(matPixel);
+
+            matPixel = srgbToLin(matPixel);
 
             ++i;
         }
+
+        i = 0;
+        std::vector<cv::Vec2d> corners_img(4);
+        for(const bpt::ptree::value_type& row : ccheckerPTree.second.get_child("positions"))
+        {
+            corners_img[i][0] = row.second.get_child("x").get_value<double>();
+            corners_img[i][1] = row.second.get_child("y").get_value<double>();
+
+            ++i;
+        }
+
+        const double area = (fabs((corners_img[0][0] - corners_img[2][0]) * (corners_img[1][1] - corners_img[3][1])) +
+                             fabs((corners_img[1][0] - corners_img[3][0]) * (corners_img[0][1] - corners_img[2][1]))) * 0.5;
+
+        double dot = 0.0;
+        for (int i = 0; i < 4; i++)
+        {
+            const double x1 = corners_img[(i + 1) % 4][0] - corners_img[i][0];
+            const double y1 = corners_img[(i + 1) % 4][1] - corners_img[i][1];
+            const double x2 = corners_img[(i + 2) % 4][0] - corners_img[(i + 1) % 4][0];
+            const double y2 = corners_img[(i + 2) % 4][1] - corners_img[(i + 1) % 4][1];
+            const double norm1 = sqrt(x1 * x1 + y1 * y1);
+            const double norm2 = sqrt(x2 * x2 + y2 * y2);
+
+            dot += fabs(x1 * x2 + y1 * y2) / norm1 / norm2;
+        }
+        dot /= 4.0; // Average of the abs value of dot products between consecutive edges, null for a frontal view.
+
+        std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(_imagePath));
+        _weight = area * (1.0 - dot) / in->spec().width / in->spec().height;
     }
 };
 
-void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& refColors)
+void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& refColors, ECorrectionMethod method = ECorrectionMethod::full)
 {
     cv::Mat imageBGR = image::imageRGBAToCvMatBGR(image, CV_32FC3);
 
     cv::ccm::ColorCorrectionModel model(refColors, cv::ccm::COLORCHECKER_Macbeth);
-    model.run();
-
-    model.setColorSpace(cv::ccm::COLOR_SPACE_sRGB);
-    // model.setCCM_TYPE(cv::ccm::CCM_3x3);
-    // model.setDistance(cv::ccm::DISTANCE_CIE2000);
-    // model.setLinear(cv::ccm::LINEARIZATION_GAMMA);
-    // model.setLinearGamma(2.2);
-    // model.setLinearDegree(3); // to prevent overfitting
+    
+    //model.setColorSpace(cv::ccm::COLOR_SPACE_sRGB);
+    //model.setCCM_TYPE(cv::ccm::CCM_3x3);
+    //model.setDistance(cv::ccm::DISTANCE_CIE2000);
+    model.setLinear(cv::ccm::LINEARIZATION_IDENTITY); // input and ref colors are linear
+    //model.setLinearGamma(2.2);
+    //model.setLinearDegree(3); // to prevent overfitting
 
     cv::Mat img;
     cvtColor(imageBGR, img, cv::COLOR_BGR2RGB);
     img.convertTo(img, CV_64F);
 
-    cv::Mat calibratedImage =
-      model.infer(img, true);  // make correction using cc matrix and assuming images are in linear color space (as RAW for example)
+    cv::Mat calibratedImage = img;
+
+    if(method == ECorrectionMethod::luminance)
+    {
+        const double lum = linToLum(refColors.at<cv::Vec3d>(21, 0));
+        const double lumTarget = srgbToLin(122.0 / 255.0); // 0.1946
+        const double gain = lumTarget / lum;
+
+        for(int r = 0; r < img.rows; r++)
+        {
+            for(int c = 0; c < img.cols; c++)
+            {
+                calibratedImage.at<cv::Vec3d>(r, c) = gain * img.at<cv::Vec3d>(r, c);
+            }
+        }
+    }
+    else if (method == ECorrectionMethod::whiteBalance)
+    {
+        const double target = srgbToLin(122.0 / 255.0); // 0.1946
+        const double gainR = target / refColors.at<cv::Vec3d>(21, 0)[0];
+        const double gainG = target / refColors.at<cv::Vec3d>(21, 0)[1];
+        const double gainB = target / refColors.at<cv::Vec3d>(21, 0)[2];
+
+        for(int r = 0; r < img.rows; r++)
+        {
+            for(int c = 0; c < img.cols; c++)
+            {
+                calibratedImage.at<cv::Vec3d>(r, c)[0] = gainR * img.at<cv::Vec3d>(r, c)[0];
+                calibratedImage.at<cv::Vec3d>(r, c)[1] = gainG * img.at<cv::Vec3d>(r, c)[1];
+                calibratedImage.at<cv::Vec3d>(r, c)[2] = gainB * img.at<cv::Vec3d>(r, c)[2];
+            }
+        }
+    }
+    else
+    {
+        model.run();
+        calibratedImage = model.infer(img, true); // make correction and return a linear image
+    }
 
     calibratedImage.convertTo(calibratedImage, CV_32FC3);
 
@@ -101,9 +247,8 @@ void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& ref
     image::cvMatBGRToImageRGBA(outImg, image);
 }
 
-void saveImage(image::Image<image::RGBAfColor>& image,
-               const std::string& inputPath,
-               const std::string& outputPath,
+
+void saveImage(image::Image<image::RGBAfColor>& image, const std::string& inputPath, const std::string& outputPath,
                const image::EStorageDataType storageDataType)
 {
     // Read metadata path
@@ -111,7 +256,7 @@ void saveImage(image::Image<image::RGBAfColor>& image,
 
     const std::string outExtension = boost::to_lower_copy(fs::path(outputPath).extension().string());
     const bool isEXR = (outExtension == ".exr");
-
+    
     // Metadata are extracted from the original images
     metadataFilePath = inputPath;
 
@@ -120,7 +265,8 @@ void saveImage(image::Image<image::RGBAfColor>& image,
 
     image::ImageWriteOptions options;
 
-    if (isEXR)
+    options.fromColorSpace(image::EImageColorSpace::LINEAR);
+    if(isEXR)
     {
         // Select storage data type
         options.storageDataType(storageDataType);
@@ -132,6 +278,7 @@ void saveImage(image::Image<image::RGBAfColor>& image,
     image::writeImage(outputPath, image, options, metadata);
 }
 
+
 int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
@@ -140,25 +287,34 @@ int aliceVision_main(int argc, char** argv)
     std::string extension;
     image::EStorageDataType storageDataType = image::EStorageDataType::Float;
     std::string outputPath;
+    ECorrectionMethod correctionMethod = ECorrectionMethod::luminance;
+    bool useBestColorCheckerOnly = true;
+    bool keepImageName = true;
 
-    // clang-format off
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
         ("input,i", po::value<std::string>(&inputExpression)->default_value(inputExpression),
-         "SfMData file input, image filenames or regex(es) on the image file path (supported regex: '#' matches a "
-         "single digit, '@' one or more digits, '?' one character and '*' zero or more).")
-        ("inputData", po::value<std::string>(&inputData)->default_value(inputData),
-         "Position and colorimetric data extracted from detected color checkers in the images.")
+        "SfMData file input, image filenames or regex(es) on the image file path (supported regex: '#' matches a "
+        "single digit, '@' one or more digits, '?' one character and '*' zero or more).")(
+        "inputData", po::value<std::string>(&inputData)->default_value(inputData),
+        "Position and colorimetric data extracted from detected color checkers in the images")
         ("output,o", po::value<std::string>(&outputPath)->required(),
-         "Output folder.");
+         "Output folder.")
+        ;
 
     po::options_description optionalParams("Optional parameters");
-    optionalParams.add_options()
-        ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
-         ("Storage data type: " + image::EStorageDataType_informations()).c_str())
-        ("extension", po::value<std::string>(&extension)->default_value(extension),
-         "Output image extension (like exr, or empty to keep the original source file format.");
-    // clang-format on
+    optionalParams.add_options()("storageDataType",
+                                 po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
+                                 ("Storage data type: " + image::EStorageDataType_informations()).c_str())(
+        "extension", po::value<std::string>(&extension)->default_value(extension),
+        "Output image extension (like exr, or empty to keep the original source file format.")(
+        "correctionMethod", po::value<ECorrectionMethod>(&correctionMethod)->default_value(correctionMethod),
+        "Correction method to apply.")(
+        "useBestColorCheckerOnly", po::value<bool>(&useBestColorCheckerOnly)->default_value(useBestColorCheckerOnly),
+        "Use only the color chart with the best orientation and size to compute the color correction model.")(
+        "keepImageName", po::value<bool>(&keepImageName)->default_value(keepImageName),
+        "Keep image filename if different from view Id.")
+        ;
 
     CmdLine cmdline("This program is used to perform color correction based on a color checker.\n"
                     "AliceVision colorCheckerCorrection");
@@ -170,14 +326,14 @@ int aliceVision_main(int argc, char** argv)
     }
 
     // check user choose an input
-    if (inputExpression.empty())
+    if(inputExpression.empty())
     {
         ALICEVISION_LOG_ERROR("Program need --input option." << std::endl << "No input images here.");
 
         return EXIT_FAILURE;
     }
 
-    if (utils::exists(inputData))
+    if(fs::exists(inputData) && correctionMethod != ECorrectionMethod::bypass)
     {
         // checkers collection
         std::vector<CChecker> ccheckers;
@@ -186,11 +342,40 @@ int aliceVision_main(int argc, char** argv)
         bpt::ptree data;
         bpt::read_json(inputData, data);
 
-        for (const bpt::ptree::value_type& ccheckerPTree : data.get_child("checkers"))
+        for(const bpt::ptree::value_type& ccheckerPTree : data.get_child("checkers"))
             ccheckers.push_back(CChecker(ccheckerPTree));
 
-        // for now the program behaves as if all the images to process are sharing the same properties
-        cv::Mat colorData = ccheckers[0]._colorData;
+        std::vector<double> ccheckerWeights;
+        double weightMax = 0.0;
+        int idxWeightMax = 0;
+        for (int i = 0; i < ccheckers.size(); i++)
+        {
+            ccheckerWeights.push_back(ccheckers[i]._weight);
+            if(ccheckers[i]._weight > weightMax)
+            {
+                weightMax = ccheckers[i]._weight;
+                idxWeightMax = i;
+            }
+        }
+
+        cv::Mat colorData;
+
+        if (useBestColorCheckerOnly)
+        {
+            colorData = ccheckers[idxWeightMax]._colorData;
+            ALICEVISION_LOG_INFO("Use color checker detected in image " << ccheckers[idxWeightMax]._imagePath);
+        }
+        else // Combine colors of all detected color checkers
+        {
+            colorData = ccheckerWeights[0] * ccheckers[0]._colorData;
+            double sumWeight = ccheckerWeights[0];
+            for (int i = 1; i < ccheckers.size(); i++)
+            {
+                colorData += ccheckerWeights[i] * ccheckers[i]._colorData;
+                sumWeight += ccheckerWeights[i];
+            }
+            colorData /= sumWeight;
+        }
 
         // Map used to store paths of the views that need to be processed
         std::unordered_map<IndexT, std::string> ViewPaths;
@@ -198,11 +383,11 @@ int aliceVision_main(int argc, char** argv)
         // Check if sfmInputDataFilename exist and is recognized as sfm data file
         const std::string inputExt = boost::to_lower_copy(fs::path(inputExpression).extension().string());
         static const std::array<std::string, 3> sfmSupportedExtensions = {".sfm", ".json", ".abc"};
-        if (!inputExpression.empty() &&
-            std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(), inputExt) != sfmSupportedExtensions.end())
+        if(!inputExpression.empty() && std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(),
+                                                 inputExt) != sfmSupportedExtensions.end())
         {
             sfmData::SfMData sfmData;
-            if (!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::VIEWS))
+            if(!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::ALL))
             {
                 ALICEVISION_LOG_ERROR("The input SfMData file '" << inputExpression << "' cannot be read.");
                 return EXIT_FAILURE;
@@ -212,7 +397,7 @@ int aliceVision_main(int argc, char** argv)
             std::unordered_map<IndexT, std::string> ViewPaths;
 
             // Iterate over all views
-            for (const auto& viewIt : sfmData.getViews())
+            for(const auto& viewIt : sfmData.getViews())
             {
                 const sfmData::View& view = *(viewIt.second);
 
@@ -222,29 +407,31 @@ int aliceVision_main(int argc, char** argv)
             const int size = ViewPaths.size();
             int i = 0;
 
-            for (auto& viewIt : ViewPaths)
+            for(auto& viewIt : ViewPaths)
             {
                 const IndexT viewId = viewIt.first;
                 const std::string viewPath = viewIt.second;
                 sfmData::View& view = sfmData.getView(viewId);
 
                 const fs::path fsPath = viewPath;
+                const std::string filename = fs::path(view.getImage().getImagePath()).stem().string();
                 const std::string fileExt = fsPath.extension().string();
                 const std::string outputExt = extension.empty() ? fileExt : (std::string(".") + extension);
-                const std::string outputfilePath = (fs::path(outputPath) / (std::to_string(viewId) + outputExt)).generic_string();
+                const std::string outputfilePath =
+                    (fs::path(outputPath) / ((keepImageName ? filename : std::to_string(viewId)) + outputExt)).generic_string();
 
                 ALICEVISION_LOG_INFO(++i << "/" << size << " - Process view '" << viewId << "' for color correction.");
 
                 // Read image options and load image
                 image::ImageReadOptions options;
-                options.workingColorSpace = image::EImageColorSpace::NO_CONVERSION;
+                options.workingColorSpace = image::EImageColorSpace::LINEAR;
                 options.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(view.getImage().getRawColorInterpretation());
 
                 image::Image<image::RGBAfColor> image;
                 image::readImage(viewPath, image, options);
 
                 // Image color correction processing
-                processColorCorrection(image, colorData);
+                processColorCorrection(image, colorData, correctionMethod);
 
                 // Save image
                 saveImage(image, viewPath, outputfilePath, storageDataType);
@@ -256,8 +443,9 @@ int aliceVision_main(int argc, char** argv)
             }
 
             // Save sfmData with modified path to images
-            const std::string sfmfilePath = (fs::path(outputPath) / fs::path(inputExpression).filename()).generic_string();
-            if (!sfmDataIO::save(sfmData, sfmfilePath, sfmDataIO::ESfMData(sfmDataIO::ALL)))
+            const std::string sfmfilePath =
+                (fs::path(outputPath) / fs::path(inputExpression).filename()).generic_string();
+            if(!sfmDataIO::save(sfmData, sfmfilePath, sfmDataIO::ESfMData(sfmDataIO::ALL)))
             {
                 ALICEVISION_LOG_ERROR("The output SfMData file '" << sfmfilePath << "' cannot be written.");
 
@@ -270,7 +458,7 @@ int aliceVision_main(int argc, char** argv)
             const fs::path inputPath(inputExpression);
             std::vector<std::string> filesStrPaths;
 
-            if (fs::is_regular_file(inputPath))
+            if(fs::is_regular_file(inputPath))
             {
                 filesStrPaths.push_back(inputPath.string());
             }
@@ -287,10 +475,11 @@ int aliceVision_main(int argc, char** argv)
 
             const int size = filesStrPaths.size();
 
-            if (!size)
+            if(!size)
             {
                 ALICEVISION_LOG_ERROR("Any images was found.");
-                ALICEVISION_LOG_ERROR("Input folders or input expression '" << inputExpression << "' may be incorrect ?");
+                ALICEVISION_LOG_ERROR("Input folders or input expression '" << inputExpression
+                                                                            << "' may be incorrect ?");
                 return EXIT_FAILURE;
             }
             else
@@ -299,7 +488,7 @@ int aliceVision_main(int argc, char** argv)
             }
 
             int i = 0;
-            for (const std::string& inputFilePath : filesStrPaths)
+            for(const std::string& inputFilePath : filesStrPaths)
             {
                 const fs::path path = fs::path(inputFilePath);
                 const std::string filename = path.stem().string();
@@ -307,17 +496,42 @@ int aliceVision_main(int argc, char** argv)
                 const std::string outputExt = extension.empty() ? fileExt : (std::string(".") + extension);
                 const std::string outputFilePath = (fs::path(outputPath) / (filename + outputExt)).generic_string();
 
-                ALICEVISION_LOG_INFO(++i << "/" << size << " - Process image '" << filename << fileExt << "' for color correction.");
+                ALICEVISION_LOG_INFO(++i << "/" << size << " - Process image '" << filename << fileExt
+                                         << "' for color correction.");
 
                 // Read original image
                 image::Image<image::RGBAfColor> image;
-                image::readImage(inputFilePath, image, image::EImageColorSpace::NO_CONVERSION);
+                image::readImage(inputFilePath, image, image::EImageColorSpace::LINEAR);
 
                 // Image color correction processing
-                processColorCorrection(image, colorData);
+                processColorCorrection(image, colorData, correctionMethod);
 
                 // Save image
                 saveImage(image, inputFilePath, outputFilePath, storageDataType);
+            }
+        }
+    }
+    else
+    {
+        // Copy sfmdata if it exists
+        // Check if sfmInputDataFilename exist and is recognized as sfm data file
+        const std::string inputExt = boost::to_lower_copy(fs::path(inputExpression).extension().string());
+        static const std::array<std::string, 3> sfmSupportedExtensions = {".sfm", ".json", ".abc"};
+        if(!inputExpression.empty() && std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(),
+                                                 inputExt) != sfmSupportedExtensions.end())
+        {
+            sfmData::SfMData sfmData;
+            if(!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::ALL))
+            {
+                ALICEVISION_LOG_ERROR("The input SfMData file '" << inputExpression << "' cannot be read.");
+                return EXIT_FAILURE;
+            }
+            const std::string sfmfilePath = (fs::path(outputPath) / fs::path(inputExpression).filename()).generic_string();
+            if(!sfmDataIO::save(sfmData, sfmfilePath, sfmDataIO::ESfMData(sfmDataIO::ALL)))
+            {
+                ALICEVISION_LOG_ERROR("The output SfMData file '" << sfmfilePath << "' cannot be written.");
+
+                return EXIT_FAILURE;
             }
         }
     }

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -41,29 +41,23 @@ namespace fs = std::filesystem;
 namespace bpt = boost::property_tree;
 namespace po = boost::program_options;
 
-double srgbToLin(double c)
-{
-    return c <= 0.04045 ? c / 12.92 : powf((c + 0.055) / 1.055, 2.4);
-}
+double srgbToLin(double c) { return c <= 0.04045 ? c / 12.92 : powf((c + 0.055) / 1.055, 2.4); }
+
 cv::Vec3d srgbToLin(cv::Vec3d pix)
 {
     cv::Vec3d pixOut(srgbToLin(pix[0]), srgbToLin(pix[1]), srgbToLin(pix[2]));
     return pixOut;
 }
-double linToSrgb(double c)
-{
-    return c < 0.0031308 ? 12.92 * c : 1.055 * powf(c, 1.f / 2.4f) - 0.055;
-}
+
+double linToSrgb(double c) { return c < 0.0031308 ? 12.92 * c : 1.055 * powf(c, 1.f / 2.4f) - 0.055; }
+
 cv::Vec3d linToSrgb(cv::Vec3d pix)
 {
     cv::Vec3d pixOut(linToSrgb(pix[0]), linToSrgb(pix[1]), linToSrgb(pix[2]));
     return pixOut;
 }
 
-double linToLum(cv::Vec3d pix)
-{
-    return 0.2126 * pix[0] + 0.7152 * pix[1] + 0.0722 * pix[2];
-}
+double linToLum(cv::Vec3d pix) { return 0.2126 * pix[0] + 0.7152 * pix[1] + 0.0722 * pix[2]; }
 
 enum class ECorrectionMethod
 {
@@ -75,7 +69,7 @@ enum class ECorrectionMethod
 
 inline std::string ECorrectionMethod_enumToString(ECorrectionMethod correctionMethod)
 {
-    switch(correctionMethod)
+    switch (correctionMethod)
     {
         case ECorrectionMethod::luminance:
             return "luminance";
@@ -92,22 +86,19 @@ inline std::string ECorrectionMethod_enumToString(ECorrectionMethod correctionMe
 inline ECorrectionMethod ECorrectionMethod_stringToEnum(std::string correctionMethod)
 {
     boost::to_lower(correctionMethod);
-    if(correctionMethod == "luminance")
+    if (correctionMethod == "luminance")
         return ECorrectionMethod::luminance;
-    if(correctionMethod == "whitebalance")
+    if (correctionMethod == "whitebalance")
         return ECorrectionMethod::whiteBalance;
-    if(correctionMethod == "full")
+    if (correctionMethod == "full")
         return ECorrectionMethod::full;
-    if(correctionMethod == "bypass")
+    if (correctionMethod == "bypass")
         return ECorrectionMethod::bypass;
 
     throw std::invalid_argument("Unrecognized correction method '" + correctionMethod + "'");
 }
 
-inline std::ostream& operator<<(std::ostream& os, ECorrectionMethod method)
-{
-    return os << ECorrectionMethod_enumToString(method);
-}
+inline std::ostream& operator<<(std::ostream& os, ECorrectionMethod method) { return os << ECorrectionMethod_enumToString(method); }
 
 inline std::istream& operator>>(std::istream& in, ECorrectionMethod& method)
 {
@@ -124,7 +115,7 @@ struct CChecker
     std::string _imagePath;
     std::string _viewId;
     cv::Mat _colorData;
-    double _weight; // In the range [0,1]. 1.0 corresponds to a Macbeth frontal view occupying the full image.
+    double _weight;  // In the range [0,1]. 1.0 corresponds to a Macbeth frontal view occupying the full image.
 
     explicit CChecker(const bpt::ptree::value_type& ccheckerPTree)
     {
@@ -135,7 +126,7 @@ struct CChecker
         _colorData = cv::Mat::zeros(24, 1, CV_64FC3);
 
         int i = 0;
-        for(const bpt::ptree::value_type& row : ccheckerPTree.second.get_child("colors"))
+        for (const bpt::ptree::value_type& row : ccheckerPTree.second.get_child("colors"))
         {
             cv::Vec3d* rowPtr = _colorData.ptr<cv::Vec3d>(i);
             cv::Vec3d& matPixel = rowPtr[0];
@@ -153,7 +144,7 @@ struct CChecker
 
         i = 0;
         std::vector<cv::Vec2d> corners_img(4);
-        for(const bpt::ptree::value_type& row : ccheckerPTree.second.get_child("positions"))
+        for (const bpt::ptree::value_type& row : ccheckerPTree.second.get_child("positions"))
         {
             corners_img[i][0] = row.second.get_child("x").get_value<double>();
             corners_img[i][1] = row.second.get_child("y").get_value<double>();
@@ -162,7 +153,8 @@ struct CChecker
         }
 
         const double area = (fabs((corners_img[0][0] - corners_img[2][0]) * (corners_img[1][1] - corners_img[3][1])) +
-                             fabs((corners_img[1][0] - corners_img[3][0]) * (corners_img[0][1] - corners_img[2][1]))) * 0.5;
+                             fabs((corners_img[1][0] - corners_img[3][0]) * (corners_img[0][1] - corners_img[2][1]))) *
+                            0.5;
 
         double dot = 0.0;
         for (int i = 0; i < 4; i++)
@@ -176,7 +168,7 @@ struct CChecker
 
             dot += fabs(x1 * x2 + y1 * y2) / norm1 / norm2;
         }
-        dot /= 4.0; // Average of the abs value of dot products between consecutive edges, null for a frontal view.
+        dot /= 4.0;  // Average of the abs value of dot products between consecutive edges, null for a frontal view.
 
         std::unique_ptr<oiio::ImageInput> in(oiio::ImageInput::open(_imagePath));
         _weight = area * (1.0 - dot) / in->spec().width / in->spec().height;
@@ -188,13 +180,8 @@ void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& ref
     cv::Mat imageBGR = image::imageRGBAToCvMatBGR(image, CV_32FC3);
 
     cv::ccm::ColorCorrectionModel model(refColors, cv::ccm::COLORCHECKER_Macbeth);
-    
-    //model.setColorSpace(cv::ccm::COLOR_SPACE_sRGB);
-    //model.setCCM_TYPE(cv::ccm::CCM_3x3);
-    //model.setDistance(cv::ccm::DISTANCE_CIE2000);
-    model.setLinear(cv::ccm::LINEARIZATION_IDENTITY); // input and ref colors are linear
-    //model.setLinearGamma(2.2);
-    //model.setLinearDegree(3); // to prevent overfitting
+
+    model.setLinear(cv::ccm::LINEARIZATION_IDENTITY);  // input and ref colors are linear
 
     cv::Mat img;
     cvtColor(imageBGR, img, cv::COLOR_BGR2RGB);
@@ -202,15 +189,15 @@ void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& ref
 
     cv::Mat calibratedImage = img;
 
-    if(method == ECorrectionMethod::luminance)
+    if (method == ECorrectionMethod::luminance)
     {
         const double lum = linToLum(refColors.at<cv::Vec3d>(21, 0));
-        const double lumTarget = srgbToLin(122.0 / 255.0); // 0.1946
+        const double lumTarget = srgbToLin(122.0 / 255.0);  // 0.1946
         const double gain = lumTarget / lum;
 
-        for(int r = 0; r < img.rows; r++)
+        for (int r = 0; r < img.rows; r++)
         {
-            for(int c = 0; c < img.cols; c++)
+            for (int c = 0; c < img.cols; c++)
             {
                 calibratedImage.at<cv::Vec3d>(r, c) = gain * img.at<cv::Vec3d>(r, c);
             }
@@ -218,14 +205,14 @@ void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& ref
     }
     else if (method == ECorrectionMethod::whiteBalance)
     {
-        const double target = srgbToLin(122.0 / 255.0); // 0.1946
+        const double target = srgbToLin(122.0 / 255.0);  // 0.1946
         const double gainR = target / refColors.at<cv::Vec3d>(21, 0)[0];
         const double gainG = target / refColors.at<cv::Vec3d>(21, 0)[1];
         const double gainB = target / refColors.at<cv::Vec3d>(21, 0)[2];
 
-        for(int r = 0; r < img.rows; r++)
+        for (int r = 0; r < img.rows; r++)
         {
-            for(int c = 0; c < img.cols; c++)
+            for (int c = 0; c < img.cols; c++)
             {
                 calibratedImage.at<cv::Vec3d>(r, c)[0] = gainR * img.at<cv::Vec3d>(r, c)[0];
                 calibratedImage.at<cv::Vec3d>(r, c)[1] = gainG * img.at<cv::Vec3d>(r, c)[1];
@@ -236,7 +223,7 @@ void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& ref
     else
     {
         model.run();
-        calibratedImage = model.infer(img, true); // make correction and return a linear image
+        calibratedImage = model.infer(img, true);  // make correction and return a linear image
     }
 
     calibratedImage.convertTo(calibratedImage, CV_32FC3);
@@ -247,8 +234,9 @@ void processColorCorrection(image::Image<image::RGBAfColor>& image, cv::Mat& ref
     image::cvMatBGRToImageRGBA(outImg, image);
 }
 
-
-void saveImage(image::Image<image::RGBAfColor>& image, const std::string& inputPath, const std::string& outputPath,
+void saveImage(image::Image<image::RGBAfColor>& image,
+               const std::string& inputPath,
+               const std::string& outputPath,
                const image::EStorageDataType storageDataType)
 {
     // Read metadata path
@@ -256,7 +244,7 @@ void saveImage(image::Image<image::RGBAfColor>& image, const std::string& inputP
 
     const std::string outExtension = boost::to_lower_copy(fs::path(outputPath).extension().string());
     const bool isEXR = (outExtension == ".exr");
-    
+
     // Metadata are extracted from the original images
     metadataFilePath = inputPath;
 
@@ -266,7 +254,7 @@ void saveImage(image::Image<image::RGBAfColor>& image, const std::string& inputP
     image::ImageWriteOptions options;
 
     options.fromColorSpace(image::EImageColorSpace::LINEAR);
-    if(isEXR)
+    if (isEXR)
     {
         // Select storage data type
         options.storageDataType(storageDataType);
@@ -277,7 +265,6 @@ void saveImage(image::Image<image::RGBAfColor>& image, const std::string& inputP
 
     image::writeImage(outputPath, image, options, metadata);
 }
-
 
 int aliceVision_main(int argc, char** argv)
 {
@@ -291,30 +278,31 @@ int aliceVision_main(int argc, char** argv)
     bool useBestColorCheckerOnly = true;
     bool keepImageName = true;
 
+    // clang-format off
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-        ("input,i", po::value<std::string>(&inputExpression)->default_value(inputExpression),
-        "SfMData file input, image filenames or regex(es) on the image file path (supported regex: '#' matches a "
-        "single digit, '@' one or more digits, '?' one character and '*' zero or more).")(
-        "inputData", po::value<std::string>(&inputData)->default_value(inputData),
+       ("input,i", po::value<std::string>(&inputExpression)->default_value(inputExpression),
+        "SfMData file input, image filenames or regex(es) on the image file path "
+        "(supported regex: '#' matches a single digit, '@' one or more digits, "
+        "'?' one character and '*' zero or more).")
+       ("inputData", po::value<std::string>(&inputData)->default_value(inputData),
         "Position and colorimetric data extracted from detected color checkers in the images")
-        ("output,o", po::value<std::string>(&outputPath)->required(),
-         "Output folder.")
-        ;
+       ("output,o", po::value<std::string>(&outputPath)->required(),
+        "Output folder.");
 
     po::options_description optionalParams("Optional parameters");
-    optionalParams.add_options()("storageDataType",
-                                 po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
-                                 ("Storage data type: " + image::EStorageDataType_informations()).c_str())(
-        "extension", po::value<std::string>(&extension)->default_value(extension),
-        "Output image extension (like exr, or empty to keep the original source file format.")(
-        "correctionMethod", po::value<ECorrectionMethod>(&correctionMethod)->default_value(correctionMethod),
-        "Correction method to apply.")(
-        "useBestColorCheckerOnly", po::value<bool>(&useBestColorCheckerOnly)->default_value(useBestColorCheckerOnly),
-        "Use only the color chart with the best orientation and size to compute the color correction model.")(
-        "keepImageName", po::value<bool>(&keepImageName)->default_value(keepImageName),
-        "Keep image filename if different from view Id.")
-        ;
+    optionalParams.add_options()
+        ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
+         ("Storage data type: " + image::EStorageDataType_informations()).c_str())
+        ("extension", po::value<std::string>(&extension)->default_value(extension),
+         "Output image extension (like exr, or empty to keep the original source file format.")
+        ("correctionMethod", po::value<ECorrectionMethod>(&correctionMethod)->default_value(correctionMethod),
+         "Correction method to apply.")
+        ("useBestColorCheckerOnly", po::value<bool>(&useBestColorCheckerOnly)->default_value(useBestColorCheckerOnly),
+         "Use only the color chart with the best orientation and size to compute the color correction model.")
+        ("keepImageName", po::value<bool>(&keepImageName)->default_value(keepImageName),
+         "Keep image filename if different from view Id.");
+    // clang-format on
 
     CmdLine cmdline("This program is used to perform color correction based on a color checker.\n"
                     "AliceVision colorCheckerCorrection");
@@ -325,24 +313,23 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    // check user choose an input
-    if(inputExpression.empty())
+    // Check user chose an input
+    if (inputExpression.empty())
     {
         ALICEVISION_LOG_ERROR("Program need --input option." << std::endl << "No input images here.");
-
         return EXIT_FAILURE;
     }
 
-    if(fs::exists(inputData) && correctionMethod != ECorrectionMethod::bypass)
+    if (fs::exists(inputData) && correctionMethod != ECorrectionMethod::bypass)
     {
-        // checkers collection
+        // Checkers collection
         std::vector<CChecker> ccheckers;
 
-        // property tree from data input
+        // Property tree from data input
         bpt::ptree data;
         bpt::read_json(inputData, data);
 
-        for(const bpt::ptree::value_type& ccheckerPTree : data.get_child("checkers"))
+        for (const bpt::ptree::value_type& ccheckerPTree : data.get_child("checkers"))
             ccheckers.push_back(CChecker(ccheckerPTree));
 
         std::vector<double> ccheckerWeights;
@@ -351,7 +338,7 @@ int aliceVision_main(int argc, char** argv)
         for (int i = 0; i < ccheckers.size(); i++)
         {
             ccheckerWeights.push_back(ccheckers[i]._weight);
-            if(ccheckers[i]._weight > weightMax)
+            if (ccheckers[i]._weight > weightMax)
             {
                 weightMax = ccheckers[i]._weight;
                 idxWeightMax = i;
@@ -365,7 +352,7 @@ int aliceVision_main(int argc, char** argv)
             colorData = ccheckers[idxWeightMax]._colorData;
             ALICEVISION_LOG_INFO("Use color checker detected in image " << ccheckers[idxWeightMax]._imagePath);
         }
-        else // Combine colors of all detected color checkers
+        else  // Combine colors of all detected color checkers
         {
             colorData = ccheckerWeights[0] * ccheckers[0]._colorData;
             double sumWeight = ccheckerWeights[0];
@@ -383,11 +370,11 @@ int aliceVision_main(int argc, char** argv)
         // Check if sfmInputDataFilename exist and is recognized as sfm data file
         const std::string inputExt = boost::to_lower_copy(fs::path(inputExpression).extension().string());
         static const std::array<std::string, 3> sfmSupportedExtensions = {".sfm", ".json", ".abc"};
-        if(!inputExpression.empty() && std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(),
-                                                 inputExt) != sfmSupportedExtensions.end())
+        if (!inputExpression.empty() &&
+            std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(), inputExt) != sfmSupportedExtensions.end())
         {
             sfmData::SfMData sfmData;
-            if(!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::ALL))
+            if (!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::ALL))
             {
                 ALICEVISION_LOG_ERROR("The input SfMData file '" << inputExpression << "' cannot be read.");
                 return EXIT_FAILURE;
@@ -397,7 +384,7 @@ int aliceVision_main(int argc, char** argv)
             std::unordered_map<IndexT, std::string> ViewPaths;
 
             // Iterate over all views
-            for(const auto& viewIt : sfmData.getViews())
+            for (const auto& viewIt : sfmData.getViews())
             {
                 const sfmData::View& view = *(viewIt.second);
 
@@ -407,7 +394,7 @@ int aliceVision_main(int argc, char** argv)
             const int size = ViewPaths.size();
             int i = 0;
 
-            for(auto& viewIt : ViewPaths)
+            for (auto& viewIt : ViewPaths)
             {
                 const IndexT viewId = viewIt.first;
                 const std::string viewPath = viewIt.second;
@@ -418,7 +405,7 @@ int aliceVision_main(int argc, char** argv)
                 const std::string fileExt = fsPath.extension().string();
                 const std::string outputExt = extension.empty() ? fileExt : (std::string(".") + extension);
                 const std::string outputfilePath =
-                    (fs::path(outputPath) / ((keepImageName ? filename : std::to_string(viewId)) + outputExt)).generic_string();
+                  (fs::path(outputPath) / ((keepImageName ? filename : std::to_string(viewId)) + outputExt)).generic_string();
 
                 ALICEVISION_LOG_INFO(++i << "/" << size << " - Process view '" << viewId << "' for color correction.");
 
@@ -442,10 +429,9 @@ int aliceVision_main(int argc, char** argv)
                 view.getImage().setHeight(image.height());
             }
 
-            // Save sfmData with modified path to images
-            const std::string sfmfilePath =
-                (fs::path(outputPath) / fs::path(inputExpression).filename()).generic_string();
-            if(!sfmDataIO::save(sfmData, sfmfilePath, sfmDataIO::ESfMData(sfmDataIO::ALL)))
+            // Save SfMData with modified path to images
+            const std::string sfmfilePath = (fs::path(outputPath) / fs::path(inputExpression).filename()).generic_string();
+            if (!sfmDataIO::save(sfmData, sfmfilePath, sfmDataIO::ESfMData(sfmDataIO::ALL)))
             {
                 ALICEVISION_LOG_ERROR("The output SfMData file '" << sfmfilePath << "' cannot be written.");
 
@@ -454,11 +440,11 @@ int aliceVision_main(int argc, char** argv)
         }
         else
         {
-            // load input as image file or image folder
+            // Load input as image file or image folder
             const fs::path inputPath(inputExpression);
             std::vector<std::string> filesStrPaths;
 
-            if(fs::is_regular_file(inputPath))
+            if (fs::is_regular_file(inputPath))
             {
                 filesStrPaths.push_back(inputPath.string());
             }
@@ -475,11 +461,10 @@ int aliceVision_main(int argc, char** argv)
 
             const int size = filesStrPaths.size();
 
-            if(!size)
+            if (!size)
             {
                 ALICEVISION_LOG_ERROR("Any images was found.");
-                ALICEVISION_LOG_ERROR("Input folders or input expression '" << inputExpression
-                                                                            << "' may be incorrect ?");
+                ALICEVISION_LOG_ERROR("Input folders or input expression '" << inputExpression << "' may be incorrect ?");
                 return EXIT_FAILURE;
             }
             else
@@ -488,7 +473,7 @@ int aliceVision_main(int argc, char** argv)
             }
 
             int i = 0;
-            for(const std::string& inputFilePath : filesStrPaths)
+            for (const std::string& inputFilePath : filesStrPaths)
             {
                 const fs::path path = fs::path(inputFilePath);
                 const std::string filename = path.stem().string();
@@ -496,8 +481,7 @@ int aliceVision_main(int argc, char** argv)
                 const std::string outputExt = extension.empty() ? fileExt : (std::string(".") + extension);
                 const std::string outputFilePath = (fs::path(outputPath) / (filename + outputExt)).generic_string();
 
-                ALICEVISION_LOG_INFO(++i << "/" << size << " - Process image '" << filename << fileExt
-                                         << "' for color correction.");
+                ALICEVISION_LOG_INFO(++i << "/" << size << " - Process image '" << filename << fileExt << "' for color correction.");
 
                 // Read original image
                 image::Image<image::RGBAfColor> image;
@@ -513,21 +497,21 @@ int aliceVision_main(int argc, char** argv)
     }
     else
     {
-        // Copy sfmdata if it exists
+        // Copy SfMData if it exists
         // Check if sfmInputDataFilename exist and is recognized as sfm data file
         const std::string inputExt = boost::to_lower_copy(fs::path(inputExpression).extension().string());
         static const std::array<std::string, 3> sfmSupportedExtensions = {".sfm", ".json", ".abc"};
-        if(!inputExpression.empty() && std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(),
-                                                 inputExt) != sfmSupportedExtensions.end())
+        if (!inputExpression.empty() &&
+            std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(), inputExt) != sfmSupportedExtensions.end())
         {
             sfmData::SfMData sfmData;
-            if(!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::ALL))
+            if (!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::ALL))
             {
                 ALICEVISION_LOG_ERROR("The input SfMData file '" << inputExpression << "' cannot be read.");
                 return EXIT_FAILURE;
             }
             const std::string sfmfilePath = (fs::path(outputPath) / fs::path(inputExpression).filename()).generic_string();
-            if(!sfmDataIO::save(sfmData, sfmfilePath, sfmDataIO::ESfMData(sfmDataIO::ALL)))
+            if (!sfmDataIO::save(sfmData, sfmfilePath, sfmDataIO::ESfMData(sfmDataIO::ALL)))
             {
                 ALICEVISION_LOG_ERROR("The output SfMData file '" << sfmfilePath << "' cannot be written.");
 

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -52,7 +52,7 @@ enum class ECCType
 
 inline std::string ECCType_enumToString(ECCType ccType)
 {
-    switch(ccType)
+    switch (ccType)
     {
         case ECCType::MCC24:
             return "mcc24";
@@ -67,20 +67,17 @@ inline std::string ECCType_enumToString(ECCType ccType)
 inline ECCType ECCType_stringToEnum(std::string ccType)
 {
     boost::to_lower(ccType);
-    if(ccType == "mcc24")
+    if (ccType == "mcc24")
         return ECCType::MCC24;
-    if(ccType == "sg140")
+    if (ccType == "sg140")
         return ECCType::SG140;
-    if(ccType == "vinyl18")
+    if (ccType == "vinyl18")
         return ECCType::VINYL18;
 
     throw std::invalid_argument("Unrecognized color checker type '" + ccType + "'");
 }
 
-inline std::ostream& operator<<(std::ostream& os, ECCType e)
-{
-    return os << ECCType_enumToString(e);
-}
+inline std::ostream& operator<<(std::ostream& os, ECCType e) { return os << ECCType_enumToString(e); }
 
 inline std::istream& operator>>(std::istream& in, ECCType& e)
 {
@@ -92,7 +89,7 @@ inline std::istream& operator>>(std::istream& in, ECCType& e)
 
 inline cv::mcc::TYPECHART ECCType_to_OpenCVECCType(ECCType ccType)
 {
-    switch(ccType)
+    switch (ccType)
     {
         case ECCType::MCC24:
             return cv::mcc::TYPECHART::MCC24;
@@ -106,15 +103,17 @@ inline cv::mcc::TYPECHART ECCType_to_OpenCVECCType(ECCType ccType)
 
 // Match values used in OpenCV MCC
 // See https://github.com/opencv/opencv_contrib/blob/342f8924cca88fe6ce979024b7776f6815c89978/modules/mcc/src/dictionary.hpp#L72
-const std::vector< cv::Point2f > MACBETH_CCHART_CORNERS_POS = {
-    {0.f, 0.f}, {1675.f, 0.f}, {1675.f, 1125.f}, {0.f, 1125.f},
+const std::vector<cv::Point2f> MACBETH_CCHART_CORNERS_POS = {
+    {0.f, 0.f},
+    {1675.f, 0.f},
+    {1675.f, 1125.f},
+    {0.f, 1125.f},
 };
 
-const std::vector< cv::Point2f > MACBETH_CCHART_CELLS_POS_CENTER =  {
-    {150.f, 150.f}, {425.f, 150.f}, {700.f, 150.f}, {975.f, 150.f}, {1250.f, 150.f}, {1525.f, 150.f},
-    {150.f, 425.f}, {425.f, 425.f}, {700.f, 425.f}, {975.f, 425.f}, {1250.f, 425.f}, {1525.f, 425.f},
-    {150.f, 700.f}, {425.f, 700.f}, {700.f, 700.f}, {975.f, 700.f}, {1250.f, 700.f}, {1525.f, 700.f},
-    {150.f, 975.f}, {425.f, 975.f}, {700.f, 975.f}, {975.f, 975.f}, {1250.f, 975.f}, {1525.f, 975.f}
+const std::vector<cv::Point2f> MACBETH_CCHART_CELLS_POS_CENTER = {
+    {150.f, 150.f},  {425.f, 150.f},  {700.f, 150.f},  {975.f, 150.f},  {1250.f, 150.f}, {1525.f, 150.f}, {150.f, 425.f},  {425.f, 425.f},
+    {700.f, 425.f},  {975.f, 425.f},  {1250.f, 425.f}, {1525.f, 425.f}, {150.f, 700.f},  {425.f, 700.f},  {700.f, 700.f},  {975.f, 700.f},
+    {1250.f, 700.f}, {1525.f, 700.f}, {150.f, 975.f},  {425.f, 975.f},  {700.f, 975.f},  {975.f, 975.f},  {1250.f, 975.f}, {1525.f, 975.f}
 };
 
 const float MACBETH_CCHART_CELLS_SIZE = 250.f * .5f;
@@ -133,12 +132,12 @@ struct QuadSVG
             ALICEVISION_LOG_ERROR("Invalid color checker box: size is not equal to 4");
             exit(EXIT_FAILURE);
         }
-        for(const auto& p : points)
+        for (const auto& p : points)
         {
             xCoords.push_back(p.x);
             yCoords.push_back(p.y);
         }
-        // close polyline
+        // Close polyline
         xCoords.push_back(points[0].x);
         yCoords.push_back(points[0].y);
     }
@@ -155,24 +154,24 @@ struct QuadSVG
     }
 };
 
-void drawSVG(const cv::Ptr<cv::mcc::CChecker> &checker, const std::string& outputPath)
+void drawSVG(const cv::Ptr<cv::mcc::CChecker>& checker, const std::string& outputPath)
 {
-    std::vector< QuadSVG > quadsToDraw;
+    std::vector<QuadSVG> quadsToDraw;
 
     // Push back the quad representing the color checker
-    quadsToDraw.push_back( QuadSVG(checker->getBox()) );
+    quadsToDraw.push_back(QuadSVG(checker->getBox()));
 
     // Transform matrix from 'theoric' to 'measured'
-    cv::Matx33f tMatrix = cv::getPerspectiveTransform(MACBETH_CCHART_CORNERS_POS,checker->getBox());
+    cv::Matx33f tMatrix = cv::getPerspectiveTransform(MACBETH_CCHART_CORNERS_POS, checker->getBox());
 
     // Push back quads representing color checker cells
     for (const auto& center : MACBETH_CCHART_CELLS_POS_CENTER)
     {
         QuadSVG quad({
-            cv::Point2f( center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5 ),
-            cv::Point2f( center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5 ),
-            cv::Point2f( center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5 ),
-            cv::Point2f( center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5 ),
+          cv::Point2f(center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5),
+          cv::Point2f(center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5),
+          cv::Point2f(center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5),
+          cv::Point2f(center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5),
         });
         quad.transform(tMatrix);
         quadsToDraw.push_back(quad);
@@ -181,10 +180,7 @@ void drawSVG(const cv::Ptr<cv::mcc::CChecker> &checker, const std::string& outpu
     svg::svgDrawer svgSurface;
     for (const auto& quad : quadsToDraw)
     {
-        svgSurface.drawPolyline(
-            quad.xCoords.begin(), quad.xCoords.end(),
-            quad.yCoords.begin(), quad.yCoords.end(),
-            svg::svgStyle().stroke("red", 2));
+        svgSurface.drawPolyline(quad.xCoords.begin(), quad.xCoords.end(), quad.yCoords.begin(), quad.yCoords.end(), svg::svgStyle().stroke("red", 2));
     }
 
     std::ofstream svgFile(outputPath);
@@ -192,8 +188,8 @@ void drawSVG(const cv::Ptr<cv::mcc::CChecker> &checker, const std::string& outpu
     svgFile.close();
 }
 
-
-struct ImageOptions {
+struct ImageOptions
+{
     fs::path imgFsPath;
     std::string viewId;
     std::string lensSerialNumber;
@@ -201,14 +197,13 @@ struct ImageOptions {
     image::ImageReadOptions readOptions;
 };
 
-
-struct CCheckerDetectionSettings {
+struct CCheckerDetectionSettings
+{
     cv::mcc::TYPECHART typechart;
     unsigned int maxCountByImage;
     std::string outputData;
     bool debug;
 };
-
 
 struct Quad
 {
@@ -218,8 +213,8 @@ struct Quad
         cv::Point2f max;
 
         BoundingBox()
-            : min(cv::Point2f(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()))
-            , max(cv::Point2f(0.f, 0.f))
+          : min(cv::Point2f(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity())),
+            max(cv::Point2f(0.f, 0.f))
         {}
 
         float sizeX() const { return max.x - min.x; }
@@ -228,52 +223,52 @@ struct Quad
         bool contains(cv::Point2f p) const { return contains(p.x, p.y); }
     };
 
-    std::vector< cv::Point > _corners;
+    std::vector<cv::Point> _corners;
     BoundingBox _bbox;
 
     Quad() = default;
 
     Quad(const std::vector<cv::Point2f>& corners)
     {
-        if(corners.size() != 4)
+        if (corners.size() != 4)
         {
             ALICEVISION_LOG_ERROR("Invalid points count, expected 4.");
             exit(EXIT_FAILURE);
         }
 
-        for(const auto& c : corners)
+        for (const auto& c : corners)
             _corners.push_back(c);
         updateBBox();
     }
 
     Quad(cv::Point2f center, float halfHeight, float halfWidth)
-        : _corners( std::vector< cv::Point >(4) )
+      : _corners(std::vector<cv::Point>(4))
     {
-        _corners[0] = cv::Point2f( center.x - halfWidth, center.y - halfHeight );
-        _corners[1] = cv::Point2f( center.x + halfWidth, center.y - halfHeight );
-        _corners[2] = cv::Point2f( center.x + halfWidth, center.y + halfHeight );
-        _corners[3] = cv::Point2f( center.x - halfWidth, center.y + halfHeight );
+        _corners[0] = cv::Point2f(center.x - halfWidth, center.y - halfHeight);
+        _corners[1] = cv::Point2f(center.x + halfWidth, center.y - halfHeight);
+        _corners[2] = cv::Point2f(center.x + halfWidth, center.y + halfHeight);
+        _corners[3] = cv::Point2f(center.x - halfWidth, center.y + halfHeight);
         updateBBox();
     }
 
     void updateBBox()
     {
-        for(auto const &c : _corners)
+        for (auto const& c : _corners)
         {
-            if(c.x < _bbox.min.x)
+            if (c.x < _bbox.min.x)
                 _bbox.min.x = c.x;
-            if(c.y < _bbox.min.y)
+            if (c.y < _bbox.min.y)
                 _bbox.min.y = c.y;
-            if(c.x > _bbox.max.x)
+            if (c.x > _bbox.max.x)
                 _bbox.max.x = c.x;
-            if(c.y > _bbox.max.y)
+            if (c.y > _bbox.max.y)
                 _bbox.max.y = c.y;
         }
     }
 
     void transform(const cv::Matx33f& transformMatrix)
     {
-        for (auto &c : _corners)
+        for (auto& c : _corners)
         {
             cv::Point3f p(c.x, c.y, 1.);
             p = transformMatrix * p;
@@ -284,7 +279,7 @@ struct Quad
 
     void translate(float dx, float dy)
     {
-        for (auto &c : _corners)
+        for (auto& c : _corners)
         {
             c.x += dx;
             c.y += dy;
@@ -292,37 +287,32 @@ struct Quad
     }
 };
 
-
-struct MacbethCCheckerQuad : Quad {
+struct MacbethCCheckerQuad : Quad
+{
     cv::Ptr<cv::mcc::CChecker> _cchecker;
     cv::Mat _colorData;
     cv::Mat _transformMat;
-    std::vector< cv::Mat > _cellMasks;
+    std::vector<cv::Mat> _cellMasks;
     ImageOptions _imgOpt;
 
     MacbethCCheckerQuad() = default;
 
-    MacbethCCheckerQuad(
-        cv::Ptr<cv::mcc::CChecker> cchecker,
-        const image::Image<image::RGBAfColor> &img,
-        const ImageOptions& imgOpt)
-        : Quad(cchecker->getBox())
-        , _cchecker(cchecker)
-        , _imgOpt(imgOpt)
-        , _cellMasks(std::vector< cv::Mat >(24))
+    MacbethCCheckerQuad(cv::Ptr<cv::mcc::CChecker> cchecker, const image::Image<image::RGBAfColor>& img, const ImageOptions& imgOpt)
+      : Quad(cchecker->getBox()),
+        _cchecker(cchecker),
+        _imgOpt(imgOpt),
+        _cellMasks(std::vector<cv::Mat>(24))
     {
         // Transform matrix from 'theoric' to 'measured'
         _transformMat = cv::getPerspectiveTransform(MACBETH_CCHART_CORNERS_POS, _cchecker->getBox());
 
         // Create an image boolean mask for each cchecker cell
-        for(int i = 0; i < _cellMasks.size(); ++i)
+        for (int i = 0; i < _cellMasks.size(); ++i)
         {
             _cellMasks[i] = cv::Mat::zeros(_bbox.sizeY(), _bbox.sizeX(), CV_8UC1);
-            Quad q(MACBETH_CCHART_CELLS_POS_CENTER[i],
-                   MACBETH_CCHART_CELLS_SIZE * .5,
-                   MACBETH_CCHART_CELLS_SIZE * .5);
+            Quad q(MACBETH_CCHART_CELLS_POS_CENTER[i], MACBETH_CCHART_CELLS_SIZE * .5, MACBETH_CCHART_CELLS_SIZE * .5);
             q.transform(_transformMat);
-            q.translate(- _bbox.min.x, - _bbox.min.y);
+            q.translate(-_bbox.min.x, -_bbox.min.y);
             cv::fillConvexPoly(_cellMasks[i], q._corners.data(), 4, cv::Scalar(255));
         }
 
@@ -330,30 +320,28 @@ struct MacbethCCheckerQuad : Quad {
         _colorData = cv::Mat::zeros(24, 1, CV_64FC3);
         cv::Mat pixelsCount = cv::Mat::zeros(24, 1, CV_32S);
 
-        for(int y = 0; y < static_cast<int>(_bbox.sizeY()); ++y)
+        for (int y = 0; y < static_cast<int>(_bbox.sizeY()); ++y)
         {
-            for(int x = 0; x < static_cast<int>(_bbox.sizeX()); ++x)
+            for (int x = 0; x < static_cast<int>(_bbox.sizeX()); ++x)
             {
-                for(int i = 0; i < static_cast<int>(_cellMasks.size()); ++i)
+                for (int i = 0; i < static_cast<int>(_cellMasks.size()); ++i)
                 {
                     const int coordX = x + _bbox.min.x;
                     const int coordY = y + _bbox.min.y;
 
                     // Check current pixel for the current image mask
-                    if(_cellMasks[i].at<uchar>(y,x) == 255 &&
-                       coordX >= 0 && coordX < img.width() &&
-                       coordY >= 0 && coordY < img.height())
+                    if (_cellMasks[i].at<uchar>(y, x) == 255 && coordX >= 0 && coordX < img.width() && coordY >= 0 && coordY < img.height())
                     {
                         const image::RGBAfColor& px = img(coordY, coordX);
-                        _colorData.at< cv::Vec3d >(i,0) += cv::Vec3d(px.r(), px.g(), px.b());
+                        _colorData.at<cv::Vec3d>(i, 0) += cv::Vec3d(px.r(), px.g(), px.b());
                         ++pixelsCount.at<int>(i);
                     }
                 }
             }
         }
 
-        for(int i = 0; i < _colorData.rows; ++i)
-            _colorData.at<cv::Vec3d>(i, 0) /= pixelsCount.at<int>(i); // average value
+        for (int i = 0; i < _colorData.rows; ++i)
+            _colorData.at<cv::Vec3d>(i, 0) /= pixelsCount.at<int>(i);  // average value
     }
 
     bpt::ptree ptree() const
@@ -371,7 +359,7 @@ struct MacbethCCheckerQuad : Quad {
             bpt::ptree ptPoint;
             ptPoint.put("x", point.x);
             ptPoint.put("y", point.y);
-            ptPositions.push_back( std::make_pair("", ptPoint) );
+            ptPositions.push_back(std::make_pair("", ptPoint));
         }
         pt.add_child("positions", ptPositions);
 
@@ -379,13 +367,13 @@ struct MacbethCCheckerQuad : Quad {
         for (int i = 0; i < _transformMat.rows; ++i)
         {
             bpt::ptree row;
-            for(int j = 0; j < _transformMat.cols; ++j)
+            for (int j = 0; j < _transformMat.cols; ++j)
             {
                 bpt::ptree cell;
                 cell.put_value(_transformMat.at<double>(i, j));
                 row.push_back(std::make_pair("", cell));
             }
-            ptTransform.push_back( std::make_pair("", row) );
+            ptTransform.push_back(std::make_pair("", row));
         }
         pt.add_child("transform", ptTransform);
 
@@ -393,10 +381,10 @@ struct MacbethCCheckerQuad : Quad {
         for (int i = 0; i < _colorData.rows; ++i)
         {
             bpt::ptree ptColor;
-            ptColor.put("r", _colorData.at<cv::Vec3d>(i,0)[0]);
-            ptColor.put("g", _colorData.at<cv::Vec3d>(i,0)[1]);
-            ptColor.put("b", _colorData.at<cv::Vec3d>(i,0)[2]);
-            ptColors.push_back( std::make_pair("", ptColor) );
+            ptColor.put("r", _colorData.at<cv::Vec3d>(i, 0)[0]);
+            ptColor.put("g", _colorData.at<cv::Vec3d>(i, 0)[1]);
+            ptColor.put("b", _colorData.at<cv::Vec3d>(i, 0)[2]);
+            ptColors.push_back(std::make_pair("", ptColor));
         }
         pt.add_child("colors", ptColors);
 
@@ -404,12 +392,10 @@ struct MacbethCCheckerQuad : Quad {
     }
 };
 
-
-void detectColorChecker(
-    std::vector<MacbethCCheckerQuad> &detectedCCheckers,
-    ImageOptions& imgOpt,
-    CCheckerDetectionSettings &settings,
-    cv::Ptr<cv::mcc::CCheckerDetector> cnnDetector = nullptr)
+void detectColorChecker(std::vector<MacbethCCheckerQuad>& detectedCCheckers,
+                        ImageOptions& imgOpt,
+                        CCheckerDetectionSettings& settings,
+                        cv::Ptr<cv::mcc::CCheckerDetector> cnnDetector = nullptr)
 {
     const std::string outputFolder = fs::path(settings.outputData).parent_path().string() + "/";
     const std::string imgSrcPath = imgOpt.imgFsPath.string();
@@ -421,7 +407,7 @@ void detectColorChecker(
     image::readImage(imgSrcPath, img, imgOpt.readOptions);
     cv::Mat imgBGR = image::imageRGBAToCvMatBGR(img, CV_8UC3);
 
-    if(imgBGR.cols == 0 || imgBGR.rows == 0)
+    if (imgBGR.cols == 0 || imgBGR.rows == 0)
     {
         ALICEVISION_LOG_ERROR("Image at: '" << imgSrcPath << "'.\n" << "is empty.");
         exit(EXIT_FAILURE);
@@ -438,7 +424,7 @@ void detectColorChecker(
         detector = cv::mcc::CCheckerDetector::create();
     }
 
-    if(!detector->process(imgBGR, settings.typechart, settings.maxCountByImage, cnnDetector != nullptr))
+    if (!detector->process(imgBGR, settings.typechart, settings.maxCountByImage, cnnDetector != nullptr))
     {
         ALICEVISION_LOG_INFO("Checker not detected in image at: '" << imgSrcPath << "'");
         return;
@@ -446,16 +432,16 @@ void detectColorChecker(
 
     int counter = 0;
 
-    for(const cv::Ptr<cv::mcc::CChecker> cchecker : detector->getListColorChecker())
+    for (const cv::Ptr<cv::mcc::CChecker> cchecker : detector->getListColorChecker())
     {
         const std::string counterStr = "_" + std::to_string(++counter);
 
-        ALICEVISION_LOG_INFO("Checker #" << counter <<" successfully detected in '" << imgSrcStem << "'");
+        ALICEVISION_LOG_INFO("Checker #" << counter << " successfully detected in '" << imgSrcStem << "'");
 
         MacbethCCheckerQuad ccq(cchecker, img, imgOpt);
         detectedCCheckers.push_back(ccq);
-        
-        if(settings.debug)
+
+        if (settings.debug)
         {
             // Output debug data
             drawSVG(cchecker, outputFolder + imgDestStem + counterStr + ".svg");
@@ -473,7 +459,6 @@ void detectColorChecker(
     }
 }
 
-
 int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
@@ -488,10 +473,12 @@ int aliceVision_main(int argc, char** argv)
     std::string modelFolder = "";
     ECCType ccType = ECCType::MCC24;
 
+    // clang-format off
     po::options_description inputParams("Required parameters");
     inputParams.add_options()
         ("input,i", po::value<std::string>(&inputExpression)->required(),
-         "SfMData file input, image filenames or regex(es) on the image file path (supported regex: '#' matches a single digit, '@' one or more digits, '?' one character and '*' zero or more).")
+         "SfMData file input, image filenames or regex(es) on the image file path "
+         "(supported regex: '#' matches a single digit, '@' one or more digits, '?' one character and '*' zero or more).")
         ("outputData", po::value<std::string>(&outputData)->required(),
          "Output path for the color checker data.");
 
@@ -508,6 +495,7 @@ int aliceVision_main(int argc, char** argv)
          "Maximum color charts count to detect in a single image.")
         ("ccType", po::value<ECCType>(&ccType)->default_value(ccType),
          "Color chart type: mcc24 (Classical macbeth 24 patches), sg140 (Digital SG 140 patches), vinyl18 (DKK colorchart 12 patches + 6 rectangles).");
+    // clang-format on
 
     CmdLine cmdline("This program is used to perform Macbeth color checker chart detection.\n"
                     "AliceVision colorCheckerDetection");
@@ -524,14 +512,14 @@ int aliceVision_main(int argc, char** argv)
     settings.outputData = outputData;
     settings.debug = debug;
 
-    std::vector< MacbethCCheckerQuad > detectedCCheckers;
+    std::vector<MacbethCCheckerQuad> detectedCCheckers;
 
     cv::Ptr<cv::mcc::CCheckerDetector> detectorCNN = nullptr;
 
     const std::string modelPath = modelFolder + "/frozen_inference_graph.pb";
     const std::string pbtxtPath = modelFolder + "/graph.pbtxt";
 
-    if(fs::exists(fs::path(modelPath)) && fs::exists(fs::path(pbtxtPath)))
+    if (fs::exists(fs::path(modelPath)) && fs::exists(fs::path(pbtxtPath)))
     {
         cv::dnn::Net net = cv::dnn::readNetFromTensorflow(modelPath, pbtxtPath);
 
@@ -539,7 +527,7 @@ int aliceVision_main(int argc, char** argv)
         net.setPreferableTarget(cv::dnn::DNN_TARGET_CUDA);
 
         detectorCNN = cv::mcc::CCheckerDetector::create();
-        if(!detectorCNN->setNet(net))
+        if (!detectorCNN->setNet(net))
         {
             ALICEVISION_LOG_INFO("Loading Model failed: Aborting");
             detectorCNN = nullptr;
@@ -553,9 +541,9 @@ int aliceVision_main(int argc, char** argv)
     // Check if inputExpression is recognized as sfm data file
     const std::string inputExt = boost::to_lower_copy(fs::path(inputExpression).extension().string());
     static const std::array<std::string, 2> sfmSupportedExtensions = {".sfm", ".abc"};
-    if(std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(), inputExt) != sfmSupportedExtensions.end())
+    if (std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(), inputExt) != sfmSupportedExtensions.end())
     {
-        // load input as sfm data file
+        // Load input as SfMData file
         sfmData::SfMData sfmData;
         if (!sfmDataIO::load(sfmData, inputExpression, sfmDataIO::ESfMData(sfmDataIO::VIEWS)))
         {
@@ -566,32 +554,33 @@ int aliceVision_main(int argc, char** argv)
         int counter = 0;
 
         // Detect color checker for each images
-        for(const auto& viewIt : sfmData.getViews())
+        for (const auto& viewIt : sfmData.getViews())
         {
             const sfmData::View& view = *(viewIt.second);
 
             boost::filesystem::path p(view.getImage().getImagePath());
             const std::regex regex = utils::filterToRegex(filter);
-            if(processAllImages || std::regex_match(p.generic_string(), regex))
+            if (processAllImages || std::regex_match(p.generic_string(), regex))
             {
-                ALICEVISION_LOG_INFO(++counter << "/" << sfmData.getViews().size() << " - Process image at: '"
-                                               << view.getImage().getImagePath() << "'.");
-                ImageOptions imgOpt = {view.getImage().getImagePath(), std::to_string(view.getViewId()),
-                                       view.getImage().getMetadataBodySerialNumber(), view.getImage().getMetadataLensSerialNumber()};
+                ALICEVISION_LOG_INFO(++counter << "/" << sfmData.getViews().size() << " - Process image at: '" << view.getImage().getImagePath()
+                                               << "'.");
+                ImageOptions imgOpt = {view.getImage().getImagePath(),
+                                       std::to_string(view.getViewId()),
+                                       view.getImage().getMetadataBodySerialNumber(),
+                                       view.getImage().getMetadataLensSerialNumber()};
                 imgOpt.readOptions.workingColorSpace = image::EImageColorSpace::SRGB;
-                imgOpt.readOptions.rawColorInterpretation =
-                    image::ERawColorInterpretation_stringToEnum(view.getImage().getRawColorInterpretation());
+                imgOpt.readOptions.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(view.getImage().getRawColorInterpretation());
                 detectColorChecker(detectedCCheckers, imgOpt, settings, detectorCNN);
             }
         }
     }
     else
     {
-        // load input as image file or image folder
+        // Load input as image file or image folder
         const fs::path inputPath(inputExpression);
         std::vector<std::string> filesStrPaths;
 
-        if(fs::is_regular_file(inputPath))
+        if (fs::is_regular_file(inputPath))
         {
             filesStrPaths.push_back(inputPath.string());
         }
@@ -601,17 +590,15 @@ int aliceVision_main(int argc, char** argv)
 
             const std::regex regex = utils::filterToRegex(processAllImages ? "" : filter);
             // Get supported files in inputPath directory which matches our regex filter
-            filesStrPaths = utils::getFilesPathsFromFolder(inputPath.generic_string(),
-               [&regex](const fs::path& path) {
-                                                               ALICEVISION_LOG_INFO(path);
-                 return image::isSupported(path.extension().string());//&&std::regex_match(path.generic_string(), regex);
-               }
-            );
+            filesStrPaths = utils::getFilesPathsFromFolder(inputPath.generic_string(), [&regex](const fs::path& path) {
+                ALICEVISION_LOG_INFO(path);
+                return image::isSupported(path.extension().string()) && std::regex_match(path.generic_string(), regex);
+            });
         }
 
         const int size = filesStrPaths.size();
 
-        if(!size)
+        if (!size)
         {
             ALICEVISION_LOG_ERROR("Any images was found.");
             ALICEVISION_LOG_ERROR("Input folders or input expression '" << inputExpression << "' may be incorrect ?");
@@ -623,11 +610,11 @@ int aliceVision_main(int argc, char** argv)
         }
 
         int counter = 0;
-        for(const std::string& imgSrcPath : filesStrPaths)
+        for (const std::string& imgSrcPath : filesStrPaths)
         {
             boost::filesystem::path p(imgSrcPath);
             const std::regex regex = utils::filterToRegex(filter);
-            if(processAllImages || std::regex_match(p.generic_string(), regex))
+            if (processAllImages || std::regex_match(p.generic_string(), regex))
             {
                 ALICEVISION_LOG_INFO(++counter << "/" << size << " - Process image at: '" << imgSrcPath << "'.");
                 ImageOptions imgOpt;
@@ -636,7 +623,6 @@ int aliceVision_main(int argc, char** argv)
                 detectColorChecker(detectedCCheckers, imgOpt, settings, detectorCNN);
             }
         }
-
     }
 
     if (detectedCCheckers.empty())

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -16,16 +16,17 @@
 
 #include <dependencies/vectorGraphics/svgDrawer.hpp>
 
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/regex.hpp>
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/mcc.hpp>
 
-#include <filesystem>
 #include <string>
 #include <fstream>
 #include <vector>
@@ -33,7 +34,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 using namespace aliceVision;
@@ -42,19 +43,79 @@ namespace fs = std::filesystem;
 namespace bpt = boost::property_tree;
 namespace po = boost::program_options;
 
-// Match values used in OpenCV MCC
-// See https://github.com/opencv/opencv_contrib/blob/342f8924cca88fe6ce979024b7776f6815c89978/modules/mcc/src/dictionary.hpp#L72
-const std::vector<cv::Point2f> MACBETH_CCHART_CORNERS_POS = {
-  {0.f, 0.f},
-  {1675.f, 0.f},
-  {1675.f, 1125.f},
-  {0.f, 1125.f},
+enum class ECCType
+{
+    MCC24,
+    SG140,
+    VINYL18
 };
 
-const std::vector<cv::Point2f> MACBETH_CCHART_CELLS_POS_CENTER = {
-  {150.f, 150.f},  {425.f, 150.f},  {700.f, 150.f},  {975.f, 150.f},  {1250.f, 150.f}, {1525.f, 150.f}, {150.f, 425.f},  {425.f, 425.f},
-  {700.f, 425.f},  {975.f, 425.f},  {1250.f, 425.f}, {1525.f, 425.f}, {150.f, 700.f},  {425.f, 700.f},  {700.f, 700.f},  {975.f, 700.f},
-  {1250.f, 700.f}, {1525.f, 700.f}, {150.f, 975.f},  {425.f, 975.f},  {700.f, 975.f},  {975.f, 975.f},  {1250.f, 975.f}, {1525.f, 975.f}};
+inline std::string ECCType_enumToString(ECCType ccType)
+{
+    switch(ccType)
+    {
+        case ECCType::MCC24:
+            return "mcc24";
+        case ECCType::SG140:
+            return "sg140";
+        case ECCType::VINYL18:
+            return "vinyl18";
+    }
+    throw std::invalid_argument("Invalid openCV color checker type enum");
+}
+
+inline ECCType ECCType_stringToEnum(std::string ccType)
+{
+    boost::to_lower(ccType);
+    if(ccType == "mcc24")
+        return ECCType::MCC24;
+    if(ccType == "sg140")
+        return ECCType::SG140;
+    if(ccType == "vinyl18")
+        return ECCType::VINYL18;
+
+    throw std::invalid_argument("Unrecognized color checker type '" + ccType + "'");
+}
+
+inline std::ostream& operator<<(std::ostream& os, ECCType e)
+{
+    return os << ECCType_enumToString(e);
+}
+
+inline std::istream& operator>>(std::istream& in, ECCType& e)
+{
+    std::string token;
+    in >> token;
+    e = ECCType_stringToEnum(token);
+    return in;
+}
+
+inline cv::mcc::TYPECHART ECCType_to_OpenCVECCType(ECCType ccType)
+{
+    switch(ccType)
+    {
+        case ECCType::MCC24:
+            return cv::mcc::TYPECHART::MCC24;
+        case ECCType::SG140:
+            return cv::mcc::TYPECHART::SG140;
+        case ECCType::VINYL18:
+            return cv::mcc::TYPECHART::VINYL18;
+    }
+    throw std::invalid_argument("Invalid openCV color checker type enum");
+}
+
+// Match values used in OpenCV MCC
+// See https://github.com/opencv/opencv_contrib/blob/342f8924cca88fe6ce979024b7776f6815c89978/modules/mcc/src/dictionary.hpp#L72
+const std::vector< cv::Point2f > MACBETH_CCHART_CORNERS_POS = {
+    {0.f, 0.f}, {1675.f, 0.f}, {1675.f, 1125.f}, {0.f, 1125.f},
+};
+
+const std::vector< cv::Point2f > MACBETH_CCHART_CELLS_POS_CENTER =  {
+    {150.f, 150.f}, {425.f, 150.f}, {700.f, 150.f}, {975.f, 150.f}, {1250.f, 150.f}, {1525.f, 150.f},
+    {150.f, 425.f}, {425.f, 425.f}, {700.f, 425.f}, {975.f, 425.f}, {1250.f, 425.f}, {1525.f, 425.f},
+    {150.f, 700.f}, {425.f, 700.f}, {700.f, 700.f}, {975.f, 700.f}, {1250.f, 700.f}, {1525.f, 700.f},
+    {150.f, 975.f}, {425.f, 975.f}, {700.f, 975.f}, {975.f, 975.f}, {1250.f, 975.f}, {1525.f, 975.f}
+};
 
 const float MACBETH_CCHART_CELLS_SIZE = 250.f * .5f;
 
@@ -72,7 +133,7 @@ struct QuadSVG
             ALICEVISION_LOG_ERROR("Invalid color checker box: size is not equal to 4");
             exit(EXIT_FAILURE);
         }
-        for (const auto& p : points)
+        for(const auto& p : points)
         {
             xCoords.push_back(p.x);
             yCoords.push_back(p.y);
@@ -94,24 +155,24 @@ struct QuadSVG
     }
 };
 
-void drawSVG(const cv::Ptr<cv::mcc::CChecker>& checker, const std::string& outputPath)
+void drawSVG(const cv::Ptr<cv::mcc::CChecker> &checker, const std::string& outputPath)
 {
-    std::vector<QuadSVG> quadsToDraw;
+    std::vector< QuadSVG > quadsToDraw;
 
     // Push back the quad representing the color checker
-    quadsToDraw.push_back(QuadSVG(checker->getBox()));
+    quadsToDraw.push_back( QuadSVG(checker->getBox()) );
 
     // Transform matrix from 'theoric' to 'measured'
-    cv::Matx33f tMatrix = cv::getPerspectiveTransform(MACBETH_CCHART_CORNERS_POS, checker->getBox());
+    cv::Matx33f tMatrix = cv::getPerspectiveTransform(MACBETH_CCHART_CORNERS_POS,checker->getBox());
 
     // Push back quads representing color checker cells
     for (const auto& center : MACBETH_CCHART_CELLS_POS_CENTER)
     {
         QuadSVG quad({
-          cv::Point2f(center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5),
-          cv::Point2f(center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5),
-          cv::Point2f(center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5),
-          cv::Point2f(center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5),
+            cv::Point2f( center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5 ),
+            cv::Point2f( center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y - MACBETH_CCHART_CELLS_SIZE * .5 ),
+            cv::Point2f( center.x + MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5 ),
+            cv::Point2f( center.x - MACBETH_CCHART_CELLS_SIZE * .5, center.y + MACBETH_CCHART_CELLS_SIZE * .5 ),
         });
         quad.transform(tMatrix);
         quadsToDraw.push_back(quad);
@@ -120,7 +181,10 @@ void drawSVG(const cv::Ptr<cv::mcc::CChecker>& checker, const std::string& outpu
     svg::svgDrawer svgSurface;
     for (const auto& quad : quadsToDraw)
     {
-        svgSurface.drawPolyline(quad.xCoords.begin(), quad.xCoords.end(), quad.yCoords.begin(), quad.yCoords.end(), svg::svgStyle().stroke("red", 2));
+        svgSurface.drawPolyline(
+            quad.xCoords.begin(), quad.xCoords.end(),
+            quad.yCoords.begin(), quad.yCoords.end(),
+            svg::svgStyle().stroke("red", 2));
     }
 
     std::ofstream svgFile(outputPath);
@@ -128,8 +192,8 @@ void drawSVG(const cv::Ptr<cv::mcc::CChecker>& checker, const std::string& outpu
     svgFile.close();
 }
 
-struct ImageOptions
-{
+
+struct ImageOptions {
     fs::path imgFsPath;
     std::string viewId;
     std::string lensSerialNumber;
@@ -137,13 +201,14 @@ struct ImageOptions
     image::ImageReadOptions readOptions;
 };
 
-struct CCheckerDetectionSettings
-{
+
+struct CCheckerDetectionSettings {
     cv::mcc::TYPECHART typechart;
     unsigned int maxCountByImage;
     std::string outputData;
     bool debug;
 };
+
 
 struct Quad
 {
@@ -153,8 +218,8 @@ struct Quad
         cv::Point2f max;
 
         BoundingBox()
-          : min(cv::Point2f(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity())),
-            max(cv::Point2f(0.f, 0.f))
+            : min(cv::Point2f(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()))
+            , max(cv::Point2f(0.f, 0.f))
         {}
 
         float sizeX() const { return max.x - min.x; }
@@ -163,52 +228,52 @@ struct Quad
         bool contains(cv::Point2f p) const { return contains(p.x, p.y); }
     };
 
-    std::vector<cv::Point> _corners;
+    std::vector< cv::Point > _corners;
     BoundingBox _bbox;
 
     Quad() = default;
 
     Quad(const std::vector<cv::Point2f>& corners)
     {
-        if (corners.size() != 4)
+        if(corners.size() != 4)
         {
             ALICEVISION_LOG_ERROR("Invalid points count, expected 4.");
             exit(EXIT_FAILURE);
         }
 
-        for (const auto& c : corners)
+        for(const auto& c : corners)
             _corners.push_back(c);
         updateBBox();
     }
 
     Quad(cv::Point2f center, float halfHeight, float halfWidth)
-      : _corners(std::vector<cv::Point>(4))
+        : _corners( std::vector< cv::Point >(4) )
     {
-        _corners[0] = cv::Point2f(center.x - halfWidth, center.y - halfHeight);
-        _corners[1] = cv::Point2f(center.x + halfWidth, center.y - halfHeight);
-        _corners[2] = cv::Point2f(center.x + halfWidth, center.y + halfHeight);
-        _corners[3] = cv::Point2f(center.x - halfWidth, center.y + halfHeight);
+        _corners[0] = cv::Point2f( center.x - halfWidth, center.y - halfHeight );
+        _corners[1] = cv::Point2f( center.x + halfWidth, center.y - halfHeight );
+        _corners[2] = cv::Point2f( center.x + halfWidth, center.y + halfHeight );
+        _corners[3] = cv::Point2f( center.x - halfWidth, center.y + halfHeight );
         updateBBox();
     }
 
     void updateBBox()
     {
-        for (auto const& c : _corners)
+        for(auto const &c : _corners)
         {
-            if (c.x < _bbox.min.x)
+            if(c.x < _bbox.min.x)
                 _bbox.min.x = c.x;
-            if (c.y < _bbox.min.y)
+            if(c.y < _bbox.min.y)
                 _bbox.min.y = c.y;
-            if (c.x > _bbox.max.x)
+            if(c.x > _bbox.max.x)
                 _bbox.max.x = c.x;
-            if (c.y > _bbox.max.y)
+            if(c.y > _bbox.max.y)
                 _bbox.max.y = c.y;
         }
     }
 
     void transform(const cv::Matx33f& transformMatrix)
     {
-        for (auto& c : _corners)
+        for (auto &c : _corners)
         {
             cv::Point3f p(c.x, c.y, 1.);
             p = transformMatrix * p;
@@ -219,7 +284,7 @@ struct Quad
 
     void translate(float dx, float dy)
     {
-        for (auto& c : _corners)
+        for (auto &c : _corners)
         {
             c.x += dx;
             c.y += dy;
@@ -227,32 +292,37 @@ struct Quad
     }
 };
 
-struct MacbethCCheckerQuad : Quad
-{
+
+struct MacbethCCheckerQuad : Quad {
     cv::Ptr<cv::mcc::CChecker> _cchecker;
     cv::Mat _colorData;
     cv::Mat _transformMat;
-    std::vector<cv::Mat> _cellMasks;
+    std::vector< cv::Mat > _cellMasks;
     ImageOptions _imgOpt;
 
     MacbethCCheckerQuad() = default;
 
-    MacbethCCheckerQuad(cv::Ptr<cv::mcc::CChecker> cchecker, const image::Image<image::RGBAfColor>& img, const ImageOptions& imgOpt)
-      : Quad(cchecker->getBox()),
-        _cchecker(cchecker),
-        _imgOpt(imgOpt),
-        _cellMasks(std::vector<cv::Mat>(24))
+    MacbethCCheckerQuad(
+        cv::Ptr<cv::mcc::CChecker> cchecker,
+        const image::Image<image::RGBAfColor> &img,
+        const ImageOptions& imgOpt)
+        : Quad(cchecker->getBox())
+        , _cchecker(cchecker)
+        , _imgOpt(imgOpt)
+        , _cellMasks(std::vector< cv::Mat >(24))
     {
         // Transform matrix from 'theoric' to 'measured'
         _transformMat = cv::getPerspectiveTransform(MACBETH_CCHART_CORNERS_POS, _cchecker->getBox());
 
         // Create an image boolean mask for each cchecker cell
-        for (int i = 0; i < _cellMasks.size(); ++i)
+        for(int i = 0; i < _cellMasks.size(); ++i)
         {
             _cellMasks[i] = cv::Mat::zeros(_bbox.sizeY(), _bbox.sizeX(), CV_8UC1);
-            Quad q(MACBETH_CCHART_CELLS_POS_CENTER[i], MACBETH_CCHART_CELLS_SIZE * .5, MACBETH_CCHART_CELLS_SIZE * .5);
+            Quad q(MACBETH_CCHART_CELLS_POS_CENTER[i],
+                   MACBETH_CCHART_CELLS_SIZE * .5,
+                   MACBETH_CCHART_CELLS_SIZE * .5);
             q.transform(_transformMat);
-            q.translate(-_bbox.min.x, -_bbox.min.y);
+            q.translate(- _bbox.min.x, - _bbox.min.y);
             cv::fillConvexPoly(_cellMasks[i], q._corners.data(), 4, cv::Scalar(255));
         }
 
@@ -260,25 +330,30 @@ struct MacbethCCheckerQuad : Quad
         _colorData = cv::Mat::zeros(24, 1, CV_64FC3);
         cv::Mat pixelsCount = cv::Mat::zeros(24, 1, CV_32S);
 
-        for (int y = 0; y < (int)_bbox.sizeY(); ++y)
+        for(int y = 0; y < static_cast<int>(_bbox.sizeY()); ++y)
         {
-            for (int x = 0; x < (int)_bbox.sizeX(); ++x)
+            for(int x = 0; x < static_cast<int>(_bbox.sizeX()); ++x)
             {
-                for (int i = 0; i < _cellMasks.size(); ++i)
+                for(int i = 0; i < static_cast<int>(_cellMasks.size()); ++i)
                 {
+                    const int coordX = x + _bbox.min.x;
+                    const int coordY = y + _bbox.min.y;
+
                     // Check current pixel for the current image mask
-                    if (_cellMasks[i].at<uchar>(y, x) == 255)
+                    if(_cellMasks[i].at<uchar>(y,x) == 255 &&
+                       coordX >= 0 && coordX < img.width() &&
+                       coordY >= 0 && coordY < img.height())
                     {
-                        const image::RGBAfColor& px = img(y + _bbox.min.y, x + _bbox.min.x);
-                        _colorData.at<cv::Vec3d>(i, 0) += cv::Vec3d(px.r(), px.g(), px.b());
+                        const image::RGBAfColor& px = img(coordY, coordX);
+                        _colorData.at< cv::Vec3d >(i,0) += cv::Vec3d(px.r(), px.g(), px.b());
                         ++pixelsCount.at<int>(i);
                     }
                 }
             }
         }
 
-        for (int i = 0; i < _colorData.rows; ++i)
-            _colorData.at<cv::Vec3d>(i, 0) /= pixelsCount.at<int>(i);  // average value
+        for(int i = 0; i < _colorData.rows; ++i)
+            _colorData.at<cv::Vec3d>(i, 0) /= pixelsCount.at<int>(i); // average value
     }
 
     bpt::ptree ptree() const
@@ -296,7 +371,7 @@ struct MacbethCCheckerQuad : Quad
             bpt::ptree ptPoint;
             ptPoint.put("x", point.x);
             ptPoint.put("y", point.y);
-            ptPositions.push_back(std::make_pair("", ptPoint));
+            ptPositions.push_back( std::make_pair("", ptPoint) );
         }
         pt.add_child("positions", ptPositions);
 
@@ -304,13 +379,13 @@ struct MacbethCCheckerQuad : Quad
         for (int i = 0; i < _transformMat.rows; ++i)
         {
             bpt::ptree row;
-            for (int j = 0; j < _transformMat.cols; ++j)
+            for(int j = 0; j < _transformMat.cols; ++j)
             {
                 bpt::ptree cell;
                 cell.put_value(_transformMat.at<double>(i, j));
                 row.push_back(std::make_pair("", cell));
             }
-            ptTransform.push_back(std::make_pair("", row));
+            ptTransform.push_back( std::make_pair("", row) );
         }
         pt.add_child("transform", ptTransform);
 
@@ -318,10 +393,10 @@ struct MacbethCCheckerQuad : Quad
         for (int i = 0; i < _colorData.rows; ++i)
         {
             bpt::ptree ptColor;
-            ptColor.put("r", _colorData.at<cv::Vec3d>(i, 0)[0]);
-            ptColor.put("g", _colorData.at<cv::Vec3d>(i, 0)[1]);
-            ptColor.put("b", _colorData.at<cv::Vec3d>(i, 0)[2]);
-            ptColors.push_back(std::make_pair("", ptColor));
+            ptColor.put("r", _colorData.at<cv::Vec3d>(i,0)[0]);
+            ptColor.put("g", _colorData.at<cv::Vec3d>(i,0)[1]);
+            ptColor.put("b", _colorData.at<cv::Vec3d>(i,0)[2]);
+            ptColors.push_back( std::make_pair("", ptColor) );
         }
         pt.add_child("colors", ptColors);
 
@@ -329,7 +404,12 @@ struct MacbethCCheckerQuad : Quad
     }
 };
 
-void detectColorChecker(std::vector<MacbethCCheckerQuad>& detectedCCheckers, ImageOptions& imgOpt, CCheckerDetectionSettings& settings)
+
+void detectColorChecker(
+    std::vector<MacbethCCheckerQuad> &detectedCCheckers,
+    ImageOptions& imgOpt,
+    CCheckerDetectionSettings &settings,
+    cv::Ptr<cv::mcc::CCheckerDetector> cnnDetector = nullptr)
 {
     const std::string outputFolder = fs::path(settings.outputData).parent_path().string() + "/";
     const std::string imgSrcPath = imgOpt.imgFsPath.string();
@@ -341,16 +421,24 @@ void detectColorChecker(std::vector<MacbethCCheckerQuad>& detectedCCheckers, Ima
     image::readImage(imgSrcPath, img, imgOpt.readOptions);
     cv::Mat imgBGR = image::imageRGBAToCvMatBGR(img, CV_8UC3);
 
-    if (imgBGR.cols == 0 || imgBGR.rows == 0)
+    if(imgBGR.cols == 0 || imgBGR.rows == 0)
     {
-        ALICEVISION_LOG_ERROR("Image at: '" << imgSrcPath << "'.\n"
-                                            << "is empty.");
+        ALICEVISION_LOG_ERROR("Image at: '" << imgSrcPath << "'.\n" << "is empty.");
         exit(EXIT_FAILURE);
     }
 
-    cv::Ptr<cv::mcc::CCheckerDetector> detector = cv::mcc::CCheckerDetector::create();
+    cv::Ptr<cv::mcc::CCheckerDetector> detector;
 
-    if (!detector->process(imgBGR, settings.typechart, settings.maxCountByImage))
+    if (cnnDetector != nullptr)
+    {
+        detector = cnnDetector;
+    }
+    else
+    {
+        detector = cv::mcc::CCheckerDetector::create();
+    }
+
+    if(!detector->process(imgBGR, settings.typechart, settings.maxCountByImage, cnnDetector != nullptr))
     {
         ALICEVISION_LOG_INFO("Checker not detected in image at: '" << imgSrcPath << "'");
         return;
@@ -358,16 +446,16 @@ void detectColorChecker(std::vector<MacbethCCheckerQuad>& detectedCCheckers, Ima
 
     int counter = 0;
 
-    for (const cv::Ptr<cv::mcc::CChecker> cchecker : detector->getListColorChecker())
+    for(const cv::Ptr<cv::mcc::CChecker> cchecker : detector->getListColorChecker())
     {
         const std::string counterStr = "_" + std::to_string(++counter);
 
-        ALICEVISION_LOG_INFO("Checker #" << counter << " successfully detected in '" << imgSrcStem << "'");
+        ALICEVISION_LOG_INFO("Checker #" << counter <<" successfully detected in '" << imgSrcStem << "'");
 
         MacbethCCheckerQuad ccq(cchecker, img, imgOpt);
         detectedCCheckers.push_back(ccq);
-
-        if (settings.debug)
+        
+        if(settings.debug)
         {
             // Output debug data
             drawSVG(cchecker, outputFolder + imgDestStem + counterStr + ".svg");
@@ -385,6 +473,7 @@ void detectColorChecker(std::vector<MacbethCCheckerQuad>& detectedCCheckers, Ima
     }
 }
 
+
 int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
@@ -394,23 +483,31 @@ int aliceVision_main(int argc, char** argv)
     // user optional parameters
     bool debug = false;
     unsigned int maxCountByImage = 1;
+    bool processAllImages = true;
+    std::string filter = "*_macbeth.*";
+    std::string modelFolder = "";
+    ECCType ccType = ECCType::MCC24;
 
-    // clang-format off
     po::options_description inputParams("Required parameters");
     inputParams.add_options()
         ("input,i", po::value<std::string>(&inputExpression)->required(),
-         "SfMData file input, image filenames or regex(es) on the image file path (supported regex: '#' matches "
-         "a single digit, '@' one or more digits, '?' one character and '*' zero or more).")
+         "SfMData file input, image filenames or regex(es) on the image file path (supported regex: '#' matches a single digit, '@' one or more digits, '?' one character and '*' zero or more).")
         ("outputData", po::value<std::string>(&outputData)->required(),
          "Output path for the color checker data.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
-        ("debug", po::value<bool>(&debug),
-         "Output debug data.")
+        ("debug", po::value<bool>(&debug), "Output debug data.")
+        ("processAllImages", po::value<bool>(&processAllImages)->default_value(processAllImages),
+         "If True, process all available images.")
+        ("filter", po::value<std::string>(&filter)->default_value(filter),
+         "Regular expression to select images to be processed.")
+        ("modelFolder", po::value<std::string>(&modelFolder)->default_value(modelFolder),
+         "Path to folder containing a cnn model.")
         ("maxCount", po::value<unsigned int>(&maxCountByImage),
-         "Maximum color charts count to detect in a single image.");
-    // clang-format on
+         "Maximum color charts count to detect in a single image.")
+        ("ccType", po::value<ECCType>(&ccType)->default_value(ccType),
+         "Color chart type: mcc24 (Classical macbeth 24 patches), sg140 (Digital SG 140 patches), vinyl18 (DKK colorchart 12 patches + 6 rectangles).");
 
     CmdLine cmdline("This program is used to perform Macbeth color checker chart detection.\n"
                     "AliceVision colorCheckerDetection");
@@ -422,17 +519,41 @@ int aliceVision_main(int argc, char** argv)
     }
 
     CCheckerDetectionSettings settings;
-    settings.typechart = cv::mcc::TYPECHART::MCC24;
+    settings.typechart = ECCType_to_OpenCVECCType(ccType);
     settings.maxCountByImage = maxCountByImage;
     settings.outputData = outputData;
     settings.debug = debug;
 
-    std::vector<MacbethCCheckerQuad> detectedCCheckers;
+    std::vector< MacbethCCheckerQuad > detectedCCheckers;
+
+    cv::Ptr<cv::mcc::CCheckerDetector> detectorCNN = nullptr;
+
+    const std::string modelPath = modelFolder + "/frozen_inference_graph.pb";
+    const std::string pbtxtPath = modelFolder + "/graph.pbtxt";
+
+    if(fs::exists(fs::path(modelPath)) && fs::exists(fs::path(pbtxtPath)))
+    {
+        cv::dnn::Net net = cv::dnn::readNetFromTensorflow(modelPath, pbtxtPath);
+
+        net.setPreferableBackend(cv::dnn::DNN_BACKEND_CUDA);
+        net.setPreferableTarget(cv::dnn::DNN_TARGET_CUDA);
+
+        detectorCNN = cv::mcc::CCheckerDetector::create();
+        if(!detectorCNN->setNet(net))
+        {
+            ALICEVISION_LOG_INFO("Loading Model failed: Aborting");
+            detectorCNN = nullptr;
+        }
+        else
+        {
+            ALICEVISION_LOG_INFO("Loading Model OK");
+        }
+    }
 
     // Check if inputExpression is recognized as sfm data file
     const std::string inputExt = boost::to_lower_copy(fs::path(inputExpression).extension().string());
     static const std::array<std::string, 2> sfmSupportedExtensions = {".sfm", ".abc"};
-    if (std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(), inputExt) != sfmSupportedExtensions.end())
+    if(std::find(sfmSupportedExtensions.begin(), sfmSupportedExtensions.end(), inputExt) != sfmSupportedExtensions.end())
     {
         // load input as sfm data file
         sfmData::SfMData sfmData;
@@ -445,18 +566,23 @@ int aliceVision_main(int argc, char** argv)
         int counter = 0;
 
         // Detect color checker for each images
-        for (const auto& viewIt : sfmData.getViews())
+        for(const auto& viewIt : sfmData.getViews())
         {
             const sfmData::View& view = *(viewIt.second);
 
-            ALICEVISION_LOG_INFO(++counter << "/" << sfmData.getViews().size() << " - Process image at: '" << view.getImage().getImagePath() << "'.");
-            ImageOptions imgOpt = {view.getImage().getImagePath(),
-                                   std::to_string(view.getViewId()),
-                                   view.getImage().getMetadataBodySerialNumber(),
-                                   view.getImage().getMetadataLensSerialNumber()};
-            imgOpt.readOptions.workingColorSpace = image::EImageColorSpace::SRGB;
-            imgOpt.readOptions.rawColorInterpretation = image::ERawColorInterpretation_stringToEnum(view.getImage().getRawColorInterpretation());
-            detectColorChecker(detectedCCheckers, imgOpt, settings);
+            boost::filesystem::path p(view.getImage().getImagePath());
+            const std::regex regex = utils::filterToRegex(filter);
+            if(processAllImages || std::regex_match(p.generic_string(), regex))
+            {
+                ALICEVISION_LOG_INFO(++counter << "/" << sfmData.getViews().size() << " - Process image at: '"
+                                               << view.getImage().getImagePath() << "'.");
+                ImageOptions imgOpt = {view.getImage().getImagePath(), std::to_string(view.getViewId()),
+                                       view.getImage().getMetadataBodySerialNumber(), view.getImage().getMetadataLensSerialNumber()};
+                imgOpt.readOptions.workingColorSpace = image::EImageColorSpace::SRGB;
+                imgOpt.readOptions.rawColorInterpretation =
+                    image::ERawColorInterpretation_stringToEnum(view.getImage().getRawColorInterpretation());
+                detectColorChecker(detectedCCheckers, imgOpt, settings, detectorCNN);
+            }
         }
     }
     else
@@ -465,24 +591,27 @@ int aliceVision_main(int argc, char** argv)
         const fs::path inputPath(inputExpression);
         std::vector<std::string> filesStrPaths;
 
-        if (fs::is_regular_file(inputPath))
+        if(fs::is_regular_file(inputPath))
         {
             filesStrPaths.push_back(inputPath.string());
         }
         else
         {
-            ALICEVISION_LOG_INFO("Working directory Path '" + inputPath.parent_path().generic_string() + "'.");
+            ALICEVISION_LOG_INFO("Working directory Path '" + inputPath.generic_string() + "'.");
 
-            const std::regex regex = utils::filterToRegex(inputExpression);
+            const std::regex regex = utils::filterToRegex(processAllImages ? "" : filter);
             // Get supported files in inputPath directory which matches our regex filter
-            filesStrPaths = utils::getFilesPathsFromFolder(inputPath.parent_path().generic_string(), [&regex](const fs::path& path) {
-                return image::isSupported(path.extension().string()) && std::regex_match(path.generic_string(), regex);
-            });
+            filesStrPaths = utils::getFilesPathsFromFolder(inputPath.generic_string(),
+               [&regex](const fs::path& path) {
+                                                               ALICEVISION_LOG_INFO(path);
+                 return image::isSupported(path.extension().string());//&&std::regex_match(path.generic_string(), regex);
+               }
+            );
         }
 
         const int size = filesStrPaths.size();
 
-        if (!size)
+        if(!size)
         {
             ALICEVISION_LOG_ERROR("Any images was found.");
             ALICEVISION_LOG_ERROR("Input folders or input expression '" << inputExpression << "' may be incorrect ?");
@@ -494,14 +623,20 @@ int aliceVision_main(int argc, char** argv)
         }
 
         int counter = 0;
-        for (const std::string& imgSrcPath : filesStrPaths)
+        for(const std::string& imgSrcPath : filesStrPaths)
         {
-            ALICEVISION_LOG_INFO(++counter << "/" << size << " - Process image at: '" << imgSrcPath << "'.");
-            ImageOptions imgOpt;
-            imgOpt.imgFsPath = imgSrcPath;
-            imgOpt.readOptions.workingColorSpace = image::EImageColorSpace::SRGB;
-            detectColorChecker(detectedCCheckers, imgOpt, settings);
+            boost::filesystem::path p(imgSrcPath);
+            const std::regex regex = utils::filterToRegex(filter);
+            if(processAllImages || std::regex_match(p.generic_string(), regex))
+            {
+                ALICEVISION_LOG_INFO(++counter << "/" << size << " - Process image at: '" << imgSrcPath << "'.");
+                ImageOptions imgOpt;
+                imgOpt.imgFsPath = imgSrcPath;
+                imgOpt.readOptions.workingColorSpace = image::EImageColorSpace::SRGB;
+                detectColorChecker(detectedCCheckers, imgOpt, settings, detectorCNN);
+            }
         }
+
     }
 
     if (detectedCCheckers.empty())


### PR DESCRIPTION
## Description

This PR cancels and replaces https://github.com/alicevision/AliceVision/pull/1532

Update the color checker detection and correction to have a better processing of linear images, enable some new processing modes and combination of several color checkers detected in the same dataset.

**Note:** With OpenCV versions that do not contain this [commit](https://github.com/opencv/opencv_contrib/commit/52eb67702f1350612bb1c1bda01843f45d681a71), detection errors can occur for color checkers that are small and take a very small amount of space in the processed images. In these cases, the color checkers are correctly detected, but their position is incorrect, thus causing errors later on when applying any type of correction. 

## Features list

- [X] Set "sRGB linear" as the processing color space for color correction.
- [X] Add processing modes "Luminance Only" and "White Balance Only" in addition to the full color processing mode.
- [X] Quality metric for a color checker in an image based on area and pose.
- [X] Enable usage of several color checkers in a set of images by combining them.

