### PR TITLE
Extracting feature matching geometric filter into new nodes for external matchers

### DIFF
--- a/meshroom/aliceVision/GeometricFilterApplying.py
+++ b/meshroom/aliceVision/GeometricFilterApplying.py
@@ -1,0 +1,89 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
+
+
+class GeometricFilterApplying(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_geometricFilterApplying {allParams}'
+    size = desc.DynamicNodeSize('input')
+    parallelization = desc.Parallelization(blockSize=20)
+    commandLineRange = '--rangeIteration {rangeIteration} --rangeBlocksCount {rangeBlocksCount}'
+
+    category = 'Sparse Reconstruction'
+    documentation = '''
+Apply precomputed transforms to matches to filter geometric matches
+'''
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="Input SfMData file.",
+            value="",
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="featuresFolder",
+                label="Features Folder",
+                description="Folder containing some extracted features and descriptors.",
+                value="",
+            ),
+            name="featuresFolders",
+            label="Features Folders",
+            description="Folder(s) containing the extracted features and descriptors.",
+            exposed=True,
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="matchesFolder",
+                label="Matches Folder",
+                description="Folder containing some matches.",
+                value="",
+            ),
+            name="matchesFolders",
+            label="Matches Folders",
+            description="Folder(s) in which computed matches are stored.",
+            exposed=True,
+        ),
+        desc.File(
+            name="filters",
+            label="Filters Folder",
+            description="Path to a folder in which the computed filters are stored.",
+            value="",
+            exposed=True
+        ),
+        desc.ChoiceParam(
+            name="describerTypes",
+            label="Describer Types",
+            description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
+            value=["dspsift"],
+            exclusive=False,
+            joinChar=",",
+            exposed=True,
+        ),
+        desc.IntParam(
+            name="maxMatches",
+            label="Max Matches",
+            description="Maximum number of matches to keep.",
+            value=0,
+            range=(0, 10000, 1),
+            advanced=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+    outputs = [
+        desc.File(
+            name="output",
+            label="Matches Folder",
+            description="Path to a folder in which the computed matches are stored.",
+            value="{nodeCacheFolder}",
+        ),
+    ]

--- a/meshroom/aliceVision/GeometricFilterEstimating.py
+++ b/meshroom/aliceVision/GeometricFilterEstimating.py
@@ -1,0 +1,104 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
+
+
+class GeometricFilterEstimating(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_geometricFilterEstimating {allParams}'
+    size = desc.DynamicNodeSize('input')
+    parallelization = desc.Parallelization(blockSize=20)
+    commandLineRange = '--rangeIteration {rangeIteration} --rangeBlocksCount {rangeBlocksCount}'
+
+    category = 'Sparse Reconstruction'
+    documentation = '''
+It performs a geometric filtering of the photometric match candidates.
+It uses the features positions in the images to make a geometric filtering by using epipolar geometry in an outlier detection framework
+called RANSAC (RANdom SAmple Consensus). It randomly selects a small set of feature correspondences and compute the fundamental (or essential) matrix,
+then it checks the number of features that validates this model and iterate through the RANSAC framework.
+
+## Online
+[https://alicevision.org/#photogrammetry/feature_matching](https://alicevision.org/#photogrammetry/feature_matching)
+'''
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="Input SfMData file.",
+            value="",
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="featuresFolder",
+                label="Features Folder",
+                description="Folder containing some extracted features and descriptors.",
+                value="",
+            ),
+            name="featuresFolders",
+            label="Features Folders",
+            description="Folder(s) containing the extracted features and descriptors.",
+            exposed=True,
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="matchesFolder",
+                label="Matches Folder",
+                description="Folder containing some matches.",
+                value="",
+            ),
+            name="matchesFolders",
+            label="Matches Folders",
+            description="Folder(s) in which computed matches are stored.",
+            exposed=True,
+        ),
+        desc.ChoiceParam(
+            name="describerTypes",
+            label="Describer Types",
+            description="Describer types used to describe an image.",
+            values=DESCRIBER_TYPES,
+            value=["dspsift"],
+            exclusive=False,
+            joinChar=",",
+            exposed=True,
+        ),
+        desc.IntParam(
+            name="maxIteration",
+            label="Max Iterations",
+            description="Maximum number of iterations allowed in the Ransac step.",
+            value=50000,
+            range=(1, 100000, 1),
+            advanced=True,
+        ),
+        desc.FloatParam(
+            name="geometricError",
+            label="Geometric Validation Error",
+            description="Maximum error (in pixels) allowed for features matching during geometric verification",
+            value=0.0,
+            range=(0.0, 10.0, 0.1),
+            advanced=True,
+        ),
+        desc.IntParam(
+            name="maxMatches",
+            label="Max Matches",
+            description="Maximum number of matches to keep.",
+            value=0,
+            range=(0, 10000, 1),
+            advanced=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+    outputs = [
+        desc.File(
+            name="output",
+            label="Filters Folder",
+            description="Path to a folder in which the computed filters are stored.",
+            value="{nodeCacheFolder}",
+        ),
+    ]

--- a/meshroom/aliceVision/ImageMatching.py
+++ b/meshroom/aliceVision/ImageMatching.py
@@ -63,9 +63,10 @@ If images have known poses, use frustum intersection else use VocabularuTree.
                         " - SequentialAndVocabularyTree:  Combines sequential approach with VocTree to enable connections between keyframes at different times.\n"
                         " - Exhaustive: Export all image pairs.\n"
                         " - Frustum: If images have known poses, computes the intersection between cameras frustums to create the list of image pairs.\n"
-                        " - FrustumOrVocabularyTree: If images have known poses, use frustum intersection else use VocabularyTree.\n",
+                        " - FrustumOrVocabularyTree: If images have known poses, use frustum intersection else use VocabularyTree.\n"
+                        " - Mirror: Try to match images with themselves. \n",
             value="SequentialAndVocabularyTree",
-            values=["VocabularyTree", "Sequential", "SequentialAndVocabularyTree", "Exhaustive", "Frustum", "FrustumOrVocabularyTree"],
+            values=["VocabularyTree", "Sequential", "SequentialAndVocabularyTree", "Exhaustive", "Frustum", "FrustumOrVocabularyTree", "Mirror"],
         ),
         desc.File(
             name="tree",

--- a/src/aliceVision/feature/feature.i
+++ b/src/aliceVision/feature/feature.i
@@ -9,6 +9,15 @@
 %include <aliceVision/config.hpp>
 %include <aliceVision/global.i>
 
+namespace std
+{
+    #ifdef LINUXPLATFORM
+    typedef long unsigned int size_t;
+    #else
+    typedef long unsigned long size_t;
+    #endif
+}
+
 %{    
 #include <aliceVision/feature/Regions.hpp>
 #include <aliceVision/feature/imageDescriberCommon.hpp>

--- a/src/aliceVision/imageMatching/ImageMatching.cpp
+++ b/src/aliceVision/imageMatching/ImageMatching.cpp
@@ -40,6 +40,8 @@ std::string EImageMatchingMethod_enumToString(EImageMatchingMethod m)
             return "Frustum";
         case EImageMatchingMethod::FRUSTUM_OR_VOCABULARYTREE:
             return "FrustumOrVocabularyTree";
+        case EImageMatchingMethod::MIRROR:
+            return "Mirror";
     }
     throw std::out_of_range("Invalid EImageMatchingMethod enum: " + std::to_string(int(m)));
 }
@@ -61,6 +63,8 @@ EImageMatchingMethod EImageMatchingMethod_stringToEnum(const std::string& m)
         return EImageMatchingMethod::FRUSTUM;
     if (mode == "frustumorvocabularytree")
         return EImageMatchingMethod::FRUSTUM_OR_VOCABULARYTREE;
+    if (mode == "mirror")
+        return EImageMatchingMethod::MIRROR;
 
     throw std::out_of_range("Invalid EImageMatchingMethod: " + m);
 }
