### PR TITLE
Add parameter to control what is a weak resection

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -102,6 +102,16 @@ class SfMExpanding(desc.AVCommandLineNode):
             advanced=True,
         ),
         desc.IntParam(
+            name="weakResectionSize",
+            label="Weak resection inliers count",
+            description="When adding a view during the expansion process, we compute the pose. If the inliers count\n"
+                        "Is less than this value, the resection is considered weak. If not all views in the batch \n"
+                        "are weak, then the weak views are put back in the list of views to estimate again",
+            value=100,
+            range=(1, 1000, 1),
+            advanced=True,
+        ),
+        desc.IntParam(
             name="minNumberOfObservationsForTriangulation",
             label="Min Observations For Triangulation",
             description="Minimum number of observations to triangulate a point.\n"

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -75,11 +75,10 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
     }
 
     //Check that at least one view has rich info
-    const int poorInliersCount = 100;
     int richViews = 0;
     for (const auto & item : intermediateInfos)
     {
-        if (item.inliersCount > poorInliersCount)
+        if (item.inliersCount > _weakResectionSize)
         {
             richViews++;
         }
@@ -91,7 +90,7 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
     {
         if (richViews > 0)
         {
-            if (item.inliersCount < poorInliersCount)
+            if (item.inliersCount < _weakResectionSize)
             {
                 _ignoredViews.insert(item.viewId);
                 continue;

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
@@ -106,6 +106,15 @@ public:
         _minTriangulationAngleDegrees = angle;
     }
 
+    /**
+     * @brief set the minimal number of inliers under which a resection is considered weak
+     * @param size the inliers count required
+    */
+    void setWeakResectionSize(size_t size)
+    {
+        _weakResectionSize = size;
+    }
+
     const std::set<IndexT> & getIgnoredViews()
     {
         return _ignoredViews;
@@ -149,6 +158,7 @@ private:
     double _minTriangulationAngleDegrees = 3.0;
     double _maxTriangulationError = 8.0;
     double _resectionMaxError = std::numeric_limits<double>::infinity();
+    size_t _weakResectionSize = 100;
 };
 
 } // namespace sfm

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -102,6 +102,7 @@ int aliceVision_main(int argc, char** argv)
     int minNbCamerasToRefinePrincipalPoint = 3;
     bool useRigConstraint = true;
     int minNbCamerasForRigCalibration = 20;
+    int weakResectionSize = 100;
 
     int randomSeed = std::mt19937::default_seed;
 
@@ -130,6 +131,10 @@ int aliceVision_main(int argc, char** argv)
     ("bundleAdjustmentMaxOutliers", po::value<int>(&bundleAdjustmentMaxOutliers)->default_value(bundleAdjustmentMaxOutliers),
          "Threshold for the maximum number of outliers allowed at the end of a bundle adjustment iteration."
          "Using a negative value for this threshold will disable BA iterations.")
+    ("weakResectionSize", po::value<int>(&weakResectionSize)->default_value(weakResectionSize), 
+        "When adding a view during the expansion process, we compute the pose. If the inliers count"
+        "Is less than this value, the resection is considered weak. If not all views in the batch"
+        "are weak, then the weak views are put back in the list of views to estimate again.")
     ("minNumberOfObservationsForTriangulation", po::value<std::size_t>(&minNbObservationsForTriangulation)->default_value(minNbObservationsForTriangulation),"Minimum number of observations to triangulate a point")
     ("minAngleForTriangulation", po::value<double>(&minAngleForTriangulation)->default_value(minAngleForTriangulation),"Minimum angle for triangulation.")
     ("minAngleForLandmark", po::value<double>(&minAngleForLandmark)->default_value(minAngleForLandmark), "Minimum angle for landmark.")
@@ -248,6 +253,7 @@ int aliceVision_main(int argc, char** argv)
     expansionChunk->setTriangulationMinPoints(minNbObservationsForTriangulation);
     expansionChunk->setMinAngleTriangulation(minAngleForTriangulation);
     expansionChunk->setPointFetcherHandler(pointFetcherHandler);
+    expansionChunk->setWeakResectionSize(weakResectionSize);
     
     sfm::ExpansionPolicy::uptr expansionPolicy;
     {


### PR DESCRIPTION
This pull request introduces a new configurable parameter to control the threshold for considering a view's resection as "weak" during the SfM (Structure-from-Motion) expansion process. The changes ensure this threshold is exposed through the command-line interface, is configurable in both Python and C++, and is properly integrated into the expansion logic.

### New parameter for weak resection threshold

* Added a new `weakResectionSize` parameter to the `SfMExpanding` node in `meshroom/aliceVision/SfmExpanding.py`, allowing users to set the minimum inliers count for a view's resection to be considered weak.

### Integration into C++ expansion logic

* Updated the `ExpansionChunk` class in `src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp` to include a `_weakResectionSize` member variable, a setter method `setWeakResectionSize`, and initialized the default value. [[1]](diffhunk://#diff-d8298c7c2cc5697417d7ca897442abd96d187627a8b6ca351064cec20d453e3cR109-R117) [[2]](diffhunk://#diff-d8298c7c2cc5697417d7ca897442abd96d187627a8b6ca351064cec20d453e3cR161)
* Modified the expansion logic in `ExpansionChunk::process` (`ExpansionChunk.cpp`) to use `_weakResectionSize` instead of a hardcoded value when determining if a view's resection is weak. [[1]](diffhunk://#diff-6902bad577d70b0956f4bc732cc25ddd47181aadd05ab0cea7a3cbac271a44f8L78-R81) [[2]](diffhunk://#diff-6902bad577d70b0956f4bc732cc25ddd47181aadd05ab0cea7a3cbac271a44f8L94-R93)

### Command-line interface and pipeline integration

* Added the `weakResectionSize` option to the command-line parameters in `main_sfmExpanding.cpp`, making it user-configurable and passing it to the expansion chunk. [[1]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R105) [[2]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R134-R137) [[3]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R256)