### PR TITLE
Update Dockerfiles

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -180,6 +180,16 @@ jobs:
         with:
             submodules: recursive
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install numpy and pytest
+        run: |
+          pip install numpy==1.*
+          pip install pytest
+
       - name: vcpkg - Clone repository
         # Uses a specific version of vcpkg
         run: |
@@ -196,7 +206,7 @@ jobs:
         uses: suisei-cn/actions-download-file@v1.3.0
         id: vcpkgDownload
         with:
-          url: "https://github.com/alicevision/vcpkg/releases/download/2025.03.11/aliceVisionDeps-2025.03.11.zip"
+          url: "https://github.com/alicevision/vcpkg/releases/download/2025.06.18/aliceVisionDeps-2025.06.18.zip"
           target: "${{ env.vcpkgDir }}"
           filename: installed.zip
 
@@ -219,18 +229,8 @@ jobs:
           cuda: '12.5.0'
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "cusparse", "npp", "npp_dev", "cufft", "cufft_dev"]'
 
-      - name: Display CUDA information
-        run: echo "Installed cuda version is "${{steps.cuda-toolkit.outputs.cuda}}
-             echo "Cuda install location "${{steps.cuda-toolkit.outputs.CUDA_PATH}}
-             nvcc -V
-             echo ${{ env.CUDA_PATH }}
-
       # Install latest CMake.
       - uses: lukka/get-cmake@latest
-
-      - name: Display remaining disk space (16 Go max)
-        run: |
-          Get-CimInstance -Class Win32_logicaldisk
 
       - name: Build
         uses: lukka/run-cmake@v3
@@ -240,7 +240,7 @@ jobs:
           buildDirectory: ${{ env.buildDir }}
           buildWithCMakeArgs: '--config Release --target install'
           cmakeAppendedArgs: -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}\scripts\buildsystems\vcpkg.cmake
-                             -DVCPKG_TARGET_TRIPLET=x64-windows
+                             -DVCPKG_TARGET_TRIPLET=x64-windows-release
                              -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
                              -A x64 -T host=x64
                              -DBUILD_SHARED_LIBS=ON
@@ -257,6 +257,7 @@ jobs:
                              -DALICEVISION_BUILD_SEGMENTATION=OFF
                              -DALICEVISION_BUILD_SWIG_BINDING=ON
                              -DALICEVISION_INSTALL_MESHROOM_PLUGIN=OFF
+                             -DPython3_EXECUTABLE=${{ env.pythonLocation }}\python
                              -DBOOST_NO_CXX11=ON
 
           cmakeBuildType: Release
@@ -275,7 +276,7 @@ jobs:
 
       - name: Python Binding - Unit Tests
         run: |
-          ${{ env.VCPKG_ROOT }}\installed\x64-windows\tools\python3\python -m pytest ./pyTests
+          pytest ./pyTests
 
       - name: Unit Tests
         uses: lukka/run-cmake@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container: ["alicevision/alicevision-deps:2025.05.15-ubuntu22.04-cuda12.1.1", "alicevision/alicevision-deps:2025.05.15-rocky9-cuda12.1.1"]
+        container: ["alicevision/alicevision-deps:2025.06.23-ubuntu22.04-cuda12.1.1", "alicevision/alicevision-deps:2025.06.23-rocky9-cuda12.1.1"]
     container:
       image: ${{ matrix.container }}
     env:
@@ -33,7 +33,7 @@ jobs:
       ALICEVISION_ROOT: ${{ github.workspace }}/../AV_install
       ALICEVISION_SENSOR_DB: ${{ github.workspace }}/../AV_install/share/aliceVision/cameraSensors.db
       ALICEVISION_LENS_PROFILE_INFO: ""
-      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2025.05.15-ubuntu22.04-cuda12.1.1' && 'ON' || 'OFF' }}"
+      BUILD_CCTAG: "${{ matrix.container == 'alicevision/alicevision-deps:2025.06.23-ubuntu22.04-cuda12.1.1' && 'ON' || 'OFF' }}"
     steps:
       - uses: actions/checkout@v1
 
@@ -65,7 +65,8 @@ jobs:
            -DCeres_DIR="${DEPS_INSTALL_DIR}/share/Ceres" \
            -DAlembic_DIR="${DEPS_INSTALL_DIR}/lib/cmake/Alembic" \
            -DSWIG_DIR="${DEPS_INSTALL_DIR}/share/swig/4.3.0" \
-           -DSWIG_EXECUTABLE="${DEPS_INSTALL_DIR}/bin-deps/swig"
+           -DSWIG_EXECUTABLE="${DEPS_INSTALL_DIR}/bin-deps/swig" \
+           -DPython3_EXECUTABLE=/usr/bin/python
 
       - name: Build
         working-directory: ./build
@@ -112,10 +113,10 @@ jobs:
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
           # Run the test pipeline
