### PR TITLE
Add `TracksMerging` node and partially add the tracks module to the Python binding

### DIFF
--- a/meshroom/aliceVision/TracksMerging.py
+++ b/meshroom/aliceVision/TracksMerging.py
@@ -1,0 +1,71 @@
+__version__ = "3.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
+
+import os.path
+
+
+class TracksMerging(desc.Node):
+    category = 'Utils'
+    documentation = '''
+Merges multiple track files into one
+'''
+
+    inputs = [
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="input",
+                label="Input Track File",
+                description="A track file.",
+                value="",
+            ),
+            name="inputs",
+            label="Inputs",
+            description="Set of track files (at least 1 is required).",
+            exposed=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        )
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output tracks file", 
+            description="Path to the output track file",
+            value="{nodeCacheFolder}/tracks.json",
+        )
+    ]
+
+    def processChunk(self, chunk):
+        from pyalicevision import track
+
+        chunk.logManager.start(chunk.node.verboseLevel.value)
+
+        trackOutput = track.TracksMap()
+
+        #Loop over inputs
+        pos = 0
+        for input in chunk.node.inputs:
+            
+            chunk.logger.info(f"Processing input file {input.value}")
+            trackInput = track.TracksMap()
+            if not track.loadTracks(trackInput, input.value):
+                chunk.logger.error("Cannot open input")
+                chunk.logManager.end()
+                raise RuntimeError()
+            
+            for key, value in trackInput.items():
+                trackOutput[pos] = value
+                pos = pos + 1
+
+        chunk.logger.info(f"Save output to file {chunk.node.output.value}")
+        track.saveTracks(trackOutput, chunk.node.output.value)
+
+        chunk.logManager.end()

--- a/src/aliceVision/aliceVision.i
+++ b/src/aliceVision/aliceVision.i
@@ -17,6 +17,7 @@
 %import <aliceVision/sfmDataIO/SfMDataIO.i>
 %import <aliceVision/sfmData/SfMData.i>
 %import <aliceVision/stl/Stl.i>
