### PR TITLE
Add Arducam Cameras to cameraSensors.db

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -5339,9 +5339,20 @@ Qmobile;Qmobile Noir S6;4.69;devicespecifications
 Ramos;Ramos M7;4.82;devicespecifications
 Ramos;Ramos MOS1 Max;4.69;devicespecifications
 Ramos;Ramos R9;4.69;devicespecifications
+RaspberryPi;RP_arducam-64mp;7.3216;devicespecifications
 RaspberryPi;RP_imx219;3.6736;devicespecifications
+RaspberryPi;RP_imx296;4.896;devicespecifications
+RaspberryPi;RP_imx298;5.21472;devicespecifications
+RaspberryPi;RP_imx335;5.184;devicespecifications
+RaspberryPi;RP_imx378;6.2868;devicespecifications
+RaspberryPi;RP_imx415;5.568;devicespecifications
 RaspberryPi;RP_imx477;6.287;devicespecifications
+RaspberryPi;RP_imx519;5.68032;devicespecifications
+RaspberryPi;RP_imx708;6.4512;devicespecifications
 RaspberryPi;RP_OV5647;3.6288;devicespecifications
+RaspberryPi;RP_OV64A40;9.225216;devicespecifications
+RaspberryPi;RP_OV7251;1.92;devicespecifications
+RaspberryPi;RP_OV9281;3.84;devicespecifications
 Realme;Realme 2 Pro;5.22;devicespecifications
 Realme;Realme 5 Pro;6.4;kimovil
 Realme;Realme 7 Pro;7.4;usercontribution


### PR DESCRIPTION
## Description

Add Arducam Cameras to the `cameraSensors.db`.

I only have a doubt about the model name for the `RP_arducam-64mp` (Arducam 64MP Hawkeye), but, to get the name I took the example of the name in the software guide of the Arducam Wiki.
