### PR TITLE
Remove hack with Custom camera model

### DIFF
--- a/src/aliceVision/sfmDataIO/viewIO.cpp
+++ b/src/aliceVision/sfmDataIO/viewIO.cpp
@@ -225,11 +225,7 @@ std::shared_ptr<camera::IntrinsicBase> getViewIntrinsic(const sfmData::View& vie
         }
     }
 
-    if (cameraBrand == "Custom")
-    {
-        intrinsicType = camera::EINTRINSIC_stringToEnum(cameraModel);
-    }
-    else if ((lcpIntrinsicType != camera::EINTRINSIC::UNKNOWN))
+    if ((lcpIntrinsicType != camera::EINTRINSIC::UNKNOWN))
     {
         intrinsicType = lcpIntrinsicType;
     }


### PR DESCRIPTION
Remove an old hack where the "Camera Model" metadata was used to force an intrinsic model in viewIO.cpp