### PR TITLE
[src] Fix dependencies depending on build options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -326,7 +326,7 @@ endif()
 # ==============================================================================
 # Nanoflann
 # ==============================================================================
-if (ALICEVISION_BUILD_MVS)
+if (ALICEVISION_BUILD_MVS OR ALICEVISION_BUILD_LIDAR)
     find_package(nanoflann REQUIRED)
 endif()
 
@@ -495,7 +495,7 @@ endif()
 # ==============================================================================
 # Assimp
 # ==============================================================================
-if (ALICEVISION_BUILD_MVS)
+if (ALICEVISION_BUILD_MVS OR ALICEVISION_BUILD_SFM)
     find_package(assimp REQUIRED)
     message(STATUS "Assimp: ${ASSIMP_LIBRARIES}, ${ASSIMP_INCLUDE_DIRS}, ${ASSIMP_LIBRARY_DIRS}")
 endif()

--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -59,10 +59,10 @@ if (ALICEVISION_BUILD_MVS)
     if (ALICEVISION_HAVE_CUDA)
         add_subdirectory(depthMap)
     endif()
+endif()
 
-    if (ALICEVISION_HAVE_ONNX)
-        add_subdirectory(segmentation)
-    endif()
+if (ALICEVISION_HAVE_ONNX)
+    add_subdirectory(segmentation)
 endif()
 
 if (ALICEVISION_BUILD_SFM AND ALICEVISION_BUILD_MVS)

--- a/src/aliceVision/CMakeLists.txt
+++ b/src/aliceVision/CMakeLists.txt
@@ -70,7 +70,7 @@ if (ALICEVISION_BUILD_SFM AND ALICEVISION_BUILD_MVS)
 endif()
 
 if (ALICEVISION_BUILD_PHOTOMETRICSTEREO)
-    if(ALICEVISION_HAVE_OPENCV)
+    if (ALICEVISION_HAVE_OPENCV)
         add_subdirectory(photometricStereo)
         if (ALICEVISION_HAVE_ONNX)
             add_subdirectory(sphereDetection)

--- a/src/software/convert/CMakeLists.txt
+++ b/src/software/convert/CMakeLists.txt
@@ -31,7 +31,7 @@ if (ALICEVISION_BUILD_SFM)
               Boost::timer
     )
 
-    if (TARGET E57Format)
+    if (TARGET E57Format AND ALICEVISION_BUILD_MVS)
         alicevision_add_software(aliceVision_importE57
             SOURCE main_importE57.cpp
             FOLDER ${FOLDER_SOFTWARE_CONVERT}

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -118,37 +118,39 @@ if (ALICEVISION_BUILD_SFM)
               Boost::json
     )
 
-    # Bootstrapping SfM
-    alicevision_add_software(aliceVision_sfmBootstraping
-        SOURCE main_sfmBootstraping.cpp
-        FOLDER ${FOLDER_SOFTWARE_PIPELINE}
-        LINKS aliceVision_system
-              aliceVision_cmdline
-              aliceVision_feature
-              aliceVision_sfm
-              aliceVision_sfmData
-              aliceVision_track
-              aliceVision_dataio
-              aliceVision_mesh
-              Boost::program_options
-              Boost::json
-    )
+    if (ALICEVISION_BUILD_MVS)
+        # Bootstrapping SfM
+        alicevision_add_software(aliceVision_sfmBootstraping
+            SOURCE main_sfmBootstraping.cpp
+            FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+            LINKS aliceVision_system
+                aliceVision_cmdline
+                aliceVision_feature
+                aliceVision_sfm
+                aliceVision_sfmData
+                aliceVision_track
+                aliceVision_dataio
+                aliceVision_mesh
+                Boost::program_options
+                Boost::json
+        )
 
