### PR TITLE
Enhancement of feature matching processing distribution amongs available chunks

### DIFF
--- a/meshroom/aliceVision/FeatureMatching.py
+++ b/meshroom/aliceVision/FeatureMatching.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "2.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
@@ -8,7 +8,7 @@ class FeatureMatching(desc.AVCommandLineNode):
     commandLine = "aliceVision_featureMatching {allParams}"
     size = avpar.DynamicViewsSize("input")
     parallelization = desc.Parallelization(blockSize=20)
-    commandLineRange = "--rangeStart {rangeStart} --rangeSize {rangeBlockSize}"
+    commandLineRange = "--rangeIteration {rangeIteration} --rangeBlocksCount {rangeBlocksCount}"
 
     category = "Sparse Reconstruction"
     documentation = """

--- a/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
+++ b/src/aliceVision/matchingImageCollection/ImagePairListIO.cpp
@@ -14,21 +14,23 @@
 namespace aliceVision {
 namespace matchingImageCollection {
 
-bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart, int rangeSize, bool useSymmetry)
+
+bool loadPairsFromFile(const std::string& sFileName,  // filename of the list file,
+                       PairSet& pairs,
+                       bool useSymmetry)
 {
+    std::ifstream in(sFileName);
+    if (!in.is_open())
+    {
+        ALICEVISION_LOG_WARNING("loadPairsFromFile: Impossible to read the specified file: \"" << sFileName << "\".");
+        return false;
+    }
+
     std::size_t nbLine = 0;
     std::string sValue;
 
-    for (; std::getline(stream, sValue); ++nbLine)
+    for (; std::getline(in, sValue); ++nbLine)
     {
-        if (rangeStart != -1 && rangeSize != 0)
-        {
-            if (nbLine < rangeStart)
-                continue;
-            if (nbLine >= rangeStart + rangeSize)
-                break;
-        }
-
         std::vector<std::string> vec_str;
         boost::trim(sValue);
         boost::split(vec_str, sValue, boost::is_any_of("\t "), boost::token_compress_on);
@@ -36,14 +38,16 @@ bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart, int rangeSi
         const size_t str_size = vec_str.size();
         if (str_size < 2)
         {
-            ALICEVISION_LOG_WARNING("loadPairs: Invalid input file.");
+            ALICEVISION_LOG_WARNING("loadPairsFromFile: Invalid input file.");
             return false;
         }
+
         std::stringstream oss;
         oss.clear();
         oss.str(vec_str[0]);
         size_t I, J;
         oss >> I;
+
         for (size_t i = 1; i < str_size; ++i)
         {
             oss.clear();
@@ -61,63 +65,11 @@ bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart, int rangeSi
                 pairToInsert = std::make_pair(I, J);
             }
 
-            if (pairs.find(pairToInsert) != pairs.end())
-            {
-                // There is no reason to have the same image pair twice in the list of image pairs
-                // to match.
-                ALICEVISION_LOG_WARNING("loadPairs: image pair (" << I << ", " << J << ") already added.");
-            }
-            ALICEVISION_LOG_TRACE("loadPairs: image pair (" << I << ", " << J << ") added.");
+            ALICEVISION_LOG_TRACE("loadPairsFromFile: image pair (" << I << ", " << J << ") added.");
             pairs.insert(pairToInsert);
         }
     }
-    return true;
-}
 
-void savePairs(std::ostream& stream, const PairSet& pairs)
-{
-    if (pairs.empty())
-    {
-        return;
-    }
-    stream << pairs.begin()->first << " " << pairs.begin()->second;
-    IndexT previousIndex = pairs.begin()->first;
-
-    // Pairs is sorted so we will always receive elements with the same first pair ID in
-    // continuous blocks.
-    for (auto it = std::next(pairs.begin()); it != pairs.end(); ++it)
-    {
-        if (it->first == previousIndex)
-        {
-            stream << " " << it->second;
-        }
-        else
-        {
-            stream << "\n" << it->first << " " << it->second;
-            previousIndex = it->first;
-        }
-    }
-    stream << "\n";
-}
-
-bool loadPairsFromFile(const std::string& sFileName,  // filename of the list file,
-                       PairSet& pairs,
-                       int rangeStart,
-                       int rangeSize,
-                       bool useSymmetry)
-{
-    std::ifstream in(sFileName);
-    if (!in.is_open())
-    {
-        ALICEVISION_LOG_WARNING("loadPairsFromFile: Impossible to read the specified file: \"" << sFileName << "\".");
-        return false;
-    }
-
-    if (!loadPairs(in, pairs, rangeStart, rangeSize, useSymmetry))
-    {
-        ALICEVISION_LOG_WARNING("loadPairsFromFile: Failed to read file: \"" << sFileName << "\".");
-        return false;
-    }
     return true;
 }
 
@@ -130,7 +82,29 @@ bool savePairsToFile(const std::string& sFileName, const PairSet& pairs)
         return false;
     }
 
-    savePairs(outStream, pairs);
+    if (pairs.empty())
+    {
+        return true;
+    }
+    
+    outStream << pairs.begin()->first << " " << pairs.begin()->second;
+    IndexT previousIndex = pairs.begin()->first;
+
+    // Pairs is sorted so we will always receive elements with the same first pair ID in
+    // continuous blocks.
+    for (auto it = std::next(pairs.begin()); it != pairs.end(); ++it)
+    {
+        if (it->first == previousIndex)
+        {
+            outStream << " " << it->second;
+        }
+        else
+        {
+            outStream << "\n" << it->first << " " << it->second;
+            previousIndex = it->first;
+        }
+    }
+    outStream << "\n";
 
     return !outStream.bad();
 }

--- a/src/aliceVision/matchingImageCollection/ImagePairListIO.hpp
+++ b/src/aliceVision/matchingImageCollection/ImagePairListIO.hpp
@@ -5,6 +5,15 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/**
+ * @file ImagePairListIO.hpp
+ * @brief Input/Output functions for reading and writing image pair lists.
+ * 
+ * This file provides utilities for loading and saving sets of image pairs
+ * to and from streams and files. Image pairs are used in the matching process
+ * to define which images should be compared for feature matching.
+ */
+
 #include <aliceVision/types.hpp>
 
 #include <iosfwd>
@@ -13,23 +22,29 @@
 namespace aliceVision {
 namespace matchingImageCollection {
 
-/// Load a set of PairSet from a stream
-/// I J K L (pair that link I)
-bool loadPairs(std::istream& stream, PairSet& pairs, int rangeStart = -1, int rangeSize = 0, bool useSymmetry = true);
-
-/// Save a set of PairSet to a stream (one pair per line)
-/// I J
-/// I K
-void savePairs(std::ostream& stream, const PairSet& pairs);
-
-/// Same as loadPairs, but loads from a given file
+/**
+ * @brief Load image pairs from a file.
+ * 
+ * Reads image pair data from the specified file and populates the pairs set.
+ * 
+ * @param[in] sFileName Path to the file containing the pair data
+ * @param[out] pairs Set of image pairs to be populated
+ * @param[in] useSymmetry If true, add (min(i,j), max(i,j)) instead of (i,j) (default: true)
+ * @return true if the file was opened and pairs were successfully loaded, false otherwise
+ */
 bool loadPairsFromFile(const std::string& sFileName,  // filename of the list file,
                        PairSet& pairs,
-                       int rangeStart = -1,
-                       int rangeSize = 0,
                        bool useSymmetry = true);
 
-/// Same as savePairs, but saves to a given file
+/**
+ * @brief Save image pairs to a file.
+ * 
+ * Writes the image pair data to the specified file.
+ * 
+ * @param[in] sFileName Path to the output file
+ * @param[in] pairs Set of image pairs to save
+ * @return true if the file was created and pairs were successfully saved, false otherwise
+ */
 bool savePairsToFile(const std::string& sFileName, const PairSet& pairs);
 
 }  // namespace matchingImageCollection

--- a/src/aliceVision/matchingImageCollection/ImagePairListIO_test.cpp
+++ b/src/aliceVision/matchingImageCollection/ImagePairListIO_test.cpp
@@ -10,6 +10,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
+#include <fstream>
+
 #include "ImagePairListIO.hpp"
 
 using namespace aliceVision;
@@ -35,26 +37,191 @@ BOOST_AUTO_TEST_CASE(read_write_pairs_to_file)
     std::remove("pairsT_IO.txt");
 }
 
-BOOST_AUTO_TEST_CASE(save_pairs)
+BOOST_AUTO_TEST_CASE(read_write_pairs_without_symmetry)
 {
-    PairSet pairs = {{0, 2}, {0, 4}, {0, 5}, {8, 2}, {0, 1}, {5, 9}};
+    // Test with useSymmetry=false to preserve order as (I, J) without sorting
+    PairSet pairSetGT;
+    pairSetGT.insert(std::make_pair(1, 0));
+    pairSetGT.insert(std::make_pair(2, 1));
+    pairSetGT.insert(std::make_pair(0, 2));
 
-    std::stringstream output;
-    savePairs(output, pairs);
-    BOOST_CHECK_EQUAL(output.str(), std::string("0 1 2 4 5\n5 9\n8 2\n"));
+    BOOST_CHECK(savePairsToFile("pairsT_IO_nosym.txt", pairSetGT));
+
+    PairSet loaded_Pairs;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_nosym.txt", loaded_Pairs, false));
+    
+    // With useSymmetry=false, pairs should be loaded as-is
+    BOOST_CHECK_EQUAL(loaded_Pairs.size(), 3);
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(0, 2)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(1, 0)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(2, 1)) != loaded_Pairs.end());
+    
+    std::remove("pairsT_IO_nosym.txt");
 }
 
-BOOST_AUTO_TEST_CASE(load_multiple_pairs_per_line)
+BOOST_AUTO_TEST_CASE(save_empty_pair_set)
 {
-    std::stringstream input;
-    input.str(R"( 0 2 4 5
-        0 1
-        5 9
-)");
-
-    PairSet loadedPairs;
-    BOOST_CHECK(loadPairs(input, loadedPairs));
-
-    PairSet expectedPairs = {{0, 2}, {0, 4}, {0, 5}, {0, 1}, {5, 9}};
-    BOOST_CHECK(loadedPairs == expectedPairs);
+    // Test saving an empty pair set
+    PairSet emptySet;
+    BOOST_CHECK(savePairsToFile("pairsT_IO_empty.txt", emptySet));
+    
+    PairSet loaded_Pairs;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_empty.txt", loaded_Pairs));
+    BOOST_CHECK(loaded_Pairs.empty());
+    
+    std::remove("pairsT_IO_empty.txt");
 }
+
+BOOST_AUTO_TEST_CASE(load_nonexistent_file)
+{
+    // Test loading from a file that doesn't exist
+    PairSet pairs;
+    BOOST_CHECK(!loadPairsFromFile("nonexistent_file_xyz123.txt", pairs));
+    BOOST_CHECK(pairs.empty());
+}
+
+BOOST_AUTO_TEST_CASE(save_to_invalid_path)
+{
+    // Test saving to an invalid path
+    PairSet pairSet;
+    pairSet.insert(std::make_pair(0, 1));
+    
+    // Using a path that should fail on most systems
+    BOOST_CHECK(!savePairsToFile("/invalid/path/that/does/not/exist/pairs.txt", pairSet));
+}
+
+BOOST_AUTO_TEST_CASE(read_single_pair)
+{
+    // Test reading a single pair
+    PairSet pairSetGT;
+    pairSetGT.insert(std::make_pair(5, 10));
+    
+    BOOST_CHECK(savePairsToFile("pairsT_IO_single.txt", pairSetGT));
+    
+    PairSet loaded_Pairs;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_single.txt", loaded_Pairs));
+    BOOST_CHECK_EQUAL(loaded_Pairs.size(), 1);
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(5, 10)) != loaded_Pairs.end());
+    
+    std::remove("pairsT_IO_single.txt");
+}
+
+BOOST_AUTO_TEST_CASE(read_multiple_pairs_from_same_image)
+{
+    // Test the file format where one line has: I J1 J2 J3 ...
+    // This should create pairs (I, J1), (I, J2), (I, J3)
+    std::ofstream out("pairsT_IO_multiple.txt");
+    out << "0 1 2 3\n";
+    out << "1 4 5\n";
+    out.close();
+    
+    PairSet loaded_Pairs;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_multiple.txt", loaded_Pairs));
+    
+    // With symmetry, pairs should be normalized to (min, max)
+    BOOST_CHECK_EQUAL(loaded_Pairs.size(), 5);
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(0, 1)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(0, 2)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(0, 3)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(1, 4)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(1, 5)) != loaded_Pairs.end());
+    
+    std::remove("pairsT_IO_multiple.txt");
+}
+
+BOOST_AUTO_TEST_CASE(duplicate_pairs_are_handled)
+{
+    // Test that duplicate pairs (after symmetry normalization) are handled correctly
+    // Create a file with duplicates, including pairs that become duplicates after normalization
+    std::ofstream out("pairsT_IO_dup.txt");
+    out << "0 1\n";   // (0, 1)
+    out << "1 0\n";   // Should normalize to (0, 1) - duplicate
+    out << "0 1\n";   // (0, 1) - duplicate
+    out << "2 3\n";   // (2, 3)
+    out << "3 2\n";   // Should normalize to (2, 3) - duplicate
+    out.close();
+    
+    PairSet loaded_Pairs;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_dup.txt", loaded_Pairs, true));
+    
+    // With symmetry normalization, all duplicates should be merged
+    // Should only have 2 unique pairs: (0, 1) and (2, 3)
+    BOOST_CHECK_EQUAL(loaded_Pairs.size(), 2);
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(0, 1)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(2, 3)) != loaded_Pairs.end());
+    
+    std::remove("pairsT_IO_dup.txt");
+}
+
+BOOST_AUTO_TEST_CASE(large_image_indices)
+{
+    // Test with large image indices
+    PairSet pairSetGT;
+    pairSetGT.insert(std::make_pair(1000, 2000));
+    pairSetGT.insert(std::make_pair(5000, 10000));
+    pairSetGT.insert(std::make_pair(999, 1001));
+    
+    BOOST_CHECK(savePairsToFile("pairsT_IO_large.txt", pairSetGT));
+    
+    PairSet loaded_Pairs;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_large.txt", loaded_Pairs));
+    BOOST_CHECK_EQUAL(loaded_Pairs.size(), 3);
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(1000, 2000)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(5000, 10000)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(999, 1001)) != loaded_Pairs.end());
+    
+    std::remove("pairsT_IO_large.txt");
+}
+
+BOOST_AUTO_TEST_CASE(symmetry_normalization)
+{
+    // Test that pairs are correctly normalized with symmetry
+    std::ofstream out("pairsT_IO_sym.txt");
+    out << "5 3\n";  // Should become (3, 5)
+    out << "1 4\n";  // Should stay (1, 4)
+    out << "8 2\n";  // Should become (2, 8)
+    out.close();
+    
+    PairSet loaded_Pairs;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_sym.txt", loaded_Pairs, true));
+    
+    BOOST_CHECK_EQUAL(loaded_Pairs.size(), 3);
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(3, 5)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(1, 4)) != loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(2, 8)) != loaded_Pairs.end());
+    
+    // These should NOT be found (wrong order)
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(5, 3)) == loaded_Pairs.end());
+    BOOST_CHECK(loaded_Pairs.find(std::make_pair(8, 2)) == loaded_Pairs.end());
+    
+    std::remove("pairsT_IO_sym.txt");
+}
+
+BOOST_AUTO_TEST_CASE(roundtrip_consistency)
+{
+    // Test that multiple save/load cycles preserve data
+    PairSet original;
+    original.insert(std::make_pair(0, 10));
+    original.insert(std::make_pair(1, 11));
+    original.insert(std::make_pair(2, 12));
+    original.insert(std::make_pair(3, 13));
+    
+    // First save/load cycle
+    BOOST_CHECK(savePairsToFile("pairsT_IO_round1.txt", original));
+    PairSet loaded1;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_round1.txt", loaded1));
+    
+    // Second save/load cycle
+    BOOST_CHECK(savePairsToFile("pairsT_IO_round2.txt", loaded1));
+    PairSet loaded2;
+    BOOST_CHECK(loadPairsFromFile("pairsT_IO_round2.txt", loaded2));
+    
+    // All should be equal
+    BOOST_CHECK(std::equal(original.begin(), original.end(), loaded1.begin()));
+    BOOST_CHECK(std::equal(original.begin(), original.end(), loaded2.begin()));
+    BOOST_CHECK(std::equal(loaded1.begin(), loaded1.end(), loaded2.begin()));
+    
+    std::remove("pairsT_IO_round1.txt");
+    std::remove("pairsT_IO_round2.txt");
+}
+

--- a/src/aliceVision/matchingImageCollection/matchingImageCollection.i
+++ b/src/aliceVision/matchingImageCollection/matchingImageCollection.i
@@ -18,3 +18,4 @@ using namespace aliceVision;
 %} 
 
 %include <aliceVision/matchingImageCollection/ImagePairListIO.hpp>
+ 

--- a/src/aliceVision/matchingImageCollection/pairBuilder.cpp
+++ b/src/aliceVision/matchingImageCollection/pairBuilder.cpp
@@ -19,29 +19,23 @@
 namespace aliceVision {
 
 /// Generate all the (I,J) pairs of the upper diagonal of the NxN matrix
-PairSet exhaustivePairs(const sfmData::Views& views, int rangeStart, int rangeSize)
+PairSet exhaustivePairs(const std::set<IndexT> & viewIds)
 {
     PairSet pairs;
-    sfmData::Views::const_iterator itA = views.begin();
-    sfmData::Views::const_iterator itAEnd = views.end();
-
-    // If we have a rangeStart, only compute the matching for (rangeStart, X).
-    if (rangeStart != -1 && rangeSize != 0)
-    {
-        if (rangeStart >= views.size())
-            return pairs;
-        std::advance(itA, rangeStart);
-        itAEnd = views.begin();
-        std::advance(itAEnd, std::min(std::size_t(rangeStart + rangeSize), views.size()));
-    }
+    auto itA = viewIds.begin();
+    auto itAEnd = viewIds.end();
 
     for (; itA != itAEnd; ++itA)
     {
-        sfmData::Views::const_iterator itB = itA;
+        auto itB = itA;
         std::advance(itB, 1);
-        for (; itB != views.end(); ++itB)
-            pairs.insert(std::make_pair(itA->first, itB->first));
+
+        for (; itB != viewIds.end(); ++itB)
+        {
+            pairs.insert(std::make_pair(*itA, *itB));
+        }
     }
+
     return pairs;
 }
 

--- a/src/aliceVision/matchingImageCollection/pairBuilder.hpp
+++ b/src/aliceVision/matchingImageCollection/pairBuilder.hpp
@@ -13,7 +13,11 @@
 
 namespace aliceVision {
 
-/// Generate all the (I,J) pairs of the upper diagonal of the NxN matrix
-PairSet exhaustivePairs(const sfmData::Views& views, int rangeStart = -1, int rangeSize = 0);
+/**
+ * @brief Generate all the (I,J) pairs of the upper diagonal of the NxN matrix
+ * @param views the sfmData views indices list
+ * @return a generated set of pairs
+ */
+PairSet exhaustivePairs(const std::set<IndexT> & viewIds);
 
 };  // namespace aliceVision

--- a/src/aliceVision/matchingImageCollection/pairBuilder_test.cpp
+++ b/src/aliceVision/matchingImageCollection/pairBuilder_test.cpp
@@ -34,20 +34,15 @@ bool checkPairOrder(const IterablePairs& pairs)
 
 BOOST_AUTO_TEST_CASE(matchingImageCollection_exhaustivePairs)
 {
-    sfmData::Views views;
     {
         // Empty
-        PairSet pairSet = exhaustivePairs(views);
+        std::set<IndexT> indices;
+        PairSet pairSet = exhaustivePairs(indices);
         BOOST_CHECK_EQUAL(0, pairSet.size());
     }
     {
-        std::vector<IndexT> indexes = {{12, 54, 89, 65}};
-        for (IndexT i : indexes)
-        {
-            views.emplace(i, std::make_shared<sfmData::View>("filepath", i));
-        }
-
-        PairSet pairSet = exhaustivePairs(views);
+        std::set<IndexT> indices = {12, 54, 89, 65};
+        PairSet pairSet = exhaustivePairs(indices);
         BOOST_CHECK(checkPairOrder(pairSet));
         BOOST_CHECK_EQUAL(6, pairSet.size());
         BOOST_CHECK(pairSet.find(std::make_pair(12, 54)) != pairSet.end());

--- a/src/software/pipeline/main_featureMatching.cpp
+++ b/src/software/pipeline/main_featureMatching.cpp
@@ -34,6 +34,7 @@
 #include <aliceVision/stl/stl.hpp>
 #include <aliceVision/camera/Pinhole.hpp>
 #include <aliceVision/camera/Equidistant.hpp>
+#include <aliceVision/system/Parallelization.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -45,7 +46,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 using namespace aliceVision::camera;
@@ -103,8 +104,8 @@ int aliceVision_main(int argc, char** argv)
     std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
     float distRatio = 0.8f;
     std::vector<std::string> predefinedPairList;
-    int rangeStart = -1;
-    int rangeSize = 0;
+    int rangeIteration = 0;
+    int rangeBlocksCount = 1;
     std::string nearestMatchingMethod = "ANN_L2";
     robustEstimation::ERobustEstimator geometricEstimator = robustEstimation::ERobustEstimator::ACRANSAC;
     double geometricErrorMax = 0.0;  //< the maximum reprojection error allowed for image matching with geometric validation
@@ -182,10 +183,10 @@ int aliceVision_main(int argc, char** argv)
          "Export debug files (svg, dot).")
         ("maxMatches", po::value<std::size_t>(&numMatchesToKeep)->default_value(numMatchesToKeep),
          "Maximum number pf matches to keep.")
-        ("rangeStart", po::value<int>(&rangeStart)->default_value(rangeStart),
-         "Range image index start.")
-        ("rangeSize", po::value<int>(&rangeSize)->default_value(rangeSize),
-         "Range size.")
+        ("rangeIteration", po::value<int>(&rangeIteration)->default_value(rangeIteration),
+         "chunk index.")
+        ("rangeBlocksCount", po::value<int>(&rangeBlocksCount)->default_value(rangeBlocksCount),
+         "Total number of chunks.")
         ("randomSeed", po::value<int>(&randomSeed)->default_value(randomSeed),
          "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.");
     // clang-format on
@@ -245,38 +246,60 @@ int aliceVision_main(int argc, char** argv)
     //    - Keep correspondences only if NearestNeighbor ratio is ok
 
     // from matching mode compute the pair list that have to be matched
-    PairSet pairs;
-    std::set<IndexT> filter;
+    PairSet allPairs;
+    
 
     // We assume that there is only one pair for (I,J) and (J,I)
     if (predefinedPairList.empty())
     {
-        pairs = exhaustivePairs(sfmData.getViews(), rangeStart, rangeSize);
+        allPairs = exhaustivePairs(sfmData.getViewsKeys());
     }
     else
     {
         for (const std::string& imagePairsFile : predefinedPairList)
         {
             ALICEVISION_LOG_INFO("Load pair list from file: " << imagePairsFile);
-            if (!matchingImageCollection::loadPairsFromFile(imagePairsFile, pairs, rangeStart, rangeSize))
+            if (!matchingImageCollection::loadPairsFromFile(imagePairsFile, allPairs))
+            {
                 return EXIT_FAILURE;
+            }
         }
     }
 
-    if (pairs.empty())
+    if (allPairs.empty())
     {
         ALICEVISION_LOG_INFO("No image pair to match.");
         // if we only compute a selection of matches, we may have no match.
-        return rangeSize ? EXIT_SUCCESS : EXIT_FAILURE;
+        return rangeBlocksCount > 1 ? EXIT_SUCCESS : EXIT_FAILURE;
     }
 
-    ALICEVISION_LOG_INFO("Number of pairs: " << pairs.size());
+    ALICEVISION_LOG_INFO("Number of pairs: " << allPairs.size());
+
+    int chunkStart, chunkEnd;
+    if (!rangeComputation(chunkStart, chunkEnd, rangeIteration, rangeBlocksCount, allPairs.size()))
+    {
+        ALICEVISION_LOG_INFO("Nothing to compute in this chunk");
+        return EXIT_SUCCESS;
+    }
+
+    ALICEVISION_LOG_INFO("A total of " << allPairs.size() << " pairs has to be processed.");
+    ALICEVISION_LOG_INFO("Current chunk will analyze pairs from " << chunkStart << " to " << chunkEnd << ".");
 
     // filter creation
-    for (const auto& pair : pairs)
+    // Keep only pairs in the chunk
+    int pos = 0;
+    PairSet pairs;
+    std::set<IndexT> filter;
+    for (const auto& pair : allPairs)
     {
-        filter.insert(pair.first);
-        filter.insert(pair.second);
+        if (pos >= chunkStart && pos < chunkEnd)
+        {
+            pairs.insert(pair);
+            filter.insert(pair.first);
+            filter.insert(pair.second);
+        }
+
+        pos++;
     }
 
     PairwiseMatches mapPutativesMatches;
@@ -357,7 +380,7 @@ int aliceVision_main(int argc, char** argv)
     {
         ALICEVISION_LOG_INFO("No putative feature matches.");
         // If we only compute a selection of matches, we may have no match.
-        return rangeSize ? EXIT_SUCCESS : EXIT_FAILURE;
+        return rangeBlocksCount > 1 ? EXIT_SUCCESS : EXIT_FAILURE;
     }
 
     if (geometricFilterType == EGeometricFilterType::HOMOGRAPHY_GROWING)
@@ -375,10 +398,10 @@ int aliceVision_main(int argc, char** argv)
         }
     }
 
-    // when a range is specified, generate a file prefix to reflect the current iteration (rangeStart/rangeSize)
+    // when a range is specified, generate a file prefix to reflect the current iteration
     // => with matchFilePerImage: avoids overwriting files if a view is present in several iterations
     // => without matchFilePerImage: avoids overwriting the unique resulting file
-    const std::string filePrefix = rangeSize > 0 ? std::to_string(rangeStart / rangeSize) + "." : "";
+    const std::string filePrefix = std::to_string(rangeIteration) + ".";
 
     ALICEVISION_LOG_INFO(std::to_string(mapPutativesMatches.size()) << " putative image pair matches");
 
@@ -389,33 +412,12 @@ int aliceVision_main(int argc, char** argv)
 
     // export putative matches
     if (savePutativeMatches)
+    {
         Save(mapPutativesMatches, (fs::path(matchesFolder) / "putativeMatches").string(), fileExtension, matchFilePerImage, filePrefix);
+    }
 
     ALICEVISION_LOG_INFO("Task (Regions Matching) done in (s): " + std::to_string(timer.elapsed()));
 
-    /*
-    // TODO: DELI
-    if(exportDebugFiles)
-    {
-      //-- export putative matches Adjacency matrix
-      PairwiseMatchingToAdjacencyMatrixSVG(sfmData.getViews().size(),
-        mapPutativesMatches,
-        (fs::path(matchesFolder) / "PutativeAdjacencyMatrix.svg").string());
-      //-- export view pair graph once putative graph matches have been computed
-      {
-        std::set<IndexT> set_ViewIds;
-
-        std::transform(sfmData.getViews().begin(), sfmData.getViews().end(),
-          std::inserter(set_ViewIds, set_ViewIds.begin()), stl::RetrieveKey());
-
-        graph::indexedGraph putativeGraph(set_ViewIds, getPairs(mapPutativesMatches));
-
-        graph::exportToGraphvizData(
-          (fs::path(matchesFolder) / "putative_matches.dot").string(),
-          putativeGraph.g);
-      }
-    }
-    */
 
 #ifdef ALICEVISION_DEBUG_MATCHING
     {

--- a/src/software/pipeline/main_relativePoseEstimating.cpp
+++ b/src/software/pipeline/main_relativePoseEstimating.cpp
@@ -273,7 +273,7 @@ int aliceVision_main(int argc, char** argv)
             PairSet pairs;
                 
             ALICEVISION_LOG_INFO("Load pair list from file: " << imagePairsFile);
-            if (!matchingImageCollection::loadPairsFromFile(imagePairsFile, pairs, 0, -1))
+            if (!matchingImageCollection::loadPairsFromFile(imagePairsFile, pairs))
             {
                 return EXIT_FAILURE;
             }


### PR DESCRIPTION
- Cleanup loading and saving of pairs of indices (Output of ImageMatching)

- Removed the "stream" version as they were never used

- Cleanup exhaustive generation of pairs of indices (used if no imageMatching output)

- Removed the obligation that pair.first < pair.second in the loaded file. This enable to have both directions in the same file (which is required for "star" roma)

- Removed error if a pair contains twice the same value (To enable mirror matching)

- Distribution of pairs to compute among chunks is now way more efficient ! Previous solution was to use the reference views as the items to distribute; But this is obviously creating problems as the numbers of pairs with the same reference image is not uniform at all.