### PR TITLE
Temporal filtering of the camera poses

### DIFF
--- a/meshroom/aliceVision/AddPoseNoise.py
+++ b/meshroom/aliceVision/AddPoseNoise.py
@@ -1,0 +1,62 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class AddPoseNoise(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_addPoseNoise {allParams}'
+    size = desc.DynamicNodeSize('input')
+
+    cpu = desc.Level.INTENSIVE
+    ram = desc.Level.INTENSIVE
+
+    category = 'Utils'
+    documentation = '''
+This node adds noise to view positions and view orientations
+'''
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="SfMData file.",
+            value="",
+        ),
+        desc.FloatParam(
+            name="positionNoise",
+            label="Position Noise",
+            description="Noise level to add to view positions.",
+            value=0.0,
+            range=(0.0, 1.0, 0.025),
+        ),
+        desc.FloatParam(
+            name="rotationNoise",
+            label="Rotation Noise",
+            description="Noise level to add to view orientations.",
+            value=0.0,
+            range=(0.0, 1.0, 0.025),
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfMData",
+            description="Path to the output SfMData file.",
+            value="{nodeCacheFolder}/sfmFiltered.abc",
+        ),
+        desc.File(
+            name="outputViewsAndPoses",
+            label="Views And Poses",
+            description="Path to the output SfMData file with cameras (views and poses).",
+            value="{nodeCacheFolder}/cameras.sfm",
+        )
+    ]

--- a/meshroom/aliceVision/SampleScene.py
+++ b/meshroom/aliceVision/SampleScene.py
@@ -1,0 +1,32 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class SampleScene(desc.AVCommandLineNode):
+    commandLine = "aliceVision_generateSampleScene {allParams}"
+
+    category = "Utils"
+    documentation = """
+Generate a sample scene and a valid SfMData with camera poses, and save it to a given file path.
+"""
+
+    inputs = [
+        desc.ChoiceParam(
+            name="scene",
+            label="Sample Scene",
+            description="Type of sample scene to generate (cube or sphere).",
+            value="sphere",
+            values=["cube", "sphere"],
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfMData",
+            description="SfMData file to generate.",
+            value="{nodeCacheFolder}/sampleScene.sfm",
+        ),
+    ]

--- a/meshroom/aliceVision/SfMTemporalFiltering.py
+++ b/meshroom/aliceVision/SfMTemporalFiltering.py
@@ -1,0 +1,76 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class SfMTemporalFiltering(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_sfmTempFiltering {allParams}'
+    size = desc.DynamicNodeSize('input')
+
+    cpu = desc.Level.INTENSIVE
+    ram = desc.Level.INTENSIVE
+
+    category = 'Sparse Reconstruction'
+    documentation = '''
+This node takes the result of SfM and fine-tune the camera poses so that the camera path is temporally smooth.
+'''
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="SfMData file.",
+            value="",
+        ),
+        desc.BoolParam(
+            name="filterPosition",
+            label="Filter Positions",
+            description="Whether to filter camera positions.",
+            value=True,
+        ),
+        desc.BoolParam(
+            name="filterRotation",
+            label="Filter Rotations",
+            description="Whether to filter camera orientations.",
+            value=True,
+        ),
+        desc.IntParam(
+            name="scaleFactor",
+            label="Scale Factor",
+            description="Scale factor to increase the filter range.",
+            value=3,
+            range=(1, 20, 1),
+            advanced=True,
+        ),
+        desc.IntParam(
+            name="iterationCount",
+            label="Iteration Count",
+            description="Number of filter iterations.",
+            value=100,
+            range=(0, 1000, 10),
+            advanced=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfMData",
+            description="Path to the output SfMData file.",
+            value="{nodeCacheFolder}/sfmFiltered.abc",
+        ),
+        desc.File(
+            name="outputViewsAndPoses",
+            label="Views And Poses",
+            description="Path to the output SfMData file with cameras (views and poses).",
+            value="{nodeCacheFolder}/cameras.sfm",
+        )
+    ]

--- a/src/aliceVision/geometry/lie.hpp
+++ b/src/aliceVision/geometry/lie.hpp
@@ -120,7 +120,7 @@ inline Eigen::Vector3d logm(const Eigen::Matrix3d& R)
     const double theta = acos(costheta);
 
     // For theta close to pi (i.e. cos(theta) close to 1), we use a specific formula to avoid numerical issues
