### PR TITLE
SwigBinding: Add binding for the `feature` and `matching` modules

### DIFF
--- a/pyTests/feature/test_feature.py
+++ b/pyTests/feature/test_feature.py
@@ -1,0 +1,27 @@
+"""
+Collection of unit tests for feature
+"""
+
+import pytest
+import os
+
+from pyalicevision import feature as feat
+
+def test_io():
+    
+    regions = feat.FakeRegions()
+
+    regions.Descriptors().append(feat.FakeDescriptor())
+    regions.Features().append(feat.PointFeature())
+    regions.Descriptors().append(feat.FakeDescriptor())
+    regions.Features().append(feat.PointFeature(1, 2, 0.5, 2))
+
+    ffeat = os.path.abspath(os.path.dirname(__file__)) + "/out.feat"
+    fdesc = os.path.abspath(os.path.dirname(__file__)) + "/out.desc"
+    
+    regions.Save(ffeat, fdesc), "Error Saving"
+
+    compare = feat.FakeRegions()
+    compare.Load(ffeat, fdesc)
+
+    assert compare.RegionCount() == regions.RegionCount(), "Did not get the same collection"

--- a/pyTests/matching/test_matching.py
+++ b/pyTests/matching/test_matching.py
@@ -1,0 +1,39 @@
+"""
+Collection of unit tests for matching
+"""
+
+import pytest
+import os
+
+from pyalicevision import matching as m
+
+def test_io():
+    
+    matches = m.IndMatches() 
+    matches.append(m.IndMatch(0, 2))
+    matches.append(m.IndMatch(3, 4))
+
+    perdesc = m.MatchesPerDescType()
+    perdesc[m.EImageDescriberType_SIFT] = matches
+
+    final = m.PairwiseMatches()
+    pair = m.Pair(0, 1)
+    final[pair] = perdesc
+
+    directory = os.path.abspath(os.path.dirname(__file__))
+    assert m.Save(final, directory, "txt", False, ""), "Error saving"
+    
+    loaded = m.PairwiseMatches()
+
+    views = m.IndexTSet()
+    views.append(0)
+    views.append(1)
+
+    directories = m.StringVector()
+    directories.append(directory)
+
+    types = m.EImageDescriberTypeVector()
+    types.append(m.EImageDescriberType_SIFT)
+
+    assert m.Load(loaded, views, directories, types, 0, 0)
+    assert len(loaded) == 1, "Invalid loaded content"

--- a/src/aliceVision/colorHarmonization/CommonDataByPair_matchedPoints.hpp
+++ b/src/aliceVision/colorHarmonization/CommonDataByPair_matchedPoints.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "aliceVision/colorHarmonization/CommonDataByPair.hpp"
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 #include "aliceVision/feature/feature.hpp"
 #include "aliceVision/feature/RegionsPerView.hpp"
 

--- a/src/aliceVision/feature/CMakeLists.txt
+++ b/src/aliceVision/feature/CMakeLists.txt
@@ -105,3 +105,18 @@ endif()
 # Unit tests
 alicevision_add_test(features_test.cpp NAME "features" LINKS aliceVision_feature)
 alicevision_add_test(metric_test.cpp   NAME "descriptor_metric"   LINKS aliceVision_feature)
+
+# SWIG Binding
+if (ALICEVISION_BUILD_SWIG_BINDING)
+    alicevision_swig_add_library(feature
+        SOURCES feature.i
+        PUBLIC_LINKS
+            aliceVision_feature
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
+    )
+endif()

--- a/src/aliceVision/feature/Descriptor.hpp
+++ b/src/aliceVision/feature/Descriptor.hpp
@@ -53,6 +53,8 @@ class Descriptor
     inline bin_type& operator[](std::size_t i) { return data[i]; }
     inline bin_type operator[](std::size_t i) const { return data[i]; }
 
