### PR TITLE
[docker] Ubuntu: Use CMake from standard repo instead of Kitware's

### DIFF
--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -26,10 +26,6 @@ RUN . ./etc/os-release && \
         ca-certificates \
         wget \
         software-properties-common && \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - > /etc/apt/trusted.gpg.d/kitware.gpg && \
-    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $UBUNTU_CODENAME main" && \
-    apt-get clean && \
-    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         git \


### PR DESCRIPTION
## Description

This PR updates the Dockerfile for AliceVision's dependencies on Ubuntu in order to use the standard version of CMake that's provided on Jammy Jellyfish instead of using Kitware's repository. 

Kitware provides the latest version of CMake (4.0.2) instead of a 3.2x, which causes many dependencies to break as their requirements on the CMake version is too low and not supported anymore.