### PR TITLE
[meshroom] ScenePreview: Hide backfaces in 3D render

### DIFF
--- a/meshroom/blender/scripts/preview.py
+++ b/meshroom/blender/scripts/preview.py
@@ -249,7 +249,6 @@ def setupWireframeShading(mesh, color):
     nodeMix1 = material.node_tree.nodes.new(type='ShaderNodeMixShader')
     # Transparent Shader node
     nodeTransparent = material.node_tree.nodes.new(type='ShaderNodeBsdfTransparent')
-    nodeTransparent.color = (1, 1, 1, 1)
     # 2nd Mix Shader node
     nodeMix2 = material.node_tree.nodes.new(type='ShaderNodeMixShader')
     # Retrieve ouput node


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->

## Description

This PR adds a transparent shader on backfaces in the ScenePreview render to avoid meshes that would hide the region of interest.

For the line art mode it was a bit more complicated because the render is created as a post-processing effect. So the only way I found was to use the [Quantitative Invisibility](https://docs.blender.org/manual/en/3.6/render/freestyle/view_layer/line_set.html#visibility) feature, by setting the minimum and max to 0 and 1 respectively we can see through the first surface. It's not a perfect solution though

| Mode   | Before   |  After |
:-------:|:--------:|:-------:
**Wireframe** | ![error](https://github.com/user-attachments/assets/70080195-7a7e-482c-937b-386195455dc5) | ![working](https://github.com/user-attachments/assets/9c285b8c-adc9-47cc-93f2-4388a640984b)
**Line Art** | ![freestyle_error](https://github.com/user-attachments/assets/415a1948-f382-453b-8d7c-89b11a87b0e4) | ![freestyle_working](https://github.com/user-attachments/assets/f8e86ba7-6628-4e48-a6cc-85cb4f86bc20)
