### PR TITLE
SwigBinding: Add support of Landmarks

### DIFF
--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -54,6 +54,11 @@ class Landmark
 
     Observations& getObservations() { return _observations; }
 
+    MapObservations getMapObservations() const 
+    { 
+        return MapObservations(_observations.begin(), _observations.end());;
+    }
+
   private:
     Observations _observations;
 };

--- a/src/aliceVision/sfmData/Landmark.i
+++ b/src/aliceVision/sfmData/Landmark.i
@@ -4,6 +4,9 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+%include <aliceVision/numeric/eigen.i>
+%eigen_typemaps(Vec3)
+
 %include <aliceVision/sfmData/Observation.i>
 %include <aliceVision/sfmData/Landmark.hpp>
 

--- a/src/aliceVision/sfmData/Observation.hpp
+++ b/src/aliceVision/sfmData/Observation.hpp
@@ -12,6 +12,8 @@
 #include <aliceVision/stl/FlatMap.hpp>
 #include <aliceVision/types.hpp>
 
+#include <map>
+
 namespace aliceVision {
 namespace sfmData {
 
@@ -63,6 +65,7 @@ class Observation
 
 /// Observations are indexed by their View_id
 typedef stl::flat_map<IndexT, Observation> Observations;
+typedef std::map<IndexT, Observation> MapObservations;
 
 }  // namespace sfmData
 }  // namespace aliceVision

--- a/src/aliceVision/sfmData/Observation.i
+++ b/src/aliceVision/sfmData/Observation.i
@@ -4,6 +4,13 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+%include <aliceVision/numeric/eigen.i>
+%eigen_typemaps(Vec2)
+
+//Ignore the non const version, as it create problems
+//with eigen wrapper. Force the use of const version
+%ignore aliceVision::sfmData::Observation::getCoordinates();
+
 %include <aliceVision/sfmData/Observation.hpp>
 
 %{

--- a/src/aliceVision/sfmData/SfMData.i
+++ b/src/aliceVision/sfmData/SfMData.i
@@ -15,11 +15,10 @@
 %include <aliceVision/sfmData/Constraint2D.i>
 %include <aliceVision/sfmData/ConstraintPoint.i>
 %include <aliceVision/sfmData/SurveyPoint.i>
-%include <aliceVision/sfmData/Landmark.i>
-%include <aliceVision/sfmData/Observation.i>
 %include <aliceVision/sfmData/Rig.i>
 %include <aliceVision/sfmData/RotationPrior.i>
 %include <aliceVision/sfmData/View.i>
+%include <aliceVision/sfmData/Landmark.i>
 
 %include <aliceVision/sfmData/SfMData.hpp>
 
@@ -36,6 +35,7 @@ using namespace aliceVision::camera;
 %template(PinholeIntrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::Pinhole>>;
 %template(EquidistantIntrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::Equidistant>>;
 %template(Landmarks) std::map<IndexT, aliceVision::sfmData::Landmark>;
+%template(Observations) std::map<IndexT, aliceVision::sfmData::Observation>;
 %template(Poses) std::map<IndexT, aliceVision::sfmData::CameraPose>;
 %template(Rigs) std::map<IndexT, aliceVision::sfmData::Rig>;
 %template(RotationPriors) std::vector<aliceVision::sfmData::RotationPrior>;
@@ -43,8 +43,3 @@ using namespace aliceVision::camera;
 
 %template(ViewsVector) std::vector<std::shared_ptr<aliceVision::sfmData::View>>;
 %template(ViewsVectorVector) std::vector<std::vector<std::shared_ptr<aliceVision::sfmData::View>>>;
-
-
-// TODO:
-// %template(PosesUncertainty) std::map<IndexT, Vec6>;
-// %template(LandmarksUncertainty) std::map<IndexT, Vec3>;


### PR DESCRIPTION
- Add support of landmarks coordinates in swig (eigen wrapper)
- Add support of observations coordinates in swig (eigen wrapper)
- Add access to observations through intermediate `MapObservations` structure as `stl::flat_map` based `Observations` is not supported by swig.  Use  `MapObservations Landmark::getMapObservations()`.