### PR TITLE
[meshroom] Fix missing connection in "CameraTracking without calibration experimental" pipeline

### DIFF
--- a/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
@@ -561,6 +561,7 @@
             ],
             "inputs": {
                 "input": "{Meshing_1.output}",
+                "imagesFolder": "{ExportImages_1.output}",
                 "inputMesh": "{MeshDecimate_1.output}"
             },
             "internalInputs": {


### PR DESCRIPTION
Fix missing link between ExportImages and Texturing