### PR TITLE
Advanced use of vcpkg through manifest mode

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -162,60 +162,66 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+
     env:
-      DEPS_INSTALL_DIR: '${{ github.workspace }}/install'
-      buildDir: '${{ github.workspace }}/build/'
-      vcpkgDir: '${{ github.workspace }}\..\vcpkg'
-      vcpkgArchive: '${{ github.workspace }}\..\vcpkg\installed.zip'
+      buildDir: '${{ github.workspace }}\build\'
+      dependenciesDir: '${{ github.workspace }}\dependencies'
+      archivePath: '${{ github.workspace }}\dependencies\installed.zip'
       BUILD_TYPE: Release
       CTEST_OUTPUT_ON_FAILURE: 1
-      ALICEVISION_ROOT: '${{ github.workspace }}/install'
-      VCPKG_ROOT: '${{ github.workspace}}\..\vcpkg'
-      PYTHONPATH: '${{ github.workspace }}/install/bundle/bin'
+      ALICEVISION_ROOT: '${{ github.workspace }}\install'
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             submodules: recursive
+      
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v2
+        with:
+          arch: x64
 
-      - name: vcpkg - Clone repository
-        # Uses a specific version of vcpkg
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install python requirements
         run: |
-          cd ..
-          git clone https://github.com/alicevision/vcpkg.git
-          cd vcpkg
-          cd ${{ github.workspace }}
-
-      - name: vcpkg - Bootstrap
+          pip install -r requirements.txt 
+          
+      - name: create Directories
         run: |
-           ${{ env.vcpkgDir }}\bootstrap-vcpkg.bat
+          mkdir -p ${{ env.dependenciesDir }}
+          mkdir -p ${{ env.ALICEVISION_ROOT }}
 
-      - name: vcpkg - Download zip file with prebuilt binaries
+      - name: Download zip file with prebuilt binaries
         uses: suisei-cn/actions-download-file@v1.3.0
         id: vcpkgDownload
         with:
-          url: "https://github.com/alicevision/vcpkg/releases/download/2025.03.11/aliceVisionDeps-2025.03.11.zip"
-          target: "${{ env.vcpkgDir }}"
+          url: "https://github.com/alicevision/vcpkg/releases/download/2025.05.06/x64-windows-release.zip"
+          target: "${{ env.dependenciesDir }}"
           filename: installed.zip
 
       - name: vcpkg - Unzip prebuilt binaries
         run: |
-          tar -xvzf "${{ env.vcpkgArchive }}" -C "${{ env.vcpkgDir }}"
-
-      - name: vcpkg - Display installed packages
-        run: |
-          ${{ env.vcpkgDir }}\vcpkg list
+          tar -xvzf "${{ env.archivePath }}" -C "${{ env.dependenciesDir }}"
 
       - name: vcpkg - Remove zip file with prebuilt binaries
         run: |
-          rm ${{ env.vcpkgArchive }}
+          rm ${{ env.archivePath }}
 
       - name: Get CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.21
         id: cuda-toolkit
         with:
-          cuda: '12.5.0'
+          cuda: '12.8.0'
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "cusparse", "npp", "npp_dev", "cufft", "cufft_dev"]'
+      
+      - name: Display remaining disk space (16 Go max)
+        run: |
+          Get-CimInstance -Class Win32_logicaldisk
 
       - name: Display CUDA information
         run: echo "Installed cuda version is "${{steps.cuda-toolkit.outputs.cuda}}
@@ -223,22 +229,17 @@ jobs:
              nvcc -V
              echo ${{ env.CUDA_PATH }}
 
-      # Install latest CMake.
-      - uses: lukka/get-cmake@latest
-
-      - name: Display remaining disk space (16 Go max)
-        run: |
-          Get-CimInstance -Class Win32_logicaldisk
-
       - name: Build
         uses: lukka/run-cmake@v3
         with:
+          cmakeBuildType: Release
+          buildWithCMake: true
           cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
           cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
           buildDirectory: ${{ env.buildDir }}
           buildWithCMakeArgs: '--config Release --target install'
