### PR TITLE
Use optional depthmaps as additional information for the sfm process

### DIFF
--- a/meshroom/aliceVision/DepthMapTracksInjecting.py
+++ b/meshroom/aliceVision/DepthMapTracksInjecting.py
@@ -1,0 +1,48 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class DepthMapTracksInjecting(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_depthmapTracksInjecting {allParams}'
+
+    category = 'Utils'
+    documentation = '''Inject depth from depthmaps into tracks.'''
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input SfMData",
+            description="Input SfMData file.",
+            value="",
+        ),
+        desc.File(
+            name="tracksFilename",
+            label="Tracks File",
+            description="Tracks file.",
+            value="",
+        ),
+        desc.File(
+            name="depthSource",
+            label="Depth Source",
+            description="Directory containing depthMaps",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output Tracks File",
+            description="Output Tracks File with updated depth",
+            value="{nodeCacheFolder}/tracks.json",
+        ),
+    ]

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -27,6 +27,7 @@ set(sfm_files_headers
     pipeline/bootstrapping/EstimateAngle.hpp
     pipeline/bootstrapping/PairsScoring.hpp
     pipeline/bootstrapping/Bootstrap.hpp
+    pipeline/bootstrapping/TracksDepths.hpp
     pipeline/expanding/SfmTriangulation.hpp
     pipeline/expanding/SfmResection.hpp
     pipeline/expanding/SfmBundle.hpp
@@ -74,6 +75,7 @@ set(sfm_files_sources
     pipeline/bootstrapping/EstimateAngle.cpp
     pipeline/bootstrapping/PairsScoring.cpp
     pipeline/bootstrapping/Bootstrap.cpp
+    pipeline/bootstrapping/TracksDepths.cpp
     pipeline/expanding/SfmTriangulation.cpp
     pipeline/expanding/SfmResection.cpp
     pipeline/expanding/SfmBundle.cpp

--- a/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
 #include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
 #include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp>
+#include <aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp>
 #include <vector>
 #include <random>
 
@@ -166,6 +167,97 @@ bool bootstrapMesh(sfmData::SfMData & sfmData,
 
             //Add observation to landmark
             sfmData::Observations & observations = outLandmarks[landmarkId].getObservations();
+            observations[nextViewId] = obs;
+        }
+    }
+
+    return true;
+}
+
+bool bootstrapDepth(sfmData::SfMData & sfmData, 
+                    const IndexT referenceViewId,
+                    const IndexT nextViewId,
+                    const track::TracksMap& tracksMap, 
+                    const track::TracksPerView & tracksPerView)
+{
+    std::mt19937 randomNumberGenerator;
+
+    const sfmData::View & viewReference = sfmData.getView(referenceViewId);
+    const sfmData::View & viewNext = sfmData.getView(nextViewId);
+
+    camera::IntrinsicBase::sptr camReference = sfmData.getIntrinsicSharedPtr(viewReference.getIntrinsicId());
+    camera::IntrinsicBase::sptr camNext = sfmData.getIntrinsicSharedPtr(viewNext.getIntrinsicId());
+
+    sfmData::CameraPose & poseReference = sfmData.getPoses()[viewReference.getPoseId()];
+    sfmData::CameraPose & poseNext = sfmData.getPoses()[viewNext.getPoseId()];
+
+            
+    sfmData::SfMData miniSfm;
+    if (!buildSfmDataFromDepthMap(miniSfm, sfmData, tracksMap, tracksPerView, referenceViewId))
+    {
+        return EXIT_FAILURE;
+    }
+
+    sfm::SfmResection resection(50000, std::numeric_limits<double>::infinity());
+
+    Eigen::Matrix4d pose;
+    double newThreshold;
+    size_t inliersCount;
+        
+    if (!resection.processView(miniSfm, 
+                            tracksMap, tracksPerView, 
+                            randomNumberGenerator,
+                            nextViewId, pose, newThreshold, inliersCount))
+    {
+        return EXIT_FAILURE;
+    }
+
+
+    geometry::Pose3 pose3(pose);
+    poseNext.setTransform(pose3);
+
+    const auto & landmarks = miniSfm.getLandmarks();
+    auto & outLandmarks = sfmData.getLandmarks();
+    
+    for (const auto & [landmarkId, landmark] : landmarks)
+    {
+        //Retrieve track object
+        const auto & track = tracksMap.at(landmarkId);
+
+        const track::TrackItem & itemReference = track.featPerView.at(referenceViewId);
+
+        //Maybe this track is not observed in the next view
+        if (track.featPerView.find(nextViewId) == track.featPerView.end())
+        {
+            continue;
+        }
+
+        //Compute error
+        const track::TrackItem & item = track.featPerView.at(nextViewId);
+        const Vec2 pt = item.coords;
+        const Vec2 estpt = camNext->transformProject(pose3, landmark.X.homogeneous(), true);
+        double err = (pt - estpt).norm();
+
+        //If error is ok, then we add it to the sfmData
+        if (err <= newThreshold)
+        {
+            sfmData::Observation obs;
+            obs.setFeatureId(item.featureId);
+            obs.setScale(item.scale);
+            obs.setCoordinates(item.coords);
+
+            sfmData::Observation obsReference;
+            obsReference.setFeatureId(itemReference.featureId);
+            obsReference.setScale(itemReference.scale);
+            obsReference.setCoordinates(itemReference.coords);
+
+            //Add landmark to sfmData
+            outLandmarks[landmarkId] = landmark;
+            outLandmarks[landmarkId].setParallaxRobust(true);
+
+            //Add observation to landmark
+            sfmData::Observations & observations = outLandmarks[landmarkId].getObservations();
+            observations[referenceViewId] = obsReference;
             observations[nextViewId] = obs;
         }
     }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.hpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.hpp
@@ -46,5 +46,21 @@ bool bootstrapMesh(sfmData::SfMData & sfmData,
                     const track::TracksMap& tracksMap, 
                     const track::TracksPerView & tracksPerView);
 
+
+/**
+ * @brief Create a minimal SfmData with poses and landmarks for two views
+ * @param sfmData the input sfmData which contains camera information
+ * @param referenceViewId the reference view id
+ * @param otherViewId the other view id
+ * @param otherTreference the relative pose
+ * @param tracksMap the input map of tracks
+ * @param tracksPerView tracks grouped by views
+ * @return true
+*/
+bool bootstrapDepth(sfmData::SfMData & sfmData, 
+                    const IndexT referenceViewId,
+                    const IndexT otherViewId,
+                    const track::TracksMap& tracksMap, 
+                    const track::TracksPerView & tracksPerView);
 }
 }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.cpp
