### PR TITLE
Improve lie algebra precision

### DIFF
--- a/src/aliceVision/geometry/CMakeLists.txt
+++ b/src/aliceVision/geometry/CMakeLists.txt
@@ -27,6 +27,7 @@ alicevision_add_library(aliceVision_geometry
 # Unit tests
 alicevision_add_test(rigidTransformation3D_test.cpp NAME "geometry_rigidTransformation3D" LINKS aliceVision_geometry)
 alicevision_add_test(halfSpaceIntersection_test.cpp NAME "geometry_halfSpaceIntersection" LINKS aliceVision_geometry)
+alicevision_add_test(lie_test.cpp NAME "geometry_lie" LINKS aliceVision_geometry)
 alicevision_add_test(Pose3d_test.cpp NAME "geometry_pose3D" LINKS aliceVision_geometry)
 alicevision_add_test(frustumIntersection_test.cpp
     NAME "geometry_frustumIntersection"

--- a/src/aliceVision/geometry/lie.hpp
+++ b/src/aliceVision/geometry/lie.hpp
@@ -104,9 +104,16 @@ inline Eigen::Vector3d logm(const Eigen::Matrix3d& R)
         costheta = 1.0;
     }
 
-    if (1.0 - costheta < 1e-24)
+    const double sintheta2 = (3.0 - R.trace()) * (1.0 + R.trace());
+
+    // For theta close to 0 (i.e. sin²(theta) close to 0), we do the approximation: sin(theta) ~ theta
+    // i.e. in the general case formula: scale ~ 0.5
+    // We check for cos(theta) > 0, as sin(theta) = 0 also for theta = pi
+    if (costheta > 0 && sintheta2 < 1e-12)
     {
-        ret.fill(0);
+        ret(0) = .5 * p1;
+        ret(1) = .5 * p2;
+        ret(2) = .5 * p3;
         return ret;
     }
 

--- a/src/aliceVision/geometry/lie.hpp
+++ b/src/aliceVision/geometry/lie.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <aliceVision/numeric/numeric.hpp>
 
 namespace aliceVision {
 
@@ -110,6 +111,38 @@ inline Eigen::Vector3d logm(const Eigen::Matrix3d& R)
     }
 
     const double theta = acos(costheta);
+
+    // For theta close to pi (i.e. cos(theta) close to 1), we use a specific formula to avoid numerical issues
+    // (However this formula is slightly less acccurate for random theta values,
+    //  and would exhibit numerical issues for theta values close to 0)
+    if (1.0 + costheta < 1e-6)
+    {
+        Eigen::Matrix3d S = R + R.transpose() + (1.0 - R.trace()) * Eigen::Matrix3d::Identity();
+
+        Eigen::Vector3d signs;
+        // Use the sign of the biggest absolute values to define the rotation axis direction (its global sign)
+        if ( abs(p1) >= abs(p2) && abs(p1) >= abs(p3) )
+        {
+            signs << SIGN(p1), SIGN(p1) * SIGN(S(1, 0)), SIGN(p1) * SIGN(S(2, 0));
+        }
+        else if ( abs(p2) >= abs(p1) && abs(p2) >= abs(p3) )
+        {
+            signs << SIGN(p2) * SIGN(S(0, 1)), SIGN(p2), SIGN(p2) * SIGN(S(2, 1));
+        }
+        else
+        {
+            signs << SIGN(p3) * SIGN(S(0, 2)), SIGN(p3) * SIGN(S(1, 2)), SIGN(p3);
+        }
+
+        Eigen::Vector3d Sdiag = S.diagonal() / (3.0 - R.trace());
+
+        ret(0) = Sdiag(0) > 0. ? signs(0) * theta * sqrt(Sdiag(0)) : 0.;
+        ret(1) = Sdiag(1) > 0. ? signs(1) * theta * sqrt(Sdiag(1)) : 0.;
+        ret(2) = Sdiag(2) > 0. ? signs(2) * theta * sqrt(Sdiag(2)) : 0.;
+
+        return ret;
+    }
+
     const double scale = theta / (2.0 * sin(theta));
 
     ret(0) = scale * p1;

--- a/src/aliceVision/geometry/lie_test.cpp
+++ b/src/aliceVision/geometry/lie_test.cpp
@@ -1,0 +1,119 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE lie
+
+//#include <aliceVision/types.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/geometry/lie.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+#include <aliceVision/unitTest.hpp>
+
+
+BOOST_AUTO_TEST_CASE(PoseFilter_lie_conversions)
+{
+    // Check lie algebra
+
+    using namespace Eigen;
+    using namespace indexing;
+    using namespace aliceVision::SO3;
+
+    // Rotation axes generated from points on a regular grid
+    std::vector<Vector3d> rotationAxes;
+    rotationAxes.reserve(728);
+    for (int x=-4; x<=4; x++)
+    for (int y=-4; y<=4; y++)
+    for (int z=-4; z<=4; z++)
+    {
+        if (x==0 && y==0 && z==0)
+        {
+            continue;
+        }
+        rotationAxes.push_back(Vector3d(x, y, z).normalized());
+    }
+
+    // Test modes:
+    // 0: rotation angles in ]0, 0.2*Pi[ and rotation axes generated from points on a regular grid
+    // 1: rotation angles in ]0, 0.2*Pi[ and random rotation axes
+    // 2: rotation angles in ]0.1*Pi, Pi[ and rotation axes generated from points on a regular grid
+    // 3: rotation angles in ]0.1*Pi, Pi[ and random rotation axes
+    for (int testMode=0; testMode<4; testMode++)
+    {
+      // only used for statistics
+      std::vector<long> histo(64, 0);
+      std::vector<double> errorSo3(64, 0);
+      std::vector<double> errorMatrix(64, 0);
+
+      for (const Vector3d& rotAxis : rotationAxes)
+      {
+        // The rotation angles are randomly sampled, so that their distribution is roughly logarithmically uniform around 0 and around pi
+        for (double scaleIter=1.; scaleIter > 1e-13; scaleIter *= .125)
+        {
+            double maxErrorSo3 = 0.;
+            double maxErrorMatrix = 0.;
+
+            for (int mainIter=0; mainIter < 100; mainIter++)
+            {
+                bool checkMinNumLimit = scaleIter==1. && mainIter == 0;
+
+                double rnd = checkMinNumLimit ? std::numeric_limits<double>::min() : abs(VectorXd::Random(1)(0));
+
+                // logIndex is only used for statistics
+                int logIndex = checkMinNumLimit ? 63 : round(-log(abs(rnd * scaleIter)));
+                histo.at(logIndex)++;
+
+                Vector3d rotationAxis = (testMode&1) ? Vector3d::Random().normalized() : rotAxis;
+
+                double angle2d = (testMode < 2) ? rnd * .2 * M_PI * scaleIter : M_PI - rnd * .9 * M_PI * scaleIter; // ]0, 0.2*Pi[ and ]0.1*Pi, Pi[
+
+                AngleAxis<double> aa(angle2d, rotationAxis);
+                Matrix3d rotation = aa.toRotationMatrix();
+
+                Vector3d so3 = logm(rotation);
+
+                double error = Array3d(so3 - (angle2d * rotationAxis)).abs().maxCoeff();
+                if ( error > errorSo3.at(logIndex) )
+                {
+                    errorSo3.at(logIndex) = error;
+                }
+                if ( error > maxErrorSo3 )
+                {
+                    maxErrorSo3 = error;
+                }
+
+                aa.fromRotationMatrix(rotation);
+                Matrix3d mat3 = expm(aa.angle()*aa.axis());
+
+                error = Array33d(mat3 - rotation).abs().maxCoeff();
+                if ( error > errorMatrix.at(logIndex) )
+                {
+                    errorMatrix.at(logIndex) = error;
+                }
+                if ( error > maxErrorMatrix )
+                {
+                    maxErrorMatrix = error;
+                }
+            }
+            // With the current lie algebra implementation, errors are bigger around pi
+            BOOST_CHECK_SMALL(maxErrorSo3, testMode < 2 ? 1e-15 : 1e-7);
+            BOOST_CHECK_SMALL(maxErrorMatrix, testMode < 2 ? 1e-15 : 3e-15);
+        }
+      }
+
+      for (int histIdx=0; histIdx<64; histIdx++)
+      {
+          if (histo[histIdx] == 0)
+          {
+              continue;
+          }
+          ALICEVISION_LOG_DEBUG(" logarithmic bin: " << histIdx <<
+                                " size: " << histo[histIdx] <<
+                                " error_so3: " << errorSo3[histIdx] <<
+                                " error_matrix: " << errorMatrix[histIdx]);
+      }
+    }
+}


### PR DESCRIPTION
This pull request improves the numerical stability and test coverage of the Lie algebra (`SO(3)`) conversions in the `aliceVision_geometry` module. The most significant changes are enhancements to the `logm` function to better handle edge cases (angles near 0 and π), reducing potential numerical errors, and the addition of a comprehensive unit test for Lie algebra conversions

**Numerical stability and algorithmic improvements:**

* Improved the `logm` function in `lie.hpp` to handle edge cases for rotation angles close to 0 and π, using specific formulas and checks to avoid numerical instability and ensure accuracy.

**Testing improvements:**

* Added a new unit test `lie_test.cpp` that thoroughly checks the correctness and numerical stability of the Lie algebra (`SO(3)`) conversion functions across a wide range of rotation axes and angles. The test is integrated into the build system. [[1]](diffhunk://#diff-659e5202b50effe5335bfb32162ef0fb90e680c0c9d2597f48c731c45844e01bR1-R119) [[2]](diffhunk://#diff-90f954358b281d3c42331fea5f0c3375ff88480e6f770842ee73069f60656cbaR30)