### PR TITLE
[Fix] Initialize resectionid depending on previous sfm

### DIFF
--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.cpp
@@ -21,10 +21,22 @@ bool ExpansionHistory::initialize(const sfmData::SfMData & sfmData)
     // Update epoch id 
     // We want to have a starting epoch larger than the one found in the existing views
     _epoch = 0;
-    for (const auto & pv : sfmData.getViews())
+    for (const auto & [viewId, view] : sfmData.getViews())
     {
-        _epoch = std::max(_epoch, static_cast<size_t>(pv.second->getResectionId()));
+        IndexT rid = view->getResectionId();
+        if (rid == UndefinedIndexT)
+        {
+            continue;
+        }
+
+        if (!sfmData.isPoseAndIntrinsicDefined(viewId))
+        {
+            continue;
+        }
+        
+        _epoch = std::max(_epoch, static_cast<size_t>(view->getResectionId()));
     }
+
 
     _epoch++;
 

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -154,8 +154,9 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    // set maxThreads
+    // set maxThreads (Limit to 100 threads on large machines)
     HardwareContext hwc = cmdline.getHardwareContext();
+    hwc.setUserCoresLimit(100);
     omp_set_num_threads(hwc.getMaxThreads());
     
     // load input SfMData scene


### PR DESCRIPTION
- Limit max threads count in sfmExpanding (for computer with huge number of cores)
- Ignore invalid views when looking for the current maximal value of resectionId among existing views