@@ -8,6 +8,8 @@
 #include <aliceVision/sfm/pipeline/bootstrapping/EstimateAngle.hpp>
 #include <aliceVision/sfm/pipeline/expanding/ExpansionPolicyLegacy.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
+#include <aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp>
+#include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -113,6 +115,101 @@ IndexT findBestPair(const sfmData::SfMData & sfmData,
         }
     }
     
+    return bestPair;
+}
+
+sfm::ReconstructedPair findBestPairFromTrackDepths(const sfmData::SfMData & sfmData, 
+                                    const std::vector<sfm::ReconstructedPair> & pairs,
+                                    const track::TracksMap& tracksMap, 
+                                    const track::TracksPerView & tracksPerView)
+{
+    std::mt19937 randomNumberGenerator;
+
+    std::set<IndexT> views;
+    for (IndexT pairId = 0; pairId < pairs.size(); pairId++)
+    {
+        views.insert(pairs[pairId].reference);
+        views.insert(pairs[pairId].next);
+    }
+
+    sfm::ReconstructedPair bestPair;
+    bestPair.reference = UndefinedIndexT;
+    
+    size_t bestCount = 0;
+
+    for (const auto & idView: views)
+    {
+        sfmData::SfMData miniSfm;
+        if (!buildSfmDataFromDepthMap(miniSfm, sfmData, tracksMap, tracksPerView, idView))
+        {
+            continue;
+        }
+
+        sfm::SfmResection resection(1024, std::numeric_limits<double>::infinity());
+
+
+        sfm::ReconstructedPair bestPairLocal;
+        size_t maxInliers = 0;
+        size_t totalInliers = 0;
+
+        for (IndexT pairId = 0; pairId < pairs.size(); pairId++)
+        {
+            const auto & pairSource = pairs[pairId];
+            sfm::ReconstructedPair pair;
+            pair.reference = idView;
+
+            if (pairSource.reference == idView)
+            {
+                pair.next = pairSource.next;
+            }
+            else if (pairSource.next == idView)
+            {
+                pair.next = pairSource.reference;
+            }
+            else
+            {
+                continue;
+            }
+
+            if (miniSfm.getViews().find(pair.next) == miniSfm.getViews().end())
+            {
+                continue;
+            }
+
+            Eigen::Matrix4d pose;
+            double newThreshold;
+            size_t inliersCount;
+            
+            if (!resection.processView(miniSfm, 
+                                    tracksMap, 
+                                    tracksPerView, 
+                                    randomNumberGenerator,
+                                    pair.next, 
+                                    pose, newThreshold, inliersCount))
+            {
+                continue;
+            }    
+
+            pair.pose = geometry::Pose3(pose);
+            pair.score = inliersCount;
+
+            if (inliersCount > maxInliers)
+            {
+                maxInliers = inliersCount;
+                bestPairLocal = pair;
+            }
+
+            totalInliers += inliersCount;
+        }
+
+        if (totalInliers > bestCount)
+        {
+            bestPair = bestPairLocal;
+            bestCount = totalInliers;
+        }
+    }
+
+
     return bestPair;
 }
 

--- a/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.hpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.hpp
@@ -37,5 +37,18 @@ IndexT findBestPair(const sfmData::SfMData & sfmData,
                     double softMinAngle,
                     double maxAngle);
 
+/**
+* @brief Get best pair from track Depths with highest score
+* @param sfmData the input sfmData which contains camera information
+* @param pairs the input list of reconstructed pairs
+* @param tracksMap the input map of tracks
+* @param tracksPerView tracks grouped by views
+* @return The best pair (pair.reference is UndefinedIndexT if nothing found)
+*/
+sfm::ReconstructedPair findBestPairFromTrackDepths(const sfmData::SfMData & sfmData, 
+                            const std::vector<sfm::ReconstructedPair> & pairs,
+                            const track::TracksMap& tracksMap, 
+                            const track::TracksPerView & tracksPerView);
+
 }
 }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.cpp
