### PR TITLE
Update minimal required CMake version to 3.5 for all modules

### DIFF
--- a/src/dependencies/MeshSDFilter/CMakeLists.txt
+++ b/src/dependencies/MeshSDFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(SDFilter)
 

--- a/src/dependencies/vectorGraphics/CMakeLists.txt
+++ b/src/dependencies/vectorGraphics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 add_executable(main_svgSample main.cpp)
 

--- a/src/software/utils/aliceVisionAs3rdParty/CMakeLists.txt
+++ b/src/software/utils/aliceVisionAs3rdParty/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(AliceVisionAs3rdParty)
 


### PR DESCRIPTION
## Description

This PR updates the minimum version that is required for CMake to 3.5 for all the modules to build. This fixes the following CMake error: `Error: Compatibility with CMake < 3.5 has been removed from CMake.`