@@ -182,6 +186,14 @@ void generateSequentialMatches(const sfmData::SfMData& sfmData, size_t nbMatches
             size_t b = sortedImagePaths[n].second;
             outPairList[std::min(a, b)].insert(std::max(a, b));
         }
+    }
+}
+
+void generateMirrorsMatches(const sfmData::SfMData& sfmData, OrderedPairList& outPairList)
+{
+    for (const auto& [index, _] : sfmData.getViews())
+    {
+        outPairList[index].insert(index);
     }
 }
 

--- a/src/aliceVision/imageMatching/ImageMatching.hpp
+++ b/src/aliceVision/imageMatching/ImageMatching.hpp
@@ -54,7 +54,8 @@ enum class EImageMatchingMethod
     SEQUENTIAL = 2,
     SEQUENTIAL_AND_VOCABULARYTREE = 3,
     FRUSTUM = 4,
-    FRUSTUM_OR_VOCABULARYTREE = 5
+    FRUSTUM_OR_VOCABULARYTREE = 5,
+    MIRROR = 6,
 };
 
 /**
@@ -116,6 +117,7 @@ EImageMatchingMode EImageMatchingMode_stringToEnum(const std::string& modeMultiS
 void convertAllMatchesToPairList(const PairList& allMatches, std::size_t numMatches, OrderedPairList& outPairList);
 
 void generateSequentialMatches(const sfmData::SfMData& sfmData, size_t nbMatches, OrderedPairList& outPairList);
+void generateMirrorsMatches(const sfmData::SfMData& sfmData, OrderedPairList& outPairList);
 void generateAllMatchesInOneMap(const std::set<IndexT>& viewIds, OrderedPairList& outPairList);
 void generateAllMatchesBetweenTwoMap(const std::set<IndexT>& viewIdsA, const std::set<IndexT>& viewIdsB, OrderedPairList& outPairList);
 

--- a/src/aliceVision/matchingImageCollection/CMakeLists.txt
+++ b/src/aliceVision/matchingImageCollection/CMakeLists.txt
@@ -14,6 +14,7 @@ set(matching_collection_images_files_headers
     ImagePairListIO.hpp
     geometricFilterUtils.hpp
     pairBuilder.hpp
+    GeometricInfo.hpp
 )
 
 # Sources
@@ -26,6 +27,7 @@ set(matching_collection_images_files_sources
     geometricFilterUtils.cpp
     ImagePairListIO.cpp
     pairBuilder.cpp
+    GeometricInfo.cpp
 )
 
 alicevision_add_library(aliceVision_matchingImageCollection
@@ -38,6 +40,7 @@ alicevision_add_library(aliceVision_matchingImageCollection
         aliceVision_sfmData
         Boost::boost
         Boost::timer
+        Boost::json
     PRIVATE_LINKS
         aliceVision_system
         ${CERES_LIBRARIES}

--- a/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
@@ -13,6 +13,7 @@
 #include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
+#include <aliceVision/matchingImageCollection/GeometricInfo.hpp>
 
 #include <map>
 #include <random>
@@ -28,7 +29,7 @@ using namespace aliceVision::matching;
  * or all the pairs and regions correspondences contained in the putativeMatches set.
  * Allow to keep only geometrically coherent matches.
  * It discards pairs that do not lead to a valid robust model estimation.
- * @param[out] geometricMatches
+ * @param[out] out_geometricMatches
  * @param[in] sfmData
  * @param[in] regionsPerView
  * @param[in] functor
@@ -39,7 +40,7 @@ using namespace aliceVision::matching;
  */
 template<typename GeometryFunctor>
 void robustModelEstimation(PairwiseMatches& out_geometricMatches,
-                           const sfmData::SfMData* sfmData,
+                           const sfmData::SfMData& sfmData,
                            const feature::RegionsPerView& regionsPerView,
                            const GeometryFunctor& functor,
                            const PairwiseMatches& putativeMatches,
@@ -73,13 +74,70 @@ void robustModelEstimation(PairwiseMatches& out_geometricMatches,
                 {
                     MatchesPerDescType guidedGeometricInliers;
                     geometricFilter.Geometry_guided_matching(sfmData, regionsPerView, imagePair, distanceRatio, guidedGeometricInliers);
-                    // ALICEVISION_LOG_DEBUG("#before/#after: " << putative_inliers.size() << "/" << guided_geometric_inliers.size());
                     std::swap(inliers, guidedGeometricInliers);
                 }
 
 #pragma omp critical
                 {
                     out_geometricMatches.emplace(currentPair, std::move(inliers));
+                }
+            }
+        }
+        ++progressDisplay;
+    }
+}
+
+/**
+ * @brief Perform robust model estimation (with optional guided_matching)
+ * or all the pairs and regions correspondences contained in the putativeMatches set.
+ * Allow to keep only geometrically coherent matches.
+ * It discards pairs that do not lead to a valid robust model estimation.
+ * @param[out] out_geometricInfos
+ * @param[in] sfmData
+ * @param[in] regionsPerView
+ * @param[in] functor
+ * @param[in] putativeMatches
+ * @param[in] randomNumberGenerator
+ */
+template<typename GeometryFunctor>
+void robustModelEstimation(PairwiseGeometricInfo& out_geometricInfos,
+                           const sfmData::SfMData& sfmData,
+                           const feature::RegionsPerView& regionsPerView,
+                           const GeometryFunctor& functor,
+                           const PairwiseMatches& putativeMatches,
+                           std::mt19937& randomNumberGenerator)
+{
+    out_geometricInfos.clear();
+
+    auto progressDisplay = system::createConsoleProgressDisplay(putativeMatches.size(), std::cout, "Robust Model Estimation\n");
+
+#pragma omp parallel for schedule(dynamic)
+    for (int i = 0; i < (int)putativeMatches.size(); ++i)
+    {
+        PairwiseMatches::const_iterator iter = putativeMatches.begin();
+        std::advance(iter, i);
+
+        const Pair currentPair = iter->first;
+        const MatchesPerDescType& putativeMatchesPerType = iter->second;
+        const Pair& imagePair = iter->first;
+
+        // apply the geometric filter (robust model estimation)
+        {
+            MatchesPerDescType inliers;
+            GeometryFunctor geometricFilter = functor;  // use a copy since we are in a multi-thread context
+            const EstimationStatus state =
+              geometricFilter.geometricEstimation(sfmData, regionsPerView, imagePair, putativeMatchesPerType, randomNumberGenerator, inliers);
+
+            if (state.hasStrongSupport)
+            {
+#pragma omp critical
+                {
+                    PairGeometricInfo info;
+                    info.model = geometricFilter.getMatrix();
+                    info.inliers = inliers.getNbAllMatches();
+                    info.threshold = geometricFilter.m_dPrecision_robust;
+                    info.type = geometricFilter.getType();
+                    out_geometricInfos.emplace(currentPair, info);
                 }
             }
         }

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <aliceVision/matchingImageCollection/GeometricFilterType.hpp>
+
 namespace aliceVision {
 
 namespace feature {
@@ -31,6 +33,10 @@ struct GeometricFilterMatrix
         m_stIteration(stIteration)
     {}
 
+    virtual Eigen::Matrix3d getMatrix() = 0;
+
+    virtual EGeometricFilterType getType() = 0;
+
     /**
      * @brief Geometry_guided_matching
      * @param sfm_data
@@ -40,7 +46,7 @@ struct GeometricFilterMatrix
      * @param matches
      * @return
      */
-    virtual bool Geometry_guided_matching(const sfmData::SfMData* sfmData,
+    virtual bool Geometry_guided_matching(const sfmData::SfMData& sfmData,
                                           const feature::RegionsPerView& regionsPerView,
                                           const Pair imageIdsPair,
                                           const double dDistanceRatio,

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_E_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_E_AC.hpp
@@ -10,8 +10,10 @@
 #include <aliceVision/types.hpp>
 #include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
+#include <aliceVision/matchingImageCollection/geometricFilterUtils.hpp>
 #include <aliceVision/robustEstimation/ACRansac.hpp>
 #include <aliceVision/matching/guidedMatching.hpp>
+#include <aliceVision/matching/supportEstimation.hpp>
 #include <aliceVision/multiview/RelativePoseKernel.hpp>
 #include <aliceVision/multiview/relativePose/Essential5PSolver.hpp>
 #include <aliceVision/multiview/relativePose/FundamentalError.hpp>
@@ -41,7 +43,7 @@ struct GeometricFilterMatrix_E_AC : public GeometricFilterMatrix
      *        relating them using a robust method (like A Contrario Ransac).
      */
     template<typename Regions_or_Features_ProviderT>
-    EstimationStatus geometricEstimation(const sfmData::SfMData* sfmData,
+    EstimationStatus geometricEstimation(const sfmData::SfMData& sfmData,
                                          const Regions_or_Features_ProviderT& regionsPerView,
                                          const Pair& pairIndex,
                                          const matching::MatchesPerDescType& putativeMatchesPerType,
@@ -60,12 +62,12 @@ struct GeometricFilterMatrix_E_AC : public GeometricFilterMatrix
             return EstimationStatus(false, false);
 
         // reject pair with missing Intrinsic information
-        const sfmData::View& viewI = sfmData->getView(I);
-        const sfmData::View& viewJ = sfmData->getView(J);
+        const sfmData::View& viewI = sfmData.getView(I);
+        const sfmData::View& viewJ = sfmData.getView(J);
 
         // Check that valid cameras can be retrieved for the pair of views
-        std::shared_ptr<camera::IntrinsicBase> cam_I = sfmData->getIntrinsicSharedPtr(viewI.getIntrinsicId());
-        std::shared_ptr<camera::IntrinsicBase> cam_J = sfmData->getIntrinsicSharedPtr(viewJ.getIntrinsicId());
+        std::shared_ptr<camera::IntrinsicBase> cam_I = sfmData.getIntrinsicSharedPtr(viewI.getIntrinsicId());
+        std::shared_ptr<camera::IntrinsicBase> cam_J = sfmData.getIntrinsicSharedPtr(viewJ.getIntrinsicId());
 
         if (!cam_I || !cam_J)
             return EstimationStatus(false, false);
@@ -127,7 +129,7 @@ struct GeometricFilterMatrix_E_AC : public GeometricFilterMatrix
      * @param matches
      * @return
      */
-    bool Geometry_guided_matching(const sfmData::SfMData* sfmData,
+    bool Geometry_guided_matching(const sfmData::SfMData& sfmData,
                                   const feature::RegionsPerView& regionsPerView,
                                   const Pair imageIdsPair,
                                   const double dDistanceRatio,
@@ -139,14 +141,14 @@ struct GeometricFilterMatrix_E_AC : public GeometricFilterMatrix
             const IndexT I = imageIdsPair.first;
             const IndexT J = imageIdsPair.second;
 
-            const sfmData::View& viewI = sfmData->getView(I);
-            const sfmData::View& viewJ = sfmData->getView(J);
+            const sfmData::View& viewI = sfmData.getView(I);
+            const sfmData::View& viewJ = sfmData.getView(J);
 
             // check that valid cameras can be retrieved for the pair of views
             const camera::IntrinsicBase* camI =
-              sfmData->getIntrinsics().count(viewI.getIntrinsicId()) ? sfmData->getIntrinsics().at(viewI.getIntrinsicId()).get() : nullptr;
+              sfmData.getIntrinsics().count(viewI.getIntrinsicId()) ? sfmData.getIntrinsics().at(viewI.getIntrinsicId()).get() : nullptr;
             const camera::IntrinsicBase* camJ =
-              sfmData->getIntrinsics().count(viewJ.getIntrinsicId()) ? sfmData->getIntrinsics().at(viewJ.getIntrinsicId()).get() : nullptr;
+              sfmData.getIntrinsics().count(viewJ.getIntrinsicId()) ? sfmData.getIntrinsics().at(viewJ.getIntrinsicId()).get() : nullptr;
             if (!camI || !camJ)
                 return false;
 
@@ -174,6 +176,13 @@ struct GeometricFilterMatrix_E_AC : public GeometricFilterMatrix
 
         return matches.getNbAllMatches() != 0;
     }
+
+    Eigen::Matrix3d getMatrix() { return m_E; }
+
+    /**
+     * @return geometric filter type represented by this class
+     */
+    EGeometricFilterType getType() { return EGeometricFilterType::ESSENTIAL_MATRIX; }
 
     // stored data
     Mat3 m_E;

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp
@@ -50,7 +50,7 @@ struct GeometricFilterMatrix_F_AC : public GeometricFilterMatrix
      * relating them using a robust method (like A Contrario Ransac).
      */
     template<class Regions_or_Features_ProviderT>
-    EstimationStatus geometricEstimation(const sfmData::SfMData* sfmData,
+    EstimationStatus geometricEstimation(const sfmData::SfMData& sfmData,
                                          const Regions_or_Features_ProviderT& regionsPerView,
                                          const Pair& pairIndex,
                                          const matching::MatchesPerDescType& putativeMatchesPerType,
@@ -63,11 +63,11 @@ struct GeometricFilterMatrix_F_AC : public GeometricFilterMatrix
         const IndexT I = pairIndex.first;
         const IndexT J = pairIndex.second;
 
-        const sfmData::View& viewI = sfmData->getView(I);
-        const sfmData::View& viewJ = sfmData->getView(J);
+        const sfmData::View& viewI = sfmData.getView(I);
+        const sfmData::View& viewJ = sfmData.getView(J);
 
-        const camera::IntrinsicBase* camI = sfmData->getIntrinsicPtr(viewI.getIntrinsicId());
-        const camera::IntrinsicBase* camJ = sfmData->getIntrinsicPtr(viewJ.getIntrinsicId());
+        const camera::IntrinsicBase* camI = sfmData.getIntrinsicPtr(viewI.getIntrinsicId());
+        const camera::IntrinsicBase* camJ = sfmData.getIntrinsicPtr(viewJ.getIntrinsicId());
 
         const std::pair<std::size_t, std::size_t> imageSizeI(viewI.getImage().getWidth(), viewI.getImage().getHeight());
         const std::pair<std::size_t, std::size_t> imageSizeJ(viewJ.getImage().getWidth(), viewJ.getImage().getHeight());
@@ -281,7 +281,7 @@ struct GeometricFilterMatrix_F_AC : public GeometricFilterMatrix
                                                       multiview::UnnormalizerT,
                                                       ModelT_>;
 
-        const KernelT kernel(xI, imageSizeI.first, imageSizeI.second, xJ, imageSizeJ.first, imageSizeJ.second, true);
+        const KernelT kernel(xI, imageSizeI.first, imageSizeI.first, xJ, imageSizeJ.first, imageSizeJ.first, true);
 
         // robustly estimate the Fundamental matrix with A Contrario ransac
         const double upperBoundPrecision = m_dPrecision;
@@ -355,7 +355,7 @@ struct GeometricFilterMatrix_F_AC : public GeometricFilterMatrix
      * @param matches
      * @return
      */
-    bool Geometry_guided_matching(const sfmData::SfMData* sfmData,
+    bool Geometry_guided_matching(const sfmData::SfMData& sfmData,
                                   const feature::RegionsPerView& regionsPerView,
                                   const Pair imageIdsPair,
                                   const double dDistanceRatio,
@@ -367,14 +367,14 @@ struct GeometricFilterMatrix_F_AC : public GeometricFilterMatrix
             const IndexT I = imageIdsPair.first;
             const IndexT J = imageIdsPair.second;
 
-            const sfmData::View& viewI = sfmData->getView(I);
-            const sfmData::View& viewJ = sfmData->getView(J);
+            const sfmData::View& viewI = sfmData.getView(I);
+            const sfmData::View& viewJ = sfmData.getView(J);
 
             // retrieve corresponding pair camera intrinsic if any
             const camera::IntrinsicBase* camI =
-              sfmData->getIntrinsics().count(viewI.getIntrinsicId()) ? sfmData->getIntrinsics().at(viewI.getIntrinsicId()).get() : nullptr;
+              sfmData.getIntrinsics().count(viewI.getIntrinsicId()) ? sfmData.getIntrinsics().at(viewI.getIntrinsicId()).get() : nullptr;
             const camera::IntrinsicBase* camJ =
-              sfmData->getIntrinsics().count(viewJ.getIntrinsicId()) ? sfmData->getIntrinsics().at(viewJ.getIntrinsicId()).get() : nullptr;
+              sfmData.getIntrinsics().count(viewJ.getIntrinsicId()) ? sfmData.getIntrinsics().at(viewJ.getIntrinsicId()).get() : nullptr;
 
             robustEstimation::Mat3Model model(m_F);
 
@@ -390,6 +390,21 @@ struct GeometricFilterMatrix_F_AC : public GeometricFilterMatrix
               matches);
         }
         return matches.getNbAllMatches() != 0;
+    }
+
+    Eigen::Matrix3d getMatrix() { return m_F; }
+
+    /**
+     * @return geometric filter type represented by this class
+     */
+    EGeometricFilterType getType()
+    {
+        if (m_estimateDistortion)
+        {
+            return EGeometricFilterType::FUNDAMENTAL_WITH_DISTORTION;
+        }
+
+        return EGeometricFilterType::FUNDAMENTAL_MATRIX;
     }
 
     // Stored data

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.cpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.cpp
@@ -4,7 +4,6 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 #include "GeometricFilterMatrix_HGrowing.hpp"
 
 #include <aliceVision/matching/svgVisualization.hpp>

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_HGrowing.hpp
@@ -13,7 +13,6 @@
 #include <aliceVision/matchingImageCollection/geometricFilterUtils.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 
-
 #include <aliceVision/utils/filesIO.hpp>
 
 #include <cmath>
@@ -94,7 +93,7 @@ struct HGrowingFilteringParam
     HGrowingFilteringParam(std::size_t maxNbHomographies, std::size_t minNbMatchesPerH, const GrowParameters& growParam)
       : _maxNbHomographies(maxNbHomographies),
         _minNbMatchesPerH(minNbMatchesPerH),
-        _growParam(growParam){};
+        _growParam(growParam) {};
 
     /// Max. number of homographies to estimate.
     std::size_t _maxNbHomographies{10};
@@ -176,7 +175,7 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
      * @return The estimation status.
      */
     template<typename Regions_or_Features_ProviderT>
-    EstimationStatus geometricEstimation(const sfmData::SfMData* sfmData,
+    EstimationStatus geometricEstimation(const sfmData::SfMData& sfmData,
                                          const Regions_or_Features_ProviderT& regionsPerView,
                                          const Pair& pairIndex,
                                          const matching::MatchesPerDescType& putativeMatchesPerType,
@@ -213,8 +212,8 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
         const IndexT viewId_I = pairIndex.first;
         const IndexT viewId_J = pairIndex.second;
 
-        const sfmData::View& viewI = *(sfmData->getViews().at(viewId_I));
-        const sfmData::View& viewJ = *(sfmData->getViews().at(viewId_J));
+        const sfmData::View& viewI = sfmData.getView(viewId_I);
+        const sfmData::View& viewJ = sfmData.getView(viewId_J);
 
         for (const EImageDescriberType& descType : descTypes)
         {
@@ -276,7 +275,7 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
      * @param matches
      * @return
      */
-    bool Geometry_guided_matching(const sfmData::SfMData* sfmData,
+    bool Geometry_guided_matching(const sfmData::SfMData& sfmData,
                                   const feature::RegionsPerView& regionsPerView,
                                   const Pair imageIdsPair,
                                   const double dDistanceRatio,
@@ -324,6 +323,22 @@ struct GeometricFilterMatrix_HGrowing : public GeometricFilterMatrix
      * @return true the number of matches is up to 0.
      */
     bool getMatches(const feature::EImageDescriberType& descType, const IndexT homographyId, matching::IndMatches& matches) const;
+
+    /**
+     * @brief A fake implementation of getMatrix
+     * Should not be used for homography growing
+     * @throw always throw an error
+     */
+    Eigen::Matrix3d getMatrix()
+    {
+        ALICEVISION_THROW_ERROR("Homography growing has no single model");
+        return Eigen::Matrix3d::Identity();
+    }
+
+    /**
+     * @return geometric filter type represented by this class
+     */
+    EGeometricFilterType getType() { return EGeometricFilterType::HOMOGRAPHY_GROWING; }
 
   private:
     // -- Results container

--- a/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_H_AC.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilterMatrix_H_AC.hpp
@@ -10,8 +10,10 @@
 #include <aliceVision/matching/MatchesCollections.hpp>
 #include <aliceVision/matching/IndMatchDecorator.hpp>
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
+#include <aliceVision/matchingImageCollection/geometricFilterUtils.hpp>
 #include <aliceVision/robustEstimation/ACRansac.hpp>
 #include <aliceVision/matching/guidedMatching.hpp>
+#include <aliceVision/matching/supportEstimation.hpp>
 #include <aliceVision/multiview/relativePose/Homography4PSolver.hpp>
 #include <aliceVision/multiview/relativePose/HomographyError.hpp>
 #include <aliceVision/multiview/RelativePoseKernel.hpp>
@@ -37,7 +39,7 @@ struct GeometricFilterMatrix_H_AC : public GeometricFilterMatrix
      * relating them using a robust method (like A Contrario Ransac).
      */
     template<typename Regions_or_Features_ProviderT>
-    EstimationStatus geometricEstimation(const sfmData::SfMData* sfmData,
+    EstimationStatus geometricEstimation(const sfmData::SfMData& sfmData,
                                          const Regions_or_Features_ProviderT& regionsPerView,
                                          const Pair& pairIndex,
                                          const matching::MatchesPerDescType& putativeMatchesPerType,
@@ -50,8 +52,8 @@ struct GeometricFilterMatrix_H_AC : public GeometricFilterMatrix
         const IndexT I = pairIndex.first;
         const IndexT J = pairIndex.second;
 
-        const sfmData::View& viewI = sfmData->getView(I);
-        const sfmData::View& viewJ = sfmData->getView(J);
+        const sfmData::View& viewI = sfmData.getView(I);
+        const sfmData::View& viewJ = sfmData.getView(J);
 
         const std::vector<feature::EImageDescriberType> descTypes = regionsPerView.getCommonDescTypes(pairIndex);
 
@@ -157,7 +159,7 @@ struct GeometricFilterMatrix_H_AC : public GeometricFilterMatrix
      * @param matches
      * @return
      */
-    bool Geometry_guided_matching(const sfmData::SfMData* sfmData,
+    bool Geometry_guided_matching(const sfmData::SfMData& sfmData,
                                   const feature::RegionsPerView& regionsPerView,
                                   const Pair imageIdsPair,
                                   const double dDistanceRatio,
@@ -174,14 +176,14 @@ struct GeometricFilterMatrix_H_AC : public GeometricFilterMatrix
             const IndexT I = imageIdsPair.first;
             const IndexT J = imageIdsPair.second;
 
-            const sfmData::View& viewI = sfmData->getView(I);
-            const sfmData::View& viewJ = sfmData->getView(J);
+            const sfmData::View& viewI = sfmData.getView(I);
+            const sfmData::View& viewJ = sfmData.getView(J);
 
             // retrieve corresponding pair camera intrinsic if any
             const camera::IntrinsicBase* camI =
-              sfmData->getIntrinsics().count(viewI.getIntrinsicId()) ? sfmData->getIntrinsics().at(viewI.getIntrinsicId()).get() : nullptr;
+              sfmData.getIntrinsics().count(viewI.getIntrinsicId()) ? sfmData.getIntrinsics().at(viewI.getIntrinsicId()).get() : nullptr;
             const camera::IntrinsicBase* camJ =
-              sfmData->getIntrinsics().count(viewJ.getIntrinsicId()) ? sfmData->getIntrinsics().at(viewJ.getIntrinsicId()).get() : nullptr;
+              sfmData.getIntrinsics().count(viewJ.getIntrinsicId()) ? sfmData.getIntrinsics().at(viewJ.getIntrinsicId()).get() : nullptr;
 
             robustEstimation::Mat3Model model(m_H);
 
@@ -228,6 +230,13 @@ struct GeometricFilterMatrix_H_AC : public GeometricFilterMatrix
 
         return matches.getNbAllMatches() != 0;
     }
+
+    Eigen::Matrix3d getMatrix() { return m_H; }
+
+    /**
+     * @return geometric filter type represented by this class
+     */
+    EGeometricFilterType getType() { return EGeometricFilterType::HOMOGRAPHY_MATRIX; }
 
     // stored data
     Mat3 m_H;

--- a/src/aliceVision/matchingImageCollection/GeometricInfo.cpp
+++ b/src/aliceVision/matchingImageCollection/GeometricInfo.cpp
@@ -1,0 +1,77 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/matchingImageCollection/GeometricInfo.hpp>
+#include <aliceVision/dataio/json.hpp>
+#include <fstream>
+
+namespace aliceVision {
+namespace matchingImageCollection {
+
+void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, aliceVision::matchingImageCollection::PairGeometricInfo const& input)
+{
+    // ATM, all model are 3x3
+    Eigen::Matrix3d M = input.model;
+
+    jv = {
+      {"type", EGeometricFilterType_enumToString(input.type)},
+      {"model", boost::json::value_from(M)},
+      {"threshold", boost::json::value_from(input.threshold)},
+      {"inliers", boost::json::value_from(input.inliers)},
+    };
+}
+
+aliceVision::matchingImageCollection::PairGeometricInfo tag_invoke(boost::json::value_to_tag<aliceVision::matchingImageCollection::PairGeometricInfo>,
+                                                                   boost::json::value const& jv)
+{
+    const boost::json::object& obj = jv.as_object();
+
+    aliceVision::matchingImageCollection::PairGeometricInfo ret;
+    ret.type = EGeometricFilterType_stringToEnum(boost::json::value_to<std::string>(obj.at("type")));
+    ret.inliers = boost::json::value_to<size_t>(obj.at("inliers"));
+    ret.threshold = boost::json::value_to<double>(obj.at("threshold"));
+    ret.model = boost::json::value_to<Eigen::Matrix3d>(obj.at("model"));
+
+    return ret;
+}
+
+bool saveGeometricInfos(const std::string& path, const PairwiseGeometricInfo& infos)
+{
+    std::ofstream giFile(path);
+    if (giFile.is_open() == false)
+    {
+        return false;
+    }
+
+    boost::json::value jv = boost::json::value_from(infos);
+
+    giFile << boost::json::serialize(jv);
+    giFile.close();
+
+    return true;
+}
+
+bool loadGeometricInfos(const std::string& path, PairwiseGeometricInfo& infos)
+{
+    std::ifstream giFile(path);
+    if (giFile.is_open() == false)
+    {
+        return false;
+    }
+
+    std::stringstream buffer;
+    buffer << giFile.rdbuf();
+    giFile.close();
+
+    // Parse json
+    boost::json::value jv = boost::json::parse(buffer.str());
+    infos = PairwiseGeometricInfo(map_value_to<aliceVision::Pair, PairGeometricInfo>(jv));
+
+    return true;
+}
+
+}  // namespace matchingImageCollection
+}  // namespace aliceVision

--- a/src/aliceVision/matchingImageCollection/GeometricInfo.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricInfo.hpp
@@ -1,0 +1,48 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <Eigen/Dense>
+#include <aliceVision/matchingImageCollection/GeometricFilterType.hpp>
+#include <aliceVision/types.hpp>
+#include <map>
+#include <boost/json.hpp>
+
+namespace aliceVision {
+namespace matchingImageCollection {
+
+struct PairGeometricInfo
+{
+    Eigen::MatrixXd model;
+    size_t inliers;
+    double threshold;
+    EGeometricFilterType type;
+};
+
+typedef std::map<Pair, PairGeometricInfo> PairwiseGeometricInfo;
+
+/**
+ * @brief Serialize PairGeometricInfo to JSON object.
+ */
+void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, aliceVision::matchingImageCollection::PairGeometricInfo const& input);
+
+/**
+ * @brief save Geometric infos to a file
+ * @param path the path to the output file
+ * @param infos the PairwiseGeometricInfo to save
+ * @return false on failure
+ */
+bool saveGeometricInfos(const std::string& path, const PairwiseGeometricInfo& infos);
+
+/**
+ * @brief load Geometric infos to a file
+ * @param path the path to the input file
+ * @param infos the PairwiseGeometricInfo to load
+ * @return false on failure
+ */
+bool loadGeometricInfos(const std::string& path, PairwiseGeometricInfo& infos);
+
+}  // namespace matchingImageCollection
+}  // namespace aliceVision

--- a/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
+++ b/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
@@ -49,11 +49,7 @@ bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart, int rangeSi
             oss.clear();
             oss.str(vec_str[i]);
             oss >> J;
-            if (I == J)
-            {
-                ALICEVISION_LOG_WARNING("loadPairs: Invalid input file. Image " << I << " sees itself.");
-                return false;
-            }
+
             Pair pairToInsert;
 
             if (useSymmetry)

--- a/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
+++ b/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
@@ -14,7 +14,7 @@
 namespace aliceVision {
 namespace matchingImageCollection {
 
-bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart, int rangeSize)
+bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart, int rangeSize, bool useSymmetry)
 {
     std::size_t nbLine = 0;
     std::string sValue;
@@ -54,14 +54,24 @@ bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart, int rangeSi
                 ALICEVISION_LOG_WARNING("loadPairs: Invalid input file. Image " << I << " sees itself.");
                 return false;
             }
-            Pair pairToInsert = (I < J) ? std::make_pair(I, J) : std::make_pair(J, I);
+            Pair pairToInsert;
+
+            if (useSymmetry)
+            {
+                pairToInsert = (I < J) ? std::make_pair(I, J) : std::make_pair(J, I);
+            }
+            else
+            {
+                pairToInsert = std::make_pair(I, J);
+            }
+
             if (pairs.find(pairToInsert) != pairs.end())
             {
                 // There is no reason to have the same image pair twice in the list of image pairs
                 // to match.
                 ALICEVISION_LOG_WARNING("loadPairs: image pair (" << I << ", " << J << ") already added.");
             }
-            ALICEVISION_LOG_INFO("loadPairs: image pair (" << I << ", " << J << ") added.");
+            ALICEVISION_LOG_TRACE("loadPairs: image pair (" << I << ", " << J << ") added.");
             pairs.insert(pairToInsert);
         }
     }
@@ -97,7 +107,8 @@ void savePairs(std::ostream& stream, const PairSet& pairs)
 bool loadPairsFromFile(const std::string& sFileName,  // filename of the list file,
                        PairSet& pairs,
                        int rangeStart,
-                       int rangeSize)
+                       int rangeSize,
+                       bool useSymmetry)
 {
     std::ifstream in(sFileName);
     if (!in.is_open())
@@ -106,7 +117,7 @@ bool loadPairsFromFile(const std::string& sFileName,  // filename of the list fi
         return false;
     }
 
-    if (!loadPairs(in, pairs, rangeStart, rangeSize))
+    if (!loadPairs(in, pairs, rangeStart, rangeSize, useSymmetry))
     {
         ALICEVISION_LOG_WARNING("loadPairsFromFile: Failed to read file: \"" << sFileName << "\".");
         return false;

--- a/src/aliceVision/matchingImageCollection/ImagePairListIO.hpp
+++ b/src/aliceVision/matchingImageCollection/ImagePairListIO.hpp
@@ -15,7 +15,7 @@ namespace matchingImageCollection {
 
 /// Load a set of PairSet from a stream
 /// I J K L (pair that link I)
-bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart = -1, int rangeSize = 0);
+bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart = -1, int rangeSize = 0, bool useSymmetry = true);
 
 /// Save a set of PairSet to a stream (one pair per line)
 /// I J
@@ -26,7 +26,8 @@ void savePairs(std::ostream& stream, const PairSet& pairs);
 bool loadPairsFromFile(const std::string& sFileName,  // filename of the list file,
                        PairSet& pairs,
                        int rangeStart = -1,
-                       int rangeSize = 0);
+                       int rangeSize = 0,
+                       bool useSymmetry = true);
 
 /// Same as savePairs, but saves to a given file
 bool savePairsToFile(const std::string& sFileName, const PairSet& pairs);

--- a/src/aliceVision/matchingImageCollection/geometricFilterUtils.hpp
+++ b/src/aliceVision/matchingImageCollection/geometricFilterUtils.hpp
@@ -129,18 +129,18 @@ void fillMatricesWithUndistortFeaturesMatches(const matching::MatchesPerDescType
 template<typename MatT>
 void fillMatricesWithUndistortFeaturesMatches(const Pair& pairIndex,
                                               const matching::MatchesPerDescType& putativeMatchesPerType,
-                                              const sfmData::SfMData* sfmData,
+                                              const sfmData::SfMData& sfmData,
                                               const feature::RegionsPerView& regionsPerView,
                                               const std::vector<feature::EImageDescriberType>& descTypes,
                                               MatT& x_I,
                                               MatT& x_J)
 {
-    const sfmData::View* view_I = sfmData->getViews().at(pairIndex.first).get();
-    const sfmData::View* view_J = sfmData->getViews().at(pairIndex.second).get();
+    const sfmData::View& view_I = sfmData.getView(pairIndex.first);
+    const sfmData::View& view_J = sfmData.getView(pairIndex.second);
 
     // Retrieve corresponding pair camera intrinsic if any
-    const camera::IntrinsicBase* cam_I = sfmData->getIntrinsicPtr(view_I->getIntrinsicId());
-    const camera::IntrinsicBase* cam_J = sfmData->getIntrinsicPtr(view_J->getIntrinsicId());
+    const camera::IntrinsicBase* cam_I = sfmData.getIntrinsicPtr(view_I.getIntrinsicId());
+    const camera::IntrinsicBase* cam_J = sfmData.getIntrinsicPtr(view_J.getIntrinsicId());
 
     fillMatricesWithUndistortFeaturesMatches(putativeMatchesPerType,
                                              cam_I,

--- a/src/aliceVision/multiview/RelativePoseKernel.hpp
+++ b/src/aliceVision/multiview/RelativePoseKernel.hpp
@@ -8,6 +8,7 @@
 
 #include <aliceVision/config.hpp>
 #include <aliceVision/numeric/numeric.hpp>
+#include <aliceVision/multiview/essential.hpp>
 #include <aliceVision/robustEstimation/conditioning.hpp>
 #include <aliceVision/robustEstimation/ISolver.hpp>
 #include <aliceVision/robustEstimation/PointFittingRansacKernel.hpp>

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -90,6 +90,36 @@ if (ALICEVISION_BUILD_SFM)
               Boost::program_options
     )
 
+    # Geometric filtering
+    alicevision_add_software(aliceVision_geometricFilterEstimating
+        SOURCE main_geometricFilterEstimating.cpp
+        FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_feature
+              aliceVision_multiview
+              aliceVision_matchingImageCollection
+              aliceVision_sfm
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              Boost::program_options
+    )
+
+    # Geometric filtering
+    alicevision_add_software(aliceVision_geometricFilterApplying
+        SOURCE main_geometricFilterApplying.cpp
+        FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_feature
+              aliceVision_multiview
+              aliceVision_matchingImageCollection
+              aliceVision_sfm
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              Boost::program_options
+    )
+
     # Track builder
     alicevision_add_software(aliceVision_tracksBuilding
         SOURCE main_tracksBuilding.cpp

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -443,7 +443,7 @@ int aliceVision_main(int argc, char** argv)
         case EGeometricFilterType::FUNDAMENTAL_MATRIX:
         {
             matchingImageCollection::robustModelEstimation(geometricMatches,
-                                                           &sfmData,
+                                                           sfmData,
                                                            regionPerView,
                                                            GeometricFilterMatrix_F_AC(geometricErrorMax, maxIteration, geometricEstimator),
                                                            mapPutativesMatches,
@@ -455,7 +455,7 @@ int aliceVision_main(int argc, char** argv)
         case EGeometricFilterType::FUNDAMENTAL_WITH_DISTORTION:
         {
             matchingImageCollection::robustModelEstimation(geometricMatches,
-                                                           &sfmData,
+                                                           sfmData,
                                                            regionPerView,
                                                            GeometricFilterMatrix_F_AC(geometricErrorMax, maxIteration, geometricEstimator, true),
                                                            mapPutativesMatches,
@@ -467,7 +467,7 @@ int aliceVision_main(int argc, char** argv)
         case EGeometricFilterType::ESSENTIAL_MATRIX:
         {
             matchingImageCollection::robustModelEstimation(geometricMatches,
-                                                           &sfmData,
+                                                           sfmData,
                                                            regionPerView,
                                                            GeometricFilterMatrix_E_AC(geometricErrorMax, maxIteration),
                                                            mapPutativesMatches,
@@ -482,7 +482,7 @@ int aliceVision_main(int argc, char** argv)
         {
             const bool onlyGuidedMatching = true;
             matchingImageCollection::robustModelEstimation(geometricMatches,
-                                                           &sfmData,
+                                                           sfmData,
                                                            regionPerView,
                                                            GeometricFilterMatrix_H_AC(geometricErrorMax, maxIteration),
                                                            mapPutativesMatches,
@@ -495,7 +495,7 @@ int aliceVision_main(int argc, char** argv)
         case EGeometricFilterType::HOMOGRAPHY_GROWING:
         {
             matchingImageCollection::robustModelEstimation(geometricMatches,
-                                                           &sfmData,
+                                                           sfmData,
                                                            regionPerView,
                                                            GeometricFilterMatrix_HGrowing(geometricErrorMax, maxIteration),
                                                            mapPutativesMatches,

--- a/src/software/pipeline/main_geometricFilterApplying.cpp
+++ b/src/software/pipeline/main_geometricFilterApplying.cpp
@@ -1,0 +1,242 @@
+﻿// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/system/Parallelization.hpp>
+
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/feature/imageDescriberCommon.hpp>
+#include <aliceVision/sfm/pipeline/regionsIO.hpp>
+#include <aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp>
+
+#include <aliceVision/robustEstimation/estimators.hpp>
+#include <aliceVision/matchingImageCollection/GeometricFilterType.hpp>
+#include <aliceVision/matching/matchesFiltering.hpp>
+
+#include <aliceVision/matchingImageCollection/GeometricFilter.hpp>
+#include <aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp>
+#include <aliceVision/system/ProgressDisplay.hpp>
+#include <boost/program_options.hpp>
+#include <sstream>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string outputMatchesFolder;
+    std::string filtersFolder;
+    std::vector<std::string> featuresFolders;
+    std::vector<std::string> matchesFolders;
+    const std::string fileExtension = "txt";
+
+    size_t numMatchesToKeep = 0;
+
+    std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
+
+    int rangeIteration = 0;
+    int rangeBlocksCount = 1;
+    int randomSeed = std::mt19937::default_seed;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(),
+         "SfMData file.")
+        ("output,o", po::value<std::string>(&outputMatchesFolder)->required(),
+         "Path to a folder in which computed matches will be stored.")
+        ("filters", po::value<std::string>(&filtersFolder)->required(),
+         "Filters Folder.")
+        ("featuresFolders,f", po::value<std::vector<std::string>>(&featuresFolders)->multitoken(),
+         "Path to folder(s) containing the extracted features.")
+        ("matchesFolders,m", po::value<std::vector<std::string>>(&matchesFolders)->multitoken(),
+         "Path to folder(s) in which computed matches are stored.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
+         feature::EImageDescriberType_informations().c_str())
+        ("maxMatches", po::value<std::size_t>(&numMatchesToKeep)->default_value(numMatchesToKeep),
+         "Maximum number pf matches to keep.")
+        ("rangeIteration", po::value<int>(&rangeIteration)->default_value(rangeIteration), "Range current iteration.")
+        ("rangeBlocksCount", po::value<int>(&rangeBlocksCount)->default_value(rangeBlocksCount), "Range number of blocks.")
+        ("randomSeed", po::value<int>(&randomSeed)->default_value(randomSeed),
+         "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.");;
+    // clang-format on
+
+    CmdLine cmdline("AliceVision geometricFilterApplying");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    std::mt19937 randomNumberGenerator(randomSeed == -1 ? std::random_device()() : randomSeed);
+
+    // load input SfMData scene
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::INTRINSICS | sfmDataIO::EXTRINSICS)))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    if (describerTypesName.empty())
+    {
+        ALICEVISION_LOG_ERROR("Empty option: --describerMethods");
+        return EXIT_FAILURE;
+    }
+
+    const std::vector<feature::EImageDescriberType> describerTypes = feature::EImageDescriberType_stringToEnums(describerTypesName);
+
+    // matches reading.
+    // We read everything even if we only process a sub part.
+    matching::PairwiseMatches pairwiseMatches;
+    ALICEVISION_LOG_INFO("Load features matches");
+    if (!sfm::loadPairwiseMatches(pairwiseMatches, sfmData, matchesFolders, describerTypes, numMatchesToKeep, 0, false))
+    {
+        ALICEVISION_LOG_ERROR("Unable to load matches.");
+        return EXIT_FAILURE;
+    }
+
+    int chunkStart, chunkEnd;
+    if (!rangeComputation(chunkStart, chunkEnd, rangeIteration, rangeBlocksCount, pairwiseMatches.size()))
+    {
+        ALICEVISION_LOG_INFO("Nothing to compute in this chunk");
+    }
+
+    // We want to process only a subset of the pairs
+    // Assuming range start lies between [0 and pairwiseMatches.size()]
+    matching::PairwiseMatches filteredMatches;
+    std::set<IndexT> filter;
+
+    int pos = 0;
+    for (const auto& [pair, content] : pairwiseMatches)
+    {
+        if (pos == chunkEnd)
+        {
+            break;
+        }
+
+        if (pos >= chunkStart)
+        {
+            filteredMatches[pair] = content;
+            filter.insert(pair.first);
+            filter.insert(pair.second);
+        }
+
+        pos++;
+    }
+
+    ALICEVISION_LOG_INFO("A total of " << pairwiseMatches.size() << " pairs has to be processed.");
+    ALICEVISION_LOG_INFO("Current chunk will analyze pairs from " << chunkStart << " to " << chunkEnd << ".");
+
+    pairwiseMatches.clear();
+
+    // features reading
+    feature::RegionsPerView regionPerView;
+    if (!sfm::loadRegionsPerView(regionPerView, sfmData, featuresFolders, describerTypes, filter))
+    {
+        ALICEVISION_LOG_ERROR("Invalid regions in '" + sfmDataFilename + "'");
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_LOG_INFO(std::to_string(pairwiseMatches.size()) << " putative image pair matches");
+
+    for (const auto& imageMatch : pairwiseMatches)
+    {
+        ALICEVISION_LOG_INFO("\t- image pair (" << imageMatch.first.first + ", " << imageMatch.first.second << ") contains "
+                                                << imageMatch.second.getNbAllMatches() << " putative matches.");
+    }
+
+    matchingImageCollection::PairwiseGeometricInfo geometricInfos;
+    std::stringstream ss;
+    ss << filtersFolder << "/matches_" << std::to_string(rangeIteration) << ".json";
+    ALICEVISION_LOG_INFO("Loading from " << ss.str());
+    if (!matchingImageCollection::loadGeometricInfos(ss.str(), geometricInfos))
+    {
+        ALICEVISION_LOG_ERROR("Impossible to save geometricInfos");
+        return EXIT_FAILURE;
+    }
+
+    int count = 0;
+    matching::PairwiseMatches finalMatches;
+
+    ALICEVISION_LOG_INFO("Processing all pairs");
+    auto progressDisplay = system::createConsoleProgressDisplay(filteredMatches.size(), std::cout);
+    for (const auto& [pair, perDesc] : filteredMatches)
+    {
+        const auto it = geometricInfos.find(pair);
+        if (it == geometricInfos.end())
+        {
+            progressDisplay += 1;
+            continue;
+        }
+
+        const auto geometricInfo = it->second;
+
+        robustEstimation::Mat3Model model(geometricInfo.model);
+        multiview::relativePose::FundamentalEpipolarDistanceError errorFunc;
+
+        const IndexT idViewI = pair.first;
+        const IndexT idViewJ = pair.second;
+        const auto& viewI = sfmData.getView(idViewI);
+        const auto& viewJ = sfmData.getView(idViewJ);
+        const auto& camI = sfmData.getIntrinsicSharedPtr(viewI.getIntrinsicId());
+        const auto& camJ = sfmData.getIntrinsicSharedPtr(viewJ.getIntrinsicId());
+
+        for (const auto& [desc, matches] : perDesc)
+        {
+            const auto& featuresI = regionPerView.getRegions(idViewI, desc).Features();
+            const auto& featuresJ = regionPerView.getRegions(idViewJ, desc).Features();
+
+            matching::IndMatches copied;
+            for (const auto& match : matches)
+            {
+                const auto& ptI = featuresI[match._i].coords().cast<double>();
+                const auto& ptJ = featuresJ[match._j].coords().cast<double>();
+
+                if (sqrt(errorFunc.error(model, ptI, ptJ)) < geometricInfo.threshold)
+                {
+                    copied.push_back(match);
+                }
+            }
+
+            if (copied.size() == 0)
+            {
+                continue;
+            }
+
+            finalMatches[pair][desc] = copied;
+        }
+
+        progressDisplay += 1;
+    }
+
+    for (const auto& imageMatch : finalMatches)
+    {
+        ALICEVISION_LOG_INFO("\t- image pair (" << imageMatch.first.first + ", " << imageMatch.first.second << ") contains "
+                                                << imageMatch.second.getNbAllMatches() << " filtered matches.");
+    }
+
+    // export geometric filtered matches
+    ALICEVISION_LOG_INFO("Save geometric matches.");
+
+    const std::string filePrefix = std::to_string(rangeIteration) + ".";
+    Save(finalMatches, outputMatchesFolder, fileExtension, false, filePrefix);
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/pipeline/main_geometricFilterEstimating.cpp
+++ b/src/software/pipeline/main_geometricFilterEstimating.cpp
@@ -1,0 +1,201 @@
+﻿// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/system/Parallelization.hpp>
+
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/feature/imageDescriberCommon.hpp>
+#include <aliceVision/sfm/pipeline/regionsIO.hpp>
+#include <aliceVision/sfm/pipeline/pairwiseMatchesIO.hpp>
+
+#include <aliceVision/robustEstimation/estimators.hpp>
+#include <aliceVision/matchingImageCollection/GeometricFilterType.hpp>
+#include <aliceVision/matching/matchesFiltering.hpp>
+
+#include <aliceVision/matchingImageCollection/GeometricFilter.hpp>
+#include <aliceVision/matchingImageCollection/GeometricFilterMatrix_F_AC.hpp>
+
+#include <boost/program_options.hpp>
+#include <sstream>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string outputMatchesFolder;
+    std::vector<std::string> featuresFolders;
+    std::vector<std::string> matchesFolders;
+
+    size_t numMatchesToKeep = 0;
+    double geometricErrorMax = 0.0;
+    int maxIteration = 50000;
+
+    std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
+
+    int rangeIteration = 0;
+    int rangeBlocksCount = 1;
+    int randomSeed = std::mt19937::default_seed;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(),
+         "SfMData file.")
+        ("output,o", po::value<std::string>(&outputMatchesFolder)->required(),
+         "Path to a folder in which computed matches will be stored.")
+        ("featuresFolders,f", po::value<std::vector<std::string>>(&featuresFolders)->multitoken(),
+         "Path to folder(s) containing the extracted features.")
+        ("matchesFolders,m", po::value<std::vector<std::string>>(&matchesFolders)->multitoken(),
+         "Path to folder(s) in which computed matches are stored.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
+         feature::EImageDescriberType_informations().c_str())
+        ("maxMatches", po::value<std::size_t>(&numMatchesToKeep)->default_value(numMatchesToKeep),
+         "Maximum number pf matches to keep.")
+        ("geometricError", po::value<double>(&geometricErrorMax)->default_value(geometricErrorMax),
+         "Maximum error (in pixels) allowed for features matching during geometric verification. "
+         "If set to 0, it lets the ACRansac select an optimal value.")
+        ("maxIteration", po::value<int>(&maxIteration)->default_value(maxIteration),
+         "Maximum number of iterations allowed in Ransac step.")
+        ("rangeIteration", po::value<int>(&rangeIteration)->default_value(rangeIteration), "Range current iteration id.")
+        ("rangeBlocksCount", po::value<int>(&rangeBlocksCount)->default_value(rangeBlocksCount), "Range blocks count.")
+        ("randomSeed", po::value<int>(&randomSeed)->default_value(randomSeed),
+         "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.");;
+    // clang-format on
+
+    CmdLine cmdline("AliceVision geometricFilterApplying");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    std::mt19937 randomNumberGenerator(randomSeed == -1 ? std::random_device()() : randomSeed);
+
+    if (geometricErrorMax == 0.0)
+    {
+        geometricErrorMax = std::numeric_limits<double>::infinity();
+    }
+
+    // load input SfMData scene
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::INTRINSICS | sfmDataIO::EXTRINSICS)))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    if (describerTypesName.empty())
+    {
+        ALICEVISION_LOG_ERROR("Empty option: --describerMethods");
+        return EXIT_FAILURE;
+    }
+
+    const std::vector<feature::EImageDescriberType> describerTypes = feature::EImageDescriberType_stringToEnums(describerTypesName);
+
+    // matches reading.
+    // We read everything even if we only process a sub part.
+    matching::PairwiseMatches pairwiseMatches;
+    ALICEVISION_LOG_INFO("Load features matches");
+    if (!sfm::loadPairwiseMatches(pairwiseMatches, sfmData, matchesFolders, describerTypes, numMatchesToKeep, 0, false))
+    {
+        ALICEVISION_LOG_ERROR("Unable to load matches.");
+        return EXIT_FAILURE;
+    }
+
+    int chunkStart, chunkEnd;
+    if (!rangeComputation(chunkStart, chunkEnd, rangeIteration, rangeBlocksCount, pairwiseMatches.size()))
+    {
+        ALICEVISION_LOG_INFO("Nothing to compute in this chunk");
+    }
+
+    ALICEVISION_LOG_INFO("processing " << chunkStart << " to " << chunkEnd << " over " << pairwiseMatches.size());
+
+    // We want to process only a subset of the pairs
+    // Assuming range start lies between [0 and pairwiseMatches.size()]
+    matching::PairwiseMatches filteredMatches;
+    std::set<IndexT> filter;
+
+    int pos = 0;
+    for (const auto& [pair, content] : pairwiseMatches)
+    {
+        if (pos == chunkEnd)
+        {
+            break;
+        }
+
+        if (pos >= chunkStart)
+        {
+            filteredMatches[pair] = content;
+            filter.insert(pair.first);
+            filter.insert(pair.second);
+        }
+
+        pos++;
+    }
+
+    ALICEVISION_LOG_INFO("A total of " << pairwiseMatches.size() << " pairs has to be processed.");
+    ALICEVISION_LOG_INFO("Current chunk will analyze pairs from " << chunkStart << " to " << chunkEnd << ".");
+
+    pairwiseMatches.clear();
+
+    // features reading
+    feature::RegionsPerView regionPerView;
+    if (!sfm::loadRegionsPerView(regionPerView, sfmData, featuresFolders, describerTypes, filter))
+    {
+        ALICEVISION_LOG_ERROR("Invalid regions in '" + sfmDataFilename + "'");
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_LOG_INFO(std::to_string(filteredMatches.size()) << " putative image pair matches");
+    for (const auto& imageMatch : filteredMatches)
+    {
+        ALICEVISION_LOG_INFO("\t- image pair (" << imageMatch.first.first << ", " << imageMatch.first.second << ") contains "
+                                                << imageMatch.second.getNbAllMatches() << " putative matches.");
+    }
+
+    // Effectively process matching and output results to geometricInfos
+    matchingImageCollection::PairwiseGeometricInfo geometricInfos;
+    matchingImageCollection::robustModelEstimation(
+      geometricInfos,
+      sfmData,
+      regionPerView,
+      matchingImageCollection::GeometricFilterMatrix_F_AC(geometricErrorMax, maxIteration, robustEstimation::ERobustEstimator::ACRANSAC),
+      filteredMatches,
+      randomNumberGenerator);
+
+    ALICEVISION_LOG_INFO(geometricInfos.size() << "/" << filteredMatches.size() << " pairs have been matched");
+    for (const auto& [pair, info] : geometricInfos)
+    {
+        ALICEVISION_LOG_INFO("Pair [" << pair.first << "," << pair.second << "] has " << info.inliers << " inliers");
+    }
+
+    // Output result to json file
+    std::stringstream ss;
+    ss << outputMatchesFolder << "/matches_" << std::to_string(rangeIteration) << ".json";
+    ALICEVISION_LOG_INFO("Saving to " << ss.str());
+    if (!matchingImageCollection::saveGeometricInfos(ss.str(), geometricInfos))
+    {
+        ALICEVISION_LOG_ERROR("Impossible to save geometricInfos");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -191,6 +191,16 @@ int aliceVision_main(int argc, char** argv)
 
     switch (method)
     {
+        case EImageMatchingMethod::MIRROR:
+            if (!useMultiSfM)
+            {
+                generateMirrorsMatches(sfmDataA, selectedPairs);
+            }
+            else
+            {
+                ALICEVISION_THROW_ERROR("Invalid mirror mode for multisfm");
+            }
+            break;
         case EImageMatchingMethod::EXHAUSTIVE:
         {
             ALICEVISION_LOG_INFO("Use EXHAUSTIVE method.");


### PR DESCRIPTION
Add two new nodes/applications :

- geometric filter estimation from a set of feature matches which generates a json file with the geometric filters found
- geometric filter apply, which takes a set of feature matches and removes the matches which does not respect the filters given in input json file.

The goal is to split the logic of the FeatureMatching Node such that the geometric filtering is made available to feature matchers where the photommetric matching is done outside of aliceVision.

Related Meshroom PR: https://github.com/alicevision/Meshroom/pull/2922