### PR TITLE
Update json utility functions

### DIFF
--- a/src/aliceVision/dataio/json.cpp
+++ b/src/aliceVision/dataio/json.cpp
@@ -5,29 +5,32 @@ std::vector<boost::json::value> readJsons(std::istream& is, boost::system::error
 {
     std::vector<boost::json::value> jvs;
     boost::json::stream_parser p;
-    std::string line;
-    std::size_t n = 0;
+    std::string content, line;
+    std::size_t totalRead;
 
-    while (true)
-    {
-        if (n == line.size())
+    while (std::getline(is, line))
+    {   
+        content += line;
+        
+        totalRead = 0;
+        while (true)
         {
-            if (!std::getline(is, line))
+            totalRead += p.write(content, ec);
+
+            // If the parser did not find a value, then it won't
+            // find anything more.
+            if (!p.done())
             {
                 break;
             }
 
-            n = 0;
-        }
-
-        // Consume at least part of the line
-        n += p.write_some(line.data() + n, line.size() - n, ec);
-
-        // If the parser found a value, add it
-        if (p.done())
-        {
+            // Store the value, and try to find another one in the remaining
+            // content
             jvs.push_back(p.release());
             p.reset();
+
+            //remove processed string from content
+            content = content.substr(totalRead);
         }
     }
 

--- a/src/aliceVision/dataio/json.hpp
+++ b/src/aliceVision/dataio/json.hpp
@@ -11,6 +11,10 @@
 #include <boost/json.hpp>
 #include <Eigen/Dense>
 
+#include <aliceVision/stl/FlatMap.hpp>
+#include <map>
+#include <unordered_map>
+
 namespace Eigen {
 template<typename T, int M, int N>
 Eigen::Matrix<T, M, N> tag_invoke(boost::json::value_to_tag<Eigen::Matrix<T, M, N>>, boost::json::value const& jv)
@@ -51,6 +55,55 @@ void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, Eige
 }  // namespace Eigen
 
 namespace aliceVision {
+
+template<class K, class T>
+stl::flat_map<K, T> flat_map_value_to(const boost::json::value& jv)
+{
+    stl::flat_map<K, T> ret;
+
+    const boost::json::array obj = jv.as_array();
+
+    for (const auto& item : obj)
+    {
+        const boost::json::array inner = item.as_array();
+        ret.insert({boost::json::value_to<K>(inner[0]), boost::json::value_to<T>(inner[1])});
+    }
+
+    return ret;
+}
+
+template<class K, class T>
+std::unordered_map<K, T> unordered_map_value_to(const boost::json::value& jv)
+{
+    std::unordered_map<K, T> ret;
+
+    const boost::json::array obj = jv.as_array();
+
+    for (const auto& item : obj)
+    {
+        const boost::json::array inner = item.as_array();
+        ret.insert({boost::json::value_to<K>(inner[0]), boost::json::value_to<T>(inner[1])});
+    }
+
+    return ret;
+}
+
+
+template<class K, class T>
+std::map<K, T> map_value_to(const boost::json::value& jv)
+{
+    std::map<K, T> ret;
+
+    const boost::json::array obj = jv.as_array();
+
+    for (const auto& item : obj)
+    {
+        const boost::json::array inner = item.as_array();
+        ret.insert({boost::json::value_to<K>(inner[0]), boost::json::value_to<T>(inner[1])});
+    }
+
+    return ret;
+}
 
 std::vector<boost::json::value> readJsons(std::istream& is, boost::system::error_code& ec);
 

--- a/src/aliceVision/track/trackIO.cpp
+++ b/src/aliceVision/track/trackIO.cpp
@@ -43,7 +43,7 @@ aliceVision::track::Track tag_invoke(boost::json::value_to_tag<aliceVision::trac
 
     aliceVision::track::Track ret;
     ret.descType = feature::EImageDescriberType_stringToEnum(boost::json::value_to<std::string>(obj.at("descType")));
-    ret.featPerView = map_value_to<track::TrackItem>(obj.at("featPerView"));
+    ret.featPerView = map_value_to<std::size_t, track::TrackItem>(obj.at("featPerView"));
 
     return ret;
 }
@@ -61,7 +61,7 @@ bool loadTracks(TracksMap& mapTracks, const std::string& filename)
 
     // Parse json
     boost::json::value jv = boost::json::parse(buffer.str());
-    mapTracks = track::TracksMap(map_value_to<track::Track>(jv));
+    mapTracks = track::TracksMap(map_value_to<std::size_t, track::Track>(jv));
 
     return true;
 }

--- a/src/aliceVision/track/trackIO.hpp
+++ b/src/aliceVision/track/trackIO.hpp
@@ -7,59 +7,11 @@
 #pragma once
 
 #include <aliceVision/track/Track.hpp>
-
 #include <boost/json.hpp>
 
 namespace aliceVision {
 namespace track {
 
-template<class T>
-stl::flat_map<size_t, T> flat_map_value_to(const boost::json::value& jv)
-{
-    stl::flat_map<size_t, T> ret;
-
-    const boost::json::array obj = jv.as_array();
-
-    for (const auto& item : obj)
-    {
-        const boost::json::array inner = item.as_array();
-        ret.insert({boost::json::value_to<std::size_t>(inner[0]), boost::json::value_to<T>(inner[1])});
-    }
-
-    return ret;
-}
-
-template<class T>
-std::unordered_map<size_t, T> unordered_map_value_to(const boost::json::value& jv)
-{
-    std::unordered_map<size_t, T> ret;
-
-    const boost::json::array obj = jv.as_array();
-
-    for (const auto& item : obj)
-    {
-        const boost::json::array inner = item.as_array();
-        ret.insert({boost::json::value_to<std::size_t>(inner[0]), boost::json::value_to<T>(inner[1])});
-    }
-
-    return ret;
-}
-
-template<class T>
-std::map<size_t, T> map_value_to(const boost::json::value& jv)
-{
-    std::map<size_t, T> ret;
-
-    const boost::json::array obj = jv.as_array();
-
-    for (const auto& item : obj)
-    {
-        const boost::json::array inner = item.as_array();
-        ret.insert({boost::json::value_to<std::size_t>(inner[0]), boost::json::value_to<T>(inner[1])});
-    }
-
-    return ret;
-}
 
 /**
  * @brief Serialize track to JSON object.

--- a/src/software/pipeline/main_nodalSfM.cpp
+++ b/src/software/pipeline/main_nodalSfM.cpp
@@ -381,7 +381,7 @@ int aliceVision_main(int argc, char** argv)
     std::stringstream buffer;
     buffer << tracksFile.rdbuf();
     boost::json::value jv = boost::json::parse(buffer.str());
-    track::TracksMap mapTracks(track::map_value_to<track::Track>(jv));
+    track::TracksMap mapTracks(map_value_to<std::size_t, track::Track>(jv));
 
     // We have loaded a list of tracks
     // A track is a list of observations per view of (we think) a same point.


### PR DESCRIPTION
This pull request introduces improvements to JSON parsing and serialization in the `aliceVision` codebase, along with refactoring to centralize and generalize utility functions for mapping JSON values to various container types. The changes enhance code reusability, readability, and maintainability.

### JSON Parsing and Processing Improvements:
* Refactored the `readJsons` function in `src/aliceVision/dataio/json.cpp` to process JSON input more efficiently by accumulating content and using a `boost::json::stream_parser`, reducing redundant operations and improving clarity.

### Centralized Utility Functions for JSON Mapping:
* Moved generic JSON-to-container mapping functions (`flat_map_value_to`, `unordered_map_value_to`, `map_value_to`) from `src/aliceVision/track/trackIO.hpp` to `src/aliceVision/dataio/json.hpp`, ensuring these utilities are reusable across the codebase. [[1]](diffhunk://#diff-25c1eb2f65b233818365146c9a8550cc2894f97c2a9a7a332edbc9071d539014R14-R17) [[2]](diffhunk://#diff-25c1eb2f65b233818365146c9a8550cc2894f97c2a9a7a332edbc9071d539014R59-R107) [[3]](diffhunk://#diff-d75dc7b6f0e286ec0deab5b13d9fc87783fba5b959b47f47fc69c9f4253786fbL10-L62)

### Code Refactoring for Consistency:
* Updated calls to `map_value_to` in `src/aliceVision/track/trackIO.cpp` and `src/software/pipeline/main_nodalSfM.cpp` to explicitly specify key and value types (e.g., `std::size_t` for keys), improving type clarity and consistency. [[1]](diffhunk://#diff-5af6d89e791bf377c36a7f050606aba5b2649ccb6097701c2fca16fb8b4666fdL46-R46) [[2]](diffhunk://#diff-5af6d89e791bf377c36a7f050606aba5b2649ccb6097701c2fca16fb8b4666fdL64-R64) [[3]](diffhunk://#diff-43dd56875c86005827364c964f66804055c6c86a9b85ca1b0d3c9e1aa1874096L384-R384)- Function to read multiple json values in the same file
- Header to load/save std::maps and similar