### PR TITLE
[cmake] Dependencies: Update OpenCV to 4.12.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: "alicevision/alicevision-deps:2025.07.17-rocky9-cuda12.1.1"
+      image: "alicevision/alicevision-deps:2025.08.05-rocky9-cuda12.1.1"
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release

--- a/docker/Dockerfile_rocky_deps
+++ b/docker/Dockerfile_rocky_deps
@@ -59,8 +59,8 @@ RUN echo "export ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVis
 COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
 RUN echo "export ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx" >> /etc/profile.d/alicevision.sh
 
-COPY dl/ColorchartDetectionModel ${AV_INSTALL}/share/aliceVision
-RUN echo "export ALICEVISION_COLORCHARTDETECTION_MODEL_FOLDER=${AV_INSTALL}/share/aliceVision/ColorchartDetectionModel" >> /etc/profile.d/alicevision.sh
+COPY dl/ColorChartDetectionModel ${AV_INSTALL}/share/aliceVision/ColorChartDetectionModel
+RUN echo "export ALICEVISION_COLORCHARTDETECTION_MODEL_FOLDER=${AV_INSTALL}/share/aliceVision/ColorChartDetectionModel" >> /etc/profile.d/alicevision.sh
 
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
 RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && echo "Build multithreading number of cores: ${CPU_CORES}"

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -68,8 +68,8 @@ RUN echo "export ALICEVISION_SPHERE_DETECTION_MODEL=${AV_INSTALL}/share/aliceVis
 COPY dl/fcn_resnet50.onnx ${AV_INSTALL}/share/aliceVision/
 RUN echo "export ALICEVISION_SEMANTIC_SEGMENTATION_MODEL=${AV_INSTALL}/share/aliceVision/fcn_resnet50.onnx" >> /etc/profile.d/alicevision.sh
 
-COPY dl/ColorchartDetectionModel ${AV_INSTALL}/share/aliceVision/ColorchartDetectionModel
-RUN echo "export ALICEVISION_COLORCHARTDETECTION_MODEL_FOLDER=${AV_INSTALL}/share/aliceVision/ColorchartDetectionModel" >> /etc/profile.d/alicevision.sh
+COPY dl/ColorChartDetectionModel ${AV_INSTALL}/share/aliceVision/ColorChartDetectionModel
+RUN echo "export ALICEVISION_COLORCHARTDETECTION_MODEL_FOLDER=${AV_INSTALL}/share/aliceVision/ColorChartDetectionModel" >> /etc/profile.d/alicevision.sh
 
 COPY docker/check-cpu.sh ${AV_DEV}/docker/check-cpu.sh
 RUN export CPU_CORES=`${AV_DEV}/docker/check-cpu.sh` && echo "Build multithreading number of cores: ${CPU_CORES}"

--- a/docker/build-rocky.sh
+++ b/docker/build-rocky.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.07.17
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.08.05
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$ROCKY_VERSION" && ROCKY_VERSION=9

--- a/docker/build-ubuntu.sh
+++ b/docker/build-ubuntu.sh
@@ -6,7 +6,7 @@ test -e docker/fetch.sh || {
 	exit 1
 }
 
-test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.07.17
+test -z "$AV_DEPS_VERSION" && AV_DEPS_VERSION=2025.08.05
 test -z "$AV_VERSION" && AV_VERSION="$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)"
 test -z "$CUDA_VERSION" && CUDA_VERSION=12.1.1
 test -z "$UBUNTU_VERSION" && UBUNTU_VERSION=22.04

--- a/docker/fetch.sh
+++ b/docker/fetch.sh
@@ -23,7 +23,8 @@ test -f dl/sphereDetection_Mask-RCNN.onnx || \
 test -f dl/fcn_resnet50.onnx || \
         wget https://gitlab.com/alicevision/semanticSegmentationModel/-/raw/main/fcn_resnet50.onnx -O dl/fcn_resnet50.onnx
 test -d dl/ColorchartDetectionModel || \
-        git clone https://gitlab.com/alicevision/ColorchartDetectionModel.git dl/ColorchartDetectionModel
+        git clone --depth=1 --branch=main https://gitlab.com/alicevision/ColorchartDetectionModel.git dl/ColorChartDetectionModel && \
+        rm dl/ColorChartDetectionModel/README.md && rm -rf dl/ColorChartDetectionModel/.git
 export CMAKE_VERSION=3.26.0
 export CMAKE_VERSION_MM=3.26
 test -f dl/cmake-${CMAKE_VERSION}.tar.gz || \

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -1002,8 +1002,8 @@ if(AV_BUILD_OPENCV)
     set(OPENCV_TARGET opencv)
 
     ExternalProject_Add(opencv_contrib
-        URL https://github.com/opencv/opencv_contrib/archive/refs/tags/4.11.0.tar.gz
-        URL_HASH MD5=7dd4bc67eb67faff96ce71745a5e3abe
+        URL https://github.com/opencv/opencv_contrib/archive/refs/tags/4.12.0.tar.gz
+        URL_HASH MD5=55603c033cc5f3d5e307b699ad72e25a
         DOWNLOAD_DIR ${BUILD_DIR}/download/opencv_contrib
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencv_contrib
         BUILD_ALWAYS 0
@@ -1014,8 +1014,8 @@ if(AV_BUILD_OPENCV)
     )
 
     ExternalProject_Add(${OPENCV_TARGET}
-        URL https://github.com/opencv/opencv/archive/refs/tags/4.11.0.tar.gz
-        URL_HASH MD5=f35fbd46350cc677af13e198805b58f7
+        URL https://github.com/opencv/opencv/archive/refs/tags/4.12.0.tar.gz
+        URL_HASH MD5=eb6f8ff4f4cd16ef1b97bc21edc74de9
         DOWNLOAD_DIR ${BUILD_DIR}/download/opencv
         UPDATE_COMMAND ""
         BUILD_IN_SOURCE 0


### PR DESCRIPTION
## Description

This PR updates the version of OpenCV in the dependencies from 4.11.0 to 4.12.0. The Docker images for the dependencies are rebuilt and pushed, and their tags are updated both in the build scripts for Docker and the continuous integration workflow.

The move to OpenCV 4.12.0 is motivated by the issue mentioned in #1852, as OpenCV 4.12.0 is the first version to integrate the commit fixing it.

Additionally, the Dockerfiles and scripts are fixed to only download the models and copy them to the Docker images (as opposed to copying the whole repository, with the documentation and the `.git` directory).