### PR TITLE
[MVS] meshPostProcessing: bugfix in the cleanup of removed free points

### DIFF
--- a/src/aliceVision/mesh/meshPostProcessing.cpp
+++ b/src/aliceVision/mesh/meshPostProcessing.cpp
@@ -51,6 +51,7 @@ void meshPostProcessing(Mesh*& inout_mesh,
             if (newId > -1)
             {
                 StaticVector<int>& ptCamsNew = inout_ptsCams[newId];
+                ptCamsNew.clear();
                 ptCamsNew.reserve(sizeOfStaticVector<int>(ptsCamsOld[i]));
                 for (int j = 0; j < sizeOfStaticVector<int>(ptsCamsOld[i]); ++j)
                 {


### PR DESCRIPTION
After  `removeTrianglesInHexahedrons()` and `removeFreePointsFromMesh();` there is a cleanup phase.

But instead of *replacing* the observing camera ids, the current code is *adding* the camera ids to "garbage" vectors. 

We had a really random result for the point visibility. 
