### PR TITLE
Add module image to python bindings

### DIFF
--- a/pyTests/image/test_image.py
+++ b/pyTests/image/test_image.py
@@ -1,0 +1,85 @@
+"""
+Collection of unit tests for image
+"""
+
+import pytest
+
+import image as img
+import numpy as np
+
+def test_default_constructor():
+    image = img.Image_uchar()
+    assert (image.width() == 0), "default width is 0"
+    assert (image.height() == 0), "default height is 0"
+    assert (image.depth() == 1), "Incorrect depth"
+    assert (image.channels() == 1), "Incorrect channels"
+
+    image = img.Image_float()
+    assert (image.width() == 0), "default width is 0"
+    assert (image.height() == 0), "default height is 0"
+    assert (image.depth() == 4), "Incorrect depth"
+    assert (image.channels() == 1), "Incorrect channels"
+
+
+    image = img.Image_RGBAfColor()
+    assert (image.width() == 0), "default width is 0"
+    assert (image.height() == 0), "default height is 0"
+    assert (image.depth() == 16), "Incorrect depth"
+    assert (image.channels() == 4), "Incorrect channels"
+
+    image = img.Image_RGBAColor()
+    assert (image.width() == 0), "default width is 0"
+    assert (image.height() == 0), "default height is 0"
+    assert (image.depth() == 4), "Incorrect depth"
+    assert (image.channels() == 4), "Incorrect channels"
+
+    image = img.Image_RGBfColor()
+    assert (image.width() == 0), "default width is 0"
+    assert (image.height() == 0), "default height is 0"
+    assert (image.depth() == 12), "Incorrect depth"
+    assert (image.channels() == 3), "Incorrect channels"
+
+    image = img.Image_RGBColor()
+    assert (image.width() == 0), "default width is 0"
+    assert (image.height() == 0), "default height is 0"
+    assert (image.depth() == 3), "Incorrect depth"
+    assert (image.channels() == 3), "Incorrect channels"
+
+def test_constructor():
+    image = img.Image_uchar(10, 12)
+    assert (image.width() == 10), "default width is 10"
+    assert (image.height() == 12), "default height is 12"
+    assert (image.depth() == 1), "Incorrect depth"
+    assert (image.channels() == 1), "Incorrect channels"
+
+    image = img.Image_float(10, 12)
+    assert (image.width() == 10), "default width is 10"
+    assert (image.height() == 12), "default height is 12"
+    assert (image.depth() == 4), "Incorrect depth"
+    assert (image.channels() == 1), "Incorrect channels"
+
+
+    image = img.Image_RGBAfColor(10, 12)
+    assert (image.width() == 10), "default width is 10"
+    assert (image.height() == 12), "default height is 12"
+    assert (image.depth() == 16), "Incorrect depth"
+    assert (image.channels() == 4), "Incorrect channels"
+
+    image = img.Image_RGBAColor(10, 12)
+    assert (image.width() == 10), "default width is 10"
+    assert (image.height() == 12), "default height is 12"
+    assert (image.depth() == 4), "Incorrect depth"
+    assert (image.channels() == 4), "Incorrect channels"
+
+    image = img.Image_RGBfColor(10, 12)
+    assert (image.width() == 10), "default width is 10"
+    assert (image.height() == 12), "default height is 12"
+    assert (image.depth() == 12), "Incorrect depth"
+    assert (image.channels() == 3), "Incorrect channels"
+
+    image = img.Image_RGBColor(10, 12)
+    assert (image.width() == 10), "default width is 10"
+    assert (image.height() == 12), "default height is 12"
+    assert (image.depth() == 3), "Incorrect depth"
+    assert (image.channels() == 3), "Incorrect channels"
+

