### PR TITLE
[meshroom] Attribute: Refacto of the validation process, using the new validation paradigm

### DIFF
--- a/meshroom/aliceVision/KeyframeSelection.py
+++ b/meshroom/aliceVision/KeyframeSelection.py
@@ -1,6 +1,7 @@
 __version__ = "5.0"
 
 from meshroom.core import desc
+from meshroom.core.desc.validators import success, error
 from meshroom.core.utils import EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 # List of supported video extensions (provided by OpenImageIO)
@@ -309,12 +310,9 @@ class KeyframeSelection(desc.AVCommandLineNode):
                         "are used to generate the output SfMData file.",
             value="none",
             values=["none", "exr", "jpg", "png"],
-            validValue=lambda node: not (any(ext in input.value.lower()
-                                             for ext in videoExts for
-                                             input in node.inputPaths.value)
-                                             and node.outputExtension.value == "none"),
-            errorMessage="A video input has been provided. The output extension should be "
-                         "different from 'none'.",
+            validators=[
+                lambda node, _ : success() if not (any(ext in input.value.lower() for ext in videoExts for input in node.inputPaths.value) and node.outputExtension.value == "none") else error("A video input has been provided. The output extension should be different from 'none'.")
+            ],
         ),
         desc.ChoiceParam(
             name="storageDataType",

--- a/meshroom/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/aliceVision/LdrToHdrCalibration.py
@@ -4,6 +4,7 @@ import json
 
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
+from .ldrToHdrCommon import ImageCountShouldBeAMultipleOfBracketNumber
 
 def findMetadata(d, keys, defaultValue):
     v = None
@@ -62,8 +63,7 @@ the true radiance values from the multiple exposures.
             range=(0, 15, 1),
             invalidate=False,
             commandLineGroup="user",  # not used directly on the command line
-            errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
-                         "Errors will occur during the computation.",
+            validators=[ImageCountShouldBeAMultipleOfBracketNumber()],
             exposed=True,
         ),
         desc.IntParam(
@@ -188,23 +188,15 @@ the true radiance values from the multiple exposures.
         if "userNbBrackets" not in node.getAttributes().keys():
             # Old version of the node
             return
-        node.userNbBrackets.validValue = True  # Reset the status of "userNbBrackets"
 
         cameraInitOutput = node.input.inputRootLink
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
         if node.userNbBrackets.value != 0:
-            # The number of brackets has been manually forced: check whether it is valid or not
-            if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
-                viewpoints = cameraInitOutput.node.viewpoints.value
-                # The number of brackets should be a multiple of the number of input images
-                if (len(viewpoints) % node.userNbBrackets.value != 0):
-                    node.userNbBrackets.validValue = False
-                else:
-                    node.userNbBrackets.validValue = True
-            node.nbBrackets.value = node.userNbBrackets.value
-            return
+            if len(node.userNbBrackets.getErrorMessages()) > 0:
+                node.nbBrackets.value = node.userNbBrackets.value
+                return
 
         if not cameraInitOutput.node.hasAttribute("viewpoints"):
             if cameraInitOutput.node.hasAttribute("input"):

--- a/meshroom/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/aliceVision/LdrToHdrMerge.py
@@ -5,6 +5,7 @@ import json
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 from pyalicevision import parallelization as avpar
+from .ldrToHdrCommon import ImageCountShouldBeAMultipleOfBracketNumber
 
 def findMetadata(d, keys, defaultValue):
     v = None
@@ -67,8 +68,7 @@ to favour well-exposed pixels, and ghost artefacts caused by moving subjects can
             range=(0, 15, 1),
             invalidate=False,
             commandLineGroup="user",  # not used directly on the command line
-            errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
-                         "Errors will occur during the computation.",
+            validators=[ImageCountShouldBeAMultipleOfBracketNumber()],
             exposed=True,
         ),
         desc.IntParam(
@@ -261,23 +261,15 @@ to favour well-exposed pixels, and ghost artefacts caused by moving subjects can
         if "userNbBrackets" not in node.getAttributes().keys():
             # Old version of the node
             return
-        node.userNbBrackets.validValue = True  # Reset the status of "userNbBrackets"
 
         cameraInitOutput = node.input.inputRootLink
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
         if node.userNbBrackets.value != 0:
-            # The number of brackets has been manually forced: check whether it is valid or not
-            if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
-                viewpoints = cameraInitOutput.node.viewpoints.value
-                # The number of brackets should be a multiple of the number of input images
-                if (len(viewpoints) % node.userNbBrackets.value != 0):
-                    node.userNbBrackets.validValue = False
-                else:
-                    node.userNbBrackets.validValue = True
-            node.nbBrackets.value = node.userNbBrackets.value
-            return
+           if len(node.userNbBrackets.getErrorMessages()) > 0:
+                node.nbBrackets.value = node.userNbBrackets.value
+                return
 
         if not cameraInitOutput.node.hasAttribute("viewpoints"):
             if cameraInitOutput.node.hasAttribute("input"):

--- a/meshroom/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/aliceVision/LdrToHdrSampling.py
@@ -5,6 +5,8 @@ import json
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, VERBOSE_LEVEL
 from pyalicevision import parallelization as avpar
+from .ldrToHdrCommon import ImageCountShouldBeAMultipleOfBracketNumber
+
 
 def findMetadata(d, keys, defaultValue):
     v = None
@@ -58,8 +60,9 @@ across the bracketed frames is essential for an accurate CRF estimation.
             range=(0, 15, 1),
             invalidate=False,
             commandLineGroup="user",  # not used directly on the command line
-            errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
-                         "Errors will occur during the computation.",
+            validators=[
+                ImageCountShouldBeAMultipleOfBracketNumber()
+            ],
             exposed=True,
         ),
         desc.IntParam(
@@ -189,23 +192,16 @@ across the bracketed frames is essential for an accurate CRF estimation.
             # Old version of the node
             return
         node.outliersNb = 0  # Reset the number of detected outliers
-        node.userNbBrackets.validValue = True  # Reset the status of "userNbBrackets"
 
         cameraInitOutput = node.input.inputRootLink
         if not cameraInitOutput:
             node.nbBrackets.value = 0
             return
+
         if node.userNbBrackets.value != 0:
-            # The number of brackets has been manually forced: check whether it is valid or not
-            if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
-                viewpoints = cameraInitOutput.node.viewpoints.value
-                # The number of brackets should be a multiple of the number of input images
-                if (len(viewpoints) % node.userNbBrackets.value != 0):
-                    node.userNbBrackets.validValue = False
-                else:
-                    node.userNbBrackets.validValue = True
-            node.nbBrackets.value = node.userNbBrackets.value
-            return
+            if len(node.userNbBrackets.getErrorMessages()) > 0:
+                node.nbBrackets.value = node.userNbBrackets.value
+                return
 
         if not cameraInitOutput.node.hasAttribute("viewpoints"):
             if cameraInitOutput.node.hasAttribute("input"):

--- a/meshroom/aliceVision/ldrToHdrCommon.py
+++ b/meshroom/aliceVision/ldrToHdrCommon.py
@@ -1,0 +1,27 @@
+from meshroom.core.attribute import Attribute
+from meshroom.core.node import Node
+from meshroom.core.desc.validators import AttributeValidator, success, error
+
+
+class ImageCountShouldBeAMultipleOfBracketNumber(AttributeValidator):
+
+    def __call__(self, node: Node, attribute: Attribute):
+
+        if node.userNbBrackets.value == 0:
+            return success()
+
+        cameraInitOutput = node.input.inputRootLink
+
+        # The number of brackets has been manually forced: check whether it is valid or not
+        if cameraInitOutput and cameraInitOutput.node and cameraInitOutput.node.hasAttribute("viewpoints"):
+            viewpoints = cameraInitOutput.node.viewpoints.value
+            # The number of brackets should be a multiple of the number of input images
+            if (len(viewpoints) % node.userNbBrackets.value != 0):
+                return error(
+                        "The set number of brackets is not a multiple of the number of input images.",
+                        "Errors will occur during the computation."
+                    )
+            else:
+                return success()
+
+        return success()


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->

## Description
Use the new validation paradigm and remove the validValue/errorMessages attributes.

[meshroom related PR](https://github.com/alicevision/Meshroom/pull/3088)


