### PR TITLE
[meshroom] `SketchfabUpload`: Import `requests` at the function-level

### DIFF
--- a/meshroom/aliceVision/SketchfabUpload.py
+++ b/meshroom/aliceVision/SketchfabUpload.py
@@ -7,7 +7,6 @@ import glob
 import os
 import json
 import zipfile
-import requests
 import io
 
 
@@ -173,6 +172,7 @@ Upload a textured mesh on Sketchfab.
     ]
     
     def upload(self, apiToken, modelFile, data, chunk):
+        import requests
         modelEndpoint = 'https://api.sketchfab.com/v3/models'
         f = open(modelFile, 'rb')
         file = {'modelFile': (os.path.basename(modelFile), f.read())}


### PR DESCRIPTION
## Description

This PR simply moves the `requests` module import from the top-level to the `upload()` method, as it is the only one to use it, and as it is not a standard Python import.

By doing so, the `SketchfabUpload` node can be loaded and registered again, and does not generate error logs when there is an attempt to load it.