### PR TITLE
Improve SWIG Module Type Sharing for Enhanced Interoperability

### DIFF
--- a/src/aliceVision/__init__.py
+++ b/src/aliceVision/__init__.py
@@ -18,3 +18,8 @@ if hasattr(os, "add_dll_directory"):
         if not os.path.isdir(p):
             continue
         os.add_dll_directory(p)
+
+#Enforce loading order
+from . import geometry
+from . import sfmData
+from . import sfmDataIO

--- a/src/aliceVision/camera/Camera.i
+++ b/src/aliceVision/camera/Camera.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") camera
+%module (package="pyalicevision") camera
 
 %include <aliceVision/global.i>
 

--- a/src/aliceVision/feature/feature.i
+++ b/src/aliceVision/feature/feature.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") feature
+%module (package="pyalicevision") feature
 
 %include <aliceVision/config.hpp>
 %include <aliceVision/global.i>

--- a/src/aliceVision/geometry/Geometry.i
+++ b/src/aliceVision/geometry/Geometry.i
@@ -4,9 +4,11 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") geometry
+%module (package="pyalicevision") geometry
 
+%include <aliceVision/global.i>
 %include <aliceVision/numeric/eigen.i>
+
 %eigen_typemaps(Vec2)
 %eigen_typemaps(Vec3)
 %eigen_typemaps(Eigen::Vector3d)

--- a/src/aliceVision/hdr/Hdr.i
+++ b/src/aliceVision/hdr/Hdr.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") hdr
+%module (package="pyalicevision") hdr
 
 %include <aliceVision/global.i>
 %include <aliceVision/hdr/Brackets.i>

--- a/src/aliceVision/image/image.i
+++ b/src/aliceVision/image/image.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") image
+%module (package="pyalicevision") image
 
 %{
   #define SWIG_FILE_WITH_INIT

--- a/src/aliceVision/matching/matching.i
+++ b/src/aliceVision/matching/matching.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") matching
+%module (package="pyalicevision") matching
 
 %include <aliceVision/config.hpp>
 %include <aliceVision/global.i>

--- a/src/aliceVision/matchingImageCollection/matchingImageCollection.i
+++ b/src/aliceVision/matchingImageCollection/matchingImageCollection.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") matchingImageCollection
+%module (package="pyalicevision") matchingImageCollection
 
 %include <aliceVision/global.i>
 %include <std_string.i>

--- a/src/aliceVision/numeric/numeric.i
+++ b/src/aliceVision/numeric/numeric.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") numeric
+%module (package="pyalicevision") numeric
 
 %include <aliceVision/numeric/eigen.i>
 %eigen_typemaps(Vec2)

--- a/src/aliceVision/sensorDB/SensorDB.i
+++ b/src/aliceVision/sensorDB/SensorDB.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") sensorDB
+%module (package="pyalicevision") sensorDB
 
 %include <aliceVision/sensorDB/Datasheet.i>
 

--- a/src/aliceVision/sfmData/CameraPose.i
+++ b/src/aliceVision/sfmData/CameraPose.i
@@ -4,6 +4,8 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+%import <aliceVision/geometry/Pose3.i>
+
 %include <aliceVision/global.i>
 %include <aliceVision/sfmData/CameraPose.hpp>
 

--- a/src/aliceVision/sfmData/SfMData.i
+++ b/src/aliceVision/sfmData/SfMData.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") sfmData
+%module (package="pyalicevision") sfmData
 
 %include <aliceVision/global.i>
 %include <aliceVision/camera/IntrinsicBase.i>

--- a/src/aliceVision/sfmDataIO/SfMDataIO.i
+++ b/src/aliceVision/sfmDataIO/SfMDataIO.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") sfmDataIO
+%module (package="pyalicevision") sfmDataIO
 
 %include <std_string.i>
 %include <aliceVision/sfmDataIO/sfmDataIO.hpp>

--- a/src/aliceVision/stl/Stl.i
+++ b/src/aliceVision/stl/Stl.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") stl
+%module (package="pyalicevision") stl
 
 %include <aliceVision/global.i>
 

--- a/src/aliceVision/track/track.i
+++ b/src/aliceVision/track/track.i
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-%module (module="pyalicevision") track
+%module (package="pyalicevision") track
 
 %include <std_map.i>
 %include <std_string.i>


### PR DESCRIPTION
This pull request introduces two key updates to the `pyalicevision` codebase: enforcing a specific module loading order in `__init__.py` and updating SWIG module declarations across multiple files to use the `package` directive instead of `module`. These changes improve module organization and compatibility with Python packaging standards.

### Module Loading Order:
* Updated `src/aliceVision/__init__.py` to enforce a specific loading order by explicitly importing `geometry`, `sfmData`, and `sfmDataIO` modules. This ensures dependencies are loaded in the correct sequence.

### SWIG Module Declaration Updates:
* Replaced `%module (module="pyalicevision")` with `%module (package="pyalicevision")` in the following files to align with Python package standards:
  - `src/aliceVision/camera/Camera.i`
  - `src/aliceVision/feature/feature.i`
  - `src/aliceVision/geometry/Geometry.i`
  - `src/aliceVision/hdr/Hdr.i`
  - `src/aliceVision/image/image.i`
  - `src/aliceVision/matching/matching.i`
  - `src/aliceVision/matchingImageCollection/matchingImageCollection.i`
  - `src/aliceVision/numeric/numeric.i`
  - `src/aliceVision/sensorDB/SensorDB.i`
  - `src/aliceVision/sfmData/SfMData.i`
  - `src/aliceVision/sfmDataIO/SfMDataIO.i`
  - `src/aliceVision/stl/Stl.i`
  - `src/aliceVision/track/track.i`

### Dependency Import:
* Added `%import <aliceVision/geometry/Pose3.i>` in `src/aliceVision/sfmData/CameraPose.i` to ensure required dependencies are explicitly imported.