### PR TITLE
Improve SfmExpanding processing

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -173,6 +173,21 @@ class SfMExpanding(desc.AVCommandLineNode):
             range=(0, 20, 1),
             advanced=True,
         ),
+        desc.BoolParam(
+            name="useRigConstraint",
+            label="Use Rig Constraint",
+            description="Enable/Disable rig constraint.",
+            value=True,
+            advanced=True,
+        ),
+        desc.IntParam(
+            name="rigMinNbCamerasForCalibration",
+            label="Min Nb Cameras For Rig Calibration",
+            description="Minimum number of cameras to start the calibration of the rig.",
+            value=20,
+            range=(1, 50, 1),
+            advanced=True,
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -32,6 +32,16 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
         return false;
     }
 
+    //How many views to resect ?
+    size_t countToProcess = 0;
+    for (const IndexT viewId : viewsChunk)
+    {
+        if (!sfmData.isPoseAndIntrinsicDefined(viewId))
+        {
+            countToProcess++;
+        }
+    }
+
 
     struct IntermediateResectionInfo
     {
@@ -71,6 +81,17 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
             {
                 intermediateInfos.push_back(iri);
             }
+        }
+    }
+
+    //Early exit if no valid resections
+    if (intermediateInfos.size() == 0)
+    {
+        //If no resection to do, then maybe we want to force recomputation
+        if (countToProcess > 0)
+        {
+            ALICEVISION_LOG_INFO("ExpansionChunk::process early end");
+            return false;
         }
     }
 

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicyLegacy.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicyLegacy.cpp
@@ -51,9 +51,16 @@ bool ExpansionPolicyLegacy::process(const sfmData::SfMData & sfmData, const trac
 
     std::vector<ViewScoring> vscoring;
 
+    //Local copy to vector for openmp, which doesn't like std::set
+    std::vector<IndexT> vectorAvailableViewsIds;
+    std::copy(_availableViewsIds.begin(), _availableViewsIds.end(), std::back_inserter(vectorAvailableViewsIds));
+
     //Loop over possible views
-    for (IndexT cViewId : _availableViewsIds)
-    {
+    #pragma omp parallel for schedule(dynamic)
+    for (int pos = 0; pos < vectorAvailableViewsIds.size(); pos++)
+    {   
+        IndexT cViewId = vectorAvailableViewsIds[pos];
+
         const sfmData::View & v = sfmData.getView(cViewId);
 
         //If this view has no intrinsic,
@@ -95,7 +102,11 @@ bool ExpansionPolicyLegacy::process(const sfmData::SfMData & sfmData, const trac
         scoring.id = cViewId;
         scoring.score = ExpansionPolicyLegacy::computeScore(tracksHandler.getAllTracks(), viewReconstructedTracksIds, cViewId, maxDim, _countPyramidLevels);
         scoring.count = viewReconstructedTracksIds.size();
-        vscoring.push_back(scoring);
+
+        #pragma omp critical
+        {
+            vscoring.push_back(scoring);
+        }
     }
 
     if (vscoring.size() == 0)

--- a/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
@@ -127,9 +127,9 @@ bool SfmTriangulation::processTrack(
         observations.push_back(coords);
         intrinsics.push_back(intrinsic);
         poses.push_back(pose);
-
-        //Weight is dependent on the feature scale
-        weights.push_back(1.0 / trackItem.scale);
+        weights.push_back(1.0);
+        //TODO, check how to use scale correctly
+        //weights.push_back(1.0 / trackItem.scale);
         
         indexedViewIds.push_back(viewId);
     }

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -268,19 +268,19 @@ int aliceVision_main(int argc, char** argv)
     expansionIteration->setExpansionPolicyHandler(expansionPolicy);
     expansionIteration->setExpansionChunkHandler(expansionChunk);
 
-    /*sfm::ExpansionPostProcess::uptr expansionPostProcess;
+    sfm::ExpansionPostProcess::uptr expansionPostProcess;
     if (useRigConstraint)
     {
         sfm::ExpansionPostProcessRig::uptr expansionPostProcessTyped = std::make_unique<sfm::ExpansionPostProcessRig>();
         expansionPostProcessTyped->setMinimalNumberCameras(minNbCamerasForRigCalibration);
         expansionPostProcess = std::move(expansionPostProcessTyped);
-    }*/
+    }
 
 
     sfm::ExpansionProcess::uptr expansionProcess = std::make_unique<sfm::ExpansionProcess>();
     expansionProcess->setExpansionHistoryHandler(expansionHistory);
     expansionProcess->setExpansionIterationHandler(expansionIteration);
-    /*expansionProcess->setExpansionIterationPostProcessHandler(expansionPostProcess);*/
+    expansionProcess->setExpansionIterationPostProcessHandler(expansionPostProcess);
 
     if (!expansionProcess->process(sfmData, tracksHandler))
     {


### PR DESCRIPTION
Reactivate rig support in sfmExpanding :

- Put back the options in the node description
- Enable post processing calibration

Rollback use of feature scale in triangulation scoring to reduce the number of outliers

Parallelize next best views estimation

A missing branch caused the bundle to be launched even if nothing new was done.