### PR TITLE
Using dedicated class for map of shared_ptr

### DIFF
--- a/src/aliceVision/sfmData/ImageInfo.hpp
+++ b/src/aliceVision/sfmData/ImageInfo.hpp
@@ -40,6 +40,11 @@ class ImageInfo
         _metadata(metadata)
     {}
 
+    ImageInfo * clone()
+    {
+        return new ImageInfo(*this);
+    }
+
     bool operator==(const ImageInfo& other) const
     {
         // image paths can be different

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -35,18 +35,8 @@ SfMData::SfMData(const SfMData & other, bool unused)
     _rigs = other._rigs;
     _posesUncertainty = other._posesUncertainty;
     _landmarksUncertainty = other._landmarksUncertainty;
-
-    for (const auto & [idView, pView]: other._views)
-    {
-        sfmData::View::sptr pOutView(pView->clone());
-        _views[idView] = pOutView;
-    }
-
-    for (const auto & [idIntrinsic, pIntrinsic]: other._intrinsics)
-    {
-        camera::IntrinsicBase::sptr pOutIntrinsic(pIntrinsic->clone());
-        _intrinsics[idIntrinsic] = pOutIntrinsic;
-    }
+    _views = other._views;
+    _intrinsics = other._intrinsics;
 }
 
 SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eigen::Vector3d & bbMax)
@@ -62,18 +52,8 @@ SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eig
     _rigs = other._rigs;
     _posesUncertainty = other._posesUncertainty;
     _landmarksUncertainty = other._landmarksUncertainty;