+%import <aliceVision/track/track.i>
 
 %{
 #include <aliceVision/version.hpp>

--- a/src/aliceVision/track/CMakeLists.txt
+++ b/src/aliceVision/track/CMakeLists.txt
@@ -28,3 +28,18 @@ alicevision_add_library(aliceVision_track
 
 # Unit tests
 alicevision_add_test(track_test.cpp NAME "track" LINKS aliceVision_track)
+
+# SWIG Binding
+if (ALICEVISION_BUILD_SWIG_BINDING)
+    alicevision_swig_add_library(track
+        SOURCES track.i
+        PUBLIC_LINKS
+            aliceVision_track
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
+    )
+endif()

--- a/src/aliceVision/track/Track.hpp
+++ b/src/aliceVision/track/Track.hpp
@@ -19,12 +19,12 @@
 #include <set>
 #include <map>
 #include <memory>
+#include <unordered_map>
 #include <aliceVision/numeric/numeric.hpp>
 
 namespace aliceVision {
 namespace track {
 
-using namespace aliceVision::matching;
 
 using FeatureId = std::pair<feature::EImageDescriberType, std::size_t>;
 
@@ -70,7 +70,7 @@ struct TrackItem
 struct Track
 {
     /// Data structure to store a track: collection of {ViewId, FeatureId}
-    using TrackInfoPerView = stl::flat_map<std::size_t, TrackItem>;
+    using TrackInfoPerView = std::unordered_map<std::size_t, TrackItem>;
 
     Track() {}
 
@@ -81,7 +81,7 @@ struct Track
 };
 
 /// A track is a collection of {trackId, Track}
-using TracksMap = stl::flat_map<std::size_t, Track>;
+using TracksMap = std::unordered_map<std::size_t, Track>;
 using TrackIdSet = std::vector<std::size_t>;
 
 /**

--- a/src/aliceVision/track/TracksBuilder.cpp
+++ b/src/aliceVision/track/TracksBuilder.cpp
@@ -42,7 +42,7 @@ TracksBuilder::TracksBuilder() { _d.reset(new TracksBuilderData()); }
 
 TracksBuilder::~TracksBuilder() = default;
 
-void TracksBuilder::build(const PairwiseMatches& pairwiseMatches)
+void TracksBuilder::build(const matching::PairwiseMatches& pairwiseMatches)
 {
     typedef std::set<IndexedFeaturePair> SetIndexedPair;
 
@@ -54,14 +54,14 @@ void TracksBuilder::build(const PairwiseMatches& pairwiseMatches)
     {
         const std::size_t& I = matchesPerDescIt.first.first;
         const std::size_t& J = matchesPerDescIt.first.second;
-        const MatchesPerDescType& matchesPerDesc = matchesPerDescIt.second;
+        const matching::MatchesPerDescType& matchesPerDesc = matchesPerDescIt.second;
 
         for (const auto& matchesIt : matchesPerDesc)
         {
             const feature::EImageDescriberType descType = matchesIt.first;
-            const IndMatches& matches = matchesIt.second;
+            const matching::IndMatches& matches = matchesIt.second;
             // we have correspondences between I and J image index.
-            for (const IndMatch& m : matches)
+            for (const matching::IndMatch& m : matches)
             {
                 IndexedFeaturePair pairI(I, KeypointId(descType, m._i));
                 IndexedFeaturePair pairJ(J, KeypointId(descType, m._j));
@@ -97,14 +97,14 @@ void TracksBuilder::build(const PairwiseMatches& pairwiseMatches)
     {
         const std::size_t& I = matchesPerDescIt.first.first;
         const std::size_t& J = matchesPerDescIt.first.second;
-        const MatchesPerDescType& matchesPerDesc = matchesPerDescIt.second;
+        const matching::MatchesPerDescType& matchesPerDesc = matchesPerDescIt.second;
 
         for (const auto& matchesIt : matchesPerDesc)
         {
             const feature::EImageDescriberType descType = matchesIt.first;
-            const IndMatches& matches = matchesIt.second;
+            const matching::IndMatches& matches = matchesIt.second;
             // we have correspondences between I and J image index.
-            for (const IndMatch& m : matches)
+            for (const matching::IndMatch& m : matches)
             {
                 IndexedFeaturePair pairI(I, KeypointId(descType, m._i));
                 IndexedFeaturePair pairJ(J, KeypointId(descType, m._j));

--- a/src/aliceVision/track/TracksBuilder.hpp
+++ b/src/aliceVision/track/TracksBuilder.hpp
@@ -53,7 +53,7 @@ class TracksBuilder
      * @param[in] pairwiseMatches PairWise matches
      * @param[in] featuresPerView all features (used for matching) in pairwiseMatches
      */
-    void build(const PairwiseMatches& pairwiseMatches);
+    void build(const matching::PairwiseMatches& pairwiseMatches);
 
     /**
      * @brief Remove bad tracks (too short or track with ids collision)

--- a/src/aliceVision/track/TracksHandler.cpp
+++ b/src/aliceVision/track/TracksHandler.cpp
@@ -16,18 +16,11 @@ namespace track {
 
 bool TracksHandler::load(const std::string& pathJson, const std::set<IndexT>& viewIds)
 {
-    std::ifstream tracksFile(pathJson);
-    if (tracksFile.is_open() == false)
+    _mapTracks.clear();
+    if (!loadTracks(_mapTracks, pathJson))
     {
         return false;
     }
-
-    std::stringstream buffer;
-    buffer << tracksFile.rdbuf();
-
-    // Parse json
-    boost::json::value jv = boost::json::parse(buffer.str());
-    _mapTracks = track::TracksMap(track::flat_map_value_to<track::Track>(jv));
 
     // Compute tracks per view
     _mapTracksPerView.clear();

--- a/src/aliceVision/track/track.i
+++ b/src/aliceVision/track/track.i
@@ -1,0 +1,29 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%module (module="pyalicevision") track
+
+%include <std_unordered_map.i>
+%include <std_string.i>
+
+%include <aliceVision/track/Track.hpp>
+%include <aliceVision/track/trackIO.hpp>
+
+namespace std
+{
+    typedef long unsigned int size_t;
+}
+
+%{    
+#include <aliceVision/track/Track.hpp>
+#include <aliceVision/track/trackIO.hpp>
+
+using namespace aliceVision;
+%} 
+
+%template(TrackInfoPerView) std::unordered_map<std::size_t, aliceVision::track::TrackItem>;
+%template(TracksMap) std::unordered_map<std::size_t, aliceVision::track::Track>;
+

--- a/src/aliceVision/track/trackIO.cpp
+++ b/src/aliceVision/track/trackIO.cpp
@@ -6,6 +6,8 @@
 
 #include "trackIO.hpp"
 #include <aliceVision/dataio/json.hpp>
+#include <fstream>
+
 namespace aliceVision {
 namespace track {
 
@@ -41,9 +43,43 @@ aliceVision::track::Track tag_invoke(boost::json::value_to_tag<aliceVision::trac
 
     aliceVision::track::Track ret;
     ret.descType = feature::EImageDescriberType_stringToEnum(boost::json::value_to<std::string>(obj.at("descType")));
-    ret.featPerView = flat_map_value_to<track::TrackItem>(obj.at("featPerView"));
+    ret.featPerView = unordered_map_value_to<track::TrackItem>(obj.at("featPerView"));
 
     return ret;
+}
+
+bool loadTracks(TracksMap& mapTracks, const std::string& filename)
+{
+    std::ifstream tracksFile(filename);
+    if (tracksFile.is_open() == false)
+    {
+        return false;
+    }
+
+    std::stringstream buffer;
+    buffer << tracksFile.rdbuf();
+
+    // Parse json
+    boost::json::value jv = boost::json::parse(buffer.str());
+    mapTracks = track::TracksMap(unordered_map_value_to<track::Track>(jv));
+
+    return true;
+}
+
+bool saveTracks(const TracksMap& mapTracks, const std::string& filename)
+{
+    std::ofstream tracksFile(filename);
+    if (tracksFile.is_open() == false)
+    {
+        return false;
+    } 
+
+    boost::json::value jv = boost::json::value_from(mapTracks);
+
+    tracksFile << boost::json::serialize(jv);
+    tracksFile.close();
+
+    return true;
 }
 
 }  // namespace track

--- a/src/aliceVision/track/trackIO.hpp
+++ b/src/aliceVision/track/trackIO.hpp
@@ -29,6 +29,22 @@ stl::flat_map<size_t, T> flat_map_value_to(const boost::json::value& jv)
     return ret;
 }
 
+template<class T>
+std::unordered_map<size_t, T> unordered_map_value_to(const boost::json::value& jv)
+{
+    std::unordered_map<size_t, T> ret;
+
+    const boost::json::array obj = jv.as_array();
+
+    for (const auto& item : obj)
+    {
+        const boost::json::array inner = item.as_array();
+        ret.insert({boost::json::value_to<std::size_t>(inner[0]), boost::json::value_to<T>(inner[1])});
+    }
+
+    return ret;
+}
+
 /**
  * @brief Serialize track to JSON object.
  */
@@ -38,6 +54,22 @@ void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, alic
  * @brief Deserialize track from JSON object.
  */
 aliceVision::track::Track tag_invoke(boost::json::value_to_tag<aliceVision::track::Track>, boost::json::value const& jv);
+
+/**
+ * @brief load tracks from file
+ * @param mapTracks the result container
+ * @param filename the input file path
+ * @return false if the load failed
+*/
+bool loadTracks(TracksMap& mapTracks, const std::string& filename);
+
+/**
+ * @brief save tracks to file
+ * @param mapTracks the input container
+ * @param filename the input file path
+ * @return false if the save failed
+*/
+bool saveTracks(const TracksMap& mapTracks, const std::string& filename);
 
 }  // namespace track
 }  // namespace aliceVision

--- a/src/aliceVision/track/tracksUtils.hpp
+++ b/src/aliceVision/track/tracksUtils.hpp
@@ -118,7 +118,7 @@ struct FunctorMapFirstEqual
  * @warning The input tracks must be composed of only two images index.
  * @warning Image index are considered sorted (increasing order).
  */
-void tracksToIndexedMatches(const TracksMap& tracks, const std::vector<IndexT>& filterIndex, std::vector<IndMatch>* outIndex);
+void tracksToIndexedMatches(const TracksMap& tracks, const std::vector<IndexT>& filterIndex, std::vector<matching::IndMatch>* outIndex);
 
 /**
  * @brief Return the occurrence of tracks length.

--- a/src/software/pipeline/main_nodalSfM.cpp
+++ b/src/software/pipeline/main_nodalSfM.cpp
@@ -381,7 +381,7 @@ int aliceVision_main(int argc, char** argv)
     std::stringstream buffer;
     buffer << tracksFile.rdbuf();
     boost::json::value jv = boost::json::parse(buffer.str());
-    track::TracksMap mapTracks(track::flat_map_value_to<track::Track>(jv));
+    track::TracksMap mapTracks(track::unordered_map_value_to<track::Track>(jv));
 
     // We have loaded a list of tracks
     // A track is a list of observations per view of (we think) a same point.


### PR DESCRIPTION
- Tracks functions and structures are now (partially) exposed to python
- A tracks files merging node for meshroom is added