### PR TITLE
[meshroom] CamTrack: Provide `PrepareDenseScene` with segmentation masks

### DIFF
--- a/meshroom/aliceVision/PrepareDenseScene.py
+++ b/meshroom/aliceVision/PrepareDenseScene.py
@@ -32,6 +32,7 @@ This node export undistorted images so the depth map and texturing can be comput
             name="imagesFolders",
             label="Images Folders",
             description="Use images from specific folder(s). Filename should be the same or the image UID.",
+            exposed=True,
         ),
         desc.ListAttribute(
             elementDesc=desc.File(
@@ -43,6 +44,7 @@ This node export undistorted images so the depth map and texturing can be comput
             name="masksFolders",
             label="Masks Folders",
             description="Use masks from specific folder(s). Filename should be the same or the image UID.",
+            exposed=True,
         ),
         desc.ChoiceParam(
             name="maskExtension",

--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -2,7 +2,6 @@
     "header": {
         "releaseVersion": "2025.1.0-develop",
         "fileVersion": "2.0",
-        "template": true,
         "nodesVersions": {
             "ApplyCalibration": "1.0",
             "CameraInit": "12.0",
@@ -18,7 +17,7 @@
             "ImageDetectionPrompt": "0.1",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
-            "ImageSegmentationBox": "0.1",
+            "ImageSegmentationBox": "0.2",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
@@ -30,7 +29,8 @@
             "SfMTriangulation": "1.0",
             "StructureFromMotion": "3.3",
             "Texturing": "6.0"
-        }
+        },
+        "template": true
     },
     "graph": {
         "ApplyCalibration_1": {
@@ -391,6 +391,9 @@
             ],
             "inputs": {
                 "input": "{SfMTriangulation_1.output}",
+                "masksFolders": [
+                    "{ImageSegmentationBox_1.output}"
+                ],
                 "maskExtension": "exr"
             },
             "internalInputs": {

--- a/meshroom/cameraTrackingExperimental.mg
+++ b/meshroom/cameraTrackingExperimental.mg
@@ -395,6 +395,9 @@
             ],
             "inputs": {
                 "input": "{SfMTriangulation_1.output}",
+                "masksFolders": [
+                    "{ImageSegmentationBox_1.output}"
+                ],
                 "maskExtension": "exr"
             },
             "internalInputs": {

--- a/meshroom/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/cameraTrackingWithoutCalibration.mg
@@ -2,7 +2,6 @@
     "header": {
         "releaseVersion": "2025.1.0-develop",
         "fileVersion": "2.0",
-        "template": true,
         "nodesVersions": {
             "ApplyCalibration": "1.0",
             "CameraInit": "12.0",
@@ -17,7 +16,7 @@
             "ImageDetectionPrompt": "0.1",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
-            "ImageSegmentationBox": "0.1",
+            "ImageSegmentationBox": "0.2",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
@@ -29,7 +28,8 @@
             "SfMTriangulation": "1.0",
             "StructureFromMotion": "3.3",
             "Texturing": "6.0"
-        }
+        },
+        "template": true
     },
     "graph": {
         "ApplyCalibration_1": {
@@ -362,6 +362,9 @@
             ],
             "inputs": {
                 "input": "{SfMTriangulation_1.output}",
+                "masksFolders": [
+                    "{ImageSegmentationBox_1.output}"
+                ],
                 "maskExtension": "exr"
             },
             "internalInputs": {

--- a/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
@@ -366,6 +366,9 @@
             ],
             "inputs": {
                 "input": "{SfMTriangulation_1.output}",
+                "masksFolders": [
+                    "{ImageSegmentationBox_1.output}"
+                ],
                 "maskExtension": "exr"
             },
             "internalInputs": {


### PR DESCRIPTION
## Description

This PR updates all the CameraTracking templates so that the segmentation masks are provided to the `PrepareDenseScene` node.

Additionally, the `Images Folders` and `Masks Folders` parameters are exposed in the `PrepareDenseScene` node.