### PR TITLE
Photogrammetry CCTAG pipelines

### DIFF
--- a/meshroom/photogrammetry-cctag-object.mg
+++ b/meshroom/photogrammetry-cctag-object.mg
@@ -1,0 +1,1162 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0",
+        "fileVersion": "2.0",
+        "nodesVersions": {
+            "CameraInit": "12.0",
+            "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ImageDetectionPrompt": "0.1",
+            "ImageMatching": "2.0",
+            "ImageSegmentationBox": "0.2",
+            "ImageTagsExtraction": "0.1",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.1",
+            "SfMDistances": "3.0",
+            "SfMTransform": "3.1",
+            "StructureFromMotion": "3.3",
+            "Texturing": "6.0"
+        }
+    },
+    "graph": {
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                0,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "4c471e04d91d618d3dddf7990cb9b81c599a7700",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "viewpoints": [],
+                "intrinsics": [],
+                "sensorDatabase": "${ALICEVISION_SENSOR_DB}",
+                "lensCorrectionProfileInfo": "${ALICEVISION_LENS_PROFILE_INFO}",
+                "lensCorrectionProfileSearchIgnoreCameraModel": true,
+                "defaultFieldOfView": 45.0,
+                "groupCameraFallback": "folder",
+                "rawColorInterpretation": "LibRawWhiteBalancing",
+                "colorProfileDatabase": "${ALICEVISION_COLOR_PROFILE_DB}",
+                "errorOnMissingColorProfile": true,
+                "viewIdMethod": "metadata",
+                "viewIdRegex": ".*?(\\d+)",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/cameraInit.sfm"
+            }
+        },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [
+                1802,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 24,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "c4956c1b70c48f28c0ee842114fe2e4816a567c0",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}",
+                "minViewAngle": 2.0,
+                "maxViewAngle": 70.0,
+                "nNearestCams": 10,
+                "minNumOfConsistentCams": 3,
+                "minNumOfConsistentCamsWithLowSimilarity": 4,
+                "pixToleranceFactor": 2.0,
+                "pixSizeBall": 0,
+                "pixSizeBallWithLowSimilarity": 0,
+                "computeNormalMaps": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "depth": "{nodeCacheFolder}/<VIEW_ID>_depthMap.exr",
+                "sim": "{nodeCacheFolder}/<VIEW_ID>_simMap.exr",
+                "normal": "{nodeCacheFolder}/<VIEW_ID>_normalMap.exr"
+            }
+        },
+        "DepthMap_1": {
+            "nodeType": "DepthMap",
+            "position": [
+                1602,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 12,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "409881ed9e73daa8043c50c46ee44866fc53d286",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{PrepareDenseScene_1.input}",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "downscale": 1,
+                "minViewAngle": 2.0,
+                "maxViewAngle": 70.0,
+                "tiling": {
+                    "tileBufferWidth": 1024,
+                    "tileBufferHeight": 1024,
+                    "tilePadding": 64,
+                    "autoAdjustSmallImage": true
+                },
+                "chooseTCamsPerTile": true,
+                "maxTCams": 10,
+                "sgm": {
+                    "sgmScale": 2,
+                    "sgmStepXY": 2,
+                    "sgmStepZ": -1,
+                    "sgmMaxTCamsPerTile": 4,
+                    "sgmWSH": 4,
+                    "sgmUseSfmSeeds": true,
+                    "sgmSeedsRangeInflate": 0.2,
+                    "sgmDepthThicknessInflate": 0.0,
+                    "sgmMaxSimilarity": 1.0,
+                    "sgmGammaC": 5.5,
+                    "sgmGammaP": 8.0,
+                    "sgmP1": 10.0,
+                    "sgmP2Weighting": 100.0,
+                    "sgmMaxDepths": 1500,
+                    "sgmFilteringAxes": "YX",
+                    "sgmDepthListPerTile": true,
+                    "sgmUseConsistentScale": false
+                },
+                "refine": {
+                    "refineEnabled": true,
+                    "refineScale": 1,
+                    "refineStepXY": 1,
+                    "refineMaxTCamsPerTile": 4,
+                    "refineSubsampling": 10,
+                    "refineHalfNbDepths": 15,
+                    "refineWSH": 3,
+                    "refineSigma": 15.0,
+                    "refineGammaC": 15.5,
+                    "refineGammaP": 8.0,
+                    "refineInterpolateMiddleDepth": false,
+                    "refineUseConsistentScale": false
+                },
+                "colorOptimization": {
+                    "colorOptimizationEnabled": true,
+                    "colorOptimizationNbIterations": 100
+                },
+                "customPatchPattern": {
+                    "sgmUseCustomPatchPattern": false,
+                    "refineUseCustomPatchPattern": false,
+                    "customPatchPatternSubparts": [],
+                    "customPatchPatternGroupSubpartsPerLevel": false
+                },
+                "intermediateResults": {
+                    "exportIntermediateDepthSimMaps": false,
+                    "exportIntermediateNormalMaps": false,
+                    "exportIntermediateVolumes": false,
+                    "exportIntermediateCrossVolumes": false,
+                    "exportIntermediateTopographicCutVolumes": false,
+                    "exportIntermediateVolume9pCsv": false,
+                    "exportTilePattern": false
+                },
+                "nbGPUs": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "depth": "{nodeCacheFolder}/<VIEW_ID>_depthMap.exr",
+                "sim": "{nodeCacheFolder}/<VIEW_ID>_simMap.exr",
+                "tilePattern": "{nodeCacheFolder}/<VIEW_ID>_tilePattern.obj",
+                "depthSgm": "{nodeCacheFolder}/<VIEW_ID>_depthMap_sgm.exr",
+                "depthSgmUpscaled": "{nodeCacheFolder}/<VIEW_ID>_depthMap_sgmUpscaled.exr",
+                "depthRefined": "{nodeCacheFolder}/<VIEW_ID>_depthMap_refinedFused.exr"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                196,
+                -12
+            ],
+            "parallelization": {
+                "blockSize": 40,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "f58e11fcb1abe8b9cf65310d9a891dcae18b0efb",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "masksFolder": "",
+                "maskExtension": "png",
+                "maskInvert": false,
+                "describerTypes": [
+                    "dspsift",
+                    "cctag3"
+                ],
+                "describerPreset": "high",
+                "maxNbFeatures": 0,
+                "describerQuality": "high",
+                "contrastFiltering": "GridSort",
+                "relativePeakThreshold": 0.01,
+                "gridFiltering": true,
+                "workingColorSpace": "sRGB",
+                "forceCpuExtraction": false,
+                "maxThreads": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "CCTAG3 and DSPSIFT Feature Extraction.",
+                "label": "",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 20,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "5f6f7e8c329b1757cd4cc821b7456423196c5f5b",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": [
+                    "dspsift"
+                ],
+                "photometricMatchingMethod": "ANN_L2",
+                "geometricEstimator": "acransac",
+                "geometricFilterType": "fundamental_matrix",
+                "distanceRatio": 0.8,
+                "maxIteration": 2048,
+                "geometricError": 0.0,
+                "knownPosesGeometricErrorMax": 5.0,
+                "minRequired2DMotion": -1.0,
+                "maxMatches": 0,
+                "savePutativeMatches": false,
+                "crossMatching": false,
+                "guidedMatching": false,
+                "matchFromKnownCameraPoses": false,
+                "exportDebugFiles": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                -166
+            ],
+            "parallelization": {
+                "blockSize": 20,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "4c7eea1ef03ffc3410680e75991698e5d6405625",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": [
+                    "cctag3"
+                ],
+                "photometricMatchingMethod": "ANN_L2",
+                "geometricEstimator": "acransac",
+                "geometricFilterType": "no_filtering",
+                "distanceRatio": 0.8,
+                "maxIteration": 2048,
+                "geometricError": 0.0,
+                "knownPosesGeometricErrorMax": 5.0,
+                "minRequired2DMotion": -1.0,
+                "maxMatches": 0,
+                "savePutativeMatches": false,
+                "crossMatching": false,
+                "guidedMatching": false,
+                "matchFromKnownCameraPoses": false,
+                "exportDebugFiles": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Only CCTAG Feature Matching",
+                "label": "FeatureMatching CCTAG",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}"
+            }
+        },
+        "ImageDetectionPrompt_1": {
+            "nodeType": "ImageDetectionPrompt",
+            "position": [
+                200,
+                266
+            ],
+            "parallelization": {
+                "blockSize": 50,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "8050a690be841177b8caa716f522fefb7901993b",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "recognitionModelPath": "${RDS_RECOGNITION_MODEL_PATH}",
+                "detectionModelPath": "${RDS_DETECTION_MODEL_PATH}",
+                "detectionConfigPath": "${RDS_DETECTION_CONFIG_PATH}",
+                "prompt": "main",
+                "synonyms": "",
+                "forceDetection": true,
+                "thresholdDetection": 0.2,
+                "bboxMargin": 0,
+                "useGpu": true,
+                "outputBboxImage": false,
+                "keepFilename": false,
+                "extension": "jpg",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Default prompt \"main\" will detect the main object in scene. You may get better results when uing tags rom ImageTagsExtraction",
+                "label": "",
+                "color": "#11523f"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "bboxes": "{nodeCacheFolder}/<VIEW_ID>.jpg"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "1e34202440440d73c1b5f1a2b1e6a326c365eb5f",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "SequentialAndVocabularyTree",
+                "tree": "${ALICEVISION_VOCTREE}",
+                "weights": "",
+                "minNbImages": 200,
+                "maxDescriptors": 500,
+                "nbMatches": 40,
+                "nbNeighbors": 5,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/imageMatches.txt"
+            }
+        },
+        "ImageSegmentationBox_1": {
+            "nodeType": "ImageSegmentationBox",
+            "position": [
+                440,
+                266
+            ],
+            "parallelization": {
+                "blockSize": 50,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "b01a1682cdea976169b3586a837bf6e068a07e02",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{ImageDetectionPrompt_1.input}",
+                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "nukeTracker": "",
+                "segmentationModelPath": "${RDS_SEGMENTATION_MODEL_PATH}",
+                "maskInvert": false,
+                "useGpu": true,
+                "keepFilename": true,
+                "extension": "png",
+                "outputBboxImage": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Input can be used to mask images in PremareDenseScene prior DepthMap. This will just reconstruct the object.",
+                "label": "",
+                "color": "#11523f"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "masks": "{nodeCacheFolder}/<FILESTEM>.png",
+                "bboxes": "{nodeCacheFolder}/bboxes_<FILESTEM>.jpg"
+            }
+        },
+        "ImageTagsExtraction_1": {
+            "nodeType": "ImageTagsExtraction",
+            "position": [
+                198,
+                150
+            ],
+            "parallelization": {
+                "blockSize": 50,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "d5a9bf04d5829486d8deffd3db10a2d31d8eb194",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "recognitionModelPath": "${RDS_RECOGNITION_MODEL_PATH}",
+                "useGpu": true,
+                "outputTaggedImage": false,
+                "keepFilename": false,
+                "extension": "jpg",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Recognized tags can be used in ImageDetectionPrompt",
+                "label": "",
+                "color": "#11523f"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "results": "{nodeCacheFolder}/<VIEW_ID>.jpg"
+            }
+        },
+        "MeshFiltering_1": {
+            "nodeType": "MeshFiltering",
+            "position": [
+                2202,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "d1ccd1e946bf362d6eea8c4f0e92916d8db4100c",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "inputMesh": "{Meshing_1.outputMesh}",
+                "outputMeshFileType": "obj",
+                "keepLargestMeshOnly": false,
+                "smoothingSubset": "all",
+                "smoothingBoundariesNeighbours": 0,
+                "smoothingIterations": 5,
+                "smoothingLambda": 1.0,
+                "filteringSubset": "all",
+                "filteringIterations": 1,
+                "filterLargeTrianglesFactor": 60.0,
+                "filterTrianglesRatio": 0.0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "outputMesh": "{nodeCacheFolder}/mesh.{outputMeshFileTypeValue}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [
+                2002,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "dc3b1a6626441b5ea3ac38ad51661de9f316d2cc",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}",
+                "outputMeshFileType": "obj",
+                "useBoundingBox": false,
+                "boundingBox": {
+                    "bboxTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxScale": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    }
+                },
+                "estimateSpaceFromSfM": true,
+                "estimateSpaceMinObservations": 3,
+                "estimateSpaceMinObservationAngle": 10.0,
+                "maxInputPoints": 50000000,
+                "maxPoints": 5000000,
+                "maxPointsPerVoxel": 1000000,
+                "minStep": 2,
+                "partitioning": "singleBlock",
+                "repartition": "multiResolution",
+                "angleFactor": 15.0,
+                "simFactor": 15.0,
+                "minVis": 2,
+                "pixSizeMarginInitCoef": 2.0,
+                "pixSizeMarginFinalCoef": 4.0,
+                "voteMarginFactor": 4.0,
+                "contributeMarginFactor": 2.0,
+                "simGaussianSizeInit": 10.0,
+                "simGaussianSize": 10.0,
+                "minAngleThreshold": 1.0,
+                "refineFuse": true,
+                "helperPointsGridSize": 10,
+                "densify": false,
+                "densifyNbFront": 1,
+                "densifyNbBack": 1,
+                "densifyScale": 20.0,
+                "nPixelSizeBehind": 4.0,
+                "fullWeight": 1.0,
+                "voteFilteringForWeaklySupportedSurfaces": true,
+                "addLandmarksToTheDensePointCloud": false,
+                "invertTetrahedronBasedOnNeighborsNbIterations": 10,
+                "minSolidAngleRatio": 0.2,
+                "nbSolidAngleFilteringIterations": 2,
+                "colorizeOutput": false,
+                "addMaskHelperPoints": false,
+                "maskHelperPointsWeight": 1.0,
+                "maskBorderSize": 4,
+                "maxNbConnectedHelperPoints": 50,
+                "saveRawDensePointCloud": false,
+                "exportDebugTetrahedralization": false,
+                "seed": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "outputMesh": "{nodeCacheFolder}/mesh.{outputMeshFileTypeValue}",
+                "output": "{nodeCacheFolder}/densePointCloud.abc"
+            }
+        },
+        "Meshing_2": {
+            "nodeType": "Meshing",
+            "position": [
+                1602,
+                -134
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "338c8fc98e8c752fad3ef587b0b780b491bf81bc",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_2.output}",
+                "depthMapsFolder": "",
+                "outputMeshFileType": "obj",
+                "useBoundingBox": false,
+                "boundingBox": {
+                    "bboxTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxScale": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    }
+                },
+                "estimateSpaceFromSfM": true,
+                "estimateSpaceMinObservations": 3,
+                "estimateSpaceMinObservationAngle": 10.0,
+                "maxInputPoints": 50000000,
+                "maxPoints": 5000000,
+                "maxPointsPerVoxel": 1000000,
+                "minStep": 2,
+                "partitioning": "singleBlock",
+                "repartition": "multiResolution",
+                "angleFactor": 15.0,
+                "simFactor": 15.0,
+                "minVis": 2,
+                "pixSizeMarginInitCoef": 2.0,
+                "pixSizeMarginFinalCoef": 4.0,
+                "voteMarginFactor": 4.0,
+                "contributeMarginFactor": 2.0,
+                "simGaussianSizeInit": 10.0,
+                "simGaussianSize": 10.0,
+                "minAngleThreshold": 1.0,
+                "refineFuse": true,
+                "helperPointsGridSize": 10,
+                "densify": false,
+                "densifyNbFront": 1,
+                "densifyNbBack": 1,
+                "densifyScale": 20.0,
+                "nPixelSizeBehind": 4.0,
+                "fullWeight": 1.0,
+                "voteFilteringForWeaklySupportedSurfaces": true,
+                "addLandmarksToTheDensePointCloud": false,
+                "invertTetrahedronBasedOnNeighborsNbIterations": 10,
+                "minSolidAngleRatio": 0.2,
+                "nbSolidAngleFilteringIterations": 2,
+                "colorizeOutput": false,
+                "addMaskHelperPoints": false,
+                "maskHelperPointsWeight": 1.0,
+                "maskBorderSize": 4,
+                "maxNbConnectedHelperPoints": 50,
+                "saveRawDensePointCloud": false,
+                "exportDebugTetrahedralization": false,
+                "seed": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Draft to preview intermediate results",
+                "label": "Meshing Draft",
+                "color": ""
+            },
+            "outputs": {
+                "outputMesh": "{nodeCacheFolder}/mesh.{outputMeshFileTypeValue}",
+                "output": "{nodeCacheFolder}/densePointCloud.abc"
+            }
+        },
+        "PrepareDenseScene_1": {
+            "nodeType": "PrepareDenseScene",
+            "position": [
+                1405,
+                21
+            ],
+            "parallelization": {
+                "blockSize": 40,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "0318a6d8fad05b2f478f9565c511f191920bc4aa",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_2.output}",
+                "imagesFolders": [],
+                "masksFolders": [
+                    "{ImageSegmentationBox_1.output}",
+                    ""
+                ],
+                "maskExtension": "png",
+                "outputFileType": "exr",
+                "saveMetadata": true,
+                "saveMatricesTxtFiles": false,
+                "evCorrection": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "undistorted": "{nodeCacheFolder}/<VIEW_ID>.{outputFileTypeValue}"
+            }
+        },
+        "SfMDistances_1": {
+            "nodeType": "SfMDistances",
+            "position": [
+                998,
+                -80
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "15bc70ca402008affdd512e720bca18b03da9e55",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{StructureFromMotion_1.output}",
+                "objectType": "landmarks",
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "A": "",
+                "B": "",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Check distances prior resizing",
+                "label": "SfMDistances",
+                "color": "#7272be"
+            },
+            "outputs": {}
+        },
+        "SfMDistances_2": {
+            "nodeType": "SfMDistances",
+            "position": [
+                1212,
+                -81
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "94ff197121858e9bd8d6561d948b684051bb6a2f",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_1.output}",
+                "objectType": "landmarks",
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "A": "",
+                "B": "",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Check distances after resizing",
+                "label": "SfMDistances Check",
+                "color": "#7272be"
+            },
+            "outputs": {}
+        },
+        "SfMTransform_1": {
+            "nodeType": "SfMTransform",
+            "position": [
+                1001,
+                56
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "42e398d1dc18a1590f701504e963e6bd45a06c0a",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{StructureFromMotion_1.output}",
+                "method": "from_markers",
+                "lineUp": "",
+                "tracksFile": "",
+                "objectFile": "",
+                "transformation": "",
+                "manualTransform": {
+                    "manualTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualScale": 1.0
+                },
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "scale": 1.0,
+                "markers": [
+                    {
+                        "markerId": 0,
+                        "markerCoord": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        }
+                    },
+                    {
+                        "markerId": 1,
+                        "markerCoord": {
+                            "x": 2.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        }
+                    }
+                ],
+                "applyScale": true,
+                "applyRotation": true,
+                "applyTranslation": true,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Transform from CCTAG Markers. You need to know the real world distances and the placing of the markers. Use the SfMDistances result and your real world distances to calculate the values.",
+                "label": "SfMTransform CCTAG Sizing",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/sfm.abc",
+                "outputViewsAndPoses": "{nodeCacheFolder}/cameras.sfm"
+            }
+        },
+        "SfMTransform_2": {
+            "nodeType": "SfMTransform",
+            "position": [
+                1215,
+                53
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "22715ca250d3942f191840ac273ded4b9e0255ab",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_1.output}",
+                "method": "from_markers",
+                "lineUp": "",
+                "tracksFile": "",
+                "objectFile": "",
+                "transformation": "",
+                "manualTransform": {
+                    "manualTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualScale": 1.0
+                },
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "scale": 1.0,
+                "markers": [
+                    {
+                        "markerId": 0,
+                        "markerCoord": {
+                            "x": 1.0,
+                            "y": 0.0,
+                            "z": 1.0
+                        }
+                    },
+                    {
+                        "markerId": 1,
+                        "markerCoord": {
+                            "x": -1.0,
+                            "y": 0.0,
+                            "z": 1.0
+                        }
+                    },
+                    {
+                        "markerId": 4,
+                        "markerCoord": {
+                            "x": -1.0,
+                            "y": 0.0,
+                            "z": -1.0
+                        }
+                    }
+                ],
+                "applyScale": false,
+                "applyRotation": true,
+                "applyTranslation": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Apply orientation based on CCTAG markers",
+                "label": "SfMTransform from CCTAG",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/sfm.abc",
+                "outputViewsAndPoses": "{nodeCacheFolder}/cameras.sfm"
+            }
+        },
+        "StructureFromMotion_1": {
+            "nodeType": "StructureFromMotion",
+            "position": [
+                800,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "a9bcca0e7ec11b6942ddef74d6810614103c3e50",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}",
+                    "{FeatureMatching_2.output}"
+                ],
+                "describerTypes": [
+                    "dspsift",
+                    "cctag3"
+                ],
+                "localizerEstimator": "acransac",
+                "observationConstraint": "Scale",
+                "localizerEstimatorMaxIterations": 4096,
+                "localizerEstimatorError": 0.0,
+                "lockScenePreviouslyReconstructed": false,
+                "useLocalBA": true,
+                "localBAGraphDistance": 1,
+                "nbFirstUnstableCameras": 30,
+                "maxImagesPerGroup": 30,
+                "bundleAdjustmentMaxOutliers": 50,
+                "maxNumberOfMatches": 0,
+                "minNumberOfMatches": 0,
+                "minInputTrackLength": 2,
+                "minNumberOfObservationsForTriangulation": 2,
+                "minAngleForTriangulation": 3.0,
+                "minAngleForLandmark": 2.0,
+                "maxReprojectionError": 4.0,
+                "minAngleInitialPair": 5.0,
+                "maxAngleInitialPair": 40.0,
+                "useOnlyMatchesFromInputFolder": false,
+                "useRigConstraint": true,
+                "rigMinNbCamerasForCalibration": 20,
+                "lockAllIntrinsics": false,
+                "minNbCamerasToRefinePrincipalPoint": 3,
+                "filterTrackForks": false,
+                "computeStructureColor": true,
+                "useAutoTransform": true,
+                "initialPairA": "",
+                "initialPairB": "",
+                "interFileExtension": ".abc",
+                "logIntermediateSteps": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/sfm.abc",
+                "outputViewsAndPoses": "{nodeCacheFolder}/cameras.sfm",
+                "extraInfoFolder": "{nodeCacheFolder}"
+            }
+        },
+        "Texturing_1": {
+            "nodeType": "Texturing",
+            "position": [
+                2419,
+                -211
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "aa94cc81e26ad96352e61db905245ff7f2bfb70b",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "normalsFolder": "",
+                "inputMesh": "{Meshing_2.outputMesh}",
+                "inputRefMesh": "",
+                "textureSide": 8192,
+                "downscale": 2,
+                "outputMeshFileType": "obj",
+                "colorMapping": {
+                    "enable": true,
+                    "colorMappingFileType": "exr"
+                },
+                "bumpMapping": {
+                    "enable": true,
+                    "bumpType": "Normal",
+                    "normalFileType": "exr",
+                    "heightFileType": "exr"
+                },
+                "displacementMapping": {
+                    "enable": true,
+                    "displacementMappingFileType": "exr"
+                },
+                "unwrapMethod": "Basic",
+                "useUDIM": true,
+                "fillHoles": false,
+                "padding": 5,
+                "multiBandDownscale": 4,
+                "multiBandNbContrib": {
+                    "high": 1,
+                    "midHigh": 5,
+                    "midLow": 10,
+                    "low": 0
+                },
+                "useScore": true,
+                "bestScoreThreshold": 0.1,
+                "angleHardThreshold": 90.0,
+                "workingColorSpace": "sRGB",
+                "outputColorSpace": "AUTO",
+                "correctEV": false,
+                "forceVisibleByAllVertices": false,
+                "flipNormals": false,
+                "visibilityRemappingMethod": "PullPush",
+                "subdivisionTargetRatio": 0.8,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "outputMesh": "{nodeCacheFolder}/texturedMesh.{outputMeshFileTypeValue}",
+                "outputMaterial": "{nodeCacheFolder}/texturedMesh.mtl",
+                "outputTextures": "{nodeCacheFolder}/texture_*.exr"
+            }
+        },
+        "Texturing_2": {
+            "nodeType": "Texturing",
+            "position": [
+                2423,
+                21
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "cac0524af2721a3b8eababcaca0c71d424fb6ea3",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{Meshing_1.output}",
+                "imagesFolder": "{DepthMap_1.imagesFolder}",
+                "normalsFolder": "",
+                "inputMesh": "{MeshFiltering_1.outputMesh}",
+                "inputRefMesh": "",
+                "textureSide": 16384,
+                "downscale": 1,
+                "outputMeshFileType": "obj",
+                "colorMapping": {
+                    "enable": true,
+                    "colorMappingFileType": "exr"
+                },
+                "bumpMapping": {
+                    "enable": true,
+                    "bumpType": "Normal",
+                    "normalFileType": "exr",
+                    "heightFileType": "exr"
+                },
+                "displacementMapping": {
+                    "enable": true,
+                    "displacementMappingFileType": "exr"
+                },
+                "unwrapMethod": "Basic",
+                "useUDIM": true,
+                "fillHoles": false,
+                "padding": 5,
+                "multiBandDownscale": 4,
+                "multiBandNbContrib": {
+                    "high": 1,
+                    "midHigh": 5,
+                    "midLow": 10,
+                    "low": 0
+                },
+                "useScore": true,
+                "bestScoreThreshold": 0.1,
+                "angleHardThreshold": 90.0,
+                "workingColorSpace": "sRGB",
+                "outputColorSpace": "AUTO",
+                "correctEV": false,
+                "forceVisibleByAllVertices": false,
+                "flipNormals": false,
+                "visibilityRemappingMethod": "PullPush",
+                "subdivisionTargetRatio": 0.8,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "outputMesh": "{nodeCacheFolder}/texturedMesh.{outputMeshFileTypeValue}",
+                "outputMaterial": "{nodeCacheFolder}/texturedMesh.mtl",
+                "outputTextures": "{nodeCacheFolder}/texture_*.exr"
+            }
+        }
+    }
+}

