### PR TITLE
Create policies system for resection validation

### DIFF
--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -85,6 +85,7 @@ set(sfm_files_sources
     pipeline/expanding/ExpansionProcess.cpp
     pipeline/expanding/ConnexityGraph.cpp
     pipeline/expanding/LbaPolicyConnexity.cpp
+    pipeline/expanding/LocalizationValidationPolicyLegacy.cpp
     pipeline/positioning/GlobalPositioning.cpp
     pipeline/regionsIO.cpp
     utils/alignment.cpp

--- a/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
@@ -8,6 +8,7 @@
 #include <aliceVision/track/tracksUtils.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
 #include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
+#include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp>
 #include <vector>
 #include <random>
 
@@ -107,7 +108,13 @@ bool bootstrapMesh(sfmData::SfMData & sfmData,
     size_t countInliers;
 
     //Compute resection for selected view
-    SfmResection resection(50000, std::numeric_limits<double>::infinity());
+    sfm::LocalizationValidationPolicy::uptr resectionValidationPolicy = std::make_unique<sfm::LocalizationValidationPolicyLegacy>();
+
+    SfmResection resection;
+    resection.setMaxIterations(50000);
+    resection.setResectionMaxError(std::numeric_limits<double>::infinity());
+    resection.setValidationPolicy(resectionValidationPolicy);
+    
     if (!resection.processView(sfmData, tracksMap, tracksPerView, randomNumberGenerator, viewId, pose, threshold, countInliers))
     {
         return false;

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -7,7 +7,6 @@
 #include "ExpansionChunk.hpp"
 
 #include <aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp>
-#include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -29,12 +28,21 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
     //Compute the pose given the existing point cloud
     if (!_bundleHandler)
     {
+        ALICEVISION_LOG_ERROR("Bundle handler is not set");
         return false;
     }
 
     //Check if historyHandler exists
     if (!_historyHandler)
     {
+        ALICEVISION_LOG_ERROR("History handler is not set");
+        return false;
+    }
+
+    //Check if resectionHandler exists
+    if (!_resectionHandler)
+    {
+        ALICEVISION_LOG_ERROR("Resection handler is not set");
         return false;
     }
 
@@ -73,10 +81,8 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
             IntermediateResectionInfo iri;
             iri.viewId = viewId;
 
-            SfmResection resection(_resectionIterations, _resectionMaxError);
-
             std::mt19937 randomNumberGenerator;
-            if (!resection.processView(sfmData, 
+            if (!_resectionHandler->processView(sfmData, 
                                 tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
                                 randomNumberGenerator, viewId, 
                                 iri.pose, iri.threshold, iri.inliersCount))

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
@@ -12,6 +12,7 @@
 #include <aliceVision/sfm/pipeline/expanding/ExpansionHistory.hpp>
 #include <aliceVision/sfm/pipeline/expanding/SfmBundle.hpp>
 #include <aliceVision/sfm/pipeline/expanding/PointFetcher.hpp>
+#include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -61,22 +62,13 @@ public:
         _pointFetcherHandler = std::move(pointFetcherHandler);
     }
 
-    void setResectionMaxIterations(size_t maxIterations)
-    {
-        _resectionIterations = maxIterations;
-    }
-
     /**
-     * @brief set the maximal error allowed for ransac resection module
-     * @param error the error value or <= 0 for automatic decision
+     * brief setup the point fetcher handler
+     * @param resectionHandler a unique ptr. the Ownership will be taken
     */
-    void setResectionMaxError(double error)
+    void setResectionHandler(SfmResection::uptr & resectionHandler)
     {
-        _resectionMaxError = error;
-        if (_resectionMaxError <= 0.0)
-        {
-            _resectionMaxError = std::numeric_limits<double>::infinity();
-        }
+        _resectionHandler = std::move(resectionHandler);
     }
 
     /**
@@ -151,13 +143,12 @@ private:
     ExpansionHistory::sptr _historyHandler;
     PointFetcher::uptr _pointFetcherHandler;
     std::set<IndexT> _ignoredViews;
+    SfmResection::uptr _resectionHandler;
 
 private:    
-    size_t _resectionIterations = 1024;
     size_t _triangulationMinPoints = 2;
     double _minTriangulationAngleDegrees = 3.0;
     double _maxTriangulationError = 8.0;
-    double _resectionMaxError = std::numeric_limits<double>::infinity();
     size_t _weakResectionSize = 100;
 };
 

--- a/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicy.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicy.hpp
@@ -1,0 +1,48 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/camera/IntrinsicBase.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+class LocalizationValidationPolicy
+{
+public:
+    using uptr = std::unique_ptr<LocalizationValidationPolicy>;
+
+public:
+    /**
+     * @brief A function to validate the result of the Ransac process using N inputs
+     * @param intrinsic the intrinsic used for the resection
+     * @param structure a list of N 3d points in world coordinates
+     * @param observations a list of N 2d points in pixels
+     * @param featureTypes a list of N feature types
+     * @param pose the estimated pose
+     * @param inliers a list of estimated inliers (index in the "structure", "observations", "featureTypes" vectors)
+     * @return true if the refinement gave a good resection
+    */
+    virtual bool validate(const camera::IntrinsicBase & intrinsic,
+                        const std::vector<Eigen::Vector3d> & structure,
+                        const std::vector<Eigen::Vector2d> & observations,
+                        const std::vector<feature::EImageDescriberType> & featureTypes,
+                        const Eigen::Matrix4d & pose,
+                        const std::vector<size_t> & inliers) = 0;
+    
+    /**
+     * @brief A function to validate the result of the refinement process
+     * The sfmData should only contains one camera.
+     * @param sfmData the sfmData containing only the information about refinement
+     * @return true if the refinement gave a good resection
+    */
+    virtual bool validateRefinement(const sfmData::SfMData & sfmData) = 0;
+};
+
+}  // namespace sfm
+}  // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.cpp
@@ -1,0 +1,31 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp>
+#include <aliceVision/matching/supportEstimation.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+bool LocalizationValidationPolicyLegacy::validate(
+                        const camera::IntrinsicBase & intrinsic,
+                        const std::vector<Eigen::Vector3d> & structure,
+                        const std::vector<Eigen::Vector2d> & observations,
+                        const std::vector<feature::EImageDescriberType> & featureTypes,
+                        const Eigen::Matrix4d & pose,
+                        const std::vector<size_t> & inliers)
+{
+    return matching::hasStrongSupport(inliers, featureTypes, 3);
+}
+    
+bool LocalizationValidationPolicyLegacy::validateRefinement(
+                        const sfmData::SfMData & sfmData)
+{
+    return true;
+}
+
+}  // namespace sfm
+}  // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp
@@ -1,0 +1,44 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicy.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+class LocalizationValidationPolicyLegacy : public LocalizationValidationPolicy
+{
+public:
+    /**
+     * @brief A function to validate the result of the Ransac process using N inputs
+     * @param intrinsic the intrinsic used for the resection
+     * @param structure a list of N 3d points in world coordinates
+     * @param observations a list of N 2d points in pixels
+     * @param featureTypes a list of N feature types
+     * @param pose the estimated pose
+     * @param inliers a list of estimated inliers (index in the "structure", "observations", "featureTypes" vectors)
+     * @return true if the refinement gave a good resection
+    */
+    virtual bool validate(const camera::IntrinsicBase & intrinsic,
+                        const std::vector<Eigen::Vector3d> & structure,
+                        const std::vector<Eigen::Vector2d> & observations,
+                        const std::vector<feature::EImageDescriberType> & featureTypes,
+                        const Eigen::Matrix4d & pose,
+                        const std::vector<size_t> & inliers);
+    
+    /**
+     * @brief A function to validate the result of the refinement process
+     * The sfmData should only contains one camera.
+     * @param sfmData the sfmData containing only the information about refinement
+     * @return true if the refinement gave a good resection
+    */
+    virtual bool validateRefinement(const sfmData::SfMData & sfmData);
+};
+
+}  // namespace sfm
+}  // namespace aliceVision