-    // (However this formula is slightly less acccurate for random theta values,
+    // (However this formula is slightly less accurate for random theta values,
     //  and would exhibit numerical issues for theta values close to 0)
     if (1.0 + costheta < 1e-6)
     {

--- a/src/aliceVision/geometry/lie_test.cpp
+++ b/src/aliceVision/geometry/lie_test.cpp
@@ -6,7 +6,6 @@
 
 #define BOOST_TEST_MODULE lie
 
-//#include <aliceVision/types.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/geometry/lie.hpp>
 #include <boost/test/unit_test.hpp>

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -166,4 +166,10 @@ alicevision_add_test(utils/alignment_test.cpp
         ${LEMON_LIBRARY}
 )
 
+alicevision_add_test(utils/poseFilter_test.cpp
+    NAME "sfm_poseFilter"
+    LINKS
+        aliceVision_sfm
+)
+
 add_subdirectory(pipeline)

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -45,6 +45,7 @@ set(sfm_files_headers
     pipeline/regionsIO.hpp
     utils/alignment.hpp
     utils/statistics.hpp
+    utils/poseNoise.hpp
     utils/preprocess.hpp
     utils/syntheticScene.hpp
     LocalBundleAdjustmentGraph.hpp
@@ -86,6 +87,7 @@ set(sfm_files_sources
     pipeline/positioning/GlobalPositioning.cpp
     pipeline/regionsIO.cpp
     utils/alignment.cpp
+    utils/poseNoise.cpp
     utils/preprocess.cpp
     utils/statistics.cpp
     utils/syntheticScene.cpp

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -45,6 +45,7 @@ set(sfm_files_headers
     pipeline/regionsIO.hpp
     utils/alignment.hpp
     utils/statistics.hpp
+    utils/poseFilter.hpp
     utils/poseNoise.hpp
     utils/preprocess.hpp
     utils/syntheticScene.hpp
@@ -87,6 +88,7 @@ set(sfm_files_sources
     pipeline/positioning/GlobalPositioning.cpp
     pipeline/regionsIO.cpp
     utils/alignment.cpp
+    utils/poseFilter.cpp
     utils/poseNoise.cpp
     utils/preprocess.cpp
     utils/statistics.cpp

--- a/src/aliceVision/sfm/utils/poseFilter.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter.cpp
@@ -1,0 +1,370 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <ceres/rotation.h>
+#include "poseFilter.hpp"
+#include <aliceVision/geometry/lie.hpp>
+#include <aliceVision/geometry/Pose3.hpp>
+#include <aliceVision/sfm/sfmFilters.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int scaleFactor, const int iterationCount)
+{
+    using namespace Eigen;
+
+    ALICEVISION_LOG_INFO("poseFilter::process start");
+
+    const int viewCount = sfmData.getViews().size();
+
+    std::vector<IndexT> viewIdsVec(viewCount);
+
+    // Get the temporally ordered view IDs in viewIdsVec
+    if (viewCount == 0 || !getOrderedViewIds(sfmData, viewIdsVec))
+    {
+        return false;
+    }
+
+    tempFilter tFilter;
+
+    tFilter.init();
+
+    MatrixXd viewRotations(4, viewCount);
+    MatrixXd viewCenters(3, viewCount);
+
+    // Get the temporally ordered view positions and orientations
+    for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
+    {
+        const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
+        const sfmData::CameraPose framePose = sfmData.getPose(frameView);
+        viewCenters.col(frameIdx) = framePose.getTransform().center();
+        AngleAxisd aa(framePose.getTransform().rotation());
+        viewRotations.col(frameIdx) << aa.angle(), aa.axis();
+    }
+
+    // Apply a temporal filter to view positions
+    if (filterPosition)
+    {
+        viewCenters = tFilter.applyMultiscale(viewCenters, scaleFactor, iterationCount, false);
+    }
+
+    // Apply a temporal filter to view orientations
+    if (filterRotation)
+    {
+        viewRotations = tFilter.applyMultiscale(viewRotations, scaleFactor, iterationCount, true);
+    }
+
+    // Save the temporally filtered poses
+    for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
+    {
+        AngleAxisd aa(viewRotations(0, frameIdx), viewRotations(seqN(1,3), frameIdx));
+        geometry::Pose3 newPose(aa.toRotationMatrix(), viewCenters.col(frameIdx));
+        const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
+        sfmData.setPose(frameView, sfmData::CameraPose(newPose));
+   }
+
+    ALICEVISION_LOG_INFO("poseFilter::process end");
+    return true;
+}
+
+
+bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, std::vector<IndexT>& viewIdsVec)
+{
+    const int viewCount = sfmData.getViews().size();
+
+    IndexT firstViewFrameId = sfmData.getViews().begin()->second->getFrameId();
+    IndexT minFrameId = firstViewFrameId;  // Arbitrary frameId init
+    IndexT maxFrameId = firstViewFrameId;  // Arbitrary frameId init
+    IndexT minFrameIdWithPose;
+
+    bool existingPoseFound = false;
+
+    // Get the frameIDs range and the frameID of the first view with an existing pose
+    for (const auto& [viewID, viewPtr] : sfmData.getViews())
+    {
+        const IndexT frameId = viewPtr->getFrameId();
+        if (frameId < minFrameId)
+        {
+            minFrameId = frameId;
+        }
+        if ( (!existingPoseFound || frameId < minFrameIdWithPose) && sfmData.existsPose(*viewPtr) )
+        {
+            existingPoseFound = true;
+            minFrameIdWithPose = frameId;
+        }
+        if (frameId > maxFrameId)
+            maxFrameId = frameId;
+    }
+
+    const int frameIdRange = maxFrameId - minFrameId + 1;
+
+    ALICEVISION_LOG_DEBUG(" minFrameId : " << minFrameId);
+
+    ALICEVISION_LOG_DEBUG(" maxFrameId : " << maxFrameId);
+
+    if ( !existingPoseFound || (frameIdRange != viewCount) )
+    {
+        return false;
+    }
+
+    // Store the temporally ordered view IDs
+    for (const auto& [viewID, viewPtr] : sfmData.getViews())
+    {
+        const IndexT frameId = viewPtr->getFrameId();
+        viewIdsVec[frameId-minFrameId] = viewID;
+    }
+
+    ALICEVISION_LOG_DEBUG(" minFrameIdWithPose : " << minFrameIdWithPose);
+
+    const sfmData::View& lastValidView = sfmData.getView(viewIdsVec[minFrameIdWithPose-minFrameId]);
+    sfmData::CameraPose lastValidPose = sfmData.getPose(lastValidView);
+
+    // Fill in the blanks within the camera poses list (so that every view gets a pose)
+    // using the first view with an existing pose for the first views without existing pose
+    // and using the last known view with an existing pose for any other view without existing pose
+
+    for (IndexT frameViewID : viewIdsVec)
+    {
+        const sfmData::View& currentView = sfmData.getView(frameViewID);
+
+        if (!sfmData.existsPose(currentView))
+            sfmData.setPose(currentView, lastValidPose);
+        else
+            lastValidPose = sfmData.getPose(currentView);
+    }
+
+    return true;
+}
+
+} // namespace sfm
+} // namespace aliceVision
+
+
+bool tempFilter::init()
+{
+    using namespace Eigen;
+    using namespace Eigen::indexing;
+
+    // Savitzky-Golay smoothing filter
+    // Reference: https://en.wikipedia.org/wiki/Savitzky-Golay_filter
+
+    filterCoeff.resize(kernelSize);
+    // Savitzky-Golay smoothing filter coefficients (window size 9, polynomial order 2)
+    filterCoeff << -21., 14., 39., 54., 59., 54., 39., 14., -21.;
+    filterCoeff = filterCoeff / 231.;
+
+    VectorXd filterCoeff_b(kernelSize);
+    // Savitzky-Golay linear term coefficients
+    filterCoeff_b << -4., -3., -2., -1., 0., 1., 2., 3., 4.;
+    filterCoeff_b = filterCoeff_b / 60.;
+
+    VectorXd filterCoeff_c(kernelSize);
+    // Savitzky-Golay quadratic term coefficients
+    filterCoeff_c << 28., 7., -8., -17., -20., -17., -8., 7., 28.;
+    filterCoeff_c = filterCoeff_c / 924.;
+
+    MatrixXd filterCoeff_x = MatrixXd(kernelSize, kernelSize);
+
+    // The above filter coefficients are defined for the center position of the filter window
+    // Below, the filter coefficients for any position in the filter window are computed
+    for (int coeffIndex = 0; coeffIndex < kernelSize; coeffIndex++)
+    {
+        double x = coeffIndex - kernelSize / 2;
+        for (int filterIndex = 0; filterIndex < kernelSize; filterIndex++)
+        {
+            filterCoeff_x(coeffIndex, filterIndex) = filterCoeff(filterIndex) + filterCoeff_b(filterIndex) * x + filterCoeff_c(filterIndex) * (x * x);
+        }
+    }
+
+    // We extract the filter coefficients for the window tail and the window head (respectively the first and last positions)
+    // These filters are respectively used for the first frames and the last frames
+    tailFilter = filterCoeff_x(all, seq(0, last/2-1));
+    headFilter = filterCoeff_x(all, seq(last/2+1, last));
+
+    diffFilterCoeff.resize(kernelSize-1);
+    // These filter coefficients (dfc) applied to the temporal delta signal
+    // are equivalent to filterCoeff (fc) applied to the same signal (s)
+    // i.e. sum( dfc(i) * (s(i+1)-s(i)) ) = sum( fc(i) * s(i) )
+    diffFilterCoeff << 21., 7., -32., -86., 86., 32., -7., -21.;
+    diffFilterCoeff = diffFilterCoeff / 231.;
+
+    MatrixXd diffFilterCoeff_x = MatrixXd(kernelSize-1, kernelSize);
+
+    // These filter coefficients (diffFilterCoeff_x) are equivalent to filterCoeff_x for the temporal delta signal
+    for (int filterIndex = 0; filterIndex < kernelSize; filterIndex++)
+    {
+        if (filterIndex > 0)
+            diffFilterCoeff_x(0, filterIndex) = -filterCoeff_x(0, filterIndex);
+
+        for (int coeffIndex = 1; coeffIndex < filterIndex; coeffIndex++)
+            diffFilterCoeff_x(coeffIndex, filterIndex) = diffFilterCoeff_x(coeffIndex-1, filterIndex) - filterCoeff_x(coeffIndex, filterIndex);
+
+        if (filterIndex < kernelSize-1)
+            diffFilterCoeff_x(kernelSize-2, filterIndex) = filterCoeff_x(kernelSize-1, filterIndex);
+
+        for (int coeffIndex = kernelSize-3; coeffIndex >= filterIndex; coeffIndex--)
+            diffFilterCoeff_x(coeffIndex, filterIndex) = diffFilterCoeff_x(coeffIndex+1, filterIndex) + filterCoeff_x(coeffIndex+1, filterIndex);
+    }
+
+    tailDiffFilter = diffFilterCoeff_x(all, seq(0, last/2-1));
+    headDiffFilter = diffFilterCoeff_x(all, seq(last/2+1, last));
+
+    initialized = true;
+    return true;
+}
+
+
+bool tempFilter::applyCoreFilter(Eigen::MatrixXd& inputSignal, Eigen::MatrixXd& filteredSignal, bool isDiffSignal)
+{
+    using namespace Eigen;
+    using namespace indexing;
+
+    const int innersize = inputSignal.cols() - 2 * (kernelSize/2) + (isDiffSignal ? 1 : 0);
+
+    if (inputSignal.cols() < kernelSize - (isDiffSignal ? 1 : 0))
+        return false;
+
+    if (isDiffSignal)
+    {
+        // Apply the filter on temporal delta signal
+        filteredSignal(all, seqN(kernelSize/2, innersize)) = inputSignal(all, seqN(fix<0>, innersize)) * diffFilterCoeff(0)
+                                                           + inputSignal(all, seqN(fix<1>, innersize)) * diffFilterCoeff(1)
+                                                           + inputSignal(all, seqN(fix<2>, innersize)) * diffFilterCoeff(2)
+                                                           + inputSignal(all, seqN(fix<3>, innersize)) * diffFilterCoeff(3)
+                                                           + inputSignal(all, seqN(fix<4>, innersize)) * diffFilterCoeff(4)
+                                                           + inputSignal(all, seqN(fix<5>, innersize)) * diffFilterCoeff(5)
+                                                           + inputSignal(all, seqN(fix<6>, innersize)) * diffFilterCoeff(6)
+                                                           + inputSignal(all, seqN(fix<7>, innersize)) * diffFilterCoeff(7);
+
+        // The first and the last frames use specific filters
+        filteredSignal(all, seqN(fix<0>, fix<4>)) = inputSignal(all, seqN(fix<0>, fix<8>)) * tailDiffFilter;
+        filteredSignal(all, seqN(last-fix<3>, fix<4>)) = inputSignal(all, seqN(last-fix<7>, fix<8>)) * headDiffFilter;
+    }
+    else
+    {
+        // Apply the filter
+        filteredSignal(all, seqN(kernelSize/2, innersize)) = inputSignal(all, seqN(fix<0>, innersize)) * filterCoeff(0)
+                                                           + inputSignal(all, seqN(fix<1>, innersize)) * filterCoeff(1)
+                                                           + inputSignal(all, seqN(fix<2>, innersize)) * filterCoeff(2)
+                                                           + inputSignal(all, seqN(fix<3>, innersize)) * filterCoeff(3)
+                                                           + inputSignal(all, seqN(fix<4>, innersize)) * filterCoeff(4)
+                                                           + inputSignal(all, seqN(fix<5>, innersize)) * filterCoeff(5)
+                                                           + inputSignal(all, seqN(fix<6>, innersize)) * filterCoeff(6)
+                                                           + inputSignal(all, seqN(fix<7>, innersize)) * filterCoeff(7)
+                                                           + inputSignal(all, seqN(fix<8>, innersize)) * filterCoeff(8);
+
+        // The first and the last frames use specific filters
+        filteredSignal(all, seqN(fix<0>, fix<4>)) = inputSignal(all, seqN(fix<0>, fix<9>)) * tailFilter;
+        filteredSignal(all, seqN(last-fix<3>, fix<4>)) = inputSignal(all, seqN(last-fix<8>, fix<9>)) * headFilter;
+    }
+
+    return true;
+}
+
+
+Eigen::MatrixXd tempFilter::apply(Eigen::MatrixXd& inputSignal, bool isAngle)
+{
+    using namespace aliceVision::SO3;
+    using namespace Eigen;
+
+    assert(initialized);
+
+    if (inputSignal.cols() < kernelSize)
+        return inputSignal;
+
+    MatrixXd filteredSignal(inputSignal.rows(), inputSignal.cols());
+
+    // The filter used for the angles is equivalent to the filter used for the positions
+    // but the filter coefficients are designed to work with temporal delta signals
+    // This means the filter coefficients (dfc) applied to the temporal delta signal
+    // are equivalent to filterCoeff (fc) applied to the same signal (s)
+    // i.e. sum( dfc(i) * (s(i+1)-s(i)) ) = sum( fc(i) * s(i) )
+    // Delta signals are used for the angles as filter operations over rotation angles are not well-defined
+    // and are more accurate for small rotation angles
+
+    if (isAngle)
+    {
+        MatrixXd diffSignal(3, inputSignal.cols()-1);
+        // If rotation angles were easy to deal with:
+        // diffSignal = inputSignal(all, seqN(1, inputSignal.cols()-1)) - inputSignal(all, seqN(0, inputSignal.cols()-1));
+
+        // The temporal delta signal is computed using rotations matrices, and then converted into so3
+        for (int col = 0; col < inputSignal.cols() - 1; col++)
+        {
+            AngleAxisd prevAA(inputSignal(0, col), inputSignal(seqN(1,3), col));
+            AngleAxisd currAA(inputSignal(0, col+1), inputSignal(seqN(1,3), col+1));
+
+            AngleAxisd diffAA = AngleAxisd(Quaterniond(currAA) * Quaterniond(prevAA).conjugate());
+            diffSignal.col(col) = diffAA.angle() * diffAA.axis();
+        }
+
+        // The filter is designed to use as input the temporal diff of the input signal,
+        // and to output a delta to the input signal
+        // i.e. diffSignal = inputSignal_(t+1) - inputSignal_(t)
+        //      filteredSignal = inputSignal_(t) + diffFilteredSignal_(t)
+        MatrixXd diffFilteredSignal(3, inputSignal.cols());
+
+        // Apply the filter on the temporal delta signal
+        applyCoreFilter(diffSignal, diffFilteredSignal, true);
+
+        // If rotation angles were easy to deal with:
+        // filteredSignal = inputSignal + diffFilteredSignal;
+
+        for (int col = 0; col < inputSignal.cols(); col++)
+        {
+            AngleAxisd inputAA = AngleAxisd(inputSignal(0, col), inputSignal(seqN(1,3), col));
+
+            double rotAngle = diffFilteredSignal.col(col).norm();
+            AngleAxisd diffFilteredAA(rotAngle, diffFilteredSignal.col(col).normalized());
+
+            AngleAxisd resAA = AngleAxisd(Quaterniond(diffFilteredAA) * Quaterniond(inputAA));
+            filteredSignal.col(col) << resAA.angle(), resAA.axis();
+        }
+    }
+    else
+    {
+        // Apply the filter
+        applyCoreFilter(inputSignal, filteredSignal, false);
+    }
+
+    return filteredSignal;
+}
+
+
+Eigen::MatrixXd tempFilter::applyMultiscale(Eigen::MatrixXd& inputSignal, const unsigned int scaleFactor, const int iterationCount, bool isAngle)
+{
+    using namespace Eigen;
+    using namespace indexing;
+
+    MatrixXd filteredSignal(inputSignal);
+
+    // This filter extends the range of the original filter by applying the filter to the sub-sampled signal
+
+    // The multi-scale filter applies filtering at decreasing scales
+    // controlled by the following constant
+    const double SCALE_REDUCTION_FACTOR = 1.4;
+
+    for (int scaleF = scaleFactor; scaleF >= 1; scaleF = (scaleF > 1) ? round(double(scaleF) / SCALE_REDUCTION_FACTOR) : 0)
+    {
+        ALICEVISION_LOG_DEBUG(" Filter scale factor : " << scaleF);
+
+        if (inputSignal.cols() < scaleF)
+            continue;
+
+        for (int phase = 0; phase < scaleF; phase++)
+        {
+            MatrixXd scaledSignal(filteredSignal(all, seq(phase, last, scaleF)));
+            for (int iterFilter = 0; iterFilter < iterationCount; iterFilter++)
+            {
+                scaledSignal = apply(scaledSignal, isAngle);
+            }
+            filteredSignal(all, seq(phase, last, scaleF)) = scaledSignal;
+        }
+    }
+
+    return filteredSignal;
+}

--- a/src/aliceVision/sfm/utils/poseFilter.hpp
+++ b/src/aliceVision/sfm/utils/poseFilter.hpp
@@ -1,0 +1,57 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/types.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+class poseFilter
+{
+public:
+    using uptr = std::unique_ptr<poseFilter>;
+
+public:
+    /**
+     * @brief Apply a temporal filter to the poses
+     * @param sfmData the scene description
+     * @param filterPosition specify whether to filter camera positions
+     * @param filterRotation specify whether to filter camera orientations
+     * @param scaleFactor integer factor to increase the filter range
+     * @param iterationCount the number of filter iterations
+     * @return false if an error occurred
+    */
+    bool process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int scaleFactor, const int iterationCount);
+
+private:
+    bool getOrderedViewIds(sfmData::SfMData& sfmData, std::vector<IndexT>& viewIdsVec);
+};
+
+} // namespace sfm
+} // namespace aliceVision
+
+
+class tempFilter
+{
+public:
+    bool init();
+    bool applyCoreFilter(Eigen::MatrixXd& inputSignal, Eigen::MatrixXd& filteredSignal, bool diffSignal);
+    Eigen::MatrixXd apply(Eigen::MatrixXd& inputSignal, bool isAngle);
+    Eigen::MatrixXd applyMultiscale(Eigen::MatrixXd& inputSignal, const unsigned int scaleFactor, const int iterationCount, bool isAngle);
+
+private:
+    bool initialized;
+    const int kernelSize = 9;
+    Eigen::VectorXd filterCoeff;
+    Eigen::MatrixXd tailFilter;
+    Eigen::MatrixXd headFilter;
+    Eigen::VectorXd diffFilterCoeff;
+    Eigen::MatrixXd tailDiffFilter;
+    Eigen::MatrixXd headDiffFilter;
+};

