### PR TITLE
Update SWIG code to remove errors

### DIFF
--- a/pyTests/camera/test_equidistant.py
+++ b/pyTests/camera/test_equidistant.py
@@ -164,10 +164,12 @@ def test_equidistant_default_constructor():
     assert intrinsic.h() == 1, "The Equidistant intrinsic's default height should be 1"
 
     scale = intrinsic.getScale()
-    assert avnum.getX(scale) == 1.0 and avnum.getY(scale) == 1.0
+    assert scale[0] == 1.0 and scale[1] == 1.0
+
+    print(scale)
 
     offset = intrinsic.getOffset()
-    assert avnum.getX(offset) == 0.0 and avnum.getY(offset) == 0.0
+    assert offset[0] == 0.0 and offset[1] == 0.0
 
     assert intrinsic.sensorWidth() == 36.0
     assert intrinsic.sensorHeight() == 24.0
@@ -199,10 +201,10 @@ def test_equidistant_constructors():
     assert intrinsic1.h() == height, "The Equidistant intrinsic's height has not been correctly set"
 
     scale = intrinsic1.getScale()
-    assert avnum.getX(scale) == focal and avnum.getY(scale) == focal
+    assert scale[0] == focal and scale[1] == focal
 
     offset = intrinsic1.getOffset()
-    assert avnum.getX(offset) == offset_x and avnum.getY(offset) == offset_y
+    assert offset[0] == offset_x and offset[1] == offset_y
 
     assert intrinsic1.sensorWidth() == 36.0
     assert intrinsic1.sensorHeight() == 24.0
@@ -222,10 +224,10 @@ def test_equidistant_constructors():
     assert intrinsic2.h() == height, "The Equidistant intrinsic's height has not been correctly set"
 
     scale = intrinsic2.getScale()
-    assert avnum.getX(scale) == focal and avnum.getY(scale) == focal
+    assert scale[0] == focal and scale[1] == focal
 
     offset = intrinsic2.getOffset()
-    assert avnum.getX(offset) == offset_x and avnum.getY(offset) == offset_y
+    assert offset[0] == offset_x and offset[1] == offset_y
 
     assert intrinsic2.sensorWidth() == 36.0
     assert intrinsic2.sensorHeight() == 24.0

--- a/pyTests/camera/test_pinhole.py
+++ b/pyTests/camera/test_pinhole.py
@@ -158,7 +158,7 @@ def test_pinhole_default_constructor():
         "The Pinhole intrinsic's focal length in Y should be 1.0"
 
     offset = intrinsic.getOffset()
-    assert avnum.getX(offset) == 0.0 and avnum.getY(offset) == 0.0
+    assert offset[0] == 0.0 and offset[1] == 0.0
 
     assert intrinsic.sensorWidth() == 36.0
     assert intrinsic.sensorHeight() == 24.0

--- a/pyTests/camera/test_undistortion_3de.py
+++ b/pyTests/camera/test_undistortion_3de.py
@@ -47,7 +47,7 @@ def test_undistortion_3de_constructor():
     undistortion = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
 
     size = undistortion.getSize()
-    assert avnum.getX(size) == WIDTH and avnum.getY(size) == HEIGHT
+    assert size[0] == WIDTH and size[1] == HEIGHT
 
     assert undistortion.getType() == av.UNDISTORTION_3DEANAMORPHIC4
 
@@ -117,12 +117,12 @@ def test_undistortion_3de_get_set_size():
     size. """
     undistortion = av.Undistortion3DEAnamorphic4(WIDTH, HEIGHT)
     size = undistortion.getSize()
-    assert avnum.getX(size) == WIDTH and avnum.getY(size) == HEIGHT
+    assert size[0] == WIDTH and size[1] == HEIGHT
 
     undistortion.setSize(HEIGHT, WIDTH)
-    assert size != undistortion.getSize()
+    assert (size != undistortion.getSize()).any()
     size = undistortion.getSize()
-    assert avnum.getX(size) == HEIGHT and avnum.getY(size) == WIDTH
+    assert size[0] == HEIGHT and size[1] == WIDTH
 
 
 @pytest.mark.skip(reason="Vec2 not binded")

--- a/pyTests/camera/test_undistortion_radial.py
+++ b/pyTests/camera/test_undistortion_radial.py
@@ -47,7 +47,7 @@ def test_undistortion_radial_constructor():
     undistortion = av.UndistortionRadialK3(WIDTH, HEIGHT)
 
     size = undistortion.getSize()
-    assert avnum.getX(size) == WIDTH and avnum.getY(size) == HEIGHT
+    assert size[0] == WIDTH and size[1] == HEIGHT
 
     assert undistortion.getType() == av.UNDISTORTION_RADIALK3
 
@@ -117,12 +117,12 @@ def test_undistortion_radial_get_set_size():
     size. """
     undistortion = av.UndistortionRadialK3(WIDTH, HEIGHT)
     size = undistortion.getSize()
-    assert avnum.getX(size) == WIDTH and avnum.getY(size) == HEIGHT
+    assert size[0] == WIDTH and size[1] == HEIGHT
 
     undistortion.setSize(HEIGHT, WIDTH)
-    assert size != undistortion.getSize()
+    assert (size != undistortion.getSize()).any()
     size = undistortion.getSize()
-    assert avnum.getX(size) == HEIGHT and avnum.getY(size) == WIDTH
+    assert size[0] == HEIGHT and size[1] == WIDTH
 
 
 @pytest.mark.skip(reason="Vec2 not binded")

--- a/src/aliceVision/camera/Camera.i
+++ b/src/aliceVision/camera/Camera.i
@@ -8,6 +8,9 @@
 
 %include <aliceVision/global.i>
 
+%include <aliceVision/numeric/eigen.i>
+%eigen_typemaps(Vec2)
+
 %{
 #include <aliceVision/camera/camera.hpp>
 #include <aliceVision/camera/cameraCommon.hpp>

--- a/src/aliceVision/numeric/numeric.i
+++ b/src/aliceVision/numeric/numeric.i
@@ -6,11 +6,11 @@
 
 %module (module="pyalicevision") numeric
 
-%include <aliceVision/global.i>
-%include <aliceVision/numeric/numeric.hpp>
-
 %include <aliceVision/numeric/eigen.i>
 %eigen_typemaps(Vec2)
+
+%include <aliceVision/global.i>
+%include <aliceVision/numeric/numeric.hpp>
 
 double getX(const Vec2 & vec);
 double getY(const Vec2 & vec);

--- a/src/aliceVision/track/track.i
+++ b/src/aliceVision/track/track.i
@@ -14,7 +14,11 @@
 
 namespace std
 {
+    #ifdef LINUXPLATFORM
     typedef long unsigned int size_t;
+    #else
+    typedef long unsigned long size_t;
+    #endif
 }
 
 %{    


### PR DESCRIPTION
- `Vec2` is now known to SWIG in the camera module
- `size_t` was wrongly defined for visual studio compiler