-          cmakeAppendedArgs: -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}\scripts\buildsystems\vcpkg.cmake
-                             -DVCPKG_TARGET_TRIPLET=x64-windows
+          cmakeAppendedArgs: -DCMAKE_TOOLCHAIN_FILE=${{ env.dependenciesDir }}\x64-windows-release\scripts\buildsystems\vcpkg.cmake
+                             -DVCPKG_TARGET_TRIPLET=x64-windows-release
                              -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
                              -A x64 -T host=x64
                              -DBUILD_SHARED_LIBS=ON
@@ -256,9 +257,8 @@ jobs:
                              -DALICEVISION_BUILD_SWIG_BINDING=ON
                              -DALICEVISION_INSTALL_MESHROOM_PLUGIN=OFF
                              -DBOOST_NO_CXX11=ON
-
-          cmakeBuildType: Release
-          buildWithCMake: true
+                             -DVCPKG_MANIFEST_MODE=OFF
+                             -DPython3_EXECUTABLE=${{ env.Python3_ROOT_DIR }}\python.exe
 
       - name: Bundle
         uses: lukka/run-cmake@v3
@@ -273,7 +273,10 @@ jobs:
 
       - name: Python Binding - Unit Tests
         run: |
-          ${{ env.VCPKG_ROOT }}\installed\x64-windows\tools\python3\python -m pytest ./pyTests
+          $Env:PYTHONPATH = "${{ env.ALICEVISION_ROOT }}\bundle\bin"
+          $Env:PYTHONPATH
+          python -m pip install pytest
+          python -m pytest ./pyTests
 
       - name: Unit Tests
         uses: lukka/run-cmake@v3

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ Production
 
 **/.vscode
 **/.vs
+
+#vcpkg
+vcpkg_installed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,68 +70,33 @@ In the scope of AliceVision, vcpkg has only been tested on Windows.
 
 1. Install vcpkg
 
-See the reference [installation guide](https://github.com/alicevision/vcpkg/blob/alicevision_master/README.md#quick-start-windows) to setup vcpkg.
-We recommend to use our vcpkg fork, where dependencies have been validated by the AliceVision development team and where some ports may have some custom changes.
 ```bash
-git clone https://github.com/alicevision/vcpkg --branch alicevision_master
+git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 .\bootstrap-vcpkg.bat
 ```
 
-2. Build the required dependencies
+2. Build
+
+* Open "x64 Native Tools command Prompt for VS 2022" shipped with Visual studio 2022
+* Move to the aliceVision root directory
+* Build the dependencies and generate the solution for building (This command may take a long time the first time as it is building and installing all the required dependencies from sources.)
+
 ```bash
-cd <VCPKG_INSTALL_DIR>
-set VCPKG_ROOT=%cd%
-
-vcpkg install ^
-          boost-algorithm boost-accumulators boost-atomic boost-container boost-date-time boost-exception ^
-          boost-geometry boost-graph boost-json boost-log boost-program-options boost-property-tree ^
-          boost-ptr-container boost-regex boost-serialization boost-system boost-test boost-thread boost-timer ^
-          boost-format ^
-          lz4 ^
-          liblemon ^
-          openexr ^
-          alembic ^
-          geogram ^
-          eigen3 ^
-          expat ^
-          flann nanoflann ^
-          onnxruntime-gpu ^
-          opencv[eigen,ffmpeg,webp,contrib,nonfree,cuda] ^
-          openimageio[opencolorio,pybind11,libraw,ffmpeg,freetype,opencv,gif,openjpeg,webp] ^
-          openmesh ^
-          ceres[suitesparse,cxsparse] ^
-          cuda ^
-          tbb ^
-          assimp ^
-          pcl ^
-          clp ^
-          libe57format ^
-          vcpkg-tool-swig ^
-          --triplet x64-windows
-
-%VCPKG_ROOT%/installed/x64-windows/tools/python3/python -m ensurepip --upgrade
-%VCPKG_ROOT%/installed/x64-windows/tools/python3/python -m pip install numpy
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=c:\path_to_vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_INSTALL_PREFIX=c:\path_to_install -DVCPKG_TARGET_TRIPLET=x64-windows-release -G "Visual Studio 17 2022" -A x64 -T host=x64 -DALICEVISION_BUILD_SWIG_BINDING=ON -DPython3_EXECUTABLE=c:\path_to_python\python.exe
 ```
 
-3. Build AliceVision
+* Effectively build AliceVision and install it to `c:\path_to_install`
+
 ```bash
-# With VCPKG_ROOT being the path to the root of vcpkg installation
-cd /path/to/aliceVision/
-mkdir build && cd build
-
-# Windows: Visual 2022 + Powershell
-cmake .. -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT"\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 17 2022" -A x64 -T host=x64
-
-# Windows: Visual 2022
-cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 17 2022" -A x64 -T host=x64
-
-# Windows: Visual 2017
-cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -G "Visual Studio 15 2017" -A x64 -T host=x64
+cmake --build build --config Release -t INSTALL
 ```
 
-This generates a "aliceVision.sln" solution inside the build folder that you can open in Visual Studio to launch the build. Do not forget to switch the build type to "Release".
+* Generate the bundle with all the dependencies in the same directory
 
+```bash
+cmake --build build --config Release -t bundle
+```
 
 Building the project with embedded dependencies (recommended on linux)
 -----------------------------------------------

--- a/pyTests/geometry/test_pose3.py
+++ b/pyTests/geometry/test_pose3.py
@@ -11,7 +11,7 @@ def test_constructor_pose3():
    p = geo.Pose3()
    assert np.array_equal(p.rotation(), np.eye(3)), "default rotation should be the identity"
    print(type(p.translation()))
-   assert np.array_equal(p.translation(), np.ndarray(shape=(3, 1), buffer=np.array([[0, 0, 0]]))), "default translation should be null"
+   assert np.array_equal(p.translation(), np.ndarray(shape=(3, 1), buffer=np.array([0.0, 0.0, 0.0], 'd'))), "default translation should be null"
 
 def test_constructor_pose3_2():
     R = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], 'd')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy<2
