### PR TITLE
Local bundle adjustment's covisibility estimation optimization

### DIFF
--- a/src/aliceVision/sfm/pipeline/expanding/ConnexityGraph.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ConnexityGraph.cpp
@@ -5,11 +5,12 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "ConnexityGraph.hpp"
-//#include <aliceVision/stl/Counter.hpp>
+#include <aliceVision/stl/stl.hpp>
 #include <lemon/bfs.h>
 
 namespace aliceVision {
 namespace sfm {
+
 
 struct viewIdScored 
 {
@@ -33,77 +34,166 @@ struct viewIdScored
     size_t card = 0;        
 };
 
-bool ConnexityGraph::build(const sfmData::SfMData & sfmData, const std::set<IndexT> & viewsOfInterest)
+bool ConnexityGraph::updateCocardinalities(const sfmData::SfMData & sfmData, 
+                              const track::TracksPerView& tracksPerViews)
+{
+    //Create a list of reconstructed views
+    std::set<IndexT> setViews;
+    for (const auto & [viewId, view] : sfmData.getViews())
+    {
+        if (sfmData.isPoseAndIntrinsicDefined(viewId))
+        {
+            setViews.insert(viewId);
+        }
+    }
+
+    //Get incoming views
+    std::set<IndexT> newViews;
+    std::set_difference(setViews.begin(), setViews.end(), 
+                        _previousViews.begin(), _previousViews.end(), 
+                        std::inserter(newViews, newViews.begin()));
+    
+    ALICEVISION_LOG_INFO("Update cocardinalities with " << newViews.size() << " new views");
+
+    //Retrieve landmarks
+    const sfmData::Landmarks & landmarks = sfmData.getLandmarks();
+    
+    //Get All landmark ids (keys)
+    std::set<IndexT> landmarkIds;
+    std::transform(landmarks.begin(), landmarks.end(), 
+                    std::inserter(landmarkIds, landmarkIds.begin()), 
+                    stl::RetrieveKey());
+
+    //For all incoming views only
+    for (const IndexT newView: newViews)
+    {
+        const track::TrackIdSet & trackIds = tracksPerViews.at(newView);
+        
+        //Build a list of landmarks observed by this view
+        std::vector<IndexT> newViewLandmarks;
+        newViewLandmarks.reserve(trackIds.size());
+        std::set_intersection(trackIds.begin(), trackIds.end(), 
+                              landmarkIds.begin(), landmarkIds.end(), 
+                              std::back_inserter(newViewLandmarks));
+
+        //Loop over all landmarks
+        std::map<IndexT, size_t> commonLandmarksCountPerView;
+        for (const IndexT & idLandmark : newViewLandmarks)
+        {   
+            //Loop over all view observing the landmark
+            const sfmData::Landmark & landmark = landmarks.at(idLandmark);
+            for (const auto & [idView, _] : landmark.getObservations())
+            {
+                if (idView == newView)
+                {
+                    continue;
+                }
+
+                //Update the coobservation counter
+                auto it = commonLandmarksCountPerView.find(idView);
+                if (it != commonLandmarksCountPerView.end())
+                {
+                    it->second++;
+                }
+                else
+                {
+                    commonLandmarksCountPerView[idView] = 1;
+                }
+            }
+        }
+
+        //Update the cocardinalities sparse matrix 
+        for (const auto [otherView, card]: commonLandmarksCountPerView)
+        {
+            Pair p;
+            p.first = std::min(newView, otherView);
+            p.second = std::max(newView, otherView);
+            _cocardinalities[p] = card;
+        }
+    }
+
+    
+
+    //Get Removed views
+    std::set<IndexT> removedViews;
+    std::set_difference(_previousViews.begin(), _previousViews.end(),
+                        setViews.begin(), setViews.end(), 
+                        std::inserter(removedViews, removedViews.begin()));
+
+    ALICEVISION_LOG_INFO("Update cocardinalities with " << removedViews.size() << " removed views");
+
+    for (const IndexT removedView : removedViews)
+    {
+        std::erase_if(_cocardinalities, 
+                    [removedView](const auto & item)
+                    {
+                        const auto & pair = item.first;
+                        return ((pair.first == removedView) || (pair.second == removedView));
+                    }
+        );
+    }
+
+    //Copy for next iteration
+    _previousViews = setViews;
+    
+    return true;
+}
+
+bool ConnexityGraph::build(const sfmData::SfMData & sfmData, 
+                        const track::TracksPerView& tracksPerViews, 
+                        const std::set<IndexT> & viewsOfInterest)
 {
     lemon::ListGraph graph;
-    std::map<IndexT, lemon::ListGraph::Node> _nodePerViewId;
+    std::map<IndexT, lemon::ListGraph::Node> nodePerViewId;
     std::map<lemon::ListGraph::Node, IndexT> viewIdPerNode;
+
+    if (!updateCocardinalities(sfmData, tracksPerViews))
+    {
+        return false;
+    }
+
+    ALICEVISION_LOG_INFO("Connexity graph begin");
+    //Reset result
+    _distancesPerPoseId.clear();
 
     //Create a list of reconstructed views
     std::vector<IndexT> views;
-    for (const auto & pv : sfmData.getViews())
+    for (const auto & [viewId, view] : sfmData.getViews())
     {
-        if (sfmData.isPoseAndIntrinsicDefined(pv.first))
+        if (sfmData.isPoseAndIntrinsicDefined(viewId))
         {
-            views.push_back(pv.first);
+            views.push_back(viewId);
 
             lemon::ListGraph::Node newNode = graph.addNode();
-            _nodePerViewId[pv.first] = newNode;
-            viewIdPerNode[newNode] = pv.first;
+            nodePerViewId[viewId] = newNode;
+            viewIdPerNode[newNode] = viewId;
         }
     }
 
-
-    //Build a list of landmarks index per view
-    std::map<IndexT, std::set<IndexT>> landmarksPerView;
-    for (const auto & pl : sfmData.getLandmarks())
-    {
-        for (const auto & po : pl.second.getObservations())
-        {
-            landmarksPerView[po.first].insert(pl.first);
-        }
-    }
     
     //For all possible unique pairs    
     std::map<IndexT, std::vector<viewIdScored>> covisibility;
-    for (int idref = 0; idref < views.size(); idref++)
+    for (const auto & [pair, s]: _cocardinalities)
     {
-        IndexT viewRef = views[idref];
-
-        const auto & ptref = landmarksPerView[viewRef];
-        
-        for (int idcur = idref + 1; idcur < views.size(); idcur++)
-        {
-            IndexT viewCur = views[idcur];
-
-            const auto & ptcur = landmarksPerView[viewCur];
-
-            std::vector<IndexT> intersection;
-            std::set_intersection(ptref.begin(), ptref.end(), ptcur.begin(), ptcur.end(), 
-                                    std::back_inserter(intersection));
-
-            size_t s = intersection.size();
-            if (s == 0)
-            {
-                continue;
-            }
-
-            covisibility[viewRef].push_back({viewCur, s});
-            covisibility[viewCur].push_back({viewRef, s});
-        }
+        covisibility[pair.first].push_back({pair.second, s});
+        covisibility[pair.second].push_back({pair.first, s});
     }
 
     //Filter out connexions without enough information
     for (auto & item : covisibility)
     {
         auto & vec = item.second;
+
+        //Just skip filtering if we don't have more than _minLinksPerView links
         if (vec.size() < _minLinksPerView)
         {
             continue;
         }
 
+        //Sort the vector by descending order of shared observations
         std::sort(vec.begin(), vec.end(), std::greater<>());
 
+        //Count the number of items with enough observations
         size_t pos = 0;
         for (; pos < vec.size(); pos++)
         {
@@ -113,6 +203,7 @@ bool ConnexityGraph::build(const sfmData::SfMData & sfmData, const std::set<Inde
             }
         }
 
+        //Keep at LEAST _minLinksPerView
         pos = std::max(pos, _minLinksPerView);
         vec.resize(pos);
     }
@@ -130,8 +221,8 @@ bool ConnexityGraph::build(const sfmData::SfMData & sfmData, const std::set<Inde
         {
             IndexT viewId2 = part.viewId;
 
-            const lemon::ListGraph::Node & node1 = _nodePerViewId[viewId1];
-            const lemon::ListGraph::Node & node2 = _nodePerViewId[viewId2];
+            const lemon::ListGraph::Node & node1 = nodePerViewId[viewId1];
+            const lemon::ListGraph::Node & node2 = nodePerViewId[viewId2];
 
             graph.addEdge(node1, node2);
         }
@@ -159,8 +250,8 @@ bool ConnexityGraph::build(const sfmData::SfMData & sfmData, const std::set<Inde
 
             if (intrinsicIdRef != intrinsicIdCur) continue;
 
-            const lemon::ListGraph::Node & node1 = _nodePerViewId[viewRef];
-            const lemon::ListGraph::Node & node2 = _nodePerViewId[viewCur];
+            const lemon::ListGraph::Node & node1 = nodePerViewId[viewRef];
+            const lemon::ListGraph::Node & node2 = nodePerViewId[viewCur];
 
             graph.addEdge(node1, node2);
         }
@@ -174,15 +265,15 @@ bool ConnexityGraph::build(const sfmData::SfMData & sfmData, const std::set<Inde
 
     for (auto id : viewsOfInterest)
     {
-        auto it = _nodePerViewId.find(id);
-        if (it != _nodePerViewId.end())
+        auto it = nodePerViewId.find(id);
+        if (it != nodePerViewId.end())
         {
             bfs.addSource(it->second);
         }
     }
 
     bfs.start();
-    for (const auto & x : _nodePerViewId)
+    for (const auto & x : nodePerViewId)
     {   
         //Retrieve the poseId associated to this view
         IndexT poseId = sfmData.getView(x.first).getPoseId();
@@ -209,6 +300,8 @@ bool ConnexityGraph::build(const sfmData::SfMData & sfmData, const std::set<Inde
             
         }
     }
+
+    ALICEVISION_LOG_INFO("Connexity graph end");
 
     return true;
 }

--- a/src/aliceVision/sfm/pipeline/expanding/ConnexityGraph.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ConnexityGraph.hpp
@@ -8,6 +8,7 @@
 
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <lemon/list_graph.h>
+#include <aliceVision/track/Track.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -15,13 +16,18 @@ namespace sfm {
 class ConnexityGraph
 {
 public:
+
     /**
      * Compute distances of all the sfmData views to the viewsOfInterest views
      * @param sfmData the sfmData containing all the views
-     * @param viewsOfInterest the list of views to compute the distance from. Those views must also be in the sfmData !
+     * @param tracksPerView list of track ids indexed per view
+     * @param viewsOfInterest the list of views to compute the distance from. 
+     * Those views must also be in the sfmData !
      * @return false if an error occurred
     */
-    bool build(const sfmData::SfMData & sfmData, const std::set<IndexT> & viewsOfInterest);
+    bool build(const sfmData::SfMData & sfmData,  
+                const track::TracksPerView& tracksPerViews,
+                const std::set<IndexT> & viewsOfInterest);
 
     /**
      * Get the distance for a particular poseId to one view of interest
@@ -32,7 +38,19 @@ public:
 
 
 private:
+    /**
+     * update the coCardinalities
+     * @param sfmData the sfmData containing all the views
+     * @param tracksPerView list of track ids indexed per view
+     * @return false if an error occurred
+    */
+    bool updateCocardinalities(const sfmData::SfMData & sfmData, 
+                              const track::TracksPerView& tracksPerViews);
+
+private:
     std::map<IndexT, int> _distancesPerPoseId;
+    std::set<IndexT> _previousViews;
+    std::map<Pair, size_t> _cocardinalities;
 
 private:
     size_t _minLinksPerView = 10;

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -32,6 +32,12 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
         return false;
     }
 
+    //Check if historyHandler exists
+    if (!_historyHandler)
+    {
+        return false;
+    }
+
     //How many views to resect ?
     size_t countToProcess = 0;
     for (const IndexT viewId : viewsChunk)
@@ -52,6 +58,7 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
     };
 
     std::vector<IntermediateResectionInfo> intermediateInfos;
+    std::set<IndexT> addedViews;
 
     ALICEVISION_LOG_INFO("Resection start");
     #pragma omp parallel for
@@ -119,6 +126,7 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
         }
         
         addPose(sfmData, item.viewId, item.pose);
+        addedViews.insert(item.viewId);
     }
 
     // Get a list of valid views
@@ -149,11 +157,8 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
     {
         setConstraints(sfmData, tracksHandler, validViewIds);
     }
-
-    if (_historyHandler)
-    {
-        _historyHandler->saveState(sfmData);
-    }
+    
+    _historyHandler->saveState(sfmData);
 
     ALICEVISION_LOG_INFO("ExpansionChunk::process end");
 

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionHistory.hpp
@@ -52,6 +52,10 @@ public:
         return _epoch;
     }
 