-    # Expanding SfM
-    alicevision_add_software(aliceVision_sfmExpanding
-        SOURCE main_sfmExpanding.cpp
-        FOLDER ${FOLDER_SOFTWARE_PIPELINE}
-        LINKS aliceVision_system
-              aliceVision_cmdline
-              aliceVision_feature
-              aliceVision_sfm
-              aliceVision_sfmData
-              aliceVision_track
-              aliceVision_dataio
-              aliceVision_mesh
-              Boost::program_options
-              Boost::json
-    )
+        # Expanding SfM
+        alicevision_add_software(aliceVision_sfmExpanding
+            SOURCE main_sfmExpanding.cpp
+            FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+            LINKS aliceVision_system
+                aliceVision_cmdline
+                aliceVision_feature
+                aliceVision_sfm
+                aliceVision_sfmData
+                aliceVision_track
+                aliceVision_dataio
+                aliceVision_mesh
+                Boost::program_options
+                Boost::json
+        )
+    endif()
 
     # Global Rotation Estimating
     alicevision_add_software(aliceVision_globalRotationEstimating

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -228,20 +228,22 @@ if (ALICEVISION_BUILD_SFM)
               Boost::program_options
     )
 
-    # SfM transform
-    alicevision_add_software(aliceVision_sfmTransform
-        SOURCE main_sfmTransform.cpp
-        FOLDER ${FOLDER_SOFTWARE_UTILS}
-        LINKS aliceVision_system
-              aliceVision_cmdline
-              aliceVision_feature
-              aliceVision_mesh
-              aliceVision_sfm
-              aliceVision_sfmData
-              aliceVision_sfmDataIO
-              Boost::program_options
-              Boost::json
-    )
+    if (ALICEVISION_BUILD_MVS)
+        # SfM transform
+        alicevision_add_software(aliceVision_sfmTransform
+            SOURCE main_sfmTransform.cpp
+            FOLDER ${FOLDER_SOFTWARE_UTILS}
+            LINKS aliceVision_system
+                aliceVision_cmdline
+                aliceVision_feature
+                aliceVision_mesh
+                aliceVision_sfm
+                aliceVision_sfmData
+                aliceVision_sfmDataIO
+                Boost::program_options
+                Boost::json
+        )
+    endif()
 
     # SfM filter
     alicevision_add_software(aliceVision_sfmFilter

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -449,23 +449,25 @@ endif()
 if (ALICEVISION_BUILD_MVS)
     if (ALICEVISION_BUILD_PHOTOMETRICSTEREO)
         # Lighting estimation from picture, albedo and geometry
-        alicevision_add_software(aliceVision_lightingEstimation
-            SOURCE main_lightingEstimation.cpp
-            FOLDER ${FOLDER_SOFTWARE_UTILS}
-            LINKS aliceVision_system
-                  aliceVision_cmdline
-                  aliceVision_numeric
-                  aliceVision_sfmData
-                  aliceVision_sfmDataIO
-                  aliceVision_mvsUtils
-                  aliceVision_image
-                  aliceVision_lightingEstimation
-                  ${Boost_LIBRARIES}
-        )
+        if (ALICEVISION_HAVE_OPENCV)
+            alicevision_add_software(aliceVision_lightingEstimation
+                SOURCE main_lightingEstimation.cpp
+                FOLDER ${FOLDER_SOFTWARE_UTILS}
+                LINKS aliceVision_system
+                    aliceVision_cmdline
+                    aliceVision_numeric
+                    aliceVision_sfmData
+                    aliceVision_sfmDataIO
+                    aliceVision_mvsUtils
+                    aliceVision_image
+                    aliceVision_lightingEstimation
+                    ${Boost_LIBRARIES}
+            )
+        endif()
     endif()
 
 
-    # Lighting estimation from picture, albedo and geometry
+    # Create SfMData with some arbitrary data
     alicevision_add_software(aliceVision_generateSampleScene
         SOURCE main_generateSampleScene.cpp
         FOLDER ${FOLDER_SOFTWARE_UTILS}


### PR DESCRIPTION
## Description

This PR fixes several build issues that occur when some flags are set to `OFF` instead of `ON`. The dependencies between executables and modules are modified when necessary to ensure that all build options work correctly.