### PR TITLE
 SwigBinding: Expose ProgressDisplay

### DIFF
--- a/pyTests/system/test_progress_display.py
+++ b/pyTests/system/test_progress_display.py
@@ -1,0 +1,27 @@
+"""
+Collection of unit tests for the ProgressDisplay logger.
+"""
+
+import pytest
+
+from pyalicevision.system import ConsoleProgressDisplay
+
+
+PROGRESS_BAR_TEMPLATE = """{desc}
+0%   10   20   30   40   50   60   70   80   90   100%
+|----|----|----|----|----|----|----|----|----|----|
+"""
+
+def test_progress_display(capfd):
+    items = range(10)
+    desc = "Iter over items"
+    stars_by_item = "*" * (50 // len(items))
+    progress = ConsoleProgressDisplay(len(items), desc + "\n")
+    for index, _i in enumerate(items):
+        assert(progress.count() == index)
+        out, _ = capfd.readouterr()  # readout is flushed each time we call this so we only have to check for diff
+        if index == 0:
+            assert out == PROGRESS_BAR_TEMPLATE.format(desc=desc)
+        else:
+            assert out == stars_by_item
+        progress += 1

--- a/src/aliceVision/system/CMakeLists.txt
+++ b/src/aliceVision/system/CMakeLists.txt
@@ -36,3 +36,18 @@ alicevision_add_library(aliceVision_system
 )
 
 alicevision_add_test(Logger_test.cpp NAME "system_Logger" LINKS aliceVision_system)
+
+# SWIG Binding
+if (ALICEVISION_BUILD_SWIG_BINDING)
+    alicevision_swig_add_library(system
+        SOURCES System.i
+        PUBLIC_LINKS
+            aliceVision_system
+            ${Python3_LIBRARIES}
+        PRIVATE_INCLUDE_DIRS
+            ../include
+            ${ALICEVISION_ROOT}/include
+            ${Python3_INCLUDE_DIRS}
+            ${Python3_NumPy_INCLUDE_DIRS}
+    )
+endif()

--- a/src/aliceVision/system/ProgressDisplay.hpp
+++ b/src/aliceVision/system/ProgressDisplay.hpp
@@ -42,10 +42,16 @@ class ProgressDisplay
     void restart(unsigned long expectedCount) { _impl->restart(expectedCount); }
 
     // Thread safe with respect to other calls to operator++ and to calls to count()
-    void operator++() { _impl->increment(1); }
+    ProgressDisplay& operator++() {
+      _impl->increment(1);
+      return *this;
+    }
 
     // Thread safe with respect to other calls to operator++ and to calls to count()
-    void operator+=(unsigned long increment) { _impl->increment(increment); }
+    ProgressDisplay& operator+=(unsigned long increment) { 
+      _impl->increment(increment);
+      return *this;
+    }
 
     // Thread safe with respect to calls to operator++
     unsigned long count() { return _impl->count(); }

--- a/src/aliceVision/system/ProgressDisplay.i
+++ b/src/aliceVision/system/ProgressDisplay.i
@@ -1,0 +1,38 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%include <aliceVision/system/ProgressDisplay.hpp>
+
+%{
+#include <iostream>
+#include <aliceVision/system/ProgressDisplay.hpp>
+
+// Use the full namespace in the wrapper
+namespace aliceVision {
+namespace system {
+
+inline ProgressDisplay ConsoleProgressDisplay(unsigned long expectedCount, 
+                                              const std::string& s1 = "\n",  // leading strings
+                                              const std::string& s2 = "",
+                                              const std::string& s3 = "")
+{
+  return createConsoleProgressDisplay(expectedCount, std::cout, s1, s2, s3);
+}
+
+} // namespace system
+} // namespace aliceVision
+
+%}
+
+// Declare the wrapper so SWIG knows it
+namespace aliceVision {
+namespace system {
+    ProgressDisplay ConsoleProgressDisplay(unsigned long expectedCount, 
+                                           const std::string& s1 = "\n", 
+                                           const std::string& s2 = "", 
+                                           const std::string& s3 = "");
+}
+}

--- a/src/aliceVision/system/System.i
+++ b/src/aliceVision/system/System.i
@@ -1,0 +1,11 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%module (package="pyalicevision") system
+
+%include <aliceVision/global.i>
+%include <aliceVision/system/ProgressDisplay.i>
+


### PR DESCRIPTION
Add bindngs for `system::ProgressDisplay` to be able to use progress bar from python nodes
- Add swig interface for system and ProgressDisplay
- Fix compound operators `+=` and `++` that need to return a reference to the current object. `+=` is required for python.
- Create a specific `ConsoleProgressDisplay` function for python that have no access to `std::cout`

Now we can use :
```py
from pyalicevision.system import ConsoleProgressDisplay

class ProgressBar:
    def __init__(self, items, desc=""):
        self.items = items
        self.__progress = ConsoleProgressDisplay(len(self.items), desc + "\n")
    
    def __iter__(self):
        return self
    
    def __next__(self):
        count = self.__progress.count()
        self.__progress += 1
        if count < len(self.items):
            return self.items[count]
        raise StopIteration


my_list = [ ... ]
for element in iter(ProgressBar(my_list)):
    # Process element
    pass
```