### PR TITLE
[docker] Dependencies: Add a symlink to `python3` to make `python` callable

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container: ["alicevision/alicevision-deps:2025.03.27-ubuntu22.04-cuda12.1.1", "alicevision/alicevision-deps:2025.03.27-rocky9-cuda12.1.1"]
+        container: ["alicevision/alicevision-deps:2025.05.15-ubuntu22.04-cuda12.1.1", "alicevision/alicevision-deps:2025.05.15-rocky9-cuda12.1.1"]
     container:
       image: ${{ matrix.container }}
     env:
@@ -33,7 +33,7 @@ jobs:
       ALICEVISION_ROOT: ${{ github.workspace }}/../AV_install
       ALICEVISION_SENSOR_DB: ${{ github.workspace }}/../AV_install/share/aliceVision/cameraSensors.db
       ALICEVISION_LENS_PROFILE_INFO: ""
-      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2025.03.27-ubuntu22.04-cuda12.1.1' && 'ON' || 'OFF' }}"
+      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2025.05.15-ubuntu22.04-cuda12.1.1' && 'ON' || 'OFF' }}"
     steps:
       - uses: actions/checkout@v1
 

--- a/docker/Dockerfile_rocky_deps
+++ b/docker/Dockerfile_rocky_deps
@@ -78,6 +78,9 @@ RUN cmake "${AV_DEV}" \
 RUN mkdir -p "${AV_INSTALL}/lib" && \
     ln -s lib "${AV_INSTALL}/lib64"
 
+# Symlink to Python3 executable in case a call to "python" instead of "python3" is ever made
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gnu/libcublas.so /usr/local/cuda/lib64/libcublas.so
 
 # RUN make -j ${CPU_CORES} onnxruntime

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -93,6 +93,9 @@ RUN cmake "${AV_DEV}" \
 RUN mkdir -p "${AV_INSTALL}/lib" && \
     ln -s lib "${AV_INSTALL}/lib64"
 
+# Symlink to Python3 executable in case a call to "python" instead of "python3" is ever made
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gnu/libcublas.so /usr/local/cuda/lib64/libcublas.so
 
 # RUN make -j ${CPU_CORES} lapack

--- a/docker/build-rocky.sh
+++ b/docker/build-rocky.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.02.21
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.05.15
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$ROCKY_VERSION" && ROCKY_VERSION=9

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.02.21
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.05.15
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=22.04


### PR DESCRIPTION
## Description

This PR updates the Docker images for the dependencies on Linux so that a symbolic link is added for `python` to be callable and use the Python 3 executable. 

This solves errors in the continuous integration, where functional tests use the `Publish` node, that itself calls Python. The error appeared following https://github.com/alicevision/Meshroom/pull/2703, which changed added the notion of local isolated computation for Python nodes, such as the `Publish` one.