-          pip3 install psutil
+          python -m pip install psutil
           cd bin/
           mkdir ./outputData
-          python3 meshroom_batch -i $PWD/../../dataset_panoramaFisheyeHdr/RAW -p panoramaFisheyeHdr -o $PWD/../outputData
+          python meshroom_batch -i $PWD/../../dataset_panoramaFisheyeHdr/RAW -p panoramaFisheyeHdr -o $PWD/../outputData
 
       - name: Functional Tests - SfM Quality Evaluation
         working-directory: ./functional_tests
@@ -127,13 +128,13 @@ jobs:
           export PYTHONPATH=${ALICEVISION_ROOT}/lib64/python:${ALICEVISION_ROOT}/lib/python$:{PYTHONPATH}
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
-          python3 EvaluationLauncher.py -s ${ALICEVISION_ROOT}/bin -i $PWD/Benchmarking_Camera_Calibration_2008/ -o $PWD/reconstructions/ -r $PWD/results.json -v
+          python EvaluationLauncher.py -s ${ALICEVISION_ROOT}/bin -i $PWD/Benchmarking_Camera_Calibration_2008/ -o $PWD/reconstructions/ -r $PWD/results.json -v
 
       - name: Python Binding - Unit Tests
         run: |
           export PYTHONPATH=${ALICEVISION_ROOT}/lib64/python:${ALICEVISION_ROOT}/lib/python:${PYTHONPATH}
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
-          pip3 install pytest
+          python -m pip install pytest
           pytest ./pyTests
 
       - name: Meshroom Plugin - Templates validity
@@ -158,7 +159,7 @@ jobs:
               sys.exit(0)
           sys.exit(1)
           " | tee test_templatesVersions.py
-          python3 test_templatesVersions.py
+          python test_templatesVersions.py
 
   build-windows:
     runs-on: windows-latest

--- a/docker/Dockerfile_rocky_deps
+++ b/docker/Dockerfile_rocky_deps
@@ -26,9 +26,8 @@ RUN dnf install -y epel-release
 # RUN update-alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-13/root/usr/bin/gcc 60
 # RUN update-alternatives --install /usr/bin/g++ g++ /opt/rh/gcc-toolset-13/root/usr/bin/g++ 60
 # RUN update-alternatives --install /usr/bin/cpp cpp /opt/rh/gcc-toolset-13/root/usr/bin/cpp 60
-RUN dnf install -y ca-certificates wget
-RUN dnf install -y cmake git unzip
-RUN dnf install -y python3-devel python3-pip
+RUN dnf install -y ca-certificates wget cmake git unzip
+RUN dnf install -y python3.11-devel python3.11-pip
 RUN dnf install -y pcre2-devel
 RUN dnf install -y xerces-c-devel
 RUN dnf install -y bison
@@ -38,7 +37,7 @@ RUN dnf install -y gfortran libasan libubsan
 RUN dnf update -y
 # RUN scl enable gcc-toolset-13 bash
 
-RUN python3 -m pip install numpy
+RUN python3.11 -m pip install numpy==1.*
 
 ENV AV_DEV=/opt/AliceVision_git \
     AV_BUILD=/tmp/AliceVision_build \
@@ -79,7 +78,7 @@ RUN mkdir -p "${AV_INSTALL}/lib" && \
     ln -s lib "${AV_INSTALL}/lib64"
 
 # Symlink to Python3 executable in case a call to "python" instead of "python3" is ever made
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /usr/bin/python3.11 /usr/bin/python
 
 RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gnu/libcublas.so /usr/local/cuda/lib64/libcublas.so
 

