### PR TITLE
[mesh] Fix mesh appearing whitened in 3D viewer

### DIFF
--- a/src/aliceVision/mesh/Material.hpp
+++ b/src/aliceVision/mesh/Material.hpp
@@ -32,7 +32,7 @@ class Material
     };
 
     Color diffuse = {0.6, 0.6, 0.6};
-    Color ambient = {0.6, 0.6, 0.6};
+    Color ambient = {0.1, 0.1, 0.1};
     Color specular = {0.0, 0.0, 0.0};
     float shininess = 0.0;
 

--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -1341,8 +1341,8 @@ void Texturing::saveAs(const fs::path& dir, const std::string& basename, EFileTy
         const aiString texName("material_" + Material::textureId(atlasId));
 
         scene.mMaterials[atlasId] = new aiMaterial;
-        scene.mMaterials[atlasId]->AddProperty(&valcolor, 1, AI_MATKEY_COLOR_AMBIENT);
-        scene.mMaterials[atlasId]->AddProperty(&valambient, 1, AI_MATKEY_COLOR_DIFFUSE);
+        scene.mMaterials[atlasId]->AddProperty(&valcolor, 1, AI_MATKEY_COLOR_DIFFUSE);
+        scene.mMaterials[atlasId]->AddProperty(&valambient, 1, AI_MATKEY_COLOR_AMBIENT);
         scene.mMaterials[atlasId]->AddProperty(&valspecular, 1, AI_MATKEY_COLOR_SPECULAR);
         scene.mMaterials[atlasId]->AddProperty(&shininess, 1, AI_MATKEY_SHININESS);
         scene.mMaterials[atlasId]->AddProperty(&texName, AI_MATKEY_NAME);


### PR DESCRIPTION
- QT 6.8 introduced a change* in phong fragment shader which change the way the mesh are displayed in meshroom.
- This PR will change the ambient value which was previously largely ignored
- This PR also swap material values which were erroneously assigned


(*) https://github.com/qt/qt3d/commit/491e25e100f5eace863a6cab4b0fc5a508cae7bf#diff-97f2251f87b19173236b771458b3e6157b3ce27a77176d7902dbabda026c30b5