+    /**
+     * Save the state after a chunk
+     * @param sfmData the current sfmData
+    */
     void saveState(const sfmData::SfMData & sfmData);
 
     /**
@@ -73,6 +77,12 @@ public:
 private:
     // History of focals per intrinsics
     std::map<IndexT, std::vector<std::pair<size_t, double>>> _focalHistory;
+
+    // History of added views
+    std::vector<std::set<IndexT>> _addedViews;
+
+    // History of removed views
+    std::vector<std::set<IndexT>> _removedViews;
     
     // epoch ID
     std::size_t _epoch = 0;

--- a/src/aliceVision/sfm/pipeline/expanding/LbaPolicyConnexity.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LbaPolicyConnexity.cpp
@@ -16,25 +16,25 @@ bool LbaPolicyConnexity::build(sfmData::SfMData & sfmData, const track::TracksHa
         setupIntrinsics(sfmData);
     }
 
-    ConnexityGraph graph;
-    if (!graph.build(sfmData, viewIds))
+    
+    if (!_graph.build(sfmData, tracksHandler.getTracksPerView(), viewIds))
     {
         return false;
     }
 
-    upgradeSfmData(sfmData, graph);
+    upgradeSfmData(sfmData);
 
     return true;
 }
 
-void LbaPolicyConnexity::upgradeSfmData(sfmData::SfMData & sfmData, const ConnexityGraph & graph)
+void LbaPolicyConnexity::upgradeSfmData(sfmData::SfMData & sfmData)
 {
     /**
      * Propagate states to views in sfmData
     */