--- a/docker/Dockerfile_ubuntu
+++ b/docker/Dockerfile_ubuntu
@@ -60,6 +60,7 @@ RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh`; \
         -DALICEVISION_BUILD_DOC:BOOL=OFF \
         -DALICEVISION_BUILD_SWIG_BINDING:BOOL=ON \
         -DSWIG_DIR:PATH="${AV_INSTALL}/share/swig/4.3.0" -DSWIG_EXECUTABLE:PATH="${AV_INSTALL}/bin-deps/swig" \
+        -DPython3_EXECUTABLE:PATH=/usr/bin/python \
         "${AV_DEV}" && \
     make install -j${CPU_CORES} && \
     make bundle && \

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -43,14 +43,16 @@ RUN . ./etc/os-release && \
         g++-12 \
         cpp-12 \
         gfortran-12 \
-        python3-dev \
-        python3-pip \
         libpcre2-dev \
         bison && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12  --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-12
 
+RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-distutils curl && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+
 # Install numpy
-RUN python3 -m pip install numpy
+RUN python3.11 -m pip install numpy==1.*
 
 ENV AV_DEV=/opt/AliceVision_git \
     AV_BUILD=/tmp/AliceVision_build \
@@ -90,7 +92,7 @@ RUN mkdir -p "${AV_INSTALL}/lib" && \
     ln -s lib "${AV_INSTALL}/lib64"
 
 # Symlink to Python3 executable in case a call to "python" instead of "python3" is ever made
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /usr/bin/python3.11 /usr/bin/python
 
 RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gnu/libcublas.so /usr/local/cuda/lib64/libcublas.so
 

--- a/docker/build-rocky.sh
+++ b/docker/build-rocky.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.05.15
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.06.23
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$ROCKY_VERSION" && ROCKY_VERSION=9

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.05.15
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.06.23
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=22.04

--- a/pyTests/geometry/test_pose3.py
+++ b/pyTests/geometry/test_pose3.py
@@ -9,9 +9,8 @@ import numpy as np
 
 def test_constructor_pose3():
    p = geo.Pose3()
-   assert np.array_equal(p.rotation(), np.eye(3)), "default rotation should be the identity"
-   print(type(p.translation()))
-   assert np.array_equal(p.translation(), np.ndarray(shape=(3, 1), buffer=np.array([[0, 0, 0]]))), "default translation should be null"
+   assert np.array_equal(p.rotation(), np.eye(3)), "Default rotation should be the identity"
+   assert np.array_equal(p.translation(), np.ndarray(shape=(3, 1), buffer=np.array([[0.], [0.], [0.]]))), "Default translation should be null"
 
 def test_constructor_pose3_2():
     R = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]], 'd')

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -103,7 +103,7 @@ set(CMAKE_CORE_BUILD_FLAGS
         -DCMAKE_INSTALL_DO_STRIP:BOOL=${CMAKE_INSTALL_DO_STRIP} 
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} 
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} 
-        -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_CXX_STANDARD=20
 )
 
 
@@ -284,7 +284,7 @@ if(AV_BUILD_EIGEN)
         BINARY_DIR ${BUILD_DIR}/eigen_build
         INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
         CONFIGURE_COMMAND ${CMAKE_COMMAND} 
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_STANDARD=20
             ${EIGEN_CMAKE_ALIGNMENT_FLAGS}
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
             <SOURCE_DIR>
@@ -633,10 +633,10 @@ if(AV_BUILD_BOOST)
             ./bootstrap.${SCRIPT_EXTENSION} --prefix=<INSTALL_DIR> --with-libraries=atomic,container,date_time,exception,graph,iostreams,json,log,math,program_options,regex,serialization,system,test,thread,stacktrace,timer
         BUILD_COMMAND
             cd <SOURCE_DIR> &&
-            ./b2 --prefix=<INSTALL_DIR> variant=${DEPS_CMAKE_BUILD_TYPE_LOWERCASE} cxxstd=17 link=shared threading=multi -j8
+            ./b2 --prefix=<INSTALL_DIR> variant=${DEPS_CMAKE_BUILD_TYPE_LOWERCASE} cxxstd=20 link=shared threading=multi -j8
         INSTALL_COMMAND
             cd <SOURCE_DIR> &&
-            ./b2 variant=${DEPS_CMAKE_BUILD_TYPE_LOWERCASE} cxxstd=17 link=shared threading=multi install
+            ./b2 variant=${DEPS_CMAKE_BUILD_TYPE_LOWERCASE} cxxstd=20 link=shared threading=multi install
         DEPENDS ${ZLIB_TARGET}
     )
 
@@ -1068,7 +1068,7 @@ if(AV_BUILD_CCTAG)
             -DCCTAG_BUILD_TESTS=OFF
             -DCCTAG_BUILD_APPS=OFF
             -DCCTAG_EIGEN_MEMORY_ALIGNMENT=ON
-            -DCCTAG_CXX_STANDARD=17
+            -DCCTAG_CXX_STANDARD=20
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
             <SOURCE_DIR>
         BUILD_COMMAND $(MAKE) -j${AV_BUILD_DEPENDENCIES_PARALLEL}

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -618,8 +618,8 @@ if(AV_BUILD_BOOST)
     endif()
     
     ExternalProject_Add(${BOOST_TARGET}
-        URL https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2
-        URL_HASH MD5=429d451cb9197143cc77962c5ff272ef
+        URL https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2
+        URL_HASH MD5=2d098ba2e1457708a02de996857c2b10
         DOWNLOAD_DIR ${BUILD_DIR}/download/boost
         PREFIX ${BUILD_DIR}
         BUILD_IN_SOURCE 0


### PR DESCRIPTION
## Description

This pull request updates all the dependencies, both for Linux and Windows:
- Boost is updated from 1.85.0 to 1.86.0, as 1.85.0 had a major issue (https://github.com/boostorg/container/issues/273).
- The vcpkg archive used for the Windows CI build is updated (see https://github.com/alicevision/vcpkg/releases/tag/2025.06.18).
- The Python 3 version is updated in all the dependencies images to 3.11.
- A Python unit test which caused errors with some numpy versions is adjusted.
- The continuous integration workflow is updated to use the latest images and use the correct version of Python. 