+    bin_type & at(std::size_t i) { return data[i]; }
+
     // Atomic addition between two descriptors
     inline This& operator+=(const This other)
     {

--- a/src/aliceVision/feature/feature.i
+++ b/src/aliceVision/feature/feature.i
@@ -1,0 +1,32 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%module (module="pyalicevision") feature
+
+%include <aliceVision/config.hpp>
+%include <aliceVision/global.i>
+
+%{    
+#include <aliceVision/feature/Regions.hpp>
+
+using namespace aliceVision;
+using namespace aliceVision::feature;
+%} 
+
+%include <aliceVision/feature/Descriptor.hpp>
+%include <aliceVision/feature/PointFeature.hpp>
+%include <aliceVision/feature/Regions.hpp>
+
+%template(Features) std::vector<aliceVision::feature::PointFeature>;
+
+%define %region_typemaps(CLASS, TYPE, LEN)
+%template(CLASS##Regions) aliceVision::feature::FeatDescRegions<TYPE, LEN, ERegionType::Scalar>;
+%template(CLASS##Descriptor) aliceVision::feature::Descriptor<TYPE, LEN>;
+%template(CLASS##Descriptors) std::vector<aliceVision::feature::Descriptor<TYPE, LEN>>;
+%enddef
+
+%region_typemaps(Fake, unsigned char, 1)
+%region_typemaps(Sift, unsigned char, 128)

--- a/src/aliceVision/localization/CCTagLocalizer.cpp
+++ b/src/aliceVision/localization/CCTagLocalizer.cpp
@@ -11,7 +11,7 @@
 
 #include <aliceVision/config.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 #include <aliceVision/sfm/pipeline/RelativePoseInfo.hpp>

--- a/src/aliceVision/matching/ArrayMatcher.hpp
+++ b/src/aliceVision/matching/ArrayMatcher.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "aliceVision/numeric/numeric.hpp"
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 
 #include <vector>
 #include <random>

--- a/src/aliceVision/matching/ArrayMatcher_cascadeHashing.hpp
+++ b/src/aliceVision/matching/ArrayMatcher_cascadeHashing.hpp
@@ -10,7 +10,7 @@
 #include <aliceVision/feature/metric.hpp>
 #include <aliceVision/matching/ArrayMatcher.hpp>
 #include <aliceVision/matching/CascadeHasher.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 
 #include <aliceVision/system/Logger.hpp>
 

--- a/src/aliceVision/matching/CMakeLists.txt
+++ b/src/aliceVision/matching/CMakeLists.txt
@@ -5,6 +5,7 @@ set(matching_files_headers
     ArrayMatcher_cascadeHashing.hpp
     ArrayMatcher_kdtreeFlann.hpp
     IndMatch.hpp
+    MatchesCollections.hpp
     IndMatchDecorator.hpp
     filters.hpp
     guidedMatching.hpp
@@ -49,3 +50,18 @@ alicevision_add_test(filters_test.cpp  NAME "matching_filters"  LINKS aliceVisio
 alicevision_add_test(indMatch_test.cpp NAME "matching_indMatch" LINKS aliceVision_matching)
 
 add_subdirectory(kvld)
+
+# SWIG Binding
+if (ALICEVISION_BUILD_SWIG_BINDING)
+    alicevision_swig_add_library(matching
+        SOURCES matching.i
+        PUBLIC_LINKS
+            aliceVision_matching
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
+    )
+endif()

--- a/src/aliceVision/matching/CascadeHasher.hpp
+++ b/src/aliceVision/matching/CascadeHasher.hpp
@@ -9,7 +9,7 @@
 
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/feature/metric.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/stl/DynamicBitset.hpp>
 
 #include <iostream>

--- a/src/aliceVision/matching/IndMatch.hpp
+++ b/src/aliceVision/matching/IndMatch.hpp
@@ -8,12 +8,8 @@
 #pragma once
 
 #include <aliceVision/types.hpp>
-#include <aliceVision/feature/imageDescriberCommon.hpp>
-
 #include <iostream>
 #include <vector>
-#include <set>
-#include <map>
 
 #define ALICEVISION_DEBUG_MATCHING
 
@@ -69,41 +65,6 @@ inline std::ostream& operator<<(std::ostream& out, const IndMatch& obj) { return
 inline std::istream& operator>>(std::istream& in, IndMatch& obj) { return in >> obj._i >> obj._j; }
 
 typedef std::vector<matching::IndMatch> IndMatches;
-
-struct MatchesPerDescType : public std::map<feature::EImageDescriberType, IndMatches>
-{
-    int getNbMatches(feature::EImageDescriberType descType) const
-    {
-        const auto& it = this->find(descType);
-        if (it == this->end())
-            return 0;
-        return it->second.size();
-    }
-    int getNbAllMatches() const
-    {
-        int nbMatches = 0;
-        for (const auto& matches : *this)
-        {
-            nbMatches += matches.second.size();
-        }
-        return nbMatches;
-    }
-};
-
-/// Pairwise matches (indexed matches for a pair <I,J>)
-/// The structure used to store corresponding point indexes per images pairs
-
-typedef std::map<Pair, MatchesPerDescType> PairwiseMatches;
-
-typedef std::map<Pair, IndMatches> PairwiseSimpleMatches;
-
-inline PairSet getImagePairs(const PairwiseMatches& matches)
-{
-    PairSet pairs;
-    for (PairwiseMatches::const_iterator it = matches.begin(); it != matches.end(); ++it)
-        pairs.insert(it->first);
-    return pairs;
-}
 
 }  // namespace matching
 }  // namespace aliceVision

--- a/src/aliceVision/matching/IndMatchDecorator.hpp
+++ b/src/aliceVision/matching/IndMatchDecorator.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <iostream>
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 #include "aliceVision/feature/feature.hpp"
 
 namespace aliceVision {

--- a/src/aliceVision/matching/MatchesCollections.hpp
+++ b/src/aliceVision/matching/MatchesCollections.hpp
@@ -1,0 +1,60 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2016 AliceVision contributors.
+// Copyright (c) 2012 openMVG contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/types.hpp>
+#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/feature/imageDescriberCommon.hpp>
+
+#include <iostream>
+#include <vector>
+#include <set>
+#include <map>
+
+#define ALICEVISION_DEBUG_MATCHING
+
+namespace aliceVision {
+namespace matching {
+
+struct MatchesPerDescType : public std::map<feature::EImageDescriberType, IndMatches>
+{
+    int getNbMatches(feature::EImageDescriberType descType) const
+    {
+        const auto& it = this->find(descType);
+        if (it == this->end())
+            return 0;
+        return it->second.size();
+    }
+    int getNbAllMatches() const
+    {
+        int nbMatches = 0;
+        for (const auto& matches : *this)
+        {
+            nbMatches += matches.second.size();
+        }
+        return nbMatches;
+    }
+};
+
+/// Pairwise matches (indexed matches for a pair <I,J>)
+/// The structure used to store corresponding point indexes per images pairs
+
+typedef std::map<Pair, MatchesPerDescType> PairwiseMatches;
+
+typedef std::map<Pair, IndMatches> PairwiseSimpleMatches;
+
+inline PairSet getImagePairs(const PairwiseMatches& matches)
+{
+    PairSet pairs;
+    for (PairwiseMatches::const_iterator it = matches.begin(); it != matches.end(); ++it)
+        pairs.insert(it->first);
+    return pairs;
+}
+
+}  // namespace matching
+}  // namespace aliceVision

--- a/src/aliceVision/matching/RegionsMatcher.hpp
+++ b/src/aliceVision/matching/RegionsMatcher.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "aliceVision/matching/matcherType.hpp"
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 #include "aliceVision/matching/IndMatchDecorator.hpp"
 #include "aliceVision/matching/filters.hpp"
 

--- a/src/aliceVision/matching/filters.hpp
+++ b/src/aliceVision/matching/filters.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 #include <algorithm>
 #include <cassert>
 #include <iterator>

--- a/src/aliceVision/matching/guidedMatching.hpp
+++ b/src/aliceVision/matching/guidedMatching.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <aliceVision/numeric/numeric.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/feature/RegionsPerView.hpp>
 #include <aliceVision/feature/Regions.hpp>
 #include <aliceVision/camera/IntrinsicBase.hpp>

--- a/src/aliceVision/matching/indMatch_test.cpp
+++ b/src/aliceVision/matching/indMatch_test.cpp
@@ -5,7 +5,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 #include "aliceVision/matching/io.hpp"
 
 #define BOOST_TEST_MODULE IndMatch

--- a/src/aliceVision/matching/io.hpp
+++ b/src/aliceVision/matching/io.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 
 #include <string>
 

--- a/src/aliceVision/matching/kvld/algorithm.h
+++ b/src/aliceVision/matching/kvld/algorithm.h
@@ -16,7 +16,7 @@
 
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/image/Image.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/feature/PointFeature.hpp>
 #include <aliceVision/types.hpp>
 

--- a/src/aliceVision/matching/matchesFiltering.hpp
+++ b/src/aliceVision/matching/matchesFiltering.hpp
@@ -10,7 +10,7 @@
 #include <aliceVision/feature/Regions.hpp>
 #include <aliceVision/feature/RegionsPerView.hpp>
 #include <aliceVision/feature/feature.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 
 namespace aliceVision {
 namespace matching {

--- a/src/aliceVision/matching/matching.i
+++ b/src/aliceVision/matching/matching.i
@@ -1,0 +1,40 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%module (module="pyalicevision") matching
+
+%include <aliceVision/config.hpp>
+%include <aliceVision/global.i>
+%include <std_map.i>
+%include <std_vector.i>
+
+%{    
+#include <aliceVision/matching/io.hpp>
+
+using namespace aliceVision;
+using namespace aliceVision::matching;
+%} 
+
+%ignore aliceVision::matching::operator<<;
+%ignore aliceVision::matching::operator>>;
+
+
+
+%include <aliceVision/matching/IndMatch.hpp>
+
+
+
+
+%template(IndMatches) std::vector<aliceVision::matching::IndMatch>;
+%template(MatchesPerDesc) std::map<enum aliceVision::feature::EImageDescriberType, aliceVision::matching::IndMatches>;
+
+%include <aliceVision/feature/imageDescriberCommon.hpp>
+%include <aliceVision/matching/MatchesCollections.hpp>
+%include <aliceVision/matching/io.hpp>
+
+%template(EImageDescriberTypeVector) std::vector<enum aliceVision::feature::EImageDescriberType>;
+
+%template(PairwiseMatches) std::map<aliceVision::Pair, aliceVision::matching::MatchesPerDescType>;

--- a/src/aliceVision/matching/pairwiseAdjacencyDisplay.hpp
+++ b/src/aliceVision/matching/pairwiseAdjacencyDisplay.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "dependencies/vectorGraphics/svgDrawer.hpp"
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 
 namespace aliceVision {
 namespace matching {

--- a/src/aliceVision/matching/supportEstimation.hpp
+++ b/src/aliceVision/matching/supportEstimation.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <aliceVision/feature/imageDescriberCommon.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 
 #include <vector>
 

--- a/src/aliceVision/matching/svgVisualization.hpp
+++ b/src/aliceVision/matching/svgVisualization.hpp
@@ -14,7 +14,7 @@
 #endif
 #include <aliceVision/feature/RegionsPerView.hpp>
 #include <aliceVision/feature/FeaturesPerView.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 
 #include <vector>
 

--- a/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
@@ -10,7 +10,7 @@
 #include <aliceVision/config.hpp>
 #include <aliceVision/feature/PointFeature.hpp>
 #include <aliceVision/feature/RegionsPerView.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_E_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_E_AC.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <aliceVision/types.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
 #include <aliceVision/robustEstimation/ACRansac.hpp>
 #include <aliceVision/matching/guidedMatching.hpp>

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
 #include <aliceVision/matchingImageCollection/geometricFilterUtils.hpp>
 #include <aliceVision/robustEstimation/estimators.hpp>

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "aliceVision/feature/RegionsPerView.hpp"
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 #include "aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp"
 #include "aliceVision/matchingImageCollection/geometricFilterUtils.hpp"
 #include "aliceVision/sfmData/SfMData.hpp"

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_H_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_H_AC.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/IndMatchDecorator.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
 #include <aliceVision/robustEstimation/ACRansac.hpp>

--- a/src/aliceVision/matchingImageCollection/IImageCollectionMatcher.hpp
+++ b/src/aliceVision/matchingImageCollection/IImageCollectionMatcher.hpp
@@ -9,7 +9,7 @@
 
 #include "aliceVision/feature/imageDescriberCommon.hpp"
 #include "aliceVision/matching/matcherType.hpp"
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 #include "aliceVision/matchingImageCollection/pairBuilder.hpp"
 #include "aliceVision/feature/RegionsPerView.hpp"
 

--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils.hpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/feature/FeaturesPerView.hpp>
 #include <aliceVision/camera/IntrinsicBase.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>

--- a/src/aliceVision/sfm/filters.hpp
+++ b/src/aliceVision/sfm/filters.hpp
@@ -9,7 +9,7 @@
 
 #include <aliceVision/multiview/rotationAveraging/common.hpp>
 #include <aliceVision/multiview/translationAveraging/common.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/system/Logger.hpp>
 
 namespace aliceVision {

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
@@ -12,7 +12,7 @@
 #include <aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp>
 #include <aliceVision/sfm/pipeline/global/reindexGlobalSfM.hpp>
 #include <aliceVision/sfm/pipeline/global/MutexSet.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/multiview/translationAveraging/common.hpp>
 #include <aliceVision/multiview/translationAveraging/solver.hpp>
 #include <aliceVision/graph/graph.hpp>

--- a/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
+++ b/src/aliceVision/sfm/pipeline/global/globalSfM_test.cpp
@@ -8,7 +8,7 @@
 #include <aliceVision/sfm/utils/statistics.hpp>
 #include <aliceVision/sfm/utils/syntheticScene.hpp>
 #include <aliceVision/feature/FeaturesPerView.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/sfm/sfm.hpp>
 
 #include <cmath>

--- a/src/aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp
+++ b/src/aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp
@@ -10,7 +10,7 @@
 #include <aliceVision/types.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/io.hpp>
 
 #include <vector>

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -17,7 +17,7 @@
 
 #include <aliceVision/feature/FeaturesPerView.hpp>
 #include <aliceVision/graph/connectedComponent.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/multiview/essential.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
 #include <aliceVision/multiview/triangulation/Triangulation.hpp>

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.cpp
@@ -7,7 +7,7 @@
 
 #include "StructureEstimationFromKnownPoses.hpp"
 #include <aliceVision/feature/metric.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/guidedMatching.hpp>
 #include <aliceVision/multiview/relativePose/FundamentalError.hpp>
 #include <aliceVision/multiview/triangulation/Triangulation.hpp>

--- a/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.hpp
+++ b/src/aliceVision/sfm/pipeline/structureFromKnownPoses/StructureEstimationFromKnownPoses.hpp
@@ -9,7 +9,7 @@
 
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/feature/RegionsPerView.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 
 namespace aliceVision {
 namespace sfm {

--- a/src/aliceVision/sfm/utils/syntheticScene.hpp
+++ b/src/aliceVision/sfm/utils/syntheticScene.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <aliceVision/feature/FeaturesPerView.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/multiview/NViewDataSet.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 

--- a/src/aliceVision/track/Track.hpp
+++ b/src/aliceVision/track/Track.hpp
@@ -9,7 +9,7 @@
 
 #include <aliceVision/config.hpp>
 #include <aliceVision/feature/imageDescriberCommon.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/stl/FlatMap.hpp>
 
 #include <algorithm>

--- a/src/aliceVision/track/track_test.cpp
+++ b/src/aliceVision/track/track_test.cpp
@@ -8,7 +8,7 @@
 #include "aliceVision/track/TracksBuilder.hpp"
 #include "aliceVision/track/TracksMerger.hpp"
 #include "aliceVision/track/tracksUtils.hpp"
-#include "aliceVision/matching/IndMatch.hpp"
+#include "aliceVision/matching/MatchesCollections.hpp"
 
 #include <vector>
 #include <utility>

--- a/src/software/export/main_exportKeypoints.cpp
+++ b/src/software/export/main_exportKeypoints.cpp
@@ -7,7 +7,7 @@
 
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/io.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>

--- a/src/software/export/main_exportMatches.cpp
+++ b/src/software/export/main_exportMatches.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 #include <aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/io.hpp>
 #include <aliceVision/image/all.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>

--- a/src/software/export/main_exportTracks.cpp
+++ b/src/software/export/main_exportTracks.cpp
@@ -11,7 +11,7 @@
 #include <aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp>
 #include <aliceVision/matching/svgVisualization.hpp>
 #include <aliceVision/feature/feature.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/io.hpp>
 #include <aliceVision/track/TracksBuilder.hpp>
 #include <aliceVision/track/tracksUtils.hpp>

--- a/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
+++ b/src/software/pipeline/main_computeStructureFromKnownPoses.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfm/sfm.hpp>
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/main.hpp>

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/stl/hash.hpp>
 #include <aliceVision/system/main.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/io.hpp>
 #include <boost/program_options.hpp>
 #include <aliceVision/geometry/rigidTransformation3D.hpp>

--- a/src/software/utils/main_voctreeQueryUtility.cpp
+++ b/src/software/utils/main_voctreeQueryUtility.cpp
@@ -11,7 +11,7 @@
 #include <aliceVision/voctree/databaseIO.hpp>
 #include <aliceVision/voctree/VocabularyTree.hpp>
 #include <aliceVision/voctree/descriptorLoader.hpp>
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -21,7 +21,7 @@
 // load features per view
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 // feature matches
-#include <aliceVision/matching/IndMatch.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/io.hpp>
 #include <aliceVision/stl/stl.hpp>
 // selection Methods


### PR DESCRIPTION
Add binding of feature and matching modules.

I only added I/O functions at the moment.

See pyTests for examples