### PR TITLE
[meshroom] `ImportAlembic`: Add missing period in file extensions

### DIFF
--- a/meshroom/aliceVision/ImportAlembic.py
+++ b/meshroom/aliceVision/ImportAlembic.py
@@ -29,8 +29,8 @@ Import an external Alembic file that does not follow the SfMData convention, and
             name="extension",
             label="Images Extension",
             description="File extension for the images in the directory to be taken into account.",
-            value="exr",
-            values=["exr", "jpg", "png"],
+            value=".exr",
+            values=[".exr", ".jpg", ".png"],
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/src/software/utils/main_importAlembic.cpp
+++ b/src/software/utils/main_importAlembic.cpp
@@ -37,10 +37,14 @@ int aliceVision_main(int argc, char** argv)
     // clang-format off
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
-        ("input,i", po::value<std::string>(&abcFilename)->required(), "Input Alembic file.")
-        ("imagesDir", po::value<std::string>(&imagesDir)->required(), "directory with images")
-        ("extension", po::value<std::string>(&extension)->required(), "images extension")
-        ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(), "SfMData output file.");
+        ("input,i", po::value<std::string>(&abcFilename)->required(),
+         "The external Alembic file to import.")
+        ("imagesDir", po::value<std::string>(&imagesDir)->required(),
+         "Directory with images.")
+        ("extension", po::value<std::string>(&extension)->required(),
+         "File extension for the images in the directory to be taken into account (should include the period, e.g. '.jpg').")
+        ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(),
+         "SfMData file populated with the camera poses from the external Alembic file.");
     // clang-format on
 
     CmdLine cmdline("AliceVision Alembic importer");


### PR DESCRIPTION
## Description

This PR fixes #1911 by adding the missing period in the list of possible file extension values for the `extension` parameter. It additionally updates the documentation strings of the command line on the executable's side so it matches the ones from the Meshroom node.
