### PR TITLE
[meshroom] Add color calibration pipeline

### DIFF
--- a/meshroom/aliceVision/ColorCheckerCorrection.py
+++ b/meshroom/aliceVision/ColorCheckerCorrection.py
@@ -5,6 +5,29 @@ from meshroom.core.utils import EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 import os.path
 
+def outputImagesValueFunct(attr):
+    basename = os.path.basename(attr.node.input.value)
+    fileStem = os.path.splitext(basename)[0]
+    inputExt = os.path.splitext(basename)[1]
+    outputExt = ('.' + attr.node.extension.value) if attr.node.extension.value else None
+
+    if inputExt in ['.abc', '.sfm']:
+        fileStem = '<FILESTEM>' if attr.node.keepImageName.value else '<VIEW_ID>'
+        # If we have an SfM in input
+        return "{nodeCacheFolder}/" + fileStem + (outputExt or '.*')
+
+    if inputExt:
+        # If we have one or multiple files in input
+        return "{nodeCacheFolder}/" + fileStem + (outputExt or inputExt)
+
+    if '*' in fileStem:
+        # The fileStem of the input param is a regular expression,
+        # so even if there is no file extension,
+        # we consider that the expression represents files.
+        return "{nodeCacheFolder}/" + fileStem + (outputExt or '.*')
+
+    # No extension and no expression means that the input param is a folder path
+    return "{nodeCacheFolder}/" + '*' + (outputExt or '.*')
 
 class ColorCheckerCorrection(desc.AVCommandLineNode):
     commandLine = "aliceVision_colorCheckerCorrection {allParams}"
@@ -102,5 +125,13 @@ If multiple color charts are submitted, only the first one will be taken in acco
             label="Folder",
             description="Output images folder.",
             value="{nodeCacheFolder}",
+        ),
+        desc.File(
+            name="outputImages",
+            label="Images",
+            description="Output images.",
+            semantic="image",
+            value=outputImagesValueFunct,
+            group="",  # do not export on the command line
         ),
     ]

--- a/meshroom/colorCalibration.mg
+++ b/meshroom/colorCalibration.mg
@@ -5,7 +5,8 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "ColorCheckerCorrection": "2.0",
-            "ColorCheckerDetection": "2.0"
+            "ColorCheckerDetection": "2.0",
+            "Publish": "1.3"
         },
         "template": true
     },
@@ -21,8 +22,8 @@
         "ColorCheckerCorrection_1": {
             "nodeType": "ColorCheckerCorrection",
             "position": [
-                194,
-                -22
+                87,
+                -24
             ],
             "inputs": {
                 "inputData": "{ColorCheckerDetection_1.outputData}",
@@ -34,11 +35,23 @@
         "ColorCheckerDetection_1": {
             "nodeType": "ColorCheckerDetection",
             "position": [
-                -64,
-                -18
+                -108,
+                -19
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}"
+            }
+        },
+        "Publish_1": {
+            "nodeType": "Publish",
+            "position": [
+                279,
+                -10
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ColorCheckerCorrection_1.output}"
+                ]
             }
         }
     }

--- a/meshroom/colorCalibration.mg
+++ b/meshroom/colorCalibration.mg
@@ -1,0 +1,45 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0-develop",
+        "fileVersion": "2.0",
+        "nodesVersions": {
+            "CameraInit": "12.0",
+            "ColorCheckerCorrection": "2.0",
+            "ColorCheckerDetection": "2.0"
+        },
+        "template": true
+    },
+    "graph": {
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                -309,
+                -26
+            ],
+            "inputs": {}
+        },
+        "ColorCheckerCorrection_1": {
+            "nodeType": "ColorCheckerCorrection",
+            "position": [
+                194,
+                -22
+            ],
+            "inputs": {
+                "inputData": "{ColorCheckerDetection_1.outputData}",
+                "input": "{ColorCheckerDetection_1.input}",
+                "correctionMethod": "full",
+                "keepImageName": false
+            }
+        },
+        "ColorCheckerDetection_1": {
+            "nodeType": "ColorCheckerDetection",
+            "position": [
+                -64,
+                -18
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description
This PR add a color calibration pipeline based on 2 nodes, color checker detection and color checker correction.
In addition, this PR enable visualization of the color corrected images in the Meshroom 2D viewer.


## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