--- a/pyTests/image/test_imageIO.py
+++ b/pyTests/image/test_imageIO.py
@@ -1,0 +1,56 @@
+"""
+Collection of unit tests for image
+"""
+
+import pytest
+import os
+
+import image as img
+import numpy as np
+
+def loop(image):
+
+    array1 = image.getNumpyArray()
+
+    #Write image to file    
+    new_path = os.path.abspath(os.path.dirname(__file__)) + "/out.exr"
+    optRead = img.ImageReadOptions(img.EImageColorSpace_NO_CONVERSION)
+    optWrite = img.ImageWriteOptions()
+    optWrite.toColorSpace(img.EImageColorSpace_NO_CONVERSION)
+    img.writeImage(new_path, image, optWrite)
+    
+    #read it back from file
+    other_image = image.__class__()
+    img.readImage(new_path, other_image, optRead)
+    array2 = other_image.getNumpyArray()
+
+    assert np.array_equal(array1, array2), "images should be equal"
+
+def test_default_constructor():
+
+    src = np.random.randint(0, 255, size=(256, 256, 1), dtype='uint8')
+    image = img.Image_uchar()
+    image.fromNumpyArray(src)
+    loop(image)
+
+    image = img.Image_float()
+    image.fromNumpyArray(np.float32(src))
+    loop(image)
+
+    src = np.random.randint(0, 255, size=(256, 256, 3), dtype='uint8')
+    image = img.Image_RGBColor()
+    image.fromNumpyArray(src)
+    loop(image)
+
+    image = img.Image_RGBfColor()
+    image.fromNumpyArray(np.float32(src))
+    loop(image)
+
+    src = np.random.randint(0, 255, size=(256, 256, 4), dtype='uint8')
+    image = img.Image_RGBAColor()
+    image.fromNumpyArray(src)
+    loop(image)
+    
+    image = img.Image_RGBAfColor()
+    image.fromNumpyArray(np.float32(src))
+    loop(image)