--- a/src/aliceVision/sfm/pipeline/expanding/SfmResection.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmResection.cpp
@@ -12,7 +12,6 @@
 #include <aliceVision/robustEstimation/NACRansac.hpp>
 #include <aliceVision/numeric/Container.hpp>
 #include <aliceVision/multiview/resection/ResectionSphericalKernel.hpp>
-#include <aliceVision/matching/supportEstimation.hpp>
 #include <aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp>
 
 namespace aliceVision {
@@ -30,6 +29,12 @@ bool SfmResection::processView(
                         size_t & inliersCount
                         )
 {
+    if (!_validationPolicy)
+    {
+        ALICEVISION_LOG_ERROR("Validation policy is not set.");
+        return false;
+    }
+    
     ALICEVISION_LOG_INFO("SfmResection::processView start " << viewId);
 
     // A. Compute 2D/3D matches
@@ -129,7 +134,7 @@ bool SfmResection::internalResection(
     auto pairResult = robustEstimation::NACRANSAC(kernel, randomNumberGenerator, inliers, _maxIterations, &model, _precision);
 
     errorMax = pairResult.first;
-    const bool resection = matching::hasStrongSupport(inliers, featureTypes, 3);
+    const bool resection = _validationPolicy->validate(*intrinsic, structure, observations, featureTypes, model, inliers);
 
     if (resection)
     {
@@ -197,6 +202,11 @@ bool SfmResection::internalRefinement(
         errorMax = std::max(errorMax, diff.norm());
     }
 
+    const bool resection = _validationPolicy->validateRefinement(tinyScene);
+    if (!resection)
+    {
+        return false;
+    }
 
     return true;
 }

--- a/src/aliceVision/sfm/pipeline/expanding/SfmResection.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmResection.hpp
@@ -9,6 +9,8 @@
 #include <aliceVision/types.hpp>
 #include <aliceVision/track/Track.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicy.hpp>
+#include <memory>
 
 namespace aliceVision {
 namespace sfm {
@@ -16,11 +18,30 @@ namespace sfm {
 class SfmResection
 {
 public:
-    SfmResection(size_t maxIterations, double precision) 
-    : _maxIterations(maxIterations),
-    _precision(precision)
-    {
+    using uptr = std::unique_ptr<SfmResection>;
 
+public:
+    void setMaxIterations(size_t maxIterations)
+    {
+        _maxIterations = maxIterations;
+    }
+
+    /**
+     * @brief set the maximal error allowed for ransac resection module
+     * @param error the error value or <= 0 for automatic decision
+    */
+    void setResectionMaxError(double error)
+    {
+        _precision = error;
+        if (_precision <= 0.0)
+        {
+            _precision = std::numeric_limits<double>::infinity();
+        }
+    }
+
+    void setValidationPolicy(LocalizationValidationPolicy::uptr & policy)
+    {
+        _validationPolicy = std::move(policy);
     }
 
     /**
@@ -68,8 +89,11 @@ private:
         );
 
 private:
-    double _precision;
-    size_t _maxIterations;
+    std::unique_ptr<LocalizationValidationPolicy> _validationPolicy;
+
+private:
+    double _precision = std::numeric_limits<double>::infinity();
+    size_t _maxIterations = 1024;
 };
 
 } // namespace sfm

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -19,6 +19,7 @@
 #include <aliceVision/sfm/pipeline/expanding/ExpansionProcess.hpp>
 #include <aliceVision/sfm/pipeline/expanding/LbaPolicyConnexity.hpp>
 #include <aliceVision/sfm/pipeline/expanding/ExpansionPostProcessRig.hpp>
+#include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp>
 
 #include <aliceVision/mesh/MeshIntersection.hpp>
 
@@ -214,7 +215,6 @@ int aliceVision_main(int argc, char** argv)
     sfm::ExpansionHistory::sptr expansionHistory = std::make_shared<sfm::ExpansionHistory>();
 
     sfm::LbaPolicy::uptr sfmPolicy;
-    
     if (useLocalBA) 
     {
         sfm::LbaPolicyConnexity::uptr sfmPolicyTyped = std::make_unique<sfm::LbaPolicyConnexity>();
@@ -244,11 +244,17 @@ int aliceVision_main(int argc, char** argv)
         pointFetcherHandler = std::move(handler);
     }
 
+    sfm::LocalizationValidationPolicy::uptr resectionValidationPolicy = std::make_unique<sfm::LocalizationValidationPolicyLegacy>();
+
+    sfm::SfmResection::uptr sfmResectionHandler = std::make_unique<sfm::SfmResection>();
+    sfmResectionHandler->setResectionMaxError(localizerEstimatorError);
+    sfmResectionHandler->setMaxIterations(localizerEstimatorMaxIterations);
+    sfmResectionHandler->setValidationPolicy(resectionValidationPolicy);
+
     sfm::ExpansionChunk::uptr expansionChunk = std::make_unique<sfm::ExpansionChunk>();
     expansionChunk->setBundleHandler(sfmBundle);
     expansionChunk->setExpansionHistoryHandler(expansionHistory);
-    expansionChunk->setResectionMaxIterations(localizerEstimatorMaxIterations);
-    expansionChunk->setResectionMaxError(localizerEstimatorError);
+    expansionChunk->setResectionHandler(sfmResectionHandler);
     expansionChunk->setTriangulationMaxError(maxTriangulationError);
     expansionChunk->setTriangulationMinPoints(minNbObservationsForTriangulation);
     expansionChunk->setMinAngleTriangulation(minAngleForTriangulation);


### PR DESCRIPTION
This pull request refactors the structure-from-motion (SfM) expansion pipeline to improve modularity and flexibility, especially around pose estimation (resection) and validation. The main changes introduce a new validation policy interface, update how resection is handled and injected, and clean up related code. These changes make it easier to swap out validation strategies and improve error handling.