### PR TITLE
[docker] Copy `meshroom` folder to be able to install nodes and templates

### DIFF
--- a/docker/Dockerfile_rocky
+++ b/docker/Dockerfile_rocky
@@ -35,6 +35,7 @@ ENV AV_DEV=/opt/AliceVision_git \
 
 COPY CMakeLists.txt *.md ${AV_DEV}/
 COPY src ${AV_DEV}/src
+COPY meshroom ${AV_DEV}/meshroom
 
 WORKDIR "${AV_BUILD}"
 

--- a/docker/Dockerfile_ubuntu
+++ b/docker/Dockerfile_ubuntu
@@ -35,6 +35,7 @@ ENV AV_DEV=/opt/AliceVision_git \
 
 COPY CMakeLists.txt *.md ${AV_DEV}/
 COPY src ${AV_DEV}/src
+COPY meshroom ${AV_DEV}/meshroom
 
 WORKDIR "${AV_BUILD}"
 


### PR DESCRIPTION
## Description

This PR fixes the installation of AliceVision in the Dockerfiles: following https://github.com/alicevision/AliceVision/pull/1845, nodes for Meshroom are installed when performing the "INSTALL" step. In the Dockerfiles, since the  `meshroom` folder has not been copied, the installation step fails when attempting to install the nodes and templates for Meshroom.

This issue is fixed by correctly copying the `meshroom` folder in the docker images.