### PR TITLE
Force Pixel Aspect Ratio in Distortion Calibration

### DIFF
--- a/meshroom/aliceVision/DistortionCalibration.py
+++ b/meshroom/aliceVision/DistortionCalibration.py
@@ -1,4 +1,4 @@
-__version__ = '5.0'
+__version__ = '6.0'
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -42,6 +42,14 @@ class DistortionCalibration(desc.AVCommandLineNode):
             label="Is Desqueezed",
             description="True if the input image is already desqueezed.",
             value=False,
+        ),
+        desc.FloatParam(
+            name="forcedPixelAspectRatio",
+            label="Force PixelAspect Ratio",
+            description="Force pixel aspect ratio value, overriding metadatas. Ignored if less than or equal 0.0.",
+            value=0.0,
+            range=(0.0, 2.0, 0.1),
+            advanced=True,
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -9,7 +9,7 @@
             "ConvertSfMFormat": "2.0",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "5.0",
+            "DistortionCalibration": "6.0",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",

--- a/meshroom/cameraTrackingExperimental.mg
+++ b/meshroom/cameraTrackingExperimental.mg
@@ -9,7 +9,7 @@
             "ConvertSfMFormat": "2.0",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "5.0",
+            "DistortionCalibration": "6.0",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "ExportImages": "1.0",

--- a/meshroom/distortionCalibration.mg
+++ b/meshroom/distortionCalibration.mg
@@ -6,7 +6,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CheckerboardDetection": "1.0",
-            "DistortionCalibration": "5.0",
+            "DistortionCalibration": "6.0",
             "ExportDistortion": "2.0",
             "Publish": "1.3"
         }

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -8,7 +8,7 @@
             "CameraInit": "12.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
-            "DistortionCalibration": "5.0",
+            "DistortionCalibration": "6.0",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -10,7 +10,7 @@
             "ConvertSfMFormat": "2.0",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "5.0",
+            "DistortionCalibration": "6.0",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",

--- a/meshroom/photogrammetryAndCameraTrackingExperimental.mg
+++ b/meshroom/photogrammetryAndCameraTrackingExperimental.mg
@@ -9,7 +9,7 @@
             "ConvertSfMFormat": "2.0",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "5.0",
+            "DistortionCalibration": "6.0",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "ExportImages": "1.0",

--- a/src/software/pipeline/main_distortionCalibration.cpp
+++ b/src/software/pipeline/main_distortionCalibration.cpp
@@ -39,8 +39,8 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 6
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
 
 namespace po = boost::program_options;
 using namespace aliceVision;
@@ -262,6 +262,7 @@ int aliceVision_main(int argc, char* argv[])
     std::string sfmOutputDataFilepath;
     bool handleSqueeze = true;
     bool isDesqueezed = false;
+    double forcedPixelAspectRatio = 0.0;
 
     std::string undistortionModelName = "3deanamorphic4";
 
@@ -282,7 +283,9 @@ int aliceVision_main(int argc, char* argv[])
         ("handleSqueeze", po::value<bool>(&handleSqueeze)->default_value(handleSqueeze),
          "Estimate squeeze after estimating distortion")
         ("isDesqueezed", po::value<bool>(&isDesqueezed)->default_value(isDesqueezed),
-         "Is the image already desqueezed");
+         "Is the image already desqueezed")
+        ("forcedPixelAspectRatio", po::value<double>(&forcedPixelAspectRatio)->default_value(forcedPixelAspectRatio),
+         "Force pixel aspect ratio value, overriding metadatas. Ignored if less than or equal 0.0.");
     // clang-format on
 
     CmdLine cmdline("This program calibrates camera distortion.\n"
@@ -348,6 +351,12 @@ int aliceVision_main(int argc, char* argv[])
         }
 
         double pixelAspectRatio = *pa.begin();
+
+        if (forcedPixelAspectRatio > 0.0)
+        {
+            pixelAspectRatio = forcedPixelAspectRatio;
+            ALICEVISION_LOG_INFO("A parameters has overriden the pixel aspect ratio to " << forcedPixelAspectRatio);
+        }
 
         // Convert to pinhole
         std::shared_ptr<camera::Pinhole> cameraIn = std::dynamic_pointer_cast<camera::Pinhole>(intrinsicPtr);


### PR DESCRIPTION
- Pixel aspect ratio is an important information about the anamorphic lens and is used during calibration of the distortion. 
- Sometimes the user unsqueeze the image manually and remove this pixel Aspect Ratio information.
- One solution is to put back this information in the metadata. Here, we add for convenience a field to force a given Pixel Aspect Ratio for all input images used for distortion calibration.