@@ -1,0 +1,85 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+bool buildSfmDataFromDepthMap(sfmData::SfMData & output,
+                            const sfmData::SfMData & sfmData, 
+                            const track::TracksMap& tracksMap, 
+                            const track::TracksPerView & tracksPerView, 
+                            IndexT viewId)
+{
+    output.clear();
+
+    const sfmData::View & view = sfmData.getView(viewId);
+    const camera::IntrinsicBase & intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
+
+    if (tracksPerView.find(viewId) == tracksPerView.end())
+    {
+        return false;
+    }
+
+    sfmData::Landmarks & landmarks = output.getLandmarks();
+
+    //Copy all intrinsics, because it's light.
+    for (const auto & [intrinsicId, intrinsic] : sfmData.getIntrinsics())
+    {
+        output.getIntrinsics().insert(
+            std::make_pair(intrinsicId, 
+                camera::IntrinsicBase::sptr(intrinsic->clone()))
+            );
+    }
+
+    std::set<IndexT> usedViewIds;
+    const auto & trackIds = tracksPerView.at(viewId);
+    for (const auto & trackId : trackIds)
+    {
+        const auto & track = tracksMap.at(trackId);
+        const auto & feat = track.featPerView.at(viewId);
+        const double & iZ = feat.idepth;
+
+        if (iZ < 0.0)
+        {
+            continue;
+        }
+
+        const double Z = 1.0 / iZ;
+        
+        const Vec2 meters = intrinsic.removeDistortion(intrinsic.ima2cam(feat.coords.cast<double>()));
+        
+        sfmData::Landmark & landmark = landmarks[trackId];
+        landmark.X.x() = meters.x() * Z;
+        landmark.X.y() = meters.y() * Z;
+        landmark.X.z() = Z;
+
+        landmark.descType = track.descType;
+
+        sfmData::Observations & observations = landmark.getObservations();
+        for (const auto & [otherViewId, otherFeat] : track.featPerView)
+        {
+            usedViewIds.insert(otherViewId);
+        }
+    }
+
+    // Copy only used views
+    for (const auto & usedViewId : usedViewIds)
+    {
+        const auto & iview = sfmData.getViewSharedPtr(usedViewId);
+
+        output.getViews().insert(
+            std::make_pair(usedViewId, 
+                sfmData::View::sptr(iview->clone()))
+            );
+    }
+
+    return true;
+}
+
+}
+}

--- a/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp
@@ -1,0 +1,30 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+#pragma once
+
+#include <aliceVision/track/Track.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+/**
+ * @brief Create a new sfmData cleared from any existing landmarks and poses
+ * But with new landmarks created from tracks if depth exists
+ * @param output the result sfmData
+ * @param sfmData the input sfmData, used for views and intrinsics
+ * @param tracksMap the input map of tracks
+ * @param tracksPerView tracks grouped by views 
+ * @param viewId the view of interest identifier
+ * @return false if an error occured
+*/
+bool buildSfmDataFromDepthMap(sfmData::SfMData & output,
+                            const sfmData::SfMData & sfmData, 
+                            const track::TracksMap& tracksMap, 
+                            const track::TracksPerView & tracksPerView, 
+                            IndexT viewId);
+}
+}

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -174,29 +174,32 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
 bool ExpansionChunk::triangulate(sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler, const std::set<IndexT> & viewIds)
 {
     ALICEVISION_LOG_INFO("ExpansionChunk::triangulate start");
+
+    auto & landmarks = sfmData.getLandmarks();
+    ALICEVISION_LOG_INFO("Existing landmarks before triangulation : " << landmarks.size());
+    
     SfmTriangulation triangulation(_triangulationMinPoints, _maxTriangulationError);
 
+    std::set<IndexT> replacedLandmarks;
     std::set<IndexT> evaluatedTracks;
     std::map<IndexT, sfmData::Landmark> outputLandmarks;
 
+    // Process all available views and try to triangulate as much views as possible 
+    // using normal parallax based triangulation
     std::mt19937 randomNumberGenerator;
     if (!triangulation.process(sfmData, tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
                                 randomNumberGenerator, viewIds, 
-                                evaluatedTracks, outputLandmarks))
+                                evaluatedTracks, outputLandmarks, false))
     {
         return false;
     }
 
-    auto & landmarks = sfmData.getLandmarks();
-    ALICEVISION_LOG_INFO("Existing landmarks : " << landmarks.size());
-
-    for (const auto & pl : outputLandmarks)
+    // Perform checks
+    for (const auto & [landmarkId, landmark] : outputLandmarks)
     {
-        const auto & landmark = pl.second;
-
-        if (landmarks.find(pl.first) != landmarks.end())
+        if (landmarks.find(landmarkId) != landmarks.end())
         {
-            landmarks.erase(pl.first);
+            landmarks.erase(landmarkId);
         }
 
         if (landmark.getObservations().size() < _triangulationMinPoints)
@@ -215,10 +218,45 @@ bool ExpansionChunk::triangulate(sfmData::SfMData & sfmData, const track::Tracks
             continue;
         }
 
-        landmarks.insert(pl);
+        landmarks.insert(std::make_pair(landmarkId, landmark));
+        replacedLandmarks.insert(landmarkId);
     }
 
     ALICEVISION_LOG_INFO("New landmarks count : " << landmarks.size());
