### PR TITLE
Replace omp_set_nested (deprecated) with omp_set_max_active_levels

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,6 +253,7 @@ endif()
 if (ALICEVISION_USE_OPENMP STREQUAL "OFF")
     set(ALICEVISION_HAVE_OPENMP 0)
 else() # ON OR AUTO
+    # set(OpenMP_RUNTIME_MSVC "llvm")
     find_package(OpenMP)
 
     if (OPENMP_FOUND)
@@ -676,13 +677,13 @@ if (NOT ALICEVISION_USE_CUDA STREQUAL "OFF")
         set(CUDA_USE_STATIC_CUDA_RUNTIME ON)
     endif()
 
-    find_package(CUDA 11.0)
+    find_package(CUDA 12.0)
 
     if (CUDA_FOUND)
         set(ALICEVISION_HAVE_CUDA 1)
         message(STATUS "CUDA found.")
     elseif (ALICEVISION_USE_CUDA STREQUAL "ON")
-        message(SEND_ERROR "Failed to find CUDA (>= 11.0).")
+        message(SEND_ERROR "Failed to find CUDA (>= 12.0).")
     endif()
 endif()
 

--- a/src/aliceVision/alicevision_omp.hpp
+++ b/src/aliceVision/alicevision_omp.hpp
@@ -17,7 +17,7 @@ inline int omp_get_thread_num() { return 0; }
 inline int omp_get_max_threads() { return 1; }
 inline void omp_set_num_threads(int num_threads) {}
 inline int omp_get_num_procs() { return 1; }
-inline void omp_set_nested(int nested) {}
+inline void omp_set_max_active_levels(int levels) {}
 
 inline void omp_init_lock(omp_lock_t* lock) {}
 inline void omp_destroy_lock(omp_lock_t* lock) {}

--- a/src/aliceVision/featureEngine/FeatureExtractor.cpp
+++ b/src/aliceVision/featureEngine/FeatureExtractor.cpp
@@ -149,7 +149,7 @@ void FeatureExtractor::process(const HardwareContext& hContext, const image::EIm
         nbThreads = std::min(cpuJobs.size(), nbThreads);
 
         ALICEVISION_LOG_INFO("# threads for extraction: " << nbThreads);
-        omp_set_nested(1);
+        omp_set_max_active_levels(2);
 
 #pragma omp parallel for num_threads(nbThreads)
         for (int i = 0; i < cpuJobs.size(); ++i)

--- a/src/aliceVision/fuseCut/PointCloud.cpp
+++ b/src/aliceVision/fuseCut/PointCloud.cpp
@@ -141,7 +141,7 @@ void createVerticesWithVisibilities(const StaticVector<int>& cams,
     for (auto& lock : locks)
         omp_init_lock(&lock);
 
-    omp_set_nested(1);
+    omp_set_max_active_levels(2);
 #pragma omp parallel for num_threads(3)
     for (int c = 0; c < cams.size(); ++c)
     {
@@ -229,7 +229,7 @@ void createVerticesWithVisibilities(const StaticVector<int>& cams,
             }
         }
     }
-    omp_set_nested(0);
+    omp_set_max_active_levels(1);
 
     for (auto& lock : locks)
         omp_destroy_lock(&lock);
@@ -294,7 +294,7 @@ void PointCloud::fuseFromDepthMaps(const StaticVector<int>& cams, const Point3d 
 
     ALICEVISION_LOG_INFO("Load depth maps and add points.");
     {
-        omp_set_nested(1);
+        omp_set_max_active_levels(2);
 #pragma omp parallel for num_threads(3)
         for (int c = 0; c < cams.size(); c++)
         {
@@ -424,7 +424,7 @@ void PointCloud::fuseFromDepthMaps(const StaticVector<int>& cams, const Point3d 
                 }
             }
         }
-        omp_set_nested(0);
+        omp_set_max_active_levels(1);
     }
 
     ALICEVISION_LOG_INFO("Filter initial 3D points by pixel size to remove duplicates.");


### PR DESCRIPTION
`omp_set_nested` is replaced by `omp_set_max_active_levels`

`omp_set_nested` was a binary choice (0 to desactivate nested omp loops, 1 to activate).
`omp_set_max_active_levels` set the number of allowed nested loops (1 to desactivate, n!=1 to set the exact number of activated nested loops).

I assumed in the code we only needed 1 nested loop, so i set `omp_set_max_active_levels` to 2 when needed.