### PR TITLE
[src] Update DLL discovery in `__init__.py` for the binding on Windows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -170,12 +170,10 @@ jobs:
       BUILD_TYPE: Release
       CTEST_OUTPUT_ON_FAILURE: 1
       ALICEVISION_ROOT: '${{ github.workspace }}/install'
+      ALICEVISION_LIBPATH: '${{ github.workspace }}/install/bundle/bin'
       VCPKG_ROOT: '${{ github.workspace}}\..\vcpkg'
       PYTHONPATH: '${{ github.workspace }}/install/bundle/lib/python;${{ github.workspace }}/install/bundle/lib64/python'
     steps:
-      - name: Add Bundle/bin to PATH
-        run: |
-          "${{ github.workspace }}/install/bundle/bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
       
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/aliceVision/__init__.py
+++ b/src/aliceVision/__init__.py
@@ -1,9 +1,20 @@
 import os
 
 # Windows only
-if hasattr(os, 'add_dll_directory'):
-    paths = os.environ['PATH'].split(os.pathsep)
-    for p in paths:
+if hasattr(os, "add_dll_directory"):
+    import pathlib
+    pyavFolder = pathlib.Path(__file__).resolve().parent
+    os.add_dll_directory(pyavFolder)
+
+    avRoot = os.environ.get("ALICEVISION_ROOT", "")
+    if not avRoot:
+        avRoot = pyavFolder.parent.parent.parent
+    avBin = os.path.join(avRoot, "bin")
+
+    os.add_dll_directory(avBin)
+
+    libfolders = os.environ.get("ALICEVISION_LIBPATH", "").split(os.pathsep)
+    for p in libfolders:
         if not os.path.isdir(p):
             continue
         os.add_dll_directory(p)


### PR DESCRIPTION

## Description

This PR edits the __init__.py file from `src/aliceVision` to update the way DLLs are looked for and loaded on Windows for the Python binding.

Rather than relying on the `PATH` variable, we are relying either on the `ALICEVISION_ROOT` variable, which is set when bundling, or the new `ALICEVISION_LIBPATH`, which is set with the same extra paths as the `PATH` variable was, except that it does not have any ambiguity.

The continuous integration workflow for Windows is updated consequently: as the bundle step occurs after `ALICEVISION_ROOT` has been set, there is a discrepancy between where the DLLs are searched for based on `ALICEVISION_ROOT` and where the DLLs to find actually are. As a consequence, we set `ALICEVISION_LIBPATH` to `ALICEVISION_ROOT/bundle/bin` for the DLLs discovery.