### PR TITLE
[meshroom] Rename `Publish` nodes to `CopyFiles` in all templates

### DIFF
--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -7,6 +7,7 @@
             "CameraInit": "12.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.0",
@@ -23,7 +24,6 @@
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "ScenePreview": "2.0",
             "SfMTransfer": "2.1",
             "SfMTriangulation": "1.0",
@@ -400,8 +400,8 @@
                 "color": "#3f3138"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 3600,
                 100

--- a/meshroom/cameraTrackingExperimental.mg
+++ b/meshroom/cameraTrackingExperimental.mg
@@ -7,6 +7,7 @@
             "CameraInit": "12.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.0",
@@ -24,7 +25,6 @@
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "Publish": "1.3",
             "RelativePoseEstimating": "3.0",
             "ScenePreview": "2.0",
             "SfMBootStrapping": "4.1",
@@ -421,8 +421,8 @@
                 "color": "#3f3138"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 5079,
                 119

--- a/meshroom/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/cameraTrackingWithoutCalibration.mg
@@ -7,6 +7,7 @@
             "CameraInit": "12.0",
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "ExportAnimatedCamera": "2.0",
@@ -22,7 +23,6 @@
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "ScenePreview": "2.0",
             "SfMTransfer": "2.1",
             "SfMTriangulation": "1.0",
@@ -371,8 +371,8 @@
                 "color": "#3f3138"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 3600,
                 100

--- a/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
@@ -7,6 +7,7 @@
             "CameraInit": "12.0",
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "ExportAnimatedCamera": "2.0",
@@ -23,7 +24,6 @@
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "Publish": "1.3",
             "RelativePoseEstimating": "3.0",
             "ScenePreview": "2.0",
             "SfMBootStrapping": "4.1",
@@ -389,8 +389,8 @@
                 "color": "#3f3138"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 5228,
                 100

--- a/meshroom/colorCalibration.mg
+++ b/meshroom/colorCalibration.mg
@@ -6,7 +6,7 @@
             "CameraInit": "12.0",
             "ColorCheckerCorrection": "2.0",
             "ColorCheckerDetection": "2.0",
-            "Publish": "1.3"
+            "CopyFiles": "1.3"
         },
         "template": true
     },
@@ -42,8 +42,8 @@
                 "input": "{CameraInit_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 279,
                 -10

--- a/meshroom/distortionCalibration.mg
+++ b/meshroom/distortionCalibration.mg
@@ -7,7 +7,7 @@
             "CheckerboardDetection": "1.0",
             "DistortionCalibration": "6.0",
             "ExportDistortion": "2.0",
-            "Publish": "1.3"
+            "CopyFiles": "1.3"
         },
         "template": true
     },
@@ -53,8 +53,8 @@
                 "input": "{DistortionCalibration_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 800,
                 0

--- a/meshroom/hdrFusion.mg
+++ b/meshroom/hdrFusion.mg
@@ -4,10 +4,10 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "LdrToHdrCalibration": "3.1",
             "LdrToHdrMerge": "4.1",
-            "LdrToHdrSampling": "4.0",
-            "Publish": "1.3"
+            "LdrToHdrSampling": "4.0"
         },
         "template": true
     },
@@ -61,8 +61,8 @@
                 "input": "{CameraInit_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 800,
                 0

--- a/meshroom/lidarMeshing.mg
+++ b/meshroom/lidarMeshing.mg
@@ -3,11 +3,11 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
+            "CopyFiles": "1.3",
             "ImportE57": "1.0",
             "LidarDecimating": "1.0",
             "LidarMerging": "1.0",
-            "LidarMeshing": "1.0",
-            "Publish": "1.3"
+            "LidarMeshing": "1.0"
         },
         "template": true
     },
@@ -50,8 +50,8 @@
                 "input": "{ImportE57_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 800,
                 0

--- a/meshroom/multi-viewPhotometricStereo.mg
+++ b/meshroom/multi-viewPhotometricStereo.mg
@@ -4,6 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
@@ -14,7 +15,6 @@
             "Meshing": "7.0",
             "PhotometricStereo": "1.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "SfMFilter": "1.0",
             "SfMTransfer": "2.1",
             "SphereDetection": "1.0",
@@ -174,8 +174,8 @@
                 "input": "{PhotometricStereo_1.outputSfmDataNormalPNG}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 2400,
                 0

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -7,6 +7,7 @@
             "CameraInit": "12.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DistortionCalibration": "6.0",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
@@ -16,7 +17,6 @@
             "ImageMatching": "2.0",
             "ImageSegmentationBox": "0.2",
             "NodalSfM": "2.0",
-            "Publish": "1.3",
             "RelativePoseEstimating": "3.0",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"
@@ -223,8 +223,8 @@
                 "color": "#80766f"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 2000,
                 0

--- a/meshroom/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/nodalCameraTrackingWithoutCalibration.mg
@@ -6,6 +6,7 @@
             "CameraInit": "12.0",
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",
@@ -14,7 +15,6 @@
             "ImageMatching": "2.0",
             "ImageSegmentationBox": "0.2",
             "NodalSfM": "2.0",
-            "Publish": "1.3",
             "RelativePoseEstimating": "3.0",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"
@@ -180,8 +180,8 @@
                 "color": "#80766f"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 2100,
                 100

