### PR TITLE
[sfmData] Add focal length naming convention

### DIFF
--- a/src/aliceVision/sfmData/ImageInfo.cpp
+++ b/src/aliceVision/sfmData/ImageInfo.cpp
@@ -397,7 +397,7 @@ int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatab
 
 double ImageInfo::getMetadataFocalLength() const
 {
-    double focalLength = getDoubleMetadata({"Exif:FocalLength", "focalLength", "focal length", "lens_focal_length"});
+    double focalLength = getDoubleMetadata({"Exif:FocalLength", "focalLength", "focal length", "lens_focal_length", "focal_length"});
 
     if (focalLength == -1)
     {


### PR DESCRIPTION
This PR adds `focal_length` to the list of possible metadata tags used to retrieve the focal length for an image.