### PR TITLE
Add more logging to new pipeline

### DIFF
--- a/src/aliceVision/matching/io.cpp
+++ b/src/aliceVision/matching/io.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/config.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/utils/filesIO.hpp>
+#include <aliceVision/utils/Histogram.hpp>
 
 #include <boost/range/iterator_range.hpp>
 
@@ -369,6 +370,21 @@ bool Save(const PairwiseMatches& matches, const std::string& folder, const std::
         exporter.saveGlobalFile();
 
     return true;
+}
+
+void displayStats(const PairwiseMatches& matches)
+{
+    int maxMatches = 5000;
+    utils::Histogram<double> histo(0, maxMatches, 100);
+
+    for (const auto [_, matchesPerDesc]: matches)
+    {
+        int max = std::min(matchesPerDesc.getNbAllMatches(), maxMatches);
+        histo.Add(max);
+    }
+
+    ALICEVISION_LOG_INFO("Matches count per pair (Clamped to " << maxMatches << " matches)");
+    ALICEVISION_LOG_INFO(histo.ToString("", 4, true));
 }
 
 }  // namespace matching

--- a/src/aliceVision/matching/io.hpp
+++ b/src/aliceVision/matching/io.hpp
@@ -87,5 +87,7 @@ bool Save(const PairwiseMatches& matches,
           bool matchFilePerImage,
           const std::string& prefix = "");
 
+void displayStats(const PairwiseMatches& matches);
+
 }  // namespace matching
 }  // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.cpp
@@ -45,6 +45,7 @@ bool ExpansionHistory::initialize(const sfmData::SfMData & sfmData)
 
 bool ExpansionHistory::beginEpoch(const sfmData::SfMData & sfmData)
 {
+    debrief(sfmData);
     return true;
 }
 
@@ -96,8 +97,15 @@ void ExpansionHistory::saveState(const sfmData::SfMData & sfmData)
         //Store usage counter
         _focalHistory[pIntrinsic.first].push_back(std::make_pair(usage, iso->getScale().x()));
     }
+}
 
-    
+void ExpansionHistory::debrief(const sfmData::SfMData & sfmData) const
+{
+    ALICEVISION_LOG_INFO("---- Current statistics ----");
+    ALICEVISION_LOG_INFO("Views : " << sfmData.getViews().size());
+    ALICEVISION_LOG_INFO("Valid views : " << sfmData.getValidViews().size());
+    ALICEVISION_LOG_INFO("Landmarks : " << sfmData.getLandmarks().size());
+    ALICEVISION_LOG_INFO("----------------------------");
 }
 
 } // namespace sfm

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.hpp
@@ -64,6 +64,12 @@ public:
         return _focalHistory[intrinsicId];
     }
 
+    /**
+     * Print statistics of the sfmData computed so far
+     * @param sfmData the input sfmData to analyze
+    */
+    void debrief(const sfmData::SfMData & sfmData) const;
+
 private:
     // History of focals per intrinsics
     std::map<IndexT, std::vector<std::pair<size_t, double>>> _focalHistory;

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
@@ -67,6 +67,8 @@ bool ExpansionProcess::process(sfmData::SfMData & sfmData, track::TracksHandler 
 
     ALICEVISION_LOG_INFO("ExpansionProcess end");
 
+    _historyHandler->debrief(sfmData);
+
     return true;
 }
 

--- a/src/aliceVision/track/TracksBuilder.cpp
+++ b/src/aliceVision/track/TracksBuilder.cpp
@@ -7,8 +7,12 @@
 
 #include "TracksBuilder.hpp"
 
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/utils/Histogram.hpp>
+
 #include <lemon/list_graph.h>
 #include <lemon/unionfind.h>
+
 
 namespace aliceVision {
 namespace track {
@@ -144,6 +148,8 @@ void TracksBuilder::filter(bool clearForks, std::size_t minTrackLength, bool mul
         }
     }
 
+    _filteredCounter = set_classToErase.size();
+
     std::for_each(set_classToErase.begin(), set_classToErase.end(), [&](int toErase) { _d->tracksUF->eraseClass(toErase); });
 }
 
@@ -219,6 +225,21 @@ std::size_t TracksBuilder::nbTracks() const
     for (lemon::UnionFindEnum<IndexMap>::ClassIt cit(*_d->tracksUF); cit != lemon::INVALID; ++cit)
         ++cpt;
     return cpt;
+}
+
+void TracksBuilder::displayStats(const TracksMap & allTracks) const
+{
+    const size_t maxLength = 25;
+    utils::Histogram<double> histo(0, maxLength, maxLength);
+
+    ALICEVISION_LOG_INFO("Tracks lengths histogram (Clamped to 25) : ");
+    for (const auto & [id, track] : allTracks)
+    {
+        histo.Add(std::min(maxLength, track.featPerView.size()));
+    }
+
+    ALICEVISION_LOG_INFO(histo.ToString("", 5, true));
+    ALICEVISION_LOG_INFO("Filtered out tracks : " << _filteredCounter);
 }
 
 }  // namespace track