--- a/meshroom/panoramaFisheyeHdr.mg
+++ b/meshroom/panoramaFisheyeHdr.mg
@@ -4,6 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
@@ -18,7 +19,6 @@
             "PanoramaPrepareImages": "1.1",
             "PanoramaSeams": "2.0",
             "PanoramaWarping": "1.1",
-            "Publish": "1.3",
             "SfMTransform": "3.1"
         },
         "template": true
@@ -209,8 +209,8 @@
                 "input": "{SfMTransform_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 3200,
                 0

--- a/meshroom/panoramaHdr.mg
+++ b/meshroom/panoramaHdr.mg
@@ -4,6 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
@@ -18,7 +19,6 @@
             "PanoramaPrepareImages": "1.1",
             "PanoramaSeams": "2.0",
             "PanoramaWarping": "1.1",
-            "Publish": "1.3",
             "SfMTransform": "3.1"
         },
         "template": true
@@ -204,8 +204,8 @@
                 "input": "{SfMTransform_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 3000,
                 0

--- a/meshroom/photogrammetry.mg
+++ b/meshroom/photogrammetry.mg
@@ -4,6 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
@@ -12,7 +13,6 @@
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "StructureFromMotion": "3.3",
             "Texturing": "6.0"
         },
@@ -116,8 +116,8 @@
                 "input": "{StructureFromMotion_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 2200,
                 0

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -7,6 +7,7 @@
             "CameraInit": "12.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.0",
@@ -23,7 +24,6 @@
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "ScenePreview": "2.0",
             "StructureFromMotion": "3.3",
             "Texturing": "6.0"
@@ -482,8 +482,8 @@
                 "color": "#384a55"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 2400,
                 -100

--- a/meshroom/photogrammetryAndCameraTrackingExperimental.mg
+++ b/meshroom/photogrammetryAndCameraTrackingExperimental.mg
@@ -7,6 +7,7 @@
             "CameraInit": "12.0",
             "CheckerboardDetection": "1.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.0",
@@ -24,7 +25,6 @@
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "Publish": "1.3",
             "RelativePoseEstimating": "3.0",
             "ScenePreview": "2.0",
             "SfMBootStrapping": "4.1",
@@ -503,8 +503,8 @@
                 "color": "#384a55"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 4725,
                 -186

--- a/meshroom/photogrammetryDraft.mg
+++ b/meshroom/photogrammetryDraft.mg
@@ -4,13 +4,13 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "StructureFromMotion": "3.3",
             "Texturing": "6.0"
         },
@@ -91,8 +91,8 @@
                 "input": "{StructureFromMotion_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 1800,
                 0

--- a/meshroom/photogrammetryExperimental.mg
+++ b/meshroom/photogrammetryExperimental.mg
@@ -4,6 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "ExportImages": "1.0",
@@ -13,7 +14,6 @@
             "IntrinsicsTransforming": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "Publish": "1.3",
             "RelativePoseEstimating": "3.0",
             "SfMBootStrapping": "4.1",
             "SfMColorizing": "1.0",
@@ -134,8 +134,8 @@
                 "depthMapsFolder": "{DepthMapFilter_1.output}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 3405,
                 -12

--- a/meshroom/photogrammetryObject.mg
+++ b/meshroom/photogrammetryObject.mg
@@ -4,6 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
@@ -14,7 +15,6 @@
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "StructureFromMotion": "3.3",
             "Texturing": "6.0"
         },
@@ -153,8 +153,8 @@
                 ]
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 2200,
                 0

--- a/meshroom/photogrammetryObjectTurntable.mg
+++ b/meshroom/photogrammetryObjectTurntable.mg
@@ -4,6 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
@@ -14,7 +15,6 @@
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "StructureFromMotion": "3.3",
             "Texturing": "6.0"
         },
@@ -155,8 +155,8 @@
                 ]
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 2600,
                 0

--- a/meshroom/photogrammetryObjectTwoSides.mg
+++ b/meshroom/photogrammetryObjectTwoSides.mg
@@ -5,6 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
@@ -16,7 +17,6 @@
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "Publish": "1.3",
             "SfMMerge": "3.0",
             "SfMTransform": "3.1",
             "SfMTriangulation": "1.0",
@@ -403,8 +403,8 @@
                 "color": "#4D3E5C"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 3200,
                 400

--- a/meshroom/photometricStereo.mg
+++ b/meshroom/photometricStereo.mg
@@ -4,9 +4,9 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "CopyFiles": "1.3",
             "LightingCalibration": "1.0",
             "PhotometricStereo": "1.0",
-            "Publish": "1.3",
             "SphereDetection": "1.0"
         },
         "template": true
@@ -42,8 +42,8 @@
                 "pathToJSONLightFile": "{LightingCalibration_1.outputFile}"
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 800,
                 0

--- a/meshroom/rawImageConversion.mg
+++ b/meshroom/rawImageConversion.mg
@@ -4,8 +4,8 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
-            "ImageProcessing": "3.3",
-            "Publish": "1.3"
+            "CopyFiles": "1.3",
+            "ImageProcessing": "3.3"
         },
         "template": true
     },
@@ -30,8 +30,8 @@
                 "keepImageFilename": true
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
                 175,
                 -43


### PR DESCRIPTION
## Description

> [!WARNING]
> This should be merged with https://github.com/alicevision/Meshroom/pull/2868.

This PR renames the `Publish` nodes in all the templates to `CopyFiles`.