-    for (auto & [poseId, pose] : sfmData.getPoses().valueRange())
+    for (auto & [idPose, pose] : sfmData.getPoses().valueRange())
     {
-        int d = graph.getDistance(poseId);
+        int d = _graph.getDistance(idPose);
         if (d <= _distanceLimit)
         {
             if (pose.isLocked())
@@ -57,15 +57,16 @@ void LbaPolicyConnexity::upgradeSfmData(sfmData::SfMData & sfmData, const Connex
     }
 
     /*Landmarks*/
-    for (auto & pl : sfmData.getLandmarks())
+    for (auto & [idLandmark, landmark] : sfmData.getLandmarks())
     {
         EEstimatorParameterState state = EEstimatorParameterState::REFINED;
 
-        // By default, the landmark is refined, except if at least one observation comes from an ignored camera
+        bool hasIgnored = false;
+        bool hasEstimated = false;
 
-        for (const auto & po : pl.second.getObservations())
+        // By default, the landmark is refined, except if at least one observation comes from an ignored camera
+        for (const auto & [viewId, _] : landmark.getObservations())
         {
-            IndexT viewId = po.first;
             IndexT poseId = sfmData.getView(viewId).getPoseId();
             
             if (poseId == UndefinedIndexT)
@@ -75,32 +76,52 @@ void LbaPolicyConnexity::upgradeSfmData(sfmData::SfMData & sfmData, const Connex
 
             if (sfmData.getAbsolutePose(poseId).getState() == EEstimatorParameterState::IGNORED)
             {
-                state = EEstimatorParameterState::IGNORED;
+                hasIgnored = true;
+            }
+
+            if (sfmData.getAbsolutePose(poseId).getState() == EEstimatorParameterState::REFINED)
+            {
+                hasEstimated = true;
             }
         }
 
-        pl.second.state = state;
+        //If no associated view which has to be computed, 
+        //then obviously we want to ignore it (should be implicit in the bundle though)
+        if ((!hasEstimated) || hasIgnored)
+        {
+            landmark.state = EEstimatorParameterState::IGNORED;
+        }
     }
 }
 
 void LbaPolicyConnexity::setupIntrinsics(sfmData::SfMData & sfmData)
 {
-    for (auto & pi : sfmData.getIntrinsics())
-    {
-        const auto & vec = _historyHandler->getFocalHistory(pi.first);
+    const int minUsage = 25;
+
+    for (auto & [idIntrinsic, intrinsic] : sfmData.getIntrinsics())
+    {   
+        //If the intrinsic is locked, we're sure we don't need to look at it
+        if (intrinsic->isLocked())
+        {
+            intrinsic->setState(EEstimatorParameterState::CONSTANT);
+            continue;
+        }
+
+        //Retrieve focal history (vector of [usageCount, focalvalue])
+        const auto & vec = _historyHandler->getFocalHistory(idIntrinsic);
         if (vec.size() == 0)
         {
-            pi.second->setState(EEstimatorParameterState::REFINED);
+            intrinsic->setState(EEstimatorParameterState::REFINED);
             continue;
         }
 
         size_t lastGood = std::numeric_limits<size_t>::max();
         std::vector<std::pair<size_t, double>> filtered;
 
+        //Sort by decreasing id
         for (int id = vec.size() - 1; id >= 0; id--)
         {
-            //Make sure the usage decrease,
-            //Remove the steps where the usage increase (we are going to the past)
+            //Make sure the usage decrease.
             if (vec[id].first < lastGood)
             {
                 lastGood = vec[id].first;
@@ -111,6 +132,15 @@ void LbaPolicyConnexity::setupIntrinsics(sfmData::SfMData & sfmData)
         std::vector<double> cropped;
         std::vector<double> focals;
         int largestCount = filtered.front().first;
+
+        //If the largest count is under a threshold, we refine.
+        if (largestCount < minUsage)
+        {
+            intrinsic->setState(EEstimatorParameterState::REFINED);
+            continue;
+        }
+
+        //Build an history of focal values to estimate its variance
         bool nomore = false;
         for (int id = 0; id < filtered.size(); id++)
         {
@@ -119,7 +149,7 @@ void LbaPolicyConnexity::setupIntrinsics(sfmData::SfMData & sfmData)
                 cropped.push_back(filtered[id].second);
             }
 
-            if (largestCount - filtered[id].first > 25)
+            if (largestCount - filtered[id].first > minUsage)
             {
                 nomore = true;
             }
@@ -138,13 +168,14 @@ void LbaPolicyConnexity::setupIntrinsics(sfmData::SfMData & sfmData)
         double maxVal = *std::max_element(focals.begin(), focals.end());
         double normStdev = stddev / (maxVal - minVal);
 
-        if (normStdev < 0.01 || pi.second->isLocked())
+        //If the focal stay fixed on a value, then consider it as constant
+        if (normStdev < 0.01)
         {
-            pi.second->setState(EEstimatorParameterState::CONSTANT);
+            intrinsic->setState(EEstimatorParameterState::CONSTANT);
         }
         else
         {
-            pi.second->setState(EEstimatorParameterState::REFINED);
+            intrinsic->setState(EEstimatorParameterState::REFINED);
         }
     }
 }

--- a/src/aliceVision/sfm/pipeline/expanding/LbaPolicyConnexity.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LbaPolicyConnexity.hpp
@@ -35,12 +35,14 @@ public:
         _distanceLimit = distanceLimit;
     }
 
+
 private:
-    void upgradeSfmData(sfmData::SfMData & sfmData, const ConnexityGraph & graph);
+    void upgradeSfmData(sfmData::SfMData & sfmData);
     void setupIntrinsics(sfmData::SfMData & sfmData);
 
 private:
     int _distanceLimit = 1;
+    ConnexityGraph _graph;
 };
 
 }

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -23,17 +23,17 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
     refineOptions |= BundleAdjustment::REFINE_STRUCTURE;
     refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;
 
-    if (!initialize(sfmData, tracksHandler, viewIds))
-    {
-        return false;
-    }
-
     options.setSparseBA();
     BundleAdjustmentCeres bundleObject(options, _minNbCamerasToRefinePrincipalPoint);
 
     //Repeat until nothing change
     do 
     {
+        if (!initializeIteration(sfmData, tracksHandler, viewIds))
+        {
+            return false;
+        }
+        
         const bool success = bundleObject.adjust(sfmData, refineOptions);
         if (!success)
         {
@@ -74,7 +74,7 @@ bool SfmBundle::cleanup(sfmData::SfMData & sfmData)
     return somethingChanged;
 }
 
-bool SfmBundle::initialize(sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler, const std::set<IndexT> & viewIds)
+bool SfmBundle::initializeIteration(sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler, const std::set<IndexT> & viewIds)
 {
     bool enableLocalStrategy = _useLBA;
 

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
@@ -72,12 +72,14 @@ public:
         _minNbCamerasToRefinePrincipalPoint = count;
     }
 
-
 private:
     /**
      * Initialize bundle properties
+     * @param sfmData the input sfmData
+     * @param tracksHandler the tracks handler
+     * @param viewIds the set of view ids which we are sure we want to be estimated
     */
-    bool initialize(sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler, const std::set<IndexT> & viewIds);
+    bool initializeIteration(sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler, const std::set<IndexT> & viewIds);
 
     /**
      * Cleanup sfmData 


### PR DESCRIPTION
Bundle adjustment is computed only on a subset of views to enhance performance.

The views are selected using some graph connexity algorithm.

This graph was computed from scratch after each computation chunk in the expanding process.

In this PR, we propose an optimization which will reuse the previous computation (previous iteration) instead of computing from scratch.