--- a/src/aliceVision/track/TracksBuilder.hpp
+++ b/src/aliceVision/track/TracksBuilder.hpp
@@ -85,8 +85,11 @@ class TracksBuilder
      */
     std::size_t nbTracks() const;
 
+    void displayStats(const TracksMap & allTracks) const;
+
   private:
     std::unique_ptr<TracksBuilderData> _d;
+    size_t _filteredCounter;
 };
 
 }  // namespace track

--- a/src/aliceVision/track/TracksHandler.cpp
+++ b/src/aliceVision/track/TracksHandler.cpp
@@ -8,6 +8,7 @@
 
 #include <aliceVision/track/trackIO.hpp>
 #include <aliceVision/track/tracksUtils.hpp>
+#include <aliceVision/utils/Histogram.hpp>
 
 #include <fstream>
 

--- a/src/aliceVision/utils/Histogram.hpp
+++ b/src/aliceVision/utils/Histogram.hpp
@@ -103,13 +103,21 @@ class Histogram
 
     // Text display of the histogram
     template<typename KeyDataType = T, typename ValueDataType = T>
-    std::string ToString(const std::string& sTitle = "", int precision = 3) const
+    std::string ToString(const std::string& sTitle = "", int precision = 3, bool removeEmpty=false) const
     {
         std::ostringstream os;
         os << std::endl << sTitle << std::endl;
         const size_t n = freq.size();
         for (size_t i = 0; i < n; ++i)
         {
+            if (removeEmpty)
+            {
+                if (i < n -1 && freq[i] == 0)
+                {
+                    continue;
+                }
+            }
+
             os << std::setprecision(precision) << KeyDataType(Start + static_cast<float>(End - Start) / n * static_cast<float>(i)) << "\t|\t"
                << ValueDataType(freq[i]) << "\n";
         }

--- a/src/software/pipeline/main_sfmBootstrapping.cpp
+++ b/src/software/pipeline/main_sfmBootstrapping.cpp
@@ -15,6 +15,8 @@
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 #include <aliceVision/feature/imageDescriberCommon.hpp>
 
+#include <aliceVision/utils/Histogram.hpp>
+
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
@@ -31,6 +33,7 @@
 #include <aliceVision/dataio/json.hpp>
 #include <aliceVision/sfm/pipeline/bootstrapping/PairsScoring.hpp>
 #include <aliceVision/sfm/pipeline/bootstrapping/Bootstrap.hpp>
+#include <aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp>
 #include <cstdlib>
 #include <random>
 #include <regex>
@@ -105,6 +108,20 @@ bool landmarksFromMesh(
     }
 
     return true;
+}
+
+void showStatsAngles(const sfmData::SfMData & sfmData)
+{
+    //Computing angle
+    utils::Histogram<double> histo(0, 90, 45);
+    for (const auto & [_, landmark] : sfmData.getLandmarks())
+    {
+        double angle = sfm::SfmTriangulation::getMaximalAngle(sfmData, landmark);
+        histo.Add(angle);
+    }
+
+    ALICEVISION_LOG_INFO("Landmarks maximal angle histogram");
+    ALICEVISION_LOG_INFO(histo.ToString());
 }
 
 int aliceVision_main(int argc, char** argv)
@@ -360,6 +377,10 @@ int aliceVision_main(int argc, char** argv)
     ALICEVISION_LOG_INFO("Best selected pair is : ");
     ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.reference).getImage().getImagePath());
     ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.next).getImage().getImagePath());
+    ALICEVISION_LOG_INFO("Landmarks count : " << sfmData.getLandmarks().size());
+
+    showStatsAngles(sfmData);
+    
 
     sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData::ALL);
 

--- a/src/software/pipeline/main_tracksBuilding.cpp
+++ b/src/software/pipeline/main_tracksBuilding.cpp
@@ -130,7 +130,8 @@ int aliceVision_main(int argc, char** argv)
     tracksBuilder.build(pairwiseMatches);
 
     ALICEVISION_LOG_INFO("Track filtering");
-    tracksBuilder.filter(filterTrackForks, minInputTrackLength);
+    size_t countFiltered = 0;
+    tracksBuilder.filter(countFiltered, filterTrackForks, minInputTrackLength);
 
     ALICEVISION_LOG_INFO("Track export to structure");
     track::TracksMap mapTracks;
@@ -144,6 +145,15 @@ int aliceVision_main(int argc, char** argv)
     std::ofstream of(tracksFilename);
     of << boost::json::serialize(jv);
     of.close();
+
+    ///////// Statistics
+
+    ALICEVISION_LOG_INFO("Number of pairs processed : " << pairwiseMatches.size());
+    matching::displayStats(pairwiseMatches);
+
+    ALICEVISION_LOG_INFO("Number of tracks : " << mapTracks.size());
+    tracksBuilder.displayStats(mapTracks);
+
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- Add a function to display histogram of matches per view
- Add a function to display statistics for sfmData (landmarks, views, valid views). Use it at each iteration and at the end of the sfmExpanding process
- Add a function to display tracks statistics. Use it at the end of trackBuilding.
- Display landmarks count and  histogram of parallax angles at the end of sfmBootstrapping.