--- a/src/aliceVision/sfm/utils/poseFilter_test.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter_test.cpp
@@ -1,0 +1,178 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE poseFilter
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+#include <aliceVision/unitTest.hpp>
+#include <aliceVision/sfm/utils/poseFilter.hpp>
+
+
+BOOST_AUTO_TEST_CASE(PoseFilter_diffFilter)
+{
+    // Check that diffFilter (dfc) applied to the temporal delta signal
+    // gives same results as the original filter (fc) applied to the same signal (s)
+    // i.e. sum( dfc(i) * (s(i+1)-s(i)) ) = sum( fc(i) * s(i) )
+
+    using namespace Eigen;
+    using namespace indexing;
+
+    tempFilter tFilter;
+
+    tFilter.init();
+
+    MatrixXd sample(3, 100);
+
+    for (int idx=0; idx<sample.cols(); idx++)
+    {
+        sample(0, idx) = 1.25 + double(idx) * (.025 - 0.125 * double(idx) ) + 100. * std::cos(double(idx));
+        sample(1, idx) = 1.5 + double(idx) * (.05 + 0.125 * double(idx) ) + 100. * std::cos(1.25*double(idx));
+        sample(2, idx) = 1.75 + double(idx) * (.075 + 0.25 * double(idx) ) + 100. * std::cos(.25*double(idx));
+    }
+
+    // Apply the filter to the sample signal
+    MatrixXd filteredSample(tFilter.apply(sample, false));
+
+    // Compute the temporal delta signal
+    MatrixXd diffSignal(sample(all, seqN(1, sample.cols()-1)) - sample(all, seqN(0, sample.cols()-1)));
+
+    MatrixXd diffFilteredSignal(sample.rows(), sample.cols());
+
+    // Apply the diff filter to the temporal delta signal
+    tFilter.applyCoreFilter(diffSignal, diffFilteredSignal, true);
+
+    // Compute the filtered signal
+    MatrixXd filteredSignal_fromDiff = sample + diffFilteredSignal;
+
+    EXPECT_MATRIX_NEAR(filteredSignal_fromDiff, filteredSample, 1e-11);
+}
+
+
+BOOST_AUTO_TEST_CASE(PoseFilter_polynomial)
+{
+    // Check that the filter converges to a 2nd order polynomial
+
+    using namespace Eigen;
+    using namespace indexing;
+
+    tempFilter tFilter;
+
+    tFilter.init();
+
+    MatrixXd sample(60, 20);
+
+    // Generate 2nd-order polynomial samples
+    for (int row=0; row<sample.rows(); row++)
+    {
+        double coeff_a = std::cos(double(row));
+        double coeff_b = std::cos(.5 * double(row) + .25);
+        double coeff_c = std::cos(.25 * double(row) + .5);
+
+        for (int idx=0; idx<sample.cols(); idx++)
+        {
+            sample(row, idx) = coeff_a + double(idx) * (coeff_b + coeff_c * double(idx));
+        }
+    }
+
+    MatrixXd distortedSample(sample);
+
+    // Create a binary mask
+    Matrix<bool, Dynamic, Dynamic> distortionMask(sample.rows(), sample.cols());
+    distortionMask.setZero();
+
+    for (int row=0; row<sample.rows(); row++)
+    {
+        //index of the value to distort
+        int idx = row%sample.cols();
+
+        // Create a binary mask to be able to easily restore the original values
+        distortionMask(row, idx) = true;
+
+        // Distort the signal (a single value per row)
+        distortedSample(row, idx) = 100. * std::cos(double(4+row));
+    }
+
+    for (int iter=0; iter<1000; iter++)
+    {
+        // Apply the filter to the distorted signal
+        distortedSample = tFilter.apply(distortedSample, false);
+
+        // Restore the original values except for the distorted values
+        distortedSample = distortionMask.select(distortedSample, sample);
+    }
+
+    // Run it once without restoring any value
+    distortedSample = tFilter.apply(distortedSample, false);
+
+    EXPECT_MATRIX_NEAR(distortedSample, sample, 1e-11);
+}
+
+
+BOOST_AUTO_TEST_CASE(PoseFilter_angles)
+{
+    // Check that the filter correctly filters orientations
+
+    using namespace Eigen;
+    using namespace indexing;
+    using namespace aliceVision;
+
+    tempFilter tFilter;
+
+    tFilter.init();
+
+    int posesNb = 60;
+
+    for (int mainIter=0; mainIter < 1000; mainIter++)
+    {
+        Vector3d arbitraryAxis = Vector3d::Random();
+        arbitraryAxis = arbitraryAxis / arbitraryAxis.norm();
+
+        Vector3d arbitraryAxis2 = Vector3d::Random();
+        arbitraryAxis2 = arbitraryAxis2 / arbitraryAxis2.norm();
+
+        MatrixXd rotationSample(4, posesNb);
+        MatrixXd saferRotationSample(4, posesNb);
+
+        // Generate poses on a circle
+        for (int idPV = 0; idPV < posesNb; idPV++)
+        {
+            double angle2d = (double(idPV) * 2. * M_PI) / posesNb;
+            AngleAxisd aa = (angle2d > M_PI) ? AngleAxisd(2. * M_PI - angle2d, -arbitraryAxis) : AngleAxisd(angle2d, arbitraryAxis);
+            rotationSample.col(idPV) << aa.angle(), aa.axis();
+
+            angle2d = (double(idPV) * 2. * M_PI + .0001) / posesNb;
+            aa = (angle2d > M_PI) ? AngleAxisd(2. * M_PI - angle2d, -arbitraryAxis) : AngleAxisd(angle2d, arbitraryAxis);
+            saferRotationSample.col(idPV) << aa.angle(), aa.axis();
+        }
+
+        MatrixXd filteredSample;
+
+        filteredSample = tFilter.apply(saferRotationSample, true);
+
+        for (int idPV = 0; idPV < posesNb; idPV++)
+        {
+            // Check in so(3) space
+            EXPECT_MATRIX_NEAR((filteredSample(0, idPV) * filteredSample(seqN(1,3), idPV)),
+                               (saferRotationSample(0, idPV) * saferRotationSample(seqN(1,3), idPV)), 2e-15);
+
+            // Check in SO(3) space (rotation matrices)
+            AngleAxisd aa(saferRotationSample(0, idPV), saferRotationSample(seqN(1,3), idPV));
+            AngleAxisd filteredAA(filteredSample(0, idPV), filteredSample(seqN(1,3), idPV));
+            EXPECT_MATRIX_NEAR(aa.toRotationMatrix(), filteredAA.toRotationMatrix(), 2e-15);
+        }
+
+        filteredSample = tFilter.apply(rotationSample, true);
+        // In rotationSample, there is a rotation with a rotation equal to pi
+        // As a rotation of pi around a given axis is equivalent to a rotation of pi around the inverted axis (-axis)
+        // there are two equivalent so(3) solutions for this rotation, thus we only use rotation matrices to check this set
+        for (int idPV = 0; idPV < posesNb; idPV++)
+        {
+            AngleAxisd aa(rotationSample(0, idPV), rotationSample(seqN(1,3), idPV));
+            AngleAxisd filteredAA(filteredSample(0, idPV), filteredSample(seqN(1,3), idPV));
+            EXPECT_MATRIX_NEAR(aa.toRotationMatrix(), filteredAA.toRotationMatrix(), 2e-15);
+        }
+    }
+}

