### PR TITLE
Update image module of Python binding

### DIFF
--- a/src/aliceVision/image/image.i
+++ b/src/aliceVision/image/image.i
@@ -149,7 +149,46 @@ int NumPyType<image::RGBColor>()
     }
 }
 
+%{
+class oiioParams
+{
+    public:
 
+    oiioParams() {}
+    oiioParams(int orientation, float pixelAspectRatio, std::string compression = "")
+    {
+        _myParamList["Orientation"] = orientation;
+        _myParamList["pixelAspectRatio"] = pixelAspectRatio;
+        if (compression != "")
+        {
+            _myParamList["compression"] = compression;
+        }
+    }
+
+    const oiio::ParamValueList & get()
+    {
+        return _myParamList;
+    }
+
+    private:
+
+    oiio::ParamValueList _myParamList;
+};
+
+%}
+class oiioParams
+{
+    public:
+
+    oiioParams();
+    oiioParams(int orientation, float pixelAspectRatio, std::string compression = "");
+
+    const oiio::ParamValueList & get();
+
+    private:
+
+    oiio::ParamValueList _myParamList;
+};
 
 %template(Image_float) aliceVision::image::Image<float>; 
 %template(Image_uchar) aliceVision::image::Image<unsigned char>; 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description

This PR allows to set 3 OpenImageIO metadata, 'Orientation', 'pixelAspectRatio' and 'Compression', when writing an image using the Python binding.


