### PR TITLE
[blender] Fix .obj import for blender 4

### DIFF
--- a/meshroom/blender/scripts/preview.py
+++ b/meshroom/blender/scripts/preview.py
@@ -215,7 +215,7 @@ def setupMask(view, folderMasks, nodeMask):
 def loadModel(filename):
     '''Load model in Alembic of OBJ format. Make sure orientation matches camera orientation.'''
     if filename.lower().endswith('.obj'):
-        bpy.ops.import_scene.obj(filepath=filename, axis_forward='Y', axis_up='Z')
+        bpy.ops.wm.obj_import(filepath=filename, forward_axis='Y', up_axis='Z')
         meshName = os.path.splitext(os.path.basename(filename))[0]
         return bpy.data.objects[meshName], bpy.data.meshes[meshName]
     elif filename.lower().endswith('.abc'):


### PR DESCRIPTION
This pull request updates the method for importing `.obj` files in the `loadModel` function to align with changes in Blender's API. The key change replaces the deprecated `bpy.ops.import_scene.obj` operator with the `bpy.ops.wm.obj_import` operator. This ensures compatibility with older and newer versions of Blender. (versions 3 and 4)