### PR TITLE
[track] Use `std::map` instead of ` std::unordered_map` to represent Tracks

### DIFF
--- a/src/aliceVision/track/Track.hpp
+++ b/src/aliceVision/track/Track.hpp
@@ -70,7 +70,7 @@ struct TrackItem
 struct Track
 {
     /// Data structure to store a track: collection of {ViewId, FeatureId}
-    using TrackInfoPerView = std::unordered_map<std::size_t, TrackItem>;
+    using TrackInfoPerView = std::map<std::size_t, TrackItem>;
 
     Track() {}
 
@@ -81,7 +81,7 @@ struct Track
 };
 
 /// A track is a collection of {trackId, Track}
-using TracksMap = std::unordered_map<std::size_t, Track>;
+using TracksMap = std::map<std::size_t, Track>;
 using TrackIdSet = std::vector<std::size_t>;
 
 /**

--- a/src/aliceVision/track/track.i
+++ b/src/aliceVision/track/track.i
@@ -6,7 +6,7 @@
 
 %module (module="pyalicevision") track
 
-%include <std_unordered_map.i>
+%include <std_map.i>
 %include <std_string.i>
 
 %include <aliceVision/track/Track.hpp>
@@ -24,6 +24,6 @@ namespace std
 using namespace aliceVision;
 %} 
 
-%template(TrackInfoPerView) std::unordered_map<std::size_t, aliceVision::track::TrackItem>;
-%template(TracksMap) std::unordered_map<std::size_t, aliceVision::track::Track>;
+%template(TrackInfoPerView) std::map<std::size_t, aliceVision::track::TrackItem>;
+%template(TracksMap) std::map<std::size_t, aliceVision::track::Track>;
 

--- a/src/aliceVision/track/trackIO.cpp
+++ b/src/aliceVision/track/trackIO.cpp
@@ -43,7 +43,7 @@ aliceVision::track::Track tag_invoke(boost::json::value_to_tag<aliceVision::trac
 
     aliceVision::track::Track ret;
     ret.descType = feature::EImageDescriberType_stringToEnum(boost::json::value_to<std::string>(obj.at("descType")));
-    ret.featPerView = unordered_map_value_to<track::TrackItem>(obj.at("featPerView"));
+    ret.featPerView = map_value_to<track::TrackItem>(obj.at("featPerView"));
 
     return ret;
 }
@@ -61,7 +61,7 @@ bool loadTracks(TracksMap& mapTracks, const std::string& filename)
 
     // Parse json
     boost::json::value jv = boost::json::parse(buffer.str());
-    mapTracks = track::TracksMap(unordered_map_value_to<track::Track>(jv));
+    mapTracks = track::TracksMap(map_value_to<track::Track>(jv));
 
     return true;
 }

--- a/src/aliceVision/track/trackIO.hpp
+++ b/src/aliceVision/track/trackIO.hpp
@@ -45,6 +45,22 @@ std::unordered_map<size_t, T> unordered_map_value_to(const boost::json::value& j
     return ret;
 }
 
+template<class T>
+std::map<size_t, T> map_value_to(const boost::json::value& jv)
+{
+    std::map<size_t, T> ret;
+
+    const boost::json::array obj = jv.as_array();
+
+    for (const auto& item : obj)
+    {
+        const boost::json::array inner = item.as_array();
+        ret.insert({boost::json::value_to<std::size_t>(inner[0]), boost::json::value_to<T>(inner[1])});
+    }
+
+    return ret;
+}
+
 /**
  * @brief Serialize track to JSON object.
  */

--- a/src/software/pipeline/main_nodalSfM.cpp
+++ b/src/software/pipeline/main_nodalSfM.cpp
@@ -381,7 +381,7 @@ int aliceVision_main(int argc, char** argv)
     std::stringstream buffer;
     buffer << tracksFile.rdbuf();
     boost::json::value jv = boost::json::parse(buffer.str());
-    track::TracksMap mapTracks(track::unordered_map_value_to<track::Track>(jv));
+    track::TracksMap mapTracks(track::map_value_to<track::Track>(jv));
 
     // We have loaded a list of tracks
     // A track is a list of observations per view of (we think) a same point.


### PR DESCRIPTION
## Description

This PR uses the `std::map` data structure for Tracks instead of `std::unordered_map` as it was originally introduced in https://github.com/alicevision/AliceVision/pull/1864. This allows to meet the expectations of the `GlobalSfM`, which expects the tracks to be ordered, and thus fixes the errors that were appearing in the unit tests. 