-
-    for (const auto & [idView, pView]: other._views)
-    {
-        sfmData::View::sptr pOutView(pView->clone());
-        _views[idView] = pOutView;
-    }
-
-    for (const auto & [idIntrinsic, pIntrinsic]: other._intrinsics)
-    {
-        camera::IntrinsicBase::sptr pOutIntrinsic(pIntrinsic->clone());
-        _intrinsics[idIntrinsic] = pOutIntrinsic;
-    }
+    _views = other._views;
+    _intrinsics = other._intrinsics;
 
     for (const auto & pl : other._landmarks)
     {
@@ -93,42 +73,15 @@ SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eig
 bool SfMData::operator==(const SfMData& other) const
 {
     // Views
-    if (_views.size() != other._views.size())
+    if (_views != other._views)
     {
         return false;
-    }
-
-    for (Views::const_iterator it = _views.begin(); it != _views.end(); ++it)
-    {
-        const View& view1 = *(it->second.get());
-        const View& view2 = *(other._views.at(it->first).get());
-        if (view1 != view2)
-        {
-            return false;
-        }
-
-        // Image paths
-        if (view1.getImage().getImagePath() != view2.getImage().getImagePath())
-        {
-            return false;
-        }
     }
 
     // Ancestors
-    if (_ancestors.size() != other._ancestors.size())
+    if (_ancestors != other._ancestors)
     {
         return false;
-    }
-
-    for (ImageInfos::const_iterator it = _ancestors.begin(); it != _ancestors.end(); ++it)
-    {
-        const ImageInfo& ancestor1 = *(it->second);
-        const ImageInfo& ancestor2 = *(other._ancestors.at(it->first));
-
-        if (ancestor1 != ancestor2)
-        {
-            return false;
-        }
     }
 
     // Poses
@@ -144,28 +97,9 @@ bool SfMData::operator==(const SfMData& other) const
     }
 
     // Intrinsics
-    if (_intrinsics.size() != other._intrinsics.size())
+    if (_intrinsics != other._intrinsics)
     {
         return false;
-    }
-
-    Intrinsics::const_iterator it = _intrinsics.begin();
-    Intrinsics::const_iterator otherIt = other._intrinsics.begin();
-    for (; it != _intrinsics.end() && otherIt != other._intrinsics.end(); ++it, ++otherIt)
-    {
-        // Index
-        if (it->first != otherIt->first)
-        {
-            return false;
-        }
-
-        // Intrinsic
-        camera::IntrinsicBase& intrinsic1 = *(it->second.get());
-        camera::IntrinsicBase& intrinsic2 = *(otherIt->second.get());
-        if (intrinsic1 != intrinsic2)
-        {
-            return false;
-        }
     }
 
     // Points IDs are not preserved

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <aliceVision/sfmData/SharedPtrMap.hpp>
 #include <aliceVision/sfmData/CameraPose.hpp>
 #include <aliceVision/sfmData/Landmark.hpp>
 #include <aliceVision/sfmData/Constraint2D.hpp>
@@ -26,16 +27,16 @@ namespace aliceVision {
 namespace sfmData {
 
 /// Define a collection of View
-using Views = std::map<IndexT, std::shared_ptr<View>>;
+using Views = SharedPtrMap<View>;
 
 /// Define a collection of Image Info
-using ImageInfos = std::map<IndexT, std::shared_ptr<ImageInfo>>;
+using ImageInfos = SharedPtrMap<ImageInfo>;
 
 /// Define a collection of Pose (indexed by view.getPoseId())
 using Poses = std::map<IndexT, CameraPose>;
 
 /// Define a collection of IntrinsicParameter (indexed by view.getIntrinsicId())
-using Intrinsics = std::map<IndexT, std::shared_ptr<aliceVision::camera::IntrinsicBase>>;
+using Intrinsics = SharedPtrMap<camera::IntrinsicBase>;
 
 /// Define a collection of landmarks are indexed by their TrackId
 using Landmarks = std::map<IndexT, Landmark>;
@@ -351,11 +352,6 @@ class SfMData
             return false;
         }
 
-        if (it->second.isRotationOnly())
-        {
-            return false;
-        }
-
         bool rigValid = ((!view.isPartOfRig() || view.isPoseIndependant() || getRigSubPose(view).status != ERigSubPoseStatus::UNINITIALIZED));
         if (!rigValid)
         {
@@ -606,9 +602,13 @@ class SfMData
     {
         auto it = _poses.find(poseId);
         if (it != _poses.end())
+        {
             _poses.erase(it);
+        }
         else if (!noThrow)
+        {
             throw std::out_of_range(std::string("Can't erase unfind pose ") + std::to_string(poseId));
+        }
     }
 
     /**
@@ -617,7 +617,9 @@ class SfMData
     void resetRigs()
     {
         for (auto rigIt : _rigs)
+        {
             rigIt.second.reset();
+        }
     }
 
     /**

--- a/src/aliceVision/sfmData/SfMData.i
+++ b/src/aliceVision/sfmData/SfMData.i
@@ -29,17 +29,82 @@ using namespace aliceVision::sfmData;
 using namespace aliceVision::camera;
 %}
 
+%template(SPViews) std::map<IndexT, std::shared_ptr<aliceVision::sfmData::View>>;
+%template(SPImageInfos) std::map<IndexT, std::shared_ptr<aliceVision::sfmData::ImageInfo>>;
+%template(SPIntrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::IntrinsicBase>>;
+%template(SPPinholeIntrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::Pinhole>>;
+%template(SPEquidistantIntrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::Equidistant>>;
+
+%include <aliceVision/sfmData/SharedPtrMap.hpp>
+
+// Add Python-specific extensions for each instantiation
+%define SPMAP_EXTENSIONS(VALUETYPE)
+%extend aliceVision::sfmData::SharedPtrMap<VALUETYPE> {
+    // Make it more Pythonic
+    int __len__() {
+        return self->size();
+    }
+    
+    bool __contains__(const IndexT& key) {
+        return (self->find(key) != self->end());
+    }
+    
+    std::shared_ptr<VALUETYPE> __getitem__(const IndexT& key) {
+        auto it = self->find(key);
+        if (it != self->end()) {
+            return it->second;
+        }
+        throw std::out_of_range("Key not found");
+    }
+    
+    void __setitem__(const IndexT& key, const std::shared_ptr<VALUETYPE>& value) {
+        self->mapType::operator[](key) = value;
+    }
+    
+    void __delitem__(const IndexT& key) {
+        auto it = self->find(key);
+        if (it != self->end()) {
+            self->erase(it);
+        } else {
+            throw std::out_of_range("Key not found");
+        }
+    }
+    
+    // Python iterator support using the getKeys method
+    %pythoncode %{
+    def __iter__(self):
+        return iter(self.getKeys())
+    
+    def keys(self):
+        return self.getKeys()
+    
+    def values(self):
+        return self.getValues()
+    
+    def items(self):
+        keys = self.getKeys()
+        values = self.getValues()
+        return list(zip(keys, values))
+    %}
+}
+%enddef
+
+SPMAP_EXTENSIONS(aliceVision::sfmData::View)
+SPMAP_EXTENSIONS(aliceVision::sfmData::ImageInfo)
+SPMAP_EXTENSIONS(aliceVision::sfmData::IntrinsicBase)
+
+%template(Views) aliceVision::sfmData::SharedPtrMap<aliceVision::sfmData::View>;
+%template(ImageInfos) aliceVision::sfmData::SharedPtrMap<aliceVision::sfmData::ImageInfo>;
+%template(Intrinsics) aliceVision::sfmData::SharedPtrMap<aliceVision::camera::IntrinsicBase>;
+%template(PinholeIntrinsics) aliceVision::sfmData::SharedPtrMap<aliceVision::camera::Pinhole>;
+%template(EquidistantIntrinsics) aliceVision::sfmData::SharedPtrMap<aliceVision::camera::Equidistant>;
+ 
 %template(Constraints2D) std::vector<aliceVision::sfmData::Constraint2D>;
-%template(ImageInfos) std::map<IndexT, std::shared_ptr<aliceVision::sfmData::ImageInfo>>;
-%template(Intrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::IntrinsicBase>>;
-%template(PinholeIntrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::Pinhole>>;
-%template(EquidistantIntrinsics) std::map<IndexT, std::shared_ptr<aliceVision::camera::Equidistant>>;
 %template(Landmarks) std::map<IndexT, aliceVision::sfmData::Landmark>;
 %template(Observations) std::map<IndexT, aliceVision::sfmData::Observation>;
 %template(Poses) std::map<IndexT, aliceVision::sfmData::CameraPose>;
 %template(Rigs) std::map<IndexT, aliceVision::sfmData::Rig>;
 %template(RotationPriors) std::vector<aliceVision::sfmData::RotationPrior>;
-%template(Views) std::map<IndexT, std::shared_ptr<aliceVision::sfmData::View>>;
 
 %template(ViewsVector) std::vector<std::shared_ptr<aliceVision::sfmData::View>>;
 %template(ViewsVectorVector) std::vector<std::vector<std::shared_ptr<aliceVision::sfmData::View>>>;

--- a/src/aliceVision/sfmData/SharedPtrMap.hpp
+++ b/src/aliceVision/sfmData/SharedPtrMap.hpp
@@ -1,0 +1,542 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <aliceVision/types.hpp>
+#include <iterator>
+#include <tuple>
+
+namespace aliceVision {
+namespace sfmData {
+
+template <class T, bool IsConstant>
+struct MapTraits
+{
+    using mapType = std::map<IndexT, std::shared_ptr<T>>;
+    using baseIterator = std::conditional_t<IsConstant, 
+                                            typename mapType::const_iterator, 
+                                            typename mapType::iterator>;
+
+    using keyType = const IndexT;
+    using valueType = std::conditional_t<IsConstant, const T, T>;
+    using pairType = std::conditional_t<IsConstant, 
+                                        const std::pair<const IndexT, T>, 
+                                        std::pair<const IndexT, T>>;
+};
+
+/**
+ * ProxyPair is a fake pair used 
+ * for reference access
+*/
+template <class T, bool IsConstant>
+class ProxyPair
+{
+public:
+    using Traits = MapTraits<T, IsConstant>;
+public:
+    explicit ProxyPair(Traits::baseIterator it) 
+    : _it(it)
+    {
+    }
+
+    Traits::baseIterator getIterator() const 
+    {
+        return _it;
+    }
+
+    Traits::keyType & first() const 
+    {
+        return _it->first;
+    }
+
+    Traits::valueType & second() const 
+    {
+        return *(_it->second);
+    }
+
+    #ifndef SWIG
+    template<std::size_t I>
+    decltype(auto) get() const
+    {
+        if constexpr (I == 0) 
+        {
+            return first();
+        }
+        else if constexpr (I == 1)
+        {
+            return second();
+        }
+        else
+        {
+            static_assert(I < 2, "Index out of bounds");
+            return first();
+        }
+    }
+    #endif
+
+private:
+    Traits::baseIterator _it;
+};
+
+/**
+ * map iterator
+ * Skip item where shared_ptr is null
+ * Returned item is the object instead of the pointer
+*/
+template <class T, bool IsConstant>
+class ValueIteratorT 
+{
+public:
+    using Traits = MapTraits<T, IsConstant>;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = Traits::pairType;
+    using difference_type = ptrdiff_t;
+    using pointer = void;
+    using reference = ProxyPair<T, IsConstant>;
+
+public:
+    
+    ValueIteratorT(Traits::baseIterator current, Traits::baseIterator end)
+    : _current(current), _end(end), _pair(current)
+    {
+        nextWhileInvalid();
+    }
+
+    reference & operator*()
+    {
+        return _pair;
+    }
+
+    ValueIteratorT& operator++() {
+        
+        ++_current;
+        nextWhileInvalid();
+        return *this;
+    }
+
+    ValueIteratorT operator++(int) {
+        ValueIteratorT tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    bool operator==(const ValueIteratorT & other) const 
+    {
+        return _current == other._current;
+    }
+
+    bool operator!=(const ValueIteratorT & other) const 
+    {
+        return !(*this == other);
+    }
+
+    const std::pair<const IndexT, std::shared_ptr<T>>& raw() const {
+        return *_current;
+    }
+
+    Traits::baseIterator baseIterator() const
+    {
+        return _current;
+    }
+
+private:
+    void nextWhileInvalid()
+    {
+        while (_current != _end)
+        {
+            if (_current->second != nullptr)
+            {
+                break;
+            }
+
+            ++_current;
+        }
+
+        if (_current != _end)
+        {
+            _pair = ProxyPair<T, IsConstant>(_current);
+        }
+    }
+
+private:
+    Traits::baseIterator _current;
+    Traits::baseIterator _end;
+    reference _pair;
+};
+
+
+/**
+ * Utility for loops to iterate over values instead of pointers
+*/
+template <typename T, bool IsConstant>
+class RangeValueT
+{
+public:
+    using Traits = MapTraits<T, IsConstant>;
+
+public:
+    RangeValueT(Traits::baseIterator begin_, Traits::baseIterator end_) 
+    : _begin(begin_), _end(end_)
+    {
+
+    }
+
+    ValueIteratorT<T, IsConstant> begin()
+    {
+        return ValueIteratorT<T, IsConstant>(_begin, _end);
+    }
+
+    ValueIteratorT<T, IsConstant> end()
+    {
+        return ValueIteratorT<T, IsConstant>(_end, _end);
+    }
+
+private:
+    Traits::baseIterator _begin;
+    Traits::baseIterator _end;
+};
+
+
+/**
+ * Fallback range
+*/
+template <typename T, bool IsConstant>
+class RangeBaseT
+{
+public:
+    using Traits = MapTraits<T, IsConstant>;
+
+public:
+    RangeBaseT(Traits::baseIterator begin_, Traits::baseIterator end_) 
+    : _begin(begin_), _end(end_)
+    {
+
+    }
+
+    Traits::baseIterator begin()
+    {
+        return _begin;
+    }
+
+    Traits::baseIterator end()
+    {
+        return _end;
+    }
+
+private:
+    Traits::baseIterator _begin;
+    Traits::baseIterator _end;
+};
+
+/**
+ * we have two iterators, one iterating over the shared_ptr
+ * the second iterating directly on the contained values
+ * ForceValueIterator make sure the value iterator is used by default
+*/
+template <class T, bool ForceValueIterator = false>
+class SharedPtrMap : public std::map<IndexT, std::shared_ptr<T>>
+{
+public:
+    using mapType = std::map<IndexT, std::shared_ptr<T>>;
+    using ValueIterator = ValueIteratorT<T, false>;
+    using ConstValueIterator = ValueIteratorT<T, true>;
+    using RangeValue = RangeValueT<T, false>;
+    using ConstRangeValue = RangeValueT<T, true>;
+    using RangeBase = RangeBaseT<T, false>;
+    using ConstRangeBase = RangeBaseT<T, true>;
+
+public:
+    SharedPtrMap() : mapType() {};
+
+    SharedPtrMap(const SharedPtrMap & other) : mapType()
+    {
+        //Clone the shared_ptr content instead of shallow copy
+        for (const auto & [key, value] : other.baseRange())
+        { 
+            this->emplace(key, value->clone());
+        }
+    }
+
+    SharedPtrMap<T> & operator=(const SharedPtrMap<T> &other)
+    {
+        if (this == &other)
+        {
+            return *this;
+        }
+        
+        //Assign by copy
+        SharedPtrMap<T> tmp(other);
+        tmp.swap(*this);
+
+        return *this;
+    }
+
+    bool operator!=(const SharedPtrMap<T> & other) const
+    {
+        return !(*this == other);
+    }
+
+    bool operator==(const SharedPtrMap<T> & other) const
+    {
+        //Check same size
+        if (this->size() != other.size())
+        {
+            return false;
+        }
+
+        //Compare all items
+        for (const auto & [key, value]: other)
+        {   
+            //Check that we have an item with same key
+            const auto it = this->mapType::find(key);
+            if (it == this->mapType::end())
+            {
+                return false;
+            }
+
+            //If both have nullptr, then it's ok, no need to compare values
+            const auto sptr = it->second;
+            if (sptr == nullptr && value == nullptr)
+            {
+                continue;
+            }
+
+            //Error if one has nullptr
+            if (sptr == nullptr || value == nullptr)
+            {
+                return false;
+            }
+
+            //Compare values
+            if (!((*sptr) == (*value)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool isValid(const IndexT &key) const 
+    {
+        //Check that the key exists
+        auto it = this->mapType::find(key);
+        if (it == this->mapType::end())
+        {
+            return false;
+        }
+
+        //Check that the value is the same
+        return (it->second != nullptr);
+    }
+
+    #ifndef SWIG
+    void assign(const IndexT & key, const T & value)
+    {
+        std::shared_ptr<T> ptr;
+
+        //Does the key exists ? If it exists, retrieve the pointer
+        auto it = this->mapType::find(key);
+        if (it != this->mapType::end())
+        {
+            ptr = it->second;
+        }
+        
+        if (ptr == nullptr)
+        {
+            ptr = std::make_shared<T>(value);
+            this->insert_or_assign(key, ptr);
+        }
+        else 
+        {
+            *ptr = value;
+        }
+    }
+    #endif
+
+    ConstRangeValue valueRange() const
+    {
+        return ConstRangeValue(mapType::begin(), mapType::end());
+    }
+
+    RangeValue valueRange()
+    {
+        return RangeValue(mapType::begin(), mapType::end());
+    }
+
+    ConstRangeBase baseRange() const
+    {
+        return ConstRangeBase(mapType::begin(), mapType::end());
+    }
+
+    RangeBase baseRange()
+    {
+        return RangeBase(mapType::begin(), mapType::end());
+    }
+
+    //Delete operators [] as we don't want to create on the fly
+    T & operator[] (const IndexT& index)
+    {
+        std::shared_ptr<T> ptr;
+
+        //Does the key exists ? If it exists, retrieve the pointer
+        auto it = this->mapType::find(index);
+        if (it != this->mapType::end())
+        {
+            ptr = it->second;
+        }
+        
+        if (ptr == nullptr)
+        {
+            ptr = std::make_shared<T>();
+            this->insert_or_assign(index, ptr);
+        }
+        
+        return *ptr;
+    }
+
+    T & operator[] (IndexT&& index) 
+    {
+        std::shared_ptr<T> ptr;
+
+        //Does the key exists ? If it exists, retrieve the pointer
+        auto it = this->mapType::find(index);
+        if (it != this->mapType::end())
+        {
+            ptr = it->second;
+        }
+        
+        if (ptr == nullptr)
+        {
+            ptr = std::make_shared<T>();
+            this->insert_or_assign(index, ptr);
+        }
+        
+        return *ptr;
+    }    
+
+    auto begin() 
+    {
+        if constexpr (ForceValueIterator)
+        {
+            return ValueIteratorT<T, false>(mapType::begin(), mapType::end());
+        }
+        else 
+        {
+            return mapType::begin();
+        }
+    }
+
+    auto end() 
+    {
+        if constexpr (ForceValueIterator)
+        {
+            return ValueIteratorT<T, false>(mapType::end(), mapType::end());
+        }
+        else 
+        {
+            return mapType::end();
+        }
+    }
+
+    auto begin() const
+    {
+        if constexpr (ForceValueIterator)
+        {
+            return ValueIteratorT<T, true>(mapType::begin(), mapType::end());
+        }
+        else 
+        {
+            return mapType::begin();
+        }
+    }
+
+    auto end() const
+    {
+        if constexpr (ForceValueIterator)
+        {
+            return ValueIteratorT<T, true>(mapType::end(), mapType::end());
+        }
+        else 
+        {
+            return mapType::end();
+        }
+    }
+
+    auto find(IndexT index) 
+    {
+        if constexpr (ForceValueIterator)
+        {
+            return ValueIteratorT<T, false>(mapType::find(index), mapType::end());
+        }
+        else 
+        {
+            return mapType::find(index);
+        }
+    }
+
+    auto find(IndexT index) const
+    {
+        if constexpr (ForceValueIterator)
+        {
+            return ValueIteratorT<T, true>(mapType::find(index), mapType::end());
+        }
+        else 
+        {
+            return mapType::find(index);
+        }
+    }
+
+    std::vector<IndexT> getKeys() const 
+    {
+        std::vector<IndexT> keys;
+        for (const auto& pair : *this) 
+        {
+            keys.push_back(pair.first);
+        }
+
+        return keys;
+    }
+
+    std::vector<std::shared_ptr<T>> getValues() const 
+    {
+        std::vector<std::shared_ptr<T>> values;
+        for (const auto& pair : *this) 
+        {
+            values.push_back(pair.second);
+        }
+
+        return values;
+    }
+};
+
+}  // namespace sfmData
+}  // namespace aliceVision
+
+namespace std
+{
+
+template <class T, bool IsConstant>
+struct tuple_size<aliceVision::sfmData::ProxyPair<T, IsConstant>> :
+std::integral_constant<std::size_t, 2> {};
+
+template<class T, bool IsConstant>
+struct tuple_element<0, aliceVision::sfmData::ProxyPair<T, IsConstant>> {
+    using type = aliceVision::sfmData::MapTraits<T, IsConstant>::keyType&;
+};
+
+template<class T, bool IsConstant>
+struct tuple_element<1, aliceVision::sfmData::ProxyPair<T, IsConstant>> {
+    using type = aliceVision::sfmData::MapTraits<T, IsConstant>::valueType&;
+};
+
+
+
+}
+

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -65,6 +65,9 @@ class View
         _image(new ImageInfo(imagePath, width, height, metadata))
     {}
 
+    View(const View& v) = default;
+
+
     /**
      * @brief Shallow View Copy
      * return a pointer to a new View
@@ -233,9 +236,6 @@ class View
      * @param[in] resectionId The given resection id
      */
     void setResectionId(IndexT resectionId) { _resectionId = resectionId; }
-
-  private:
-    View(const View& v) = default;
 
   private:
     /// view id

--- a/src/aliceVision/sfmDataIO/ExternalAlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/ExternalAlembicImporter.cpp
@@ -115,9 +115,9 @@ void ExternalAlembicImporter::visitObject(Alembic::Abc::IObject iObj, const Alem
             cam->setSensorHeight(vapp / (dh * 0.1 / sensorWidthPix));
             cam->setFocalLength(camSample.getFocalLength(), 1.0, false);
 
-            sfmdata.getIntrinsics()[frame] = cam;
+            sfmdata.getIntrinsics().emplace(frame, cam);
             sfmdata.getPoses()[frame] = sfmData::CameraPose(pose);
-            sfmdata.getViews()[frame] = std::make_shared<sfmData::View>(files[frame], frame, frame, frame, w, h);
+            sfmdata.getViews().emplace(frame, std::make_shared<sfmData::View>(files[frame], frame, frame, frame, w, h));
         }
     }
 


### PR DESCRIPTION
This pull request refactors several core data structures in the Structure-from-Motion (SfM) module to use a new `SharedPtrMap` container, simplifying code and improving consistency. It also streamlines copy and equality operations in the `SfMData` class, and makes minor improvements to exception handling and container usage.

### Data Structure Refactoring

* Replaced standard `std::map<IndexT, std::shared_ptr<T>>` containers for `Views`, `ImageInfos`, and `Intrinsics` with the new `SharedPtrMap<T>` type alias in `SfMData.hpp`, improving code clarity and maintainability. [[1]](diffhunk://#diff-5264ebc8ca85404cfd73695fd96c7e66fc635bda06e502dd04272f0c894c1c4cR10) [[2]](diffhunk://#diff-5264ebc8ca85404cfd73695fd96c7e66fc635bda06e502dd04272f0c894c1c4cL29-R39)
* Updated usages of these containers throughout the codebase, including in the Alembic importer, to use `emplace` instead of direct assignment for consistency with the new container type.

### Copy and Equality Operations

* Simplified copy constructors for `SfMData` by directly copying `Views` and `Intrinsics` containers instead of cloning individual elements, relying on shared pointer semantics. [[1]](diffhunk://#diff-f64b65d73de3bc8923c999e3186f55d07357ced340de2a8e0d70cae60bc48877L38-R39) [[2]](diffhunk://#diff-f64b65d73de3bc8923c999e3186f55d07357ced340de2a8e0d70cae60bc48877L65-R56)
* Streamlined equality checks in `SfMData` by comparing containers directly, removing manual element-wise comparison logic for `Views`, `ImageInfos`, and `Intrinsics`. [[1]](diffhunk://#diff-f64b65d73de3bc8923c999e3186f55d07357ced340de2a8e0d70cae60bc48877L96-L132) [[2]](diffhunk://#diff-f64b65d73de3bc8923c999e3186f55d07357ced340de2a8e0d70cae60bc48877L147-L170)

### Minor Improvements

* Added a `clone()` method to the `ImageInfo` class to support deep copying when necessary.
* Improved exception handling and code clarity in pose removal and rig reset methods by adding braces and explicit control flow.
* Removed redundant rotation-only check in the rig validation logic for `SfMData`.