### PR TITLE
Update oiioParams binding

### DIFF
--- a/pyTests/image/test_imageIO.py
+++ b/pyTests/image/test_imageIO.py
@@ -8,11 +8,11 @@ import os
 from pyalicevision import image as img
 import numpy as np
 
-def loop(image, orientation : int = 1, pixelAspectRatio : float = 1.0, compression : str = "zips"):
+def loop(image, orientation : int = 1, pixelAspectRatio : float = 1.0, compression : str = "zips", name : str = "name", value : str = "value"):
     """
     Tests the integrity of an image I/O process by writing the image to disk, reading it back, and verifying that the output is identical to the original input.
     Raises:
-        AssertionError: If the image read from disk does not match the original input.
+        AssertionError: If the image or the metadata read from disk does not match the original inputs.
     """
     array1 = image.getNumpyArray()
 
@@ -22,6 +22,8 @@ def loop(image, orientation : int = 1, pixelAspectRatio : float = 1.0, compressi
     optWrite = img.ImageWriteOptions()
     optWrite.toColorSpace(img.EImageColorSpace_NO_CONVERSION)
     oiio_params = img.oiioParams(orientation, pixelAspectRatio, compression)
+    oiio_params.add(name, value)
+
     img.writeImage(new_path, image, optWrite, oiio_params.get())
 
     #read it back from file
@@ -29,9 +31,20 @@ def loop(image, orientation : int = 1, pixelAspectRatio : float = 1.0, compressi
     img.readImage(new_path, other_image, optRead)
     array2 = other_image.getNumpyArray()
 
+    metadata = img.readImageMetadataAsMap(new_path)
+    pixelAspectRatio2 = float(metadata['PixelAspectRatio']) if 'PixelAspectRatio' in metadata else -1.0
+    orientation2 = int(metadata['Orientation']) if 'Orientation' in metadata else -1
+    compression2 = metadata['compression'] if 'compression' in metadata else "missing"
+    value2 = metadata[name]
+
+    info2 = [pixelAspectRatio2, orientation2, compression2, value2]
+    # In case of existing 'compression' metadata but set as an empty string, oiio set 'zips' as default compression value
+    info1 = [pixelAspectRatio, orientation, compression if len(compression)>0 else 'zips', value]
+
     os.remove(new_path)
 
     assert np.array_equal(array1, array2), "images should be equal"
+    assert np.array_equal(info1, info2), "metadata should exist and be equal"
 
 def test_default_constructor():
 
@@ -48,6 +61,11 @@ def test_default_constructor():
     image = img.Image_RGBColor()
     image.fromNumpyArray(src)
     loop(image, orientation=3, pixelAspectRatio=2.0, compression="")
+
+    src = np.random.randint(0, 255, size=(256, 256, 3), dtype='uint8')
+    image = img.Image_RGBColor()
+    image.fromNumpyArray(src)
+    loop(image, orientation=3, pixelAspectRatio=2.0, compression="zips", name="metaName", value="metaValue")
 
     image = img.Image_RGBfColor()
     image.fromNumpyArray(np.float32(src))

--- a/src/aliceVision/image/image.i
+++ b/src/aliceVision/image/image.i
@@ -173,6 +173,14 @@ class oiioParams
         return _myParamList;
     }
 
+    void add(const std::string & name, const std::string & value)
+    {
+        if (name != "" && value != "")
+        {
+            _myParamList[name] = value;
+        }
+    }
+
     private:
 
     oiio::ParamValueList _myParamList;
@@ -187,6 +195,7 @@ class oiioParams
     oiioParams(int orientation, float pixelAspectRatio, std::string compression = "");
 
     const oiio::ParamValueList & get();
+    void add(std::string name, std::string value);
 
     private:
 

--- a/src/aliceVision/image/image.i
+++ b/src/aliceVision/image/image.i
@@ -153,6 +153,11 @@ int NumPyType<image::RGBColor>()
 }
 
 %{
+std::map<std::string, std::string> readImageMetadataAsMap(const std::string& path)
+{
+    return(getMapFromMetadata(readImageMetadata(path)));
+}
+
 class oiioParams
 {
     public:
@@ -167,6 +172,7 @@ class oiioParams
             _myParamList["compression"] = compression;
         }
     }
+    ~oiioParams() {}
 
     const oiio::ParamValueList & get()
     {
@@ -187,12 +193,15 @@ class oiioParams
 };
 
 %}
+std::map<std::string, std::string> readImageMetadataAsMap(const std::string& path);
+
 class oiioParams
 {
     public:
 
     oiioParams();
     oiioParams(int orientation, float pixelAspectRatio, std::string compression = "");
+    ~oiioParams();
 
     const oiio::ParamValueList & get();
     void add(std::string name, std::string value);


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description

This PR updates the image binding by adding a method "add" to the oiioParams object.

Up to now, only orientation, pixel aspect ratio and compression was set through the binding of oiioParams. The new "add" method enables adding any other string metadata.

This is very useful when saving an image with new metadata that must be embedded.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