+pytest

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,22 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "d5182f703b51d7b258f83f94d936ac03488dcdbe",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    },
+    {
+      "kind": "filesystem",
+      "path": "./vcpkg",
+      "packages": ["vcpkg-tool-swig"]
+    }
+  ],
+  "overlay-ports": [
+    "vcpkg/overlay_ports"
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,90 @@
+{
+  "dependencies": [
+    "boost-algorithm",
+    "boost-accumulators",
+    "boost-atomic",
+    "boost-container",
+    "boost-date-time",
+    "boost-exception",
+    "boost-geometry", 
+    "boost-graph", 
+    "boost-json", 
+    "boost-log", 
+    "boost-program-options", 
+    "boost-property-tree",
+    "boost-ptr-container",
+    "boost-regex",
+    "boost-serialization",
+    "boost-system",
+    "boost-test",
+    "boost-thread",
+    "boost-timer",
+    "boost-format",
+    "libe57format",
+    "assimp",
+    "openexr",
+    "alembic",
+    "geogram",
+    "eigen3",
+    "expat",
+    "flann",
+    "nanoflann",
+    "onnxruntime-gpu",
+    "openmesh",
+    "tbb",
+    "cuda",
+    "liblemon",
+    "clp",
+    "coinutils",
+    "osi",
+    "vcpkg-tool-swig",
+    {
+      "name":"openimageio",
+      "features": ["opencolorio","libraw","gif","openjpeg"],
+      "default-features": false
+    },
+    {
+      "name":"ceres",
+      "features": ["suitesparse"]
+    },
+    {
+      "name": "opencv",
+      "features": ["eigen", "contrib", "nonfree", "cuda"],
+      "default-features": false
+    }
+  ],
+  "overrides": [
+    { 
+      "name": "openimageio", 
+      "version": "2.5.16.0" 
+    },
+    {
+      "name": "suitesparse",
+      "version": "5.8.0"
+    },
+    {
+      "name": "opencv",
+      "version": "4.10.0#0"
+    },
+    {
+      "name": "liblemon",
+      "version": "2019-06-13#10"
+    },
+    {
+      "name": "clp",
+      "version": "1.17.6#1"
+    },
+    {
+      "name": "osi",
+      "version": "0.108.6#1"
+    },
+    {
+      "name": "coinutils",
+      "version": "2.11.4#1"
+    },
+    {
+      "name": "ceres",
+      "version": "2.2.0#0"
+    }
+  ]
+}

--- a/vcpkg/overlay_ports/liblemon/cpp-20-adaptors.patch
+++ b/vcpkg/overlay_ports/liblemon/cpp-20-adaptors.patch
@@ -1,0 +1,13 @@
+diff --git a/lemon/adaptors.h b/lemon/adaptors.h
+index 1a40f8e..ffeb12d 100644
+--- a/lemon/adaptors.h
++++ b/lemon/adaptors.h
+@@ -37,7 +37,7 @@
+ 
+ namespace lemon {
+ 
+-#ifdef _MSC_VER
++#if defined _MSC_VER and __cplusplus < 202002L
+ #define LEMON_SCOPE_FIX(OUTER, NESTED) OUTER::NESTED
+ #else
+ #define LEMON_SCOPE_FIX(OUTER, NESTED) typename OUTER::template NESTED

--- a/vcpkg/overlay_ports/liblemon/cpp-20-arraymap.patch
+++ b/vcpkg/overlay_ports/liblemon/cpp-20-arraymap.patch
@@ -1,0 +1,106 @@
+diff --git a/lemon/bits/array_map.h b/lemon/bits/array_map.h
+index 355ee00..c3992cf 100644
+--- a/lemon/bits/array_map.h
++++ b/lemon/bits/array_map.h
+@@ -88,7 +88,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        std::allocator_traits<Allocator>::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -102,7 +102,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), value);
++        std::allocator_traits<Allocator>::construct(allocator, &(values[id]), value);
+       }
+     }
+ 
+@@ -121,7 +121,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), copy.values[id]);
++        std::allocator_traits<Allocator>::construct(allocator, &(values[id]), copy.values[id]);
+       }
+     }
+ 
+@@ -218,15 +218,15 @@ namespace lemon {
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+           int jd = nf->id(it);;
+           if (id != jd) {
+-            allocator.construct(&(new_values[jd]), values[jd]);
+-            allocator.destroy(&(values[jd]));
++            std::allocator_traits<Allocator>::construct(allocator, &(new_values[jd]), values[jd]);
++            std::allocator_traits<Allocator>::destroy(allocator, &(values[jd]));
+           }
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+         capacity = new_capacity;
+       }
+-      allocator.construct(&(values[id]), Value());
++      std::allocator_traits<Allocator>::construct(allocator, &(values[id]), Value());
+     }
+ 
+     // \brief Adds more new keys to the map.
+@@ -260,8 +260,8 @@ namespace lemon {
+             }
+           }
+           if (found) continue;
+-          allocator.construct(&(new_values[id]), values[id]);
+-          allocator.destroy(&(values[id]));
++          std::allocator_traits<Allocator>::construct(allocator, &(new_values[id]), values[id]);
++          std::allocator_traits<Allocator>::destroy(allocator, &(values[id]));
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+@@ -269,7 +269,7 @@ namespace lemon {
+       }
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = nf->id(keys[i]);
+-        allocator.construct(&(values[id]), Value());
++        std::allocator_traits<Allocator>::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -279,7 +279,7 @@ namespace lemon {
+     // and it overrides the erase() member function of the observer base.
+     virtual void erase(const Key& key) {
+       int id = Parent::notifier()->id(key);
+-      allocator.destroy(&(values[id]));
++      std::allocator_traits<Allocator>::destroy(allocator, &(values[id]));
+     }
+ 
+     // \brief Erase more keys from the map.
+@@ -289,7 +289,7 @@ namespace lemon {
+     virtual void erase(const std::vector<Key>& keys) {
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = Parent::notifier()->id(keys[i]);
+-        allocator.destroy(&(values[id]));
++        std::allocator_traits<Allocator>::destroy(allocator, &(values[id]));
+       }
+     }
+ 
+@@ -303,7 +303,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        std::allocator_traits<Allocator>::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -317,7 +317,7 @@ namespace lemon {
+         Item it;
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+           int id = nf->id(it);
+-          allocator.destroy(&(values[id]));
++          std::allocator_traits<Allocator>::destroy(allocator, &(values[id]));
+         }
+         allocator.deallocate(values, capacity);
+         capacity = 0;

--- a/vcpkg/overlay_ports/liblemon/fix-cmake-version.patch
+++ b/vcpkg/overlay_ports/liblemon/fix-cmake-version.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4406bc2..d89120b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,13 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+-
+-IF(POLICY CMP0048) 
+-  CMAKE_POLICY(SET CMP0048 OLD) 
+-ENDIF(POLICY CMP0048)
+-
+-IF(POLICY CMP0026)
+-  #This is for copying the dll's needed by glpk (in lp_test and mip_test)
+-  CMAKE_POLICY(SET CMP0026 OLD) 
+-ENDIF(POLICY CMP0026)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
+ 
+ SET(PROJECT_NAME "LEMON")
+ PROJECT(${PROJECT_NAME})

--- a/vcpkg/overlay_ports/liblemon/fix-cmake.patch
+++ b/vcpkg/overlay_ports/liblemon/fix-cmake.patch
@@ -1,0 +1,78 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4406bc2..5717680 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -295,7 +295,7 @@ CONFIGURE_FILE(
+   ${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake
+   @ONLY
+ )
+-IF(UNIX)
++IF(UNIX OR TRUE)
+   INSTALL(
+     FILES ${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake
+     DESTINATION share/lemon/cmake
+@@ -307,6 +307,13 @@ ELSEIF(WIN32)
+   )
+ ENDIF()
+ 
++install(
++    EXPORT lemon-targets
++    FILE lemon-targets.cmake
++    NAMESPACE unofficial::lemon::
++    DESTINATION share/lemon/cmake
++)
++
+ CONFIGURE_FILE(
+   ${PROJECT_SOURCE_DIR}/cmake/version.cmake.in
+   ${PROJECT_BINARY_DIR}/cmake/version.cmake
+diff --git a/cmake/LEMONConfig.cmake.in b/cmake/LEMONConfig.cmake.in
+index b0d2d8b..6bb662a 100644
+--- a/cmake/LEMONConfig.cmake.in
++++ b/cmake/LEMONConfig.cmake.in
+@@ -1,4 +1,4 @@
+-SET(LEMON_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/include" CACHE PATH "LEMON include directory")
++SET(LEMON_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../include" CACHE PATH "LEMON include directory")
+ SET(LEMON_INCLUDE_DIRS "${LEMON_INCLUDE_DIR}")
+ 
+ IF(UNIX)
+@@ -7,7 +7,12 @@ ELSEIF(WIN32)
+   SET(LEMON_LIB_NAME "lemon.lib")
+ ENDIF(UNIX)
+ 
+-SET(LEMON_LIBRARY "@CMAKE_INSTALL_PREFIX@/lib/${LEMON_LIB_NAME}" CACHE FILEPATH "LEMON library")
++SET(LEMON_LIBRARY
++  optimized "${CMAKE_CURRENT_LIST_DIR}/../../lib/${LEMON_LIB_NAME}"
++  debug "${CMAKE_CURRENT_LIST_DIR}/../../debug/lib/${LEMON_LIB_NAME}"
++  CACHE FILEPATH "LEMON library")
+ SET(LEMON_LIBRARIES "${LEMON_LIBRARY}")
+ 
+ MARK_AS_ADVANCED(LEMON_LIBRARY LEMON_INCLUDE_DIR)
++
++INCLUDE(${CMAKE_CURRENT_LIST_DIR}/lemon-targets.cmake)
+diff --git a/lemon/CMakeLists.txt b/lemon/CMakeLists.txt
+index 4e6567e..ad6f5bf 100644
+--- a/lemon/CMakeLists.txt
++++ b/lemon/CMakeLists.txt
+@@ -56,6 +56,10 @@ ENDIF()
+ 
+ ADD_LIBRARY(lemon ${LEMON_SOURCES})
+ 
++INCLUDE(GNUInstallDirs)
++
++TARGET_INCLUDE_DIRECTORIES(lemon PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++
+ TARGET_LINK_LIBRARIES(lemon
+   ${GLPK_LIBRARIES} ${COIN_LIBRARIES} ${ILOG_LIBRARIES} ${SOPLEX_LIBRARIES}
+   )
+@@ -71,6 +75,11 @@ INSTALL(
+   COMPONENT library
+ )
+ 
++install(TARGETS lemon EXPORT lemon-targets
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib
++)
++
+ INSTALL(
+   DIRECTORY . bits concepts
+   DESTINATION include/lemon

--- a/vcpkg/overlay_ports/liblemon/portfile.cmake
+++ b/vcpkg/overlay_ports/liblemon/portfile.cmake
@@ -1,0 +1,46 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+set(VERSION ed2c21cbd6ef)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://lemon.cs.elte.hu/hg/lemon/archive/${VERSION}.zip"
+    FILENAME "lemon-${VERSION}.zip"
+    SHA512 029640e4f791a18068cb2e2b4e794d09822d9d56fb957eb3e2cceae3a30065c0041a31c465637cfcadf7b2473564070b34adc88513439cdf9046831854e2aa70
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    SOURCE_BASE "${VERSION}"
+    PATCHES
+        fix-cmake.patch
+        fix-cmake-version.patch
+        cpp-20-arraymap.patch
+        cpp-20-adaptors.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLEMON_ENABLE_GLPK=OFF
+        -DLEMON_ENABLE_ILOG=OFF
+        -DLEMON_ENABLE_COIN=OFF
+        -DLEMON_ENABLE_SOPLEX=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH share/lemon/cmake PACKAGE_NAME lemon)
+
+vcpkg_fixup_pkgconfig()
+
+file(GLOB EXE "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+file(COPY ${EXE} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/liblemon/")
+vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/liblemon")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg/overlay_ports/liblemon/vcpkg.json
+++ b/vcpkg/overlay_ports/liblemon/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "liblemon",
+  "version-date": "2019-06-13",
+  "port-version": 10,
+  "description": "Library for Efficient Modeling and Optimization in Networks",
+  "homepage": "https://lemon.cs.elte.hu/trac/lemon",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg/ports/vcpkg-tool-swig/portfile.cmake
+++ b/vcpkg/ports/vcpkg-tool-swig/portfile.cmake
@@ -1,0 +1,30 @@
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO swig/swig
+    REF "v${VERSION}"
+    SHA512 0a9bdcc4a28f1374f9e564fdb372f684bd277bf7b590491218c3538c230bcacd8de32365717a37cf5d7d02165dec9f3955e1bb1207181885fb5b7fbc7476ff04
+    HEAD_REF master
+)
+
+vcpkg_find_acquire_program(BISON)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBISON_EXECUTABLE=${BISON}"
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_tools(
+    TOOL_NAMES swig
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/swig"
+)
+
+file(COPY "${CURRENT_PACKAGES_DIR}/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/swig")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg/ports/vcpkg-tool-swig/vcpkg.json
+++ b/vcpkg/ports/vcpkg-tool-swig/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "vcpkg-tool-swig",
+  "version": "4.3.0",
+  "port-version": 0,
+  "description": "A software development tool that connects programs written in C and C++ with a variety of high-level programming languages.",
+  "homepage": "https://www.swig.org/",
+  "license": "GPL-3.0-only",
+  "supports": "!uwp",
+  "dependencies": [
+    "pcre2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg/versions/baseline.json
+++ b/vcpkg/versions/baseline.json
@@ -1,0 +1,8 @@
+{
+  "default": { 
+    "vcpkg-tool-swig": {
+      "baseline": "4.3.0",
+      "port-version": 0
+    }
+  }
+}

--- a/vcpkg/versions/v-/vcpkg-tool-swig.json
+++ b/vcpkg/versions/v-/vcpkg-tool-swig.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "version": "4.3.0",
+      "port-version": 0,
+      "path": "$/ports/vcpkg-tool-swig"
+    }
+  ]
+}


### PR DESCRIPTION
I added manifest configuration files for vcpkg.

This enable more advanced control on vcpkg and remove the needs for our vcpkg repository fork.

Vcpkg packages are now automatically selected and built using `vcpkg.exe install`