--- a/src/aliceVision/sfm/utils/poseNoise.cpp
+++ b/src/aliceVision/sfm/utils/poseNoise.cpp
@@ -1,0 +1,67 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "poseNoise.hpp"
+#include <aliceVision/geometry/Pose3.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+bool addPoseNoise(sfmData::SfMData& sfmData, const float positionNoise, const float rotationNoise)
+{
+    if (positionNoise == 0. && rotationNoise == 0.)
+    {
+        ALICEVISION_LOG_INFO("poseNoise::nothing to do");
+        return true;
+    }
+
+    ALICEVISION_LOG_INFO("poseNoise::process start");
+
+    using namespace Eigen;
+
+    std::mt19937 gen;
+    std::uniform_real_distribution<double> dist(-1., 1.);
+
+    for (const auto& [viewID, viewPtr] : sfmData.getViews())
+    {
+        const sfmData::CameraPose viewPose = sfmData.getPose(*viewPtr);
+        Vector3d viewCenter = viewPose.getTransform().center();
+        Matrix3d viewRotation = viewPose.getTransform().rotation();
+
+        // Add noise to view position
+        if (positionNoise != 0.)
+        {
+            viewCenter = viewCenter + positionNoise * Vector3d::Random();
+        }
+
+        // Add noise to view orientation
+        if (rotationNoise != 0.)
+        {
+            AngleAxisd aa(viewRotation);
+            double viewRotAngle = aa.angle();
+            Vector3d viewRotAxis = aa.axis();
+
+            // Add noise to the rotation angle
+            viewRotAngle = viewRotAngle + rotationNoise * M_PI * dist(gen);
+
+            // Apply a random rotation to the rotation axis
+            // (the random rotation axis coordinates do not need to be weighted by rotationNoise)
+            AngleAxisd randomRot(rotationNoise * M_PI * dist(gen), Vector3d(dist(gen), dist(gen), dist(gen)).normalized());
+            viewRotAxis = randomRot.toRotationMatrix() * viewRotAxis;
+
+            aa = AngleAxisd(viewRotAngle, viewRotAxis);
+            viewRotation = aa.toRotationMatrix();
+        }
+
+        geometry::Pose3 newPose(viewRotation, viewCenter);
+        sfmData.setPose(*viewPtr, sfmData::CameraPose(newPose));
+    }
+
+    ALICEVISION_LOG_INFO("poseNoise::process end");
+    return true;
+}
+} // namespace sfm
+} // namespace aliceVision