+
+    std::map<IndexT, sfmData::Landmark> outputLandmarksPriors;
+    if (!triangulation.process(sfmData, tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
+                                randomNumberGenerator, viewIds, 
+                                evaluatedTracks, outputLandmarksPriors, true))
+    {
+        return false;
+    }
+
+
+    // Perform checks
+    for (const auto & [landmarkId, landmark] : outputLandmarksPriors)
+    {
+        if (replacedLandmarks.find(landmarkId) != replacedLandmarks.end())
+        {
+            //This has already been updated using parallax
+            continue;
+        }
+
+        if (landmark.getObservations().size() < _triangulationMinPoints)
+        {
+            continue;
+        }
+
+        if (!SfmTriangulation::checkChierality(sfmData, landmark))
+        {
+            continue;
+        }
+
+        landmarks.insert(std::make_pair(landmarkId, landmark));
+    }
+
+    ALICEVISION_LOG_INFO("New landmarks count after priors use: " << landmarks.size());
+
     ALICEVISION_LOG_INFO("ExpansionChunk::triangulate end");
 
     return true;

--- a/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
@@ -32,7 +32,8 @@ bool SfmTriangulation::process(
             std::mt19937 &randomNumberGenerator,
             const std::set<IndexT> &viewIds,
             std::set<IndexT> & evaluatedTracks,
-            std::map<IndexT, sfmData::Landmark> & outputLandmarks
+            std::map<IndexT, sfmData::Landmark> & outputLandmarks,
+            bool useDepthPrior
         )
 {
     evaluatedTracks.clear();
@@ -53,7 +54,7 @@ bool SfmTriangulation::process(
     allInterestingViews.insert(validViews.begin(), validViews.end());
 
 
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for(int pos = 0; pos < viewTracksVector.size(); pos++)
     {
         const std::size_t trackId = viewTracksVector[pos];
@@ -82,9 +83,21 @@ bool SfmTriangulation::process(
         }
 
         sfmData::Landmark result;
-        if (!processTrack(sfmData, track, randomNumberGenerator, trackViewsFiltered, result))
+        
+
+        if (useDepthPrior)
         {
-            continue;
+            if (!processTrackWithPrior(sfmData, track, randomNumberGenerator, trackViewsFiltered, result))
+            {
+                continue;
+            }
+        }
+        else 
+        {
+            if (!processTrack(sfmData, track, randomNumberGenerator, trackViewsFiltered, result))
+            {
+                continue;
+            }
         }
 
         #pragma omp critical
@@ -172,6 +185,92 @@ bool SfmTriangulation::processTrack(
         o.setFeatureId(trackItem.featureId);
         o.setScale(trackItem.scale);
         o.setCoordinates(trackItem.coords);
+    }
+
+    return true;
+}
+
+bool SfmTriangulation::processTrackWithPrior(
+            const sfmData::SfMData & sfmData,
+            const track::Track & track,
+            std::mt19937 &randomNumberGenerator,
+            const std::set<IndexT> & viewIds,
+            sfmData::Landmark & result
+        )
+{
+    size_t bestInliersCount = 0;
+
+    for (auto referenceViewId : viewIds)
+    {   
+        if (track.featPerView.find(referenceViewId) == track.featPerView.end())
+        {
+            continue;
+        }
+
+        const auto & refTrackItem = track.featPerView.at(referenceViewId);
+        if (refTrackItem.idepth < 0.0)
+        {
+            continue;
+        }
+
+        //Retrieve pose and feature coordinates for this observation
+        const sfmData::View & rView = sfmData.getView(referenceViewId);
+        const camera::IntrinsicBase & rIntrinsic = sfmData.getIntrinsic(rView.getIntrinsicId());
+        const geometry::Pose3 rPose = sfmData.getPose(rView).getTransform();        
+
+        const double iZ = refTrackItem.idepth;
+        const double Z = 1.0 / iZ;
+        const Vec2 meters = rIntrinsic.removeDistortion(rIntrinsic.ima2cam(refTrackItem.coords.cast<double>()));
+        Vec3 cX;
+        cX.x() = meters.x() * Z;
+        cX.y() = meters.y() * Z;
+        cX.z() = Z;
+        const Vec3 oX = rPose.inverse()(cX);
+        
+        sfmData::Landmark landmark;
+        landmark.setParallaxRobust(true);
+        landmark.X = oX;
+        landmark.descType = track.descType;
+
+        for (auto viewId : viewIds)
+        {
+            if (track.featPerView.find(viewId) == track.featPerView.end())
+            {
+                continue;
+            }
+
+            const auto & trackItem = track.featPerView.at(viewId);
+
+            const sfmData::View & view = sfmData.getView(viewId);
+            const camera::IntrinsicBase & intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
+            const geometry::Pose3 pose = sfmData.getPose(view).getTransform();    
+
+            const Vec2 est = intrinsic.transformProject(pose, oX.homogeneous(), true);
+            const Vec2 mes = trackItem.coords.cast<double>();
+            double err = (est - mes).norm() / trackItem.scale;
+
+            if (err > _maxError)
+            {
+                continue;
+            }
+
+            sfmData::Observation & o = landmark.getObservations()[viewId];
+            o.setFeatureId(trackItem.featureId);
+            o.setScale(trackItem.scale);
+            o.setCoordinates(trackItem.coords);
+        }
+
+        int count = landmark.getObservations().size();
+        if (count > bestInliersCount)
+        {
+            bestInliersCount = count;
+            result = landmark;
+        }
+    }
+
+    if (bestInliersCount < 2)
+    {
+        return false;
     }
 
     return true;

--- a/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp
@@ -36,6 +36,7 @@ public:
      * @param viewIds the set of view ids to process. Only tracks observed in these views will be considered
      * @param evaluatedTracks output list of track ids which were evaluated (Not necessarily with success)
      * @param outputLandmarks a set of generated landmarks indexed by their landmark id (the associated track id)
+     * @param useDepthPrior use depth prior found in tracks
      * @return false if a critical error occurred
     */
     bool process(
@@ -45,7 +46,8 @@ public:
             std::mt19937 &randomNumberGenerator,
             const std::set<IndexT> & viewIds,
             std::set<IndexT> & evaluatedTracks,
-            std::map<IndexT, sfmData::Landmark> & outputLandmarks
+            std::map<IndexT, sfmData::Landmark> & outputLandmarks,
+            bool useDepthPrior
         );
 
 public:
@@ -76,6 +78,23 @@ private:
      * @return false if a critical error occurred
     */
     bool processTrack(
+            const sfmData::SfMData & sfmData,
+            const track::Track & track,
+            std::mt19937 &randomNumberGenerator,
+            const std::set<IndexT> & viewIds,
+            sfmData::Landmark & result
+        );  
+    
+    /**
+     * Process triangulation of a track with depth prior enabled
+     * @param sfmData the actual state of the sfm
+     * @param track the track of interest
+     * @param randomNumberGenerator random number generator object
+     * @param viewIds the set of view ids to process. Only tracks observed in these views will be considered
+     * @param result the output landmark
+     * @return false if a critical error occurred
+    */
+    bool processTrackWithPrior(
             const sfmData::SfMData & sfmData,
             const track::Track & track,
             std::mt19937 &randomNumberGenerator,

--- a/src/aliceVision/sfm/sfmFilters.cpp
+++ b/src/aliceVision/sfm/sfmFilters.cpp
@@ -49,7 +49,9 @@ IndexT removeOutliersWithPixelResidualError(sfmData::SfMData& sfmData,
                 itObs = observations.erase(itObs);
             }
             else
+            {
                 ++itObs;
+            }
         }
 
         if (observations.empty() || observations.size() < minTrackLength)
@@ -75,7 +77,13 @@ IndexT removeOutliersWithAngleError(sfmData::SfMData& sfmData, const double dMin
 #pragma omp parallel for
     for (int landmarkIndex = 0; landmarkIndex < vKeys.size(); ++landmarkIndex)
     {
-        const sfmData::Observations& observations = sfmData.getLandmarks().at(vKeys[landmarkIndex]).getObservations();
+        const sfmData::Landmark & landmark = sfmData.getLandmarks().at(vKeys[landmarkIndex]);
+        if (landmark.isParallaxRobust())
+        {
+            continue;
+        }
+
+        const sfmData::Observations& observations = landmark.getObservations();
 
         // create matrix for observation directions from camera to point
         Mat3X viewDirections(3, observations.size());

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -72,9 +72,21 @@ class Landmark
             X(Eigen::Index(i)) = data.at(i);
         }
     }
+    /**
+     * @Brief Is this landmark robustness independent of parallax
+     * @return true if this landmark has this special property
+    */
+   bool isParallaxRobust() const { return _parallaxRobust; }
+
+   /**
+    * @Brief decide if this landmark is robust event if its parallax is low
+    * @param parallaxRobust True if robust to lack of parallax
+   */
+   void setParallaxRobust(bool parallaxRobust) { _parallaxRobust = parallaxRobust; }
 
   private:
     Observations _observations;
+    bool _parallaxRobust = false;
 };
 
 }  // namespace sfmData

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -396,6 +396,12 @@ class SfMData
      * @return the corresponding view reference
      */
     const View& getView(IndexT viewId) const { return *(_views.at(viewId)); }
+
+    /**
+     * @brief Gives the view of the input view id.
+     * @param[in] viewId The given view ID
+     * @return the corresponding view reference
+     */
     View& getView(IndexT viewId) { return *(_views.at(viewId)); }
 
     /**
@@ -404,7 +410,20 @@ class SfMData
      * @return the corresponding view ptr
      */
     const View::ptr getViewPtr(IndexT viewId) const { return _views.at(viewId).get(); }
+
+    /**
+     * @brief Gives the view of the input view id.
+     * @param[in] viewId The given view ID
+     * @return the corresponding view ptr
+     */
     View::ptr getViewPtr(IndexT viewId) { return _views.at(viewId).get(); }
+
+    /**
+     * @brief Gives the view of the input view id.
+     * @param[in] viewId The given view ID
+     * @return the corresponding view ptr
+     */
+    const View::sptr getViewSharedPtr(IndexT viewId) const { return _views.at(viewId); }
 
     /**
      * @brief Gives the view of the input view id.

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -508,6 +508,7 @@ void AlembicExporter::addLandmarks(const sfmData::Landmarks& landmarks,
     std::vector<V3f> positions;
     std::vector<Imath::C3f> colors;
     std::vector<Alembic::Util::uint32_t> descTypes;
+    std::vector<Alembic::Util::bool_t> isParallaxRobust;
     positions.reserve(landmarks.size());
     descTypes.reserve(landmarks.size());
 
@@ -520,6 +521,7 @@ void AlembicExporter::addLandmarks(const sfmData::Landmarks& landmarks,
         positions.emplace_back(pt[0], -pt[1], -pt[2]);
         colors.emplace_back(color.r() / 255.f, color.g() / 255.f, color.b() / 255.f);
         descTypes.emplace_back(static_cast<Alembic::Util::uint8_t>(landmark.second.descType));
+        isParallaxRobust.emplace_back(static_cast<Alembic::Util::bool_t>(landmark.second.isParallaxRobust()));
     }
 
     std::vector<Alembic::Util::uint64_t> ids(positions.size());
@@ -542,6 +544,7 @@ void AlembicExporter::addLandmarks(const sfmData::Landmarks& landmarks,
     OCompoundProperty userProps = pSchema.getUserProperties();
 
     OUInt32ArrayProperty(userProps, "mvg_describerType").set(descTypes);
+    OBoolArrayProperty(userProps, "mvg_isParallaxRobust").set(isParallaxRobust);
 
     if (withVisibility)
     {

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -186,6 +186,19 @@ bool readPointCloud(const Version& abcVersion, IObject iObj, M44d mat, sfmData::
         }
     }
 
+    BoolArraySamplePtr sampleIsParallaxRobust;
+    if (userProps && userProps.getPropertyHeader("mvg_isParallaxRobust"))
+    {
+        IBoolArrayProperty propIsParallaxRobust(userProps, "mvg_isParallaxRobust");
+        propIsParallaxRobust.get(sampleIsParallaxRobust);
+
+        if (sampleIsParallaxRobust->size() != positions->size())
+        {
+            ALICEVISION_LOG_WARNING("[Alembic Importer] isParallaxRobust property will be ignored.");
+            sampleIsParallaxRobust->reset();
+        }
+    }
+
     // Number of points before adding the Alembic data
     const std::size_t nbPointsInit = sfmdata.getLandmarks().size();
     for (std::size_t point3d_i = 0; point3d_i < positions->size(); ++point3d_i)
@@ -216,6 +229,12 @@ bool readPointCloud(const Version& abcVersion, IObject iObj, M44d mat, sfmData::
         {
             const std::size_t descType_i = sampleDescs[point3d_i];
             landmark.descType = static_cast<feature::EImageDescriberType>(descType_i);
+        }
+
+        if (sampleIsParallaxRobust)
+        {
+            const bool isParallaxRobust = sampleIsParallaxRobust->get()[point3d_i];
+            landmark.setParallaxRobust(isParallaxRobust);
         }
     }
 

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -501,6 +501,7 @@ void saveLandmark(const std::string& name,
 
     landmarkTree.put("landmarkId", landmarkId);
     landmarkTree.put("descType", feature::EImageDescriberType_enumToString(landmark.descType));
+    landmarkTree.put("isParallaxRobust", landmark.isParallaxRobust());
 
     saveMatrix("color", landmark.rgb, landmarkTree);
     saveMatrix("X", landmark.X, landmarkTree);
@@ -538,6 +539,7 @@ void loadLandmark(IndexT& landmarkId, sfmData::Landmark& landmark, bpt::ptree& l
 {
     landmarkId = landmarkTree.get<IndexT>("landmarkId");
     landmark.descType = feature::EImageDescriberType_stringToEnum(landmarkTree.get<std::string>("descType"));
+    landmark.setParallaxRobust(landmarkTree.get<bool>("isParallaxRobust", false));
 
     loadMatrix("color", landmark.rgb, landmarkTree);
     loadMatrix("X", landmark.X, landmarkTree);

--- a/src/aliceVision/track/Track.hpp
+++ b/src/aliceVision/track/Track.hpp
@@ -61,6 +61,7 @@ struct TrackItem
     std::size_t featureId;
     Vec2 coords;
     double scale;
+    double depth;
 };
 
 /**

--- a/src/aliceVision/track/Track.hpp
+++ b/src/aliceVision/track/Track.hpp
@@ -61,7 +61,7 @@ struct TrackItem
     std::size_t featureId;
     Vec2 coords;
     double scale;
-    double depth;
+    double idepth;
 };
 
 /**

--- a/src/aliceVision/track/TracksBuilder.cpp
+++ b/src/aliceVision/track/TracksBuilder.cpp
@@ -214,6 +214,7 @@ void TracksBuilder::exportToSTL(TracksMap& allTracks, const feature::FeaturesPer
 
                 item.coords = feature.coords().cast<double>();
                 item.scale = feature.scale();
+                item.depth = -1.0;
             }
         }
     }

--- a/src/aliceVision/track/TracksBuilder.cpp
+++ b/src/aliceVision/track/TracksBuilder.cpp
@@ -214,7 +214,7 @@ void TracksBuilder::exportToSTL(TracksMap& allTracks, const feature::FeaturesPer
 
                 item.coords = feature.coords().cast<double>();
                 item.scale = feature.scale();
-                item.depth = -1.0;
+                item.idepth = -1.0;
             }
         }
     }

--- a/src/aliceVision/track/trackIO.cpp
+++ b/src/aliceVision/track/trackIO.cpp
@@ -17,6 +17,7 @@ void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, alic
       {"featureId", boost::json::value_from(input.featureId)},
       {"coords", boost::json::value_from(input.coords)},
       {"scale", boost::json::value_from(input.scale)},
+      {"depth", boost::json::value_from(input.depth)},
     };
 }
 
@@ -28,6 +29,7 @@ aliceVision::track::TrackItem tag_invoke(boost::json::value_to_tag<aliceVision::
     ret.featureId = boost::json::value_to<std::size_t>(obj.at("featureId"));
     ret.coords = boost::json::value_to<Vec2>(obj.at("coords"));
     ret.scale = boost::json::value_to<double>(obj.at("scale"));
+    ret.depth = boost::json::value_to<double>(obj.at("depth"));
 
     return ret;
 }

--- a/src/aliceVision/track/trackIO.cpp
+++ b/src/aliceVision/track/trackIO.cpp
@@ -17,7 +17,7 @@ void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, alic
       {"featureId", boost::json::value_from(input.featureId)},
       {"coords", boost::json::value_from(input.coords)},
       {"scale", boost::json::value_from(input.scale)},
-      {"depth", boost::json::value_from(input.depth)},
+      {"idepth", boost::json::value_from(input.idepth)},
     };
 }
 
@@ -29,7 +29,7 @@ aliceVision::track::TrackItem tag_invoke(boost::json::value_to_tag<aliceVision::
     ret.featureId = boost::json::value_to<std::size_t>(obj.at("featureId"));
     ret.coords = boost::json::value_to<Vec2>(obj.at("coords"));
     ret.scale = boost::json::value_to<double>(obj.at("scale"));
-    ret.depth = boost::json::value_to<double>(obj.at("depth"));
+    ret.idepth = boost::json::value_to<double>(obj.at("idepth"));
 
     return ret;
 }

--- a/src/software/pipeline/main_sfmBootstrapping.cpp
+++ b/src/software/pipeline/main_sfmBootstrapping.cpp
@@ -34,6 +34,7 @@
 #include <aliceVision/sfm/pipeline/bootstrapping/PairsScoring.hpp>
 #include <aliceVision/sfm/pipeline/bootstrapping/Bootstrap.hpp>
 #include <aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp>
+#include <aliceVision/sfm/pipeline/bootstrapping/EstimateAngle.hpp>
 #include <cstdlib>
 #include <random>
 #include <regex>
@@ -125,6 +126,8 @@ void showStatsAngles(const sfmData::SfMData & sfmData)
     ALICEVISION_LOG_INFO("Landmarks maximal angle histogram");
     ALICEVISION_LOG_INFO(histo.ToString());
 }
+
+
 
 int aliceVision_main(int argc, char** argv)
 {
@@ -347,16 +350,48 @@ int aliceVision_main(int argc, char** argv)
                             tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
                             filterIn, filterOut,
                             minAngleHard, minAngleSoft, maxAngle);
-
+    
+    
     if (bestPairId == UndefinedIndexT)
     {
-        ALICEVISION_LOG_INFO("No valid pair");
+        ALICEVISION_LOG_INFO("No valid pair using normal algorithm.");
+        
+        bestPair = sfm::findBestPairFromTrackDepths(sfmData, 
+                                                reconstructedPairs,
+                                                tracksHandler.getAllTracks(), 
+                                                tracksHandler.getTracksPerView());
+
+        if (bestPair.reference == UndefinedIndexT)
+        {
+            ALICEVISION_LOG_INFO("No valid pair using depth prior based algorithm.");
+            return EXIT_FAILURE;
+        }
+    }
+    else 
+    {
+        bestPair = reconstructedPairs[bestPairId];
+    }
+
+    double angle = 0.0;
+    std::vector<size_t> usedTracks;
+    if (!sfm::estimatePairAngle(sfmData, 
+                            bestPair.reference, bestPair.next, bestPair.pose, 
+                            tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
+                            angle, usedTracks))
+    {
         return EXIT_FAILURE;
     }
-    
-    bestPair = reconstructedPairs[bestPairId];
 
-    if (useMesh)
+    if (radianToDegree(angle) < minAngleHard)
+    {
+        if (!sfm::bootstrapDepth(sfmData, 
+                        bestPair.reference, bestPair.next, 
+                        tracksHandler.getAllTracks(), tracksHandler.getTracksPerView()))
+        {
+            return EXIT_FAILURE;
+        }
+    }
+    else if (useMesh)
     {
         if (!sfm::bootstrapMesh(sfmData, 
                         landmarks,

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -76,6 +76,21 @@ if (ALICEVISION_BUILD_SFM)
               Boost::json
     )
 
+
+    # Track from depthmap
+    alicevision_add_software(aliceVision_depthmapTracksInjecting
+        SOURCE main_depthmapTracksInjecting.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              aliceVision_track
+              aliceVision_image
+              Boost::program_options
+              Boost::json
+    )
+
     if (ALICEVISION_HAVE_OPENCV)
         target_link_libraries(aliceVision_imageProcessing_exe PRIVATE ${OpenCV_LIBS})
     endif()

--- a/src/software/utils/main_depthmapTracksInjecting.cpp
+++ b/src/software/utils/main_depthmapTracksInjecting.cpp
@@ -1,0 +1,131 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/types.hpp>
+#include <aliceVision/config.hpp>
+
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+
+#include <aliceVision/image/io.hpp>
+#include <aliceVision/image/Image.hpp>
+
+#include <aliceVision/track/trackIO.hpp>
+#include <aliceVision/track/TracksHandler.hpp>
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+
+#include <filesystem>
+
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string tracksInputFilename;
+    std::string tracksOutputFilename;
+    std::string depthSource;
+    
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+    ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
+    ("tracksFilename", po::value<std::string>(&tracksInputFilename)->required(), "Tracks input file.")
+    ("output,o", po::value<std::string>(&tracksOutputFilename)->required(), "Tracks output file.")
+    ("depthSource", po::value<std::string>(&depthSource)->required(), "Depth Source directory.");
+
+    CmdLine cmdline("AliceVision DepthMapTracksInjecting");
+
+    cmdline.add(requiredParams);
+    if(!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    // Load input scene
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::VIEWS))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    // Load tracks
+    ALICEVISION_LOG_INFO("Load tracks");
+    track::TracksHandler tracksHandler;
+    if (!tracksHandler.load(tracksInputFilename, sfmData.getViewsKeys()))
+    {
+        ALICEVISION_LOG_ERROR("The input tracks file '" + tracksInputFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    const auto & tracksPerView = tracksHandler.getTracksPerView();
+    auto & tracks = tracksHandler.getAllTracksMutable();
+
+    for (const auto & [idView, view]: sfmData.getViews())
+    {
+        if (tracksPerView.find(idView) == tracksPerView.end())
+        {
+            continue;
+        }
+
+        fs::path depthDir(depthSource);
+        fs::path path(view->getImage().getImagePath());
+        fs::path depthPath = depthDir / path.stem() / "depth.exr";
+
+        image::Image<float> depthImg;
+
+        try
+        {
+            image::readImage(depthPath.string(), depthImg, image::EImageColorSpace::NO_CONVERSION);
+        }
+        catch(...)
+        {
+            continue;
+        }
+
+        for (const auto & trackId: tracksPerView.at(idView))
+        {
+            track::Track & track = tracks[trackId];
+
+            auto & feature = track.featPerView.at(idView);
+            
+            int ix = int(feature.coords.x());
+            int iy = int(feature.coords.y());
+
+            if (ix < 0 || ix > depthImg.width()) continue;
+            if (iy < 0 || iy > depthImg.height()) continue;
+
+            feature.depth = depthImg(iy, ix);
+        }
+    }
+
+    // Save tracks
+    ALICEVISION_LOG_INFO("Saving to " << tracksOutputFilename);
+    ALICEVISION_LOG_INFO("File has " << tracksHandler.getAllTracks().size() << " tracks.");
+    if (!track::saveTracks(tracksHandler.getAllTracks(), tracksOutputFilename))
+    {
+        ALICEVISION_LOG_ERROR("Failed to save file");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_depthmapTracksInjecting.cpp
+++ b/src/software/utils/main_depthmapTracksInjecting.cpp
@@ -89,9 +89,10 @@ int aliceVision_main(int argc, char** argv)
 
         fs::path depthDir(depthSource);
         fs::path path(view->getImage().getImagePath());
-        fs::path depthPath = depthDir / path.stem() / "depth.exr";
+        fs::path depthPath = depthDir / "depth" / (path.stem().string() + "_depth.exr");
 
         image::Image<float> depthImg;
+        ALICEVISION_LOG_INFO("Processing depth " << depthPath.string());
 
         try
         {
@@ -113,8 +114,13 @@ int aliceVision_main(int argc, char** argv)
 
             if (ix < 0 || ix > depthImg.width()) continue;
             if (iy < 0 || iy > depthImg.height()) continue;
+            
 
-            feature.depth = depthImg(iy, ix);
+            feature.idepth = depthImg(iy, ix);
+            if (feature.idepth < 0.15)
+            {
+                feature.idepth = -1;
+            }
         }
     }
 

--- a/src/software/utils/main_sfmFilter.cpp
+++ b/src/software/utils/main_sfmFilter.cpp
@@ -85,6 +85,21 @@ int aliceVision_main(int argc, char** argv)
     std::set<IndexT> viewIdsToRemove;
     std::set<IndexT> viewIdsToKeep;
 
+    auto & landmarks = outputSfMData_selected.getLandmarks();
+    landmarks.clear();
+    
+    for (const auto & [id, landmark] : sfmData.getLandmarks())
+    {
+        for (const auto & [viewId, _] : landmark.getObservations())
+        {
+            auto it = std::find(selectedViews.begin(), selectedViews.end(), viewId);
+            if (it != selectedViews.end())
+            {
+                landmarks[id] = landmark;
+            }
+        }
+    }
+
     for (auto& viewIt : outputSfMData_selected.getViews())
     {
         const IndexT viewId = viewIt.first;


### PR DESCRIPTION
- Tracks are modified to contains an optional depth field for each observation
- A node has been added to inject depthmaps information into this track field
- SfmBootstrap is now able to use this prior information if he's not able to find a pair with enough parallax
- SfmExpanding is now using this prior information if the same tracks has not enough parallax. The landmark is replaced with measured / triangulated information as soon as enough parallax is available