--- a/meshroom/photogrammetry-cctag.mg
+++ b/meshroom/photogrammetry-cctag.mg
@@ -823,7 +823,7 @@
             },
             "internalInputs": {
                 "invalidation": "",
-                "comment": "",
+                "comment": "Apply orientation based on CCTAG markers",
                 "label": "SfMTransform from CCTAG",
                 "color": "#7272be"
             },
@@ -1046,4 +1046,5 @@
             }
         }
     }
+
 }

--- a/meshroom/photogrammetry-cctag.mg
+++ b/meshroom/photogrammetry-cctag.mg
@@ -1,0 +1,1049 @@
+{
+    "header": {
+        "releaseVersion": "2025.1.0",
+        "fileVersion": "2.0",
+        "nodesVersions": {
+            "CameraInit": "12.0",
+            "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ImageMatching": "2.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
+            "PrepareDenseScene": "3.1",
+            "SfMDistances": "3.0",
+            "SfMTransform": "3.1",
+            "StructureFromMotion": "3.3",
+            "Texturing": "6.0"
+        }
+    },
+    "graph": {
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                0,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "4c471e04d91d618d3dddf7990cb9b81c599a7700",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "viewpoints": [],
+                "intrinsics": [],
+                "sensorDatabase": "${ALICEVISION_SENSOR_DB}",
+                "lensCorrectionProfileInfo": "${ALICEVISION_LENS_PROFILE_INFO}",
+                "lensCorrectionProfileSearchIgnoreCameraModel": true,
+                "defaultFieldOfView": 45.0,
+                "groupCameraFallback": "folder",
+                "rawColorInterpretation": "LibRawWhiteBalancing",
+                "colorProfileDatabase": "${ALICEVISION_COLOR_PROFILE_DB}",
+                "errorOnMissingColorProfile": true,
+                "viewIdMethod": "metadata",
+                "viewIdRegex": ".*?(\\d+)",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/cameraInit.sfm"
+            }
+        },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [
+                1802,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 24,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "0f4a27ad54b8924d3621a8f1dbf6976ea94d7dfa",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}",
+                "minViewAngle": 2.0,
+                "maxViewAngle": 70.0,
+                "nNearestCams": 10,
+                "minNumOfConsistentCams": 3,
+                "minNumOfConsistentCamsWithLowSimilarity": 4,
+                "pixToleranceFactor": 2.0,
+                "pixSizeBall": 0,
+                "pixSizeBallWithLowSimilarity": 0,
+                "computeNormalMaps": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "depth": "{nodeCacheFolder}/<VIEW_ID>_depthMap.exr",
+                "sim": "{nodeCacheFolder}/<VIEW_ID>_simMap.exr",
+                "normal": "{nodeCacheFolder}/<VIEW_ID>_normalMap.exr"
+            }
+        },
+        "DepthMap_1": {
+            "nodeType": "DepthMap",
+            "position": [
+                1602,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 12,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "10634a6db8eba89f91312e328f19dc9347a8a7d6",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{PrepareDenseScene_1.input}",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "downscale": 1,
+                "minViewAngle": 2.0,
+                "maxViewAngle": 70.0,
+                "tiling": {
+                    "tileBufferWidth": 1024,
+                    "tileBufferHeight": 1024,
+                    "tilePadding": 64,
+                    "autoAdjustSmallImage": true
+                },
+                "chooseTCamsPerTile": true,
+                "maxTCams": 10,
+                "sgm": {
+                    "sgmScale": 2,
+                    "sgmStepXY": 2,
+                    "sgmStepZ": -1,
+                    "sgmMaxTCamsPerTile": 4,
+                    "sgmWSH": 4,
+                    "sgmUseSfmSeeds": true,
+                    "sgmSeedsRangeInflate": 0.2,
+                    "sgmDepthThicknessInflate": 0.0,
+                    "sgmMaxSimilarity": 1.0,
+                    "sgmGammaC": 5.5,
+                    "sgmGammaP": 8.0,
+                    "sgmP1": 10.0,
+                    "sgmP2Weighting": 100.0,
+                    "sgmMaxDepths": 1500,
+                    "sgmFilteringAxes": "YX",
+                    "sgmDepthListPerTile": true,
+                    "sgmUseConsistentScale": false
+                },
+                "refine": {
+                    "refineEnabled": true,
+                    "refineScale": 1,
+                    "refineStepXY": 1,
+                    "refineMaxTCamsPerTile": 4,
+                    "refineSubsampling": 10,
+                    "refineHalfNbDepths": 15,
+                    "refineWSH": 3,
+                    "refineSigma": 15.0,
+                    "refineGammaC": 15.5,
+                    "refineGammaP": 8.0,
+                    "refineInterpolateMiddleDepth": false,
+                    "refineUseConsistentScale": false
+                },
+                "colorOptimization": {
+                    "colorOptimizationEnabled": true,
+                    "colorOptimizationNbIterations": 100
+                },
+                "customPatchPattern": {
+                    "sgmUseCustomPatchPattern": false,
+                    "refineUseCustomPatchPattern": false,
+                    "customPatchPatternSubparts": [],
+                    "customPatchPatternGroupSubpartsPerLevel": false
+                },
+                "intermediateResults": {
+                    "exportIntermediateDepthSimMaps": false,
+                    "exportIntermediateNormalMaps": false,
+                    "exportIntermediateVolumes": false,
+                    "exportIntermediateCrossVolumes": false,
+                    "exportIntermediateTopographicCutVolumes": false,
+                    "exportIntermediateVolume9pCsv": false,
+                    "exportTilePattern": false
+                },
+                "nbGPUs": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "depth": "{nodeCacheFolder}/<VIEW_ID>_depthMap.exr",
+                "sim": "{nodeCacheFolder}/<VIEW_ID>_simMap.exr",
+                "tilePattern": "{nodeCacheFolder}/<VIEW_ID>_tilePattern.obj",
+                "depthSgm": "{nodeCacheFolder}/<VIEW_ID>_depthMap_sgm.exr",
+                "depthSgmUpscaled": "{nodeCacheFolder}/<VIEW_ID>_depthMap_sgmUpscaled.exr",
+                "depthRefined": "{nodeCacheFolder}/<VIEW_ID>_depthMap_refinedFused.exr"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                196,
+                -12
+            ],
+            "parallelization": {
+                "blockSize": 40,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "f58e11fcb1abe8b9cf65310d9a891dcae18b0efb",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "masksFolder": "",
+                "maskExtension": "png",
+                "maskInvert": false,
+                "describerTypes": [
+                    "dspsift",
+                    "cctag3"
+                ],
+                "describerPreset": "high",
+                "maxNbFeatures": 0,
+                "describerQuality": "high",
+                "contrastFiltering": "GridSort",
+                "relativePeakThreshold": 0.01,
+                "gridFiltering": true,
+                "workingColorSpace": "sRGB",
+                "forceCpuExtraction": false,
+                "maxThreads": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "CCTAG3 and DSPSIFT Feature Extraction.",
+                "label": "",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 20,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "5f6f7e8c329b1757cd4cc821b7456423196c5f5b",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": [
+                    "dspsift"
+                ],
+                "photometricMatchingMethod": "ANN_L2",
+                "geometricEstimator": "acransac",
+                "geometricFilterType": "fundamental_matrix",
+                "distanceRatio": 0.8,
+                "maxIteration": 2048,
+                "geometricError": 0.0,
+                "knownPosesGeometricErrorMax": 5.0,
+                "minRequired2DMotion": -1.0,
+                "maxMatches": 0,
+                "savePutativeMatches": false,
+                "crossMatching": false,
+                "guidedMatching": false,
+                "matchFromKnownCameraPoses": false,
+                "exportDebugFiles": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                -166
+            ],
+            "parallelization": {
+                "blockSize": 20,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "4c7eea1ef03ffc3410680e75991698e5d6405625",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": [
+                    "cctag3"
+                ],
+                "photometricMatchingMethod": "ANN_L2",
+                "geometricEstimator": "acransac",
+                "geometricFilterType": "no_filtering",
+                "distanceRatio": 0.8,
+                "maxIteration": 2048,
+                "geometricError": 0.0,
+                "knownPosesGeometricErrorMax": 5.0,
+                "minRequired2DMotion": -1.0,
+                "maxMatches": 0,
+                "savePutativeMatches": false,
+                "crossMatching": false,
+                "guidedMatching": false,
+                "matchFromKnownCameraPoses": false,
+                "exportDebugFiles": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Only CCTAG Feature Matching",
+                "label": "FeatureMatching CCTAG",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "1e34202440440d73c1b5f1a2b1e6a326c365eb5f",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "SequentialAndVocabularyTree",
+                "tree": "${ALICEVISION_VOCTREE}",
+                "weights": "",
+                "minNbImages": 200,
+                "maxDescriptors": 500,
+                "nbMatches": 40,
+                "nbNeighbors": 5,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/imageMatches.txt"
+            }
+        },
+        "MeshFiltering_1": {
+            "nodeType": "MeshFiltering",
+            "position": [
+                2202,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "82bc3987ba557ea7da33a1d47e043ce61608cd7a",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "inputMesh": "{Meshing_1.outputMesh}",
+                "outputMeshFileType": "obj",
+                "keepLargestMeshOnly": false,
+                "smoothingSubset": "all",
+                "smoothingBoundariesNeighbours": 0,
+                "smoothingIterations": 5,
+                "smoothingLambda": 1.0,
+                "filteringSubset": "all",
+                "filteringIterations": 1,
+                "filterLargeTrianglesFactor": 60.0,
+                "filterTrianglesRatio": 0.0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "outputMesh": "{nodeCacheFolder}/mesh.{outputMeshFileTypeValue}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [
+                2002,
+                26
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "4c625aeaa2b5ccda85100ac178a814943a979f64",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}",
+                "outputMeshFileType": "obj",
+                "useBoundingBox": false,
+                "boundingBox": {
+                    "bboxTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxScale": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    }
+                },
+                "estimateSpaceFromSfM": true,
+                "estimateSpaceMinObservations": 3,
+                "estimateSpaceMinObservationAngle": 10.0,
+                "maxInputPoints": 50000000,
+                "maxPoints": 5000000,
+                "maxPointsPerVoxel": 1000000,
+                "minStep": 2,
+                "partitioning": "singleBlock",
+                "repartition": "multiResolution",
+                "angleFactor": 15.0,
+                "simFactor": 15.0,
+                "minVis": 2,
+                "pixSizeMarginInitCoef": 2.0,
+                "pixSizeMarginFinalCoef": 4.0,
+                "voteMarginFactor": 4.0,
+                "contributeMarginFactor": 2.0,
+                "simGaussianSizeInit": 10.0,
+                "simGaussianSize": 10.0,
+                "minAngleThreshold": 1.0,
+                "refineFuse": true,
+                "helperPointsGridSize": 10,
+                "densify": false,
+                "densifyNbFront": 1,
+                "densifyNbBack": 1,
+                "densifyScale": 20.0,
+                "nPixelSizeBehind": 4.0,
+                "fullWeight": 1.0,
+                "voteFilteringForWeaklySupportedSurfaces": true,
+                "addLandmarksToTheDensePointCloud": false,
+                "invertTetrahedronBasedOnNeighborsNbIterations": 10,
+                "minSolidAngleRatio": 0.2,
+                "nbSolidAngleFilteringIterations": 2,
+                "colorizeOutput": false,
+                "addMaskHelperPoints": false,
+                "maskHelperPointsWeight": 1.0,
+                "maskBorderSize": 4,
+                "maxNbConnectedHelperPoints": 50,
+                "saveRawDensePointCloud": false,
+                "exportDebugTetrahedralization": false,
+                "seed": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "outputMesh": "{nodeCacheFolder}/mesh.{outputMeshFileTypeValue}",
+                "output": "{nodeCacheFolder}/densePointCloud.abc"
+            }
+        },
+        "Meshing_2": {
+            "nodeType": "Meshing",
+            "position": [
+                1602,
+                -134
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "338c8fc98e8c752fad3ef587b0b780b491bf81bc",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_2.output}",
+                "depthMapsFolder": "",
+                "outputMeshFileType": "obj",
+                "useBoundingBox": false,
+                "boundingBox": {
+                    "bboxTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "bboxScale": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    }
+                },
+                "estimateSpaceFromSfM": true,
+                "estimateSpaceMinObservations": 3,
+                "estimateSpaceMinObservationAngle": 10.0,
+                "maxInputPoints": 50000000,
+                "maxPoints": 5000000,
+                "maxPointsPerVoxel": 1000000,
+                "minStep": 2,
+                "partitioning": "singleBlock",
+                "repartition": "multiResolution",
+                "angleFactor": 15.0,
+                "simFactor": 15.0,
+                "minVis": 2,
+                "pixSizeMarginInitCoef": 2.0,
+                "pixSizeMarginFinalCoef": 4.0,
+                "voteMarginFactor": 4.0,
+                "contributeMarginFactor": 2.0,
+                "simGaussianSizeInit": 10.0,
+                "simGaussianSize": 10.0,
+                "minAngleThreshold": 1.0,
+                "refineFuse": true,
+                "helperPointsGridSize": 10,
+                "densify": false,
+                "densifyNbFront": 1,
+                "densifyNbBack": 1,
+                "densifyScale": 20.0,
+                "nPixelSizeBehind": 4.0,
+                "fullWeight": 1.0,
+                "voteFilteringForWeaklySupportedSurfaces": true,
+                "addLandmarksToTheDensePointCloud": false,
+                "invertTetrahedronBasedOnNeighborsNbIterations": 10,
+                "minSolidAngleRatio": 0.2,
+                "nbSolidAngleFilteringIterations": 2,
+                "colorizeOutput": false,
+                "addMaskHelperPoints": false,
+                "maskHelperPointsWeight": 1.0,
+                "maskBorderSize": 4,
+                "maxNbConnectedHelperPoints": 50,
+                "saveRawDensePointCloud": false,
+                "exportDebugTetrahedralization": false,
+                "seed": 0,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Draft to preview intermediate results",
+                "label": "Meshing Draft",
+                "color": ""
+            },
+            "outputs": {
+                "outputMesh": "{nodeCacheFolder}/mesh.{outputMeshFileTypeValue}",
+                "output": "{nodeCacheFolder}/densePointCloud.abc"
+            }
+        },
+        "PrepareDenseScene_1": {
+            "nodeType": "PrepareDenseScene",
+            "position": [
+                1405,
+                21
+            ],
+            "parallelization": {
+                "blockSize": 40,
+                "size": 0,
+                "split": 0
+            },
+            "uid": "4367a90c82785367a16fda9624c286dc5d1201b4",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_2.output}",
+                "imagesFolders": [],
+                "masksFolders": [
+                    "",
+                    ""
+                ],
+                "maskExtension": "png",
+                "outputFileType": "exr",
+                "saveMetadata": true,
+                "saveMatricesTxtFiles": false,
+                "evCorrection": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "undistorted": "{nodeCacheFolder}/<VIEW_ID>.{outputFileTypeValue}"
+            }
+        },
+        "SfMDistances_1": {
+            "nodeType": "SfMDistances",
+            "position": [
+                998,
+                -80
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "15bc70ca402008affdd512e720bca18b03da9e55",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{StructureFromMotion_1.output}",
+                "objectType": "landmarks",
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "A": "",
+                "B": "",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Check distances prior resizing",
+                "label": "SfMDistances",
+                "color": "#7272be"
+            },
+            "outputs": {}
+        },
+        "SfMDistances_2": {
+            "nodeType": "SfMDistances",
+            "position": [
+                1212,
+                -81
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "94ff197121858e9bd8d6561d948b684051bb6a2f",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_1.output}",
+                "objectType": "landmarks",
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "A": "",
+                "B": "",
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Check distances after resizing",
+                "label": "SfMDistances Check",
+                "color": "#7272be"
+            },
+            "outputs": {}
+        },
+        "SfMTransform_1": {
+            "nodeType": "SfMTransform",
+            "position": [
+                1001,
+                56
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "42e398d1dc18a1590f701504e963e6bd45a06c0a",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{StructureFromMotion_1.output}",
+                "method": "from_markers",
+                "lineUp": "",
+                "tracksFile": "",
+                "objectFile": "",
+                "transformation": "",
+                "manualTransform": {
+                    "manualTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualScale": 1.0
+                },
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "scale": 1.0,
+                "markers": [
+                    {
+                        "markerId": 0,
+                        "markerCoord": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        }
+                    },
+                    {
+                        "markerId": 1,
+                        "markerCoord": {
+                            "x": 2.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        }
+                    }
+                ],
+                "applyScale": true,
+                "applyRotation": true,
+                "applyTranslation": true,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "Transform from CCTAG Markers. You need to know the real world distances and the placing of the markers. Use the SfMDistances result and your real world distances to calculate the values.",
+                "label": "SfMTransform CCTAG Sizing",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/sfm.abc",
+                "outputViewsAndPoses": "{nodeCacheFolder}/cameras.sfm"
+            }
+        },
+        "SfMTransform_2": {
+            "nodeType": "SfMTransform",
+            "position": [
+                1215,
+                53
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "22715ca250d3942f191840ac273ded4b9e0255ab",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{SfMTransform_1.output}",
+                "method": "from_markers",
+                "lineUp": "",
+                "tracksFile": "",
+                "objectFile": "",
+                "transformation": "",
+                "manualTransform": {
+                    "manualTranslation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualRotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "manualScale": 1.0
+                },
+                "landmarksDescriberTypes": [
+                    "cctag3"
+                ],
+                "scale": 1.0,
+                "markers": [
+                    {
+                        "markerId": 0,
+                        "markerCoord": {
+                            "x": 1.0,
+                            "y": 0.0,
+                            "z": 1.0
+                        }
+                    },
+                    {
+                        "markerId": 1,
+                        "markerCoord": {
+                            "x": -1.0,
+                            "y": 0.0,
+                            "z": 1.0
+                        }
+                    },
+                    {
+                        "markerId": 4,
+                        "markerCoord": {
+                            "x": -1.0,
+                            "y": 0.0,
+                            "z": -1.0
+                        }
+                    }
+                ],
+                "applyScale": false,
+                "applyRotation": true,
+                "applyTranslation": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "SfMTransform from CCTAG",
+                "color": "#7272be"
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/sfm.abc",
+                "outputViewsAndPoses": "{nodeCacheFolder}/cameras.sfm"
+            }
+        },
+        "StructureFromMotion_1": {
+            "nodeType": "StructureFromMotion",
+            "position": [
+                800,
+                0
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 0,
+                "split": 1
+            },
+            "uid": "a9bcca0e7ec11b6942ddef74d6810614103c3e50",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}",
+                    "{FeatureMatching_2.output}"
+                ],
+                "describerTypes": [
+                    "dspsift",
+                    "cctag3"
+                ],
+                "localizerEstimator": "acransac",
+                "observationConstraint": "Scale",
+                "localizerEstimatorMaxIterations": 4096,
+                "localizerEstimatorError": 0.0,
+                "lockScenePreviouslyReconstructed": false,
+                "useLocalBA": true,
+                "localBAGraphDistance": 1,
+                "nbFirstUnstableCameras": 30,
+                "maxImagesPerGroup": 30,
+                "bundleAdjustmentMaxOutliers": 50,
+                "maxNumberOfMatches": 0,
+                "minNumberOfMatches": 0,
+                "minInputTrackLength": 2,
+                "minNumberOfObservationsForTriangulation": 2,
+                "minAngleForTriangulation": 3.0,
+                "minAngleForLandmark": 2.0,
+                "maxReprojectionError": 4.0,
+                "minAngleInitialPair": 5.0,
+                "maxAngleInitialPair": 40.0,
+                "useOnlyMatchesFromInputFolder": false,
+                "useRigConstraint": true,
+                "rigMinNbCamerasForCalibration": 20,
+                "lockAllIntrinsics": false,
+                "minNbCamerasToRefinePrincipalPoint": 3,
+                "filterTrackForks": false,
+                "computeStructureColor": true,
+                "useAutoTransform": true,
+                "initialPairA": "",
+                "initialPairB": "",
+                "interFileExtension": ".abc",
+                "logIntermediateSteps": false,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}/sfm.abc",
+                "outputViewsAndPoses": "{nodeCacheFolder}/cameras.sfm",
+                "extraInfoFolder": "{nodeCacheFolder}"
+            }
+        },
+        "Texturing_1": {
+            "nodeType": "Texturing",
+            "position": [
+                2419,
+                -211
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "61e29a418ba65ee287fb70080c4250d36a853111",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "",
+                "imagesFolder": "{PrepareDenseScene_1.output}",
+                "normalsFolder": "",
+                "inputMesh": "{Meshing_2.outputMesh}",
+                "inputRefMesh": "",
+                "textureSide": 8192,
+                "downscale": 2,
+                "outputMeshFileType": "obj",
+                "colorMapping": {
+                    "enable": true,
+                    "colorMappingFileType": "exr"
+                },
+                "bumpMapping": {
+                    "enable": true,
+                    "bumpType": "Normal",
+                    "normalFileType": "exr",
+                    "heightFileType": "exr"
+                },
+                "displacementMapping": {
+                    "enable": true,
+                    "displacementMappingFileType": "exr"
+                },
+                "unwrapMethod": "Basic",
+                "useUDIM": true,
+                "fillHoles": false,
+                "padding": 5,
+                "multiBandDownscale": 4,
+                "multiBandNbContrib": {
+                    "high": 1,
+                    "midHigh": 5,
+                    "midLow": 10,
+                    "low": 0
+                },
+                "useScore": true,
+                "bestScoreThreshold": 0.1,
+                "angleHardThreshold": 90.0,
+                "workingColorSpace": "sRGB",
+                "outputColorSpace": "AUTO",
+                "correctEV": false,
+                "forceVisibleByAllVertices": false,
+                "flipNormals": false,
+                "visibilityRemappingMethod": "PullPush",
+                "subdivisionTargetRatio": 0.8,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "outputMesh": "{nodeCacheFolder}/texturedMesh.{outputMeshFileTypeValue}",
+                "outputMaterial": "{nodeCacheFolder}/texturedMesh.mtl",
+                "outputTextures": "{nodeCacheFolder}/texture_*.exr"
+            }
+        },
+        "Texturing_2": {
+            "nodeType": "Texturing",
+            "position": [
+                2423,
+                21
+            ],
+            "parallelization": {
+                "blockSize": 0,
+                "size": 1,
+                "split": 1
+            },
+            "uid": "2bc047bb37396c5508e29c76c79d27e6078ea403",
+            "internalFolder": "{cache}/{nodeType}/{uid}",
+            "inputs": {
+                "input": "{Meshing_1.output}",
+                "imagesFolder": "{DepthMap_1.imagesFolder}",
+                "normalsFolder": "",
+                "inputMesh": "{MeshFiltering_1.outputMesh}",
+                "inputRefMesh": "",
+                "textureSide": 16384,
+                "downscale": 1,
+                "outputMeshFileType": "obj",
+                "colorMapping": {
+                    "enable": true,
+                    "colorMappingFileType": "exr"
+                },
+                "bumpMapping": {
+                    "enable": true,
+                    "bumpType": "Normal",
+                    "normalFileType": "exr",
+                    "heightFileType": "exr"
+                },
+                "displacementMapping": {
+                    "enable": true,
+                    "displacementMappingFileType": "exr"
+                },
+                "unwrapMethod": "Basic",
+                "useUDIM": true,
+                "fillHoles": false,
+                "padding": 5,
+                "multiBandDownscale": 4,
+                "multiBandNbContrib": {
+                    "high": 1,
+                    "midHigh": 5,
+                    "midLow": 10,
+                    "low": 0
+                },
+                "useScore": true,
+                "bestScoreThreshold": 0.1,
+                "angleHardThreshold": 90.0,
+                "workingColorSpace": "sRGB",
+                "outputColorSpace": "AUTO",
+                "correctEV": false,
+                "forceVisibleByAllVertices": false,
+                "flipNormals": false,
+                "visibilityRemappingMethod": "PullPush",
+                "subdivisionTargetRatio": 0.8,
+                "verboseLevel": "info"
+            },
+            "internalInputs": {
+                "invalidation": "",
+                "comment": "",
+                "label": "",
+                "color": ""
+            },
+            "outputs": {
+                "output": "{nodeCacheFolder}",
+                "outputMesh": "{nodeCacheFolder}/texturedMesh.{outputMeshFileTypeValue}",
+                "outputMaterial": "{nodeCacheFolder}/texturedMesh.mtl",
+                "outputTextures": "{nodeCacheFolder}/texture_*.exr"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description

Photogrammetry CCTAG scaling and orientation - default pipeline (with draft meshing for quick validation)

<img width="1421" height="364" alt="grafik" src="https://github.com/user-attachments/assets/413dfa3c-8a1e-4fca-927d-e4db602d234c" />

Photogrammetry Object with CCTAG scaling and orientation (with draft meshing for quick validation)

<img width="1426" height="381" alt="grafik" src="https://github.com/user-attachments/assets/4da74630-de93-4018-b56d-6fc2cb4d6885" />


