### PR TITLE
Fix division zero at Texturing

### DIFF
--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -441,6 +441,7 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
     const int memoryPerAtlas = (imageMaxMemSize + imagePyramidMaxMemSize) + atlasPyramidMaxMemSize;
     int nbAtlasMax = std::floor(availableMem / double(memoryPerAtlas));  // maximum number of textures laplacian pyramid in RAM
     nbAtlasMax = std::min(nbAtlas, nbAtlasMax);                          // if enough memory, do it with all atlases
+    nbAtlasMax = std::max(1, nbAtlasMax);                                // avoid division zero calculating chunks
 
     ALICEVISION_LOG_INFO("nbAtlas: " << nbAtlas);
     ALICEVISION_LOG_INFO("availableRam: " << availableRam);

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -450,6 +450,9 @@ void Texturing::generateTextures(const mvsUtils::MultiViewParams& mp,
 
     ALICEVISION_LOG_DEBUG("nbAtlasMax: " << nbAtlasMax);
 
+    if (availableMem < memoryPerAtlas)
+        ALICEVISION_LOG_WARNING("Memory may be insufficient to complete the job. Lack (MB): " << memoryPerAtlas - availableMem);
+
     // Add rounding to have a uniform repartition between chunks (avoid a small chunk at the end)
     const int nChunks = divideRoundUp(nbAtlas, nbAtlasMax);
     nbAtlasMax = divideRoundUp(nbAtlas, nChunks);


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description
If availableMem < memoryPerAtlas, Texturing crash with no error message.  
This PR allow the program to continue with warning.

## Features list
Fix [AliceVision #1641](https://github.com/alicevision/AliceVision/issues/1641) [Meshroom #2097](https://github.com/alicevision/Meshroom/issues/2097) [Meshroom #2176](https://github.com/alicevision/Meshroom/issues/2176) [Meshroom #2231](https://github.com/alicevision/Meshroom/issues/2231) [Meshroom #2319](https://github.com/alicevision/Meshroom/issues/2319) [Meshroom #2553](https://github.com/alicevision/Meshroom/issues/2553) 
<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks
if nbAtlasMax equals 0, make it 1, and warning for memory insufficiency.  
Why not stop: usually OS assign memory dynamically, so the program may still be able to run. Even if memory is really lacked, the program should be stopped by OS, not division by zero.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