--- a/src/aliceVision/sfm/utils/poseNoise.hpp
+++ b/src/aliceVision/sfm/utils/poseNoise.hpp
@@ -1,0 +1,25 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/types.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+/**
+ * @brief Apply a temporal filter to the poses
+ * @param sfmData the scene description
+ * @param positionNoise noise level to add to camera positions
+ * @param rotationNoise noise level to add to camera orientations
+ * @return false if an error occurred
+*/
+bool addPoseNoise(sfmData::SfMData& sfmData, const float positionNoise, const float rotationNoise);
+
+} // namespace sfm
+} // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/sceneSample.cpp
+++ b/src/aliceVision/sfmDataIO/sceneSample.cpp
@@ -9,7 +9,66 @@
 namespace aliceVision {
 namespace sfmDataIO {
 
-void generateSampleScene(sfmData::SfMData& output)
+ESceneType ESceneType_stringToEnum(const std::string& SScene)
+{
+    std::string scene = SScene;
+    std::transform(scene.begin(), scene.end(), scene.begin(), ::tolower);
+
+    if (scene == "cube")
+    {
+        return ESceneType::SCENE_CUBE;
+    }
+    if (scene == "sphere")
+    {
+        return ESceneType::SCENE_SPHERE;
+    }
+    throw std::invalid_argument("Invalid scene type: " + scene);
+}
+
+std::string ESceneType_enumToString(const ESceneType EScene)
+{
+    if (EScene == ESceneType::SCENE_CUBE)
+    {
+        return "cube";
+    }
+    if (EScene == ESceneType::SCENE_SPHERE)
+    {
+        return "sphere";
+    }
+    throw std::invalid_argument("Unrecognized ESceneType: " + std::to_string(int(EScene)));
+}
+
+std::ostream& operator<<(std::ostream& os, ESceneType p) { return os << ESceneType_enumToString(p); }
+
+std::istream& operator>>(std::istream& in, ESceneType& p)
+{
+    std::string token(std::istreambuf_iterator<char>(in), {});
+    p = ESceneType_stringToEnum(token);
+    return in;
+}
+
+
+void generateSampleScene(sfmData::SfMData& output, ESceneType scene)
+{
+    // Cleanup sfmData
+    output.clear();
+
+    if (scene == ESceneType::SCENE_CUBE)
+    {
+        generateCubeScene(output);
+    }
+    else if (scene == ESceneType::SCENE_SPHERE)
+    {
+        generateSphereScene(output, 1000, 240);
+    }
+    else
+    {
+        throw std::out_of_range("Invalid ESceneType");
+    }
+}
+
+
+void generateCubeScene(sfmData::SfMData& output)
 {
     // Generate points on a cube
     IndexT idpt = 0;
@@ -62,6 +121,40 @@ void generateSampleScene(sfmData::SfMData& output)
                 ++idpose;
             }
         }
+    }
+}
+
+void generateSphereScene(sfmData::SfMData& output, int pointsNb, int posesNb)
+{
+    // Generate random points on a sphere
+    IndexT idpt = 0;
+    for (int pt = 0; pt < pointsNb; pt++)
+    {
+        Eigen::Vector3d point3D = Eigen::Vector3d::Random();
+        point3D = 1. * point3D / point3D.norm();
+
+        output.getLandmarks().emplace(idpt, sfmData::Landmark(point3D, feature::EImageDescriberType::UNKNOWN));
+        ++idpt;
+    }
+
+    const int w = 4092;
+    const int h = 2048;
+    const double focalLengthPixX = 1000.0;
+    const double focalLengthPixY = 2000.0;
+    output.getIntrinsics().emplace(
+      0, camera::createPinhole(camera::EDISTORTION::DISTORTION_NONE, camera::EUNDISTORTION::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, 0, 0));
+
+    // Generate poses on a circle
+    for (IndexT idPV = 0; idPV < posesNb; idPV++)
+    {
+        double angle2d = (double(idPV) * 2. * M_PI) / posesNb;
+        Eigen::AngleAxis<double> aa(angle2d + .5 * M_PI, Eigen::Vector3d::UnitY());
+        Eigen::Matrix3d rotation = aa.toRotationMatrix();
+        Eigen::Vector3d position(std::cos(angle2d), 0., std::sin(angle2d));
+        geometry::Pose3 pose(rotation, 10. * position);
+        output.getPoses().assign(idPV, sfmData::CameraPose(pose));
+        output.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, w, h));
+        output.getView(idPV).setFrameId(idPV);
     }
 }
 