--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -59,3 +59,18 @@ alicevision_add_test(io_test.cpp           NAME "image_io"         LINKS aliceVi
 alicevision_add_test(drawing_test.cpp      NAME "image_drawing"    LINKS aliceVision_image)
 alicevision_add_test(filtering_test.cpp    NAME "image_filtering"  LINKS aliceVision_image)
 alicevision_add_test(resampling_test.cpp   NAME "image_resampling" LINKS aliceVision_image)
+
+# SWIG Binding
+if (ALICEVISION_BUILD_SWIG_BINDING)
+    alicevision_swig_add_library(image
+        SOURCES image.i
+        PUBLIC_LINKS
+            aliceVision_image
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
+    )
+endif()

--- a/src/aliceVision/image/Image.hpp
+++ b/src/aliceVision/image/Image.hpp
@@ -42,7 +42,7 @@ class Image : public Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::Row
      * @param fInit Tell if the image should be initialized
      * @param val If fInit is true, set all pixel to the specified value
      */
-    inline Image(int width, int height, bool fInit = false, const T val = T{})
+    inline Image(int width, int height, bool fInit = false, const T val = T())
     {
         Base::resize(height, width);
         if (fInit)
@@ -92,7 +92,7 @@ class Image : public Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::Row
      * @param fInit Indicate if new image should be initialized
      * @param val if fInit is true all pixel in the new image are set to this value
      */
-    inline void resize(int width, int height, bool fInit = true, const T val = T{})
+    inline void resize(int width, int height, bool fInit = true, const T val = T())
     {
         Base::resize(height, width);
         if (fInit)

--- a/src/aliceVision/image/image.i
+++ b/src/aliceVision/image/image.i
@@ -1,0 +1,159 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%module (module="pyalicevision") image
+
+%{
+  #define SWIG_FILE_WITH_INIT
+%}
+
+%include <aliceVision/numeric/numpy.i>
+%include <std_string.i>
+
+
+%init
+%{
+  import_array();
+%}
+
+%{    
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
+ 
+using namespace aliceVision;
+using namespace aliceVision::image;
+
+template <typename T> 
+int NumPyType() 
+{
+    return -1;
+}
+
+template<> 
+int NumPyType<float>() 
+{
+    return NPY_FLOAT;
+}
+
+template<> 
+int NumPyType<unsigned char>() 
+{
+    return NPY_UINT8;
+}
+
+template<> 
+int NumPyType<image::RGBAfColor>() 
+{
+    return NPY_FLOAT;
+}
+
+template<> 
+int NumPyType<image::RGBAColor>() 
+{
+    return NPY_UINT8;
+}
+
+template<> 
+int NumPyType<image::RGBfColor>() 
+{
+    return NPY_FLOAT;
+}
+
+template<> 
+int NumPyType<image::RGBColor>() 
+{
+    return NPY_UINT8;
+}
+
+%} 
+
+%include <OpenImageIO/oiioversion.h>
+%include <aliceVision/image/colorspace.hpp> 
+%include <aliceVision/image/Image.hpp>
+%include <aliceVision/image/io.hpp> 
+
+
+%fragment("NumPy_Fragments");
+%extend aliceVision::image::Image
+{
+    PyObject * getNumpyArray()
+    {
+        aliceVision::image::Image<T> & image = *$self;
+
+        npy_intp dims[3] = {image.height(), image.width(), NbChannels<T>::size};
+        PyObject * ret = PyArray_SimpleNew(3, dims, NumPyType<T>());
+        if (!ret)
+        {
+            return nullptr;
+        }
+
+        T * data = static_cast<T*>(PyArray_DATA((PyArrayObject*)ret));
+        for (int i = 0; i != dims[0]; ++i)
+        {
+            for (int j = 0; j != dims[1]; ++j)
+            {
+                data[i*dims[1]+j] = image(i,j);
+            }
+        }
+
+        return ret;
+    }
+
+    bool fromNumpyArray(PyObject * obj)
+    {
+        // Check object type
+        if (!is_array(obj))
+        {
+            PyErr_SetString(PyExc_ValueError, "The given input is not known as a NumPy array or matrix.");
+            return false;
+        }
+        
+        if (array_type(obj) != NumPyType<T>())
+        {
+            PyErr_SetString(PyExc_ValueError, "Type mismatch between NumPy and Eigen objects.");
+            return false;
+        }
+        
+        if (array_numdims(obj) != 3)
+        {
+            PyErr_SetString(PyExc_ValueError, "Image requires a 3D numpy array");
+            return false;
+        }
+
+        int rows = array_size(obj, 0);
+        int cols = array_size(obj, 1);
+        int channels = array_size(obj, 2);
+
+        if (channels != NbChannels<T>::size)
+        {
+            PyErr_SetString(PyExc_ValueError, "Numpy array 3rd dimension in incorrect.");
+            return false;
+        }
+
+        aliceVision::image::Image<T> & image = *$self;
+        image.resize(cols, rows, false);
+
+        const T * const data = static_cast<const T * const>(PyArray_DATA((PyArrayObject*)obj));
+        for (int i = 0; i != rows; ++i)
+        {
+            for (int j = 0; j != cols; ++j)
+            {
+                image(i,j) = data[i*cols+j];
+            }
+        }
+
+        return true;
+    }
+}
+
+
+
+%template(Image_float) aliceVision::image::Image<float>; 
+%template(Image_uchar) aliceVision::image::Image<unsigned char>; 
+%template(Image_RGBAfColor) aliceVision::image::Image<RGBAfColor>; 
+%template(Image_RGBAColor) aliceVision::image::Image<RGBAColor>;
+%template(Image_RGBfColor) aliceVision::image::Image<RGBfColor>; 
+%template(Image_RGBColor) aliceVision::image::Image<RGBColor>;

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -1248,6 +1248,11 @@ void readImage(const std::string& path, Image<float>& image, const ImageReadOpti
     readImage(path, oiio::TypeDesc::FLOAT, 1, image, imageReadOptions);
 }
 
+void readImage(const std::string& path, Image<IndexT>& image, const ImageReadOptions& imageReadOptions)
+{
+    readImage(path, oiio::TypeDesc::UINT32, 1, image, imageReadOptions);
+}
+
 void readImage(const std::string& path, Image<unsigned char>& image, const ImageReadOptions& imageReadOptions)
 {
     readImage(path, oiio::TypeDesc::UINT8, 1, image, imageReadOptions);


### PR DESCRIPTION
- Adding the major bricks of aliceVision image modules to the python bindings

- Templated class `Image` is supported for : 

[x] unsigned char
[x] float
[x] RGBAfColor
[x] RGBfColor
[x] RGBAColor
[x] RGBAfColor

- IO functions `readImage`, `writeImage `and associated parameter structures should be available.

- Adding related pytests. They may act as a temporary example.