### PR TITLE
[fix] Remove invalid default value in ldr2hdrCalibration

### DIFF
--- a/meshroom/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/aliceVision/LdrToHdrCalibration.py
@@ -46,7 +46,7 @@ Calibrate LDR to HDR response curve from samples.
             name="samples",
             label="Samples Folder",
             description="Samples folder.",
-            value="{nodeCacheFolder}",
+            value="",
         ),
         desc.IntParam(
             name="userNbBrackets",


### PR DESCRIPTION
Default value for Ldr2HdrCalibration node created crash in meshroom. 

This fix remove the default value. 

However, the crash seems not "normal". 

https://github.com/alicevision/Meshroom/blob/7d1ebe679cc1180d21fd4406beaf27e21524660b/meshroom/core/attribute.py#L375

`link.split('.')` crash because the link string is `'{nodeCacheFolder}'` and as such as no '.' character