--- a/src/aliceVision/sfmDataIO/sceneSample.hpp
+++ b/src/aliceVision/sfmDataIO/sceneSample.hpp
@@ -11,11 +11,26 @@
 namespace aliceVision {
 namespace sfmDataIO {
 
+enum ESceneType
+{
+    SCENE_CUBE,
+    SCENE_SPHERE,
+};
+
+ESceneType ESceneType_stringToEnum(const std::string& SScene);
+std::string ESceneType_enumToString(const ESceneType EScene);
+std::ostream& operator<<(std::ostream& os, ESceneType p);
+std::istream& operator>>(std::istream& in, ESceneType& p);
+
 /**
  * @brief Create an SfmData with some arbitrary content.
  * This is used in unit tests to validate read/write sfmData files.
  */
-void generateSampleScene(sfmData::SfMData& output);
+void generateSampleScene(sfmData::SfMData& output, ESceneType scene=ESceneType::SCENE_CUBE);
+
+void generateCubeScene(sfmData::SfMData& output);
+
+void generateSphereScene(sfmData::SfMData& output, int pointsNb, int posesNb);
 
 }  // namespace sfmDataIO
 }  // namespace aliceVision

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -151,6 +151,22 @@ if (ALICEVISION_BUILD_SFM)
                 Boost::program_options
                 Boost::json
         )
+
+        # SfM Temporal Filtering
+        alicevision_add_software(aliceVision_sfmTempFiltering
+            SOURCE main_sfmTemporalFiltering.cpp
+            FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+            LINKS aliceVision_system
+                aliceVision_cmdline
+                aliceVision_feature
+                aliceVision_sfm
+                aliceVision_sfmData
+                aliceVision_track
+                aliceVision_dataio
+                aliceVision_mesh
+                Boost::program_options
+                Boost::json
+        )
     endif()
 
     # Global Rotation Estimating
@@ -379,7 +395,7 @@ if (ALICEVISION_BUILD_SFM)
               Boost::boost
               Boost::timer
     )
-         
+
 endif() # if(ALICEVISION_BUILD_SFM)
 
 if (ALICEVISION_BUILD_PANORAMA)

--- a/src/software/pipeline/main_sfmTemporalFiltering.cpp
+++ b/src/software/pipeline/main_sfmTemporalFiltering.cpp
@@ -1,0 +1,93 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2024 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/hardwareContext.hpp>
+
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+
+#include <aliceVision/sfm/utils/poseFilter.hpp>
+
+#include <boost/program_options.hpp>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string sfmDataOutputFilename;
+    std::string outputSfMViewsAndPoses;
+
+    bool filterPosition = true;
+    bool filterRotation = true;
+    int iterationCount = 100;
+    int scaleFactor = 3;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
+        ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(), "SfMData output file.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("filterPosition", po::value<bool>(&filterPosition)->default_value(filterPosition), "Whether to filter camera positions.")
+        ("filterRotation", po::value<bool>(&filterRotation)->default_value(filterRotation), "Whether to filter camera orientations.")
+        ("scaleFactor", po::value<int>(&scaleFactor)->default_value(scaleFactor), "Scale factor to increase the filter range.")
+        ("iterationCount", po::value<int>(&iterationCount)->default_value(iterationCount), "Number of filter iterations.")
+        ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision SfM Temporal Filtering");
+
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if(!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    // load input SfMData scene
+    sfmData::SfMData sfmData;
+    if(!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    sfm::poseFilter::uptr poseFilter = std::make_unique<sfm::poseFilter>();
+
+    if (!poseFilter->process(sfmData, filterPosition, filterRotation, scaleFactor, iterationCount))
+    {
+        ALICEVISION_LOG_INFO("Error processing sfmData");
+        return EXIT_FAILURE;
+    }
+
+    sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData::ALL);
+
+    if (!outputSfMViewsAndPoses.empty())
+    {
+        sfmDataIO::save(sfmData, outputSfMViewsAndPoses,
+            sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::EXTRINSICS | sfmDataIO::INTRINSICS)
+        );
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -493,6 +493,20 @@ if (ALICEVISION_BUILD_MVS)
     endif()
 
 
+    # Add random noise to SfMData pose
+    alicevision_add_software(aliceVision_addPoseNoise
+        SOURCE main_addPoseNoise.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_numeric
+              aliceVision_sfm
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              aliceVision_mvsUtils
+              ${Boost_LIBRARIES}
+    )
+
     # Create SfMData with some arbitrary data
     alicevision_add_software(aliceVision_generateSampleScene
         SOURCE main_generateSampleScene.cpp

--- a/src/software/utils/main_addPoseNoise.cpp
+++ b/src/software/utils/main_addPoseNoise.cpp
@@ -1,0 +1,84 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2021 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/numeric/numeric.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfm/utils/poseNoise.hpp>
+
+#include <boost/program_options.hpp>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string sfmDataOutputFilename;
+    std::string outputSfMViewsAndPoses;
+    float positionNoise = 0.;
+    float rotationNoise = 0.;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
+        ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(), "SfMData output file.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("positionNoise", po::value<float>(&positionNoise)->default_value(positionNoise), "Noise level to add to view positions.")
+        ("rotationNoise", po::value<float>(&rotationNoise)->default_value(rotationNoise), "Noise level to add to view orientations. [0..1]")
+        ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).");
+    // clang-format on
+
+    CmdLine cmdline("This program adds noise to view positions and view orientations and saves it to a given file path.\n"
+                    "AliceVision addPoseNoise");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // load input SfMData scene
+    sfmData::SfMData sfmData;
+    if(!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    if (!sfm::addPoseNoise(sfmData, positionNoise, rotationNoise))
+    {
+        ALICEVISION_LOG_INFO("Error during sfmData processing");
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_LOG_INFO("Export SfM: " << sfmDataOutputFilename);
+    if (!sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The output SfMData file '" << sfmDataOutputFilename << "' cannot be written.");
+        return EXIT_FAILURE;
+    }
+
+    if (!outputSfMViewsAndPoses.empty())
+    {
+        sfmDataIO::save(sfmData, outputSfMViewsAndPoses,
+                        sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::EXTRINSICS | sfmDataIO::INTRINSICS));
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_generateSampleScene.cpp
+++ b/src/software/utils/main_generateSampleScene.cpp
@@ -27,13 +27,16 @@ namespace po = boost::program_options;
 int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
-    std::string sfmOutputDataFilepath;  // output folder for split images
+    std::string sfmOutputDataFilepath;  // output file path for SfM Data
+    sfmDataIO::ESceneType sceneSample = sfmDataIO::ESceneType::SCENE_SPHERE;  // scene type to generate ('cube' or 'sphere')
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
     requiredParams.add_options()
         ("output,o", po::value<std::string>(&sfmOutputDataFilepath)->required(),
-         "Output sfm file to generate.");
+         "Output sfm file to generate.")
+        ("scene,s", po::value<sfmDataIO::ESceneType>(&sceneSample)->default_value(sceneSample),
+         "Scene sample to generate. ['cube', 'sphere']");
     // clang-format on
 
     CmdLine cmdline("This program is used to generate a sample scene and save it to a given file path.\n"
@@ -45,7 +48,7 @@ int aliceVision_main(int argc, char** argv)
     }
 
     sfmData::SfMData sfmData;
-    sfmDataIO::generateSampleScene(sfmData);
+    sfmDataIO::generateSampleScene(sfmData, sceneSample);
 
     ALICEVISION_LOG_INFO("Export SfM: " << sfmOutputDataFilepath);
     if (!sfmDataIO::save(sfmData, sfmOutputDataFilepath, sfmDataIO::ESfMData(sfmDataIO::ALL)))


### PR DESCRIPTION
## Features list
This pull request introduces a new feature to the AliceVision pipeline: a temporal filtering tool for Structure-from-Motion (SfM) camera poses. It also extends the utility to generate sample scenes. The most important changes are grouped below.

**New temporal filtering functionality for SfM:**

* Added a new `SfMTemporalFiltering` node to Meshroom, which exposes parameters for filtering camera positions and rotations, scale factor, and iteration count, producing filtered SfMData outputs. (`meshroom/aliceVision/SfMTemporalFiltering.py`)
* Implemented the core temporal pose filtering algorithm in new files `poseFilter.cpp` and `poseFilter.hpp`, providing methods to smooth camera trajectories in SfM reconstructions. (`src/aliceVision/sfm/utils/poseFilter.cpp`, `src/aliceVision/sfm/utils/poseFilter.hpp`) [[1]](diffhunk://#diff-2563b7dd0e80824e7ce4b3281b1c1b0a2f41c3eef8a92a20da5f8bba7c23da78R1-R302) [[2]](diffhunk://#diff-779117770eb14dfbe1cfafef93ca2c12d0de40697640d8fb6a8bb559b9547668R1-R53)

**Sample scene generation improvements:**

* Extended the sample scene generation utility to generate a new sphere scene, with parameters for noise and number of points/poses. (`src/aliceVision/sfmDataIO/sceneSample.cpp`, `src/aliceVision/sfmDataIO/sceneSample.hpp`) [[1]](diffhunk://#diff-84d01fbfa77e0d7b497280bfcb15f8ae81d995fd7e516fe6462db479c126b589L12-R25) [[2]](diffhunk://#diff-84d01fbfa77e0d7b497280bfcb15f8ae81d995fd7e516fe6462db479c126b589R79-R121) [[3]](diffhunk://#diff-c2b33a4c582ee742b72b9fa1f7f40e6a1f66da0dcc956219a9b4b19ef36080fdL18-R22)
* Added a new `SampleScene` node to Meshroom, allowing users to generate either a cube or sphere sample scene with optional position and rotation noise, outputting an SfMData file. (`meshroom/aliceVision/SampleScene.py`)
