### PR TITLE
set camera frame rate in exportAnimatedCamera

### DIFF
--- a/meshroom/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/aliceVision/ExportAnimatedCamera.py
@@ -69,6 +69,13 @@ Based on the input image filenames, it will recognize the input video sequence t
             description="Correct principal point.",
             value=False,
         ),
+        desc.FloatParam(
+            name="frameRate",
+            label="Camera Frame Rate",
+            description="Define the camera's Frames per seconds.",
+            value=24.0,
+            range=(1.0, 60.0, 1.0),
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -673,11 +673,11 @@ void AlembicExporter::addCamera(const std::string& name,
     _dataImpl->addCamera(name, view, pose, intrinsic, uncertainty);
 }
 
-void AlembicExporter::initAnimatedCamera(const std::string& cameraName, std::size_t startFrame)
+void AlembicExporter::initAnimatedCamera(const std::string& cameraName, std::size_t startFrame, double frameRate)
 {
     // Sample the time in order to have one keyframe every frame
     // nb: it HAS TO be attached to EACH keyframed properties
-    TimeSamplingPtr tsp(new TimeSampling(1.0 / 24.0, startFrame / 24.0));
+    TimeSamplingPtr tsp(new TimeSampling(1.0 / frameRate, startFrame / frameRate));
 
     // Create the camera transform object
     std::stringstream ss;

--- a/src/aliceVision/sfmDataIO/AlembicExporter.hpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.hpp
@@ -102,7 +102,7 @@ class AlembicExporter
      * @brief Initiate an animated camera
      * @param[in] name The camera identifier
      */
-    void initAnimatedCamera(const std::string& name, std::size_t startFrame = 1);
+    void initAnimatedCamera(const std::string& name, std::size_t startFrame = 1, double frameRate = 24.0);
 
     /**
      * @brief Register keyframe on the previous values

--- a/src/software/export/main_exportAnimatedCamera.cpp
+++ b/src/software/export/main_exportAnimatedCamera.cpp
@@ -108,6 +108,7 @@ int aliceVision_main(int argc, char** argv)
     std::string sfmDataFilterFilepath;
     std::string outImageFileTypeName = image::EImageFileType_enumToString(image::EImageFileType::JPEG);
     std::string outMapFileTypeName = image::EImageFileType_enumToString(image::EImageFileType::EXR);
+    double frameRate = 24.0;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -133,7 +134,9 @@ int aliceVision_main(int argc, char** argv)
         ("sfmDataFilter", po::value<std::string>(&sfmDataFilterFilepath)->default_value(sfmDataFilterFilepath),
          "Filter out cameras from the export if they are part of this SfMData. Export all cameras if empty.")
         ("undistortedImageType", po::value<std::string>(&outImageFileTypeName)->default_value(outImageFileTypeName),
-         image::EImageFileType_informations().c_str());
+         image::EImageFileType_informations().c_str())
+         ("frameRate", po::value<double>(&frameRate)->default_value(frameRate),
+         "Define the camera's Frames per seconds.");
     // clang-format on
 
     CmdLine cmdline("AliceVision exportAnimatedCamera");
@@ -443,7 +446,7 @@ int aliceVision_main(int argc, char** argv)
         const std::map<std::size_t, IndexT>& frameToView = cameraViews.second;
         const std::size_t firstFrame = cameraViews.second.begin()->first;
 
-        exporter.initAnimatedCamera(cameraViews.first, firstFrame);
+        exporter.initAnimatedCamera(cameraViews.first, firstFrame, frameRate);
 
         for (std::size_t frame = firstFrame; frame <= frameToView.rbegin()->first; ++frame)
         {


### PR DESCRIPTION
This pull request introduces support for specifying the camera frame rate when exporting animated cameras. The changes add a new `frameRate` parameter to both the command-line interface and internal methods, allowing users to define the number of frames per second for camera animation exports.

### Animated Camera Export Improvements

* Added a `frameRate` parameter to the `ExportAnimatedCamera` node, allowing users to define the camera's frames per second via the UI.
* Updated the `initAnimatedCamera` method in `AlembicExporter` to accept a `frameRate` argument, and adjusted the time sampling logic to use the specified frame rate instead of a fixed value.
* Added a `frameRate` variable to the main export tool and exposed it as a command-line option, enabling users to set the frame rate when running the export tool.
* Modified the call to `initAnimatedCamera` in the export tool to pass the user-defined `frameRate` value, ensuring the exported animation uses the correct timing.