### PR TITLE
Stop using `image`'s "all.hpp" use to reduce change overload

### DIFF
--- a/src/aliceVision/colorHarmonization/CommonDataByPair.hpp
+++ b/src/aliceVision/colorHarmonization/CommonDataByPair.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/utils/Histogram.hpp>
 
 #include <string>

--- a/src/aliceVision/colorHarmonization/CommonDataByPair_matchedPoints.hpp
+++ b/src/aliceVision/colorHarmonization/CommonDataByPair_matchedPoints.hpp
@@ -7,10 +7,11 @@
 
 #pragma once
 
-#include "aliceVision/colorHarmonization/CommonDataByPair.hpp"
-#include "aliceVision/matching/MatchesCollections.hpp"
-#include "aliceVision/feature/feature.hpp"
-#include "aliceVision/feature/RegionsPerView.hpp"
+#include <aliceVision/colorHarmonization/CommonDataByPair.hpp>
+#include <aliceVision/matching/MatchesCollections.hpp>
+#include <aliceVision/feature/feature.hpp>
+#include <aliceVision/feature/RegionsPerView.hpp>
+#include <aliceVision/image/drawing.hpp>
 
 #include <vector>
 

--- a/src/aliceVision/colorHarmonization/gainOffsetConstraintBuilder_test.cpp
+++ b/src/aliceVision/colorHarmonization/gainOffsetConstraintBuilder_test.cpp
@@ -13,7 +13,7 @@
 
 // ColorHarmonization solver
 #include <aliceVision/colorHarmonization/GainOffsetConstraintBuilder.hpp>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/config.hpp>
 
 #include <aliceVision/utils/Histogram.hpp>

--- a/src/aliceVision/feature/akaze/AKAZE.cpp
+++ b/src/aliceVision/feature/akaze/AKAZE.cpp
@@ -6,6 +6,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/feature/akaze/AKAZE.hpp>
+#include <aliceVision/image/resampling.hpp>
+#include <aliceVision/image/filtering.hpp>
+#include <aliceVision/image/diffusion.hpp>
 #include <aliceVision/feature/imageStats.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/config.hpp>

--- a/src/aliceVision/feature/akaze/AKAZE.hpp
+++ b/src/aliceVision/feature/akaze/AKAZE.hpp
@@ -11,7 +11,7 @@
     #pragma warning(once : 4244)
 #endif
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <aliceVision/numeric/MathTrait.hpp>
 #include <aliceVision/feature/PointFeature.hpp>

--- a/src/aliceVision/feature/akaze/descriptorLIOP.cpp
+++ b/src/aliceVision/feature/akaze/descriptorLIOP.cpp
@@ -6,6 +6,8 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/feature/akaze/descriptorLIOP.hpp>
+#include <aliceVision/image/Sampler.hpp>
+#include <aliceVision/image/filtering.hpp>
 
 #include <float.h>
 #include <algorithm>

--- a/src/aliceVision/feature/akaze/descriptorLIOP.hpp
+++ b/src/aliceVision/feature/akaze/descriptorLIOP.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/feature/PointFeature.hpp>
 
 #include <map>

--- a/src/aliceVision/feature/akaze/descriptorMLDB.hpp
+++ b/src/aliceVision/feature/akaze/descriptorMLDB.hpp
@@ -9,7 +9,7 @@
 
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/feature/PointFeature.hpp>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/numeric/MathTrait.hpp>
 
 namespace aliceVision {

--- a/src/aliceVision/feature/akaze/descriptorMSURF.hpp
+++ b/src/aliceVision/feature/akaze/descriptorMSURF.hpp
@@ -10,6 +10,7 @@
 #include <aliceVision/feature/Descriptor.hpp>
 #include <aliceVision/feature/PointFeature.hpp>
 #include <aliceVision/numeric/MathTrait.hpp>
+#include <aliceVision/image/Sampler.hpp>
 
 namespace aliceVision {
 namespace feature {

--- a/src/aliceVision/feature/imageStats.cpp
+++ b/src/aliceVision/feature/imageStats.cpp
@@ -7,7 +7,9 @@
 
 #include "imageStats.hpp"
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/filtering.hpp>
+#include <aliceVision/image/convolution.hpp>
 
 namespace aliceVision {
 namespace feature {

--- a/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.cpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_AKAZE_OCV.cpp
@@ -7,7 +7,7 @@
 
 #include "ImageDescriber_AKAZE_OCV.hpp"
 
-#include "aliceVision/image/all.hpp"
+#include "aliceVision/image/Image.hpp"
 
 #include <opencv2/opencv.hpp>
 #include <opencv2/core/eigen.hpp>

--- a/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp
@@ -7,7 +7,7 @@
 
 #include "ImageDescriber_SIFT_OCV.hpp"
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/system/Timer.hpp>
 #include <aliceVision/system/Logger.hpp>
 

--- a/src/aliceVision/hdr/DebevecCalibrate.cpp
+++ b/src/aliceVision/hdr/DebevecCalibrate.cpp
@@ -9,7 +9,7 @@
 
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 
 #include <OpenImageIO/imagebufalgo.h>

--- a/src/aliceVision/hdr/hdrMerge.cpp
+++ b/src/aliceVision/hdr/hdrMerge.cpp
@@ -13,6 +13,7 @@
 
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/system/Logger.hpp>
+#include <aliceVision/image/filtering.hpp>
 
 namespace aliceVision {
 namespace hdr {

--- a/src/aliceVision/hdr/hdrMerge.hpp
+++ b/src/aliceVision/hdr/hdrMerge.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 #include "rgbCurve.hpp"
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <cmath>
 
 namespace aliceVision {

--- a/src/aliceVision/hdr/hdrTestCommon.hpp
+++ b/src/aliceVision/hdr/hdrTestCommon.hpp
@@ -1,5 +1,6 @@
 #pragma once
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/utils/filesIO.hpp>
 

--- a/src/aliceVision/hdr/sampling.hpp
+++ b/src/aliceVision/hdr/sampling.hpp
@@ -6,7 +6,9 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/types.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 #include <set>
 

--- a/src/aliceVision/keyframe/KeyframeSelector.hpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.hpp
@@ -7,7 +7,8 @@
 #pragma once
 
 #include <aliceVision/dataio/FeedProvider.hpp>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/sensorDB/parseDatabase.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>

--- a/src/aliceVision/lightingEstimation/lightingCalibration.cpp
+++ b/src/aliceVision/lightingEstimation/lightingCalibration.cpp
@@ -8,7 +8,7 @@
 #include "lightingEstimation.hpp"
 #include "ellipseGeometry.hpp"
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/convolution.hpp>
 #include <aliceVision/photometricStereo/photometricStereo.hpp>

--- a/src/aliceVision/matching/kvld/kvld.cpp
+++ b/src/aliceVision/matching/kvld/kvld.cpp
@@ -16,7 +16,7 @@
 #include "algorithm.h"
 #include <functional>
 #include <numeric>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/config.hpp>
 
 using namespace aliceVision;

--- a/src/aliceVision/matching/kvld/kvld_draw.h
+++ b/src/aliceVision/matching/kvld/kvld_draw.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "aliceVision/image/all.hpp"
+#include "aliceVision/image/Image.hpp"
 #include "aliceVision/feature/PointFeature.hpp"
 #include <vector>
 

--- a/src/aliceVision/panorama/cachedImage.hpp
+++ b/src/aliceVision/panorama/cachedImage.hpp
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/image/cache.hpp>
+
 #include <aliceVision/panorama/boundingBox.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/types.hpp>

--- a/src/aliceVision/panorama/compositer.hpp
+++ b/src/aliceVision/panorama/compositer.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 #include "cachedImage.hpp"
 #include "imageOps.hpp"

--- a/src/aliceVision/panorama/coordinatesMap.hpp
+++ b/src/aliceVision/panorama/coordinatesMap.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/camera/camera.hpp>
 
 #include "boundingBox.hpp"

--- a/src/aliceVision/panorama/distance.hpp
+++ b/src/aliceVision/panorama/distance.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 #include "coordinatesMap.hpp"
 

--- a/src/aliceVision/panorama/feathering.hpp
+++ b/src/aliceVision/panorama/feathering.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 #include <aliceVision/panorama/cachedImage.hpp>
 

--- a/src/aliceVision/panorama/gaussian.hpp
+++ b/src/aliceVision/panorama/gaussian.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 namespace aliceVision {
 

--- a/src/aliceVision/panorama/graphcut.hpp
+++ b/src/aliceVision/panorama/graphcut.hpp
@@ -9,7 +9,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/boykov_kolmogorov_max_flow.hpp>
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 #include "distance.hpp"
 #include "boundingBox.hpp"

--- a/src/aliceVision/panorama/imageOps.hpp
+++ b/src/aliceVision/panorama/imageOps.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "cachedImage.hpp"
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/half.hpp>
 
 namespace aliceVision {

--- a/src/aliceVision/panorama/laplacianPyramid.hpp
+++ b/src/aliceVision/panorama/laplacianPyramid.hpp
@@ -8,7 +8,7 @@
 
 #include "imageOps.hpp"
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 namespace aliceVision {
 

--- a/src/aliceVision/panorama/seams.cpp
+++ b/src/aliceVision/panorama/seams.cpp
@@ -11,6 +11,8 @@
 #include "compositer.hpp"
 #include "feathering.hpp"
 
+#include <aliceVision/image/io.hpp>
+
 namespace aliceVision {
 
 bool computeSeamsMap(image::Image<unsigned char>& seams, const image::Image<IndexT>& labels)

--- a/src/aliceVision/panorama/seams.hpp
+++ b/src/aliceVision/panorama/seams.hpp
@@ -7,7 +7,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/types.hpp>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 
 #include "cachedImage.hpp"
 #include "graphcut.hpp"

--- a/src/aliceVision/panorama/warper.cpp
+++ b/src/aliceVision/panorama/warper.cpp
@@ -5,7 +5,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "warper.hpp"
+
 #include <aliceVision/half.hpp>
+#include <aliceVision/image/Sampler.hpp>
 
 namespace aliceVision {
 

--- a/src/aliceVision/photometricStereo/photometricStereo.cpp
+++ b/src/aliceVision/photometricStereo/photometricStereo.cpp
@@ -7,7 +7,7 @@
 #include "photometricStereo.hpp"
 #include "photometricDataIO.hpp"
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/imageAlgo.hpp>
 #include <aliceVision/utils/filesIO.hpp>

--- a/src/aliceVision/segmentation/segmentation.cpp
+++ b/src/aliceVision/segmentation/segmentation.cpp
@@ -10,7 +10,8 @@
     #include <cuda_runtime.h>
 #endif
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/imageAlgo.hpp>
 #include <aliceVision/numeric/numeric.hpp>
 

--- a/src/aliceVision/sphereDetection/sphereDetection.cpp
+++ b/src/aliceVision/sphereDetection/sphereDetection.cpp
@@ -11,7 +11,7 @@
 #include <numeric>
 
 // AliceVision image library
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/Image.hpp>
 

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -4,8 +4,9 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
+#include <aliceVision/image/conversion.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>

--- a/src/software/pipeline/main_LdrToHdrSampling.cpp
+++ b/src/software/pipeline/main_LdrToHdrSampling.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>

--- a/src/software/pipeline/main_imageSegmentation.cpp
+++ b/src/software/pipeline/main_imageSegmentation.cpp
@@ -9,7 +9,7 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
 // Image
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/imageAlgo.hpp>
 
 // System

--- a/src/software/pipeline/main_lightingCalibration.cpp
+++ b/src/software/pipeline/main_lightingCalibration.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 
 // SFMData

--- a/src/software/pipeline/main_normalIntegration.cpp
+++ b/src/software/pipeline/main_normalIntegration.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 
 // SFMData

--- a/src/software/pipeline/main_panoramaCompositing.cpp
+++ b/src/software/pipeline/main_panoramaCompositing.cpp
@@ -14,8 +14,9 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
 // Image
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/imageAlgo.hpp>
+#include <aliceVision/image/io.hpp>
 
 // System
 #include <aliceVision/system/Logger.hpp>

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -16,7 +16,6 @@
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
-#include <aliceVision/image/all.hpp>
 
 #include <boost/program_options.hpp>
 

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -4,7 +4,9 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
+#include <aliceVision/image/Sampler.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/numeric/numeric.hpp>

--- a/src/software/pipeline/main_panoramaMerging.cpp
+++ b/src/software/pipeline/main_panoramaMerging.cpp
@@ -9,8 +9,9 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
 // Image
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/imageAlgo.hpp>
+#include <aliceVision/image/io.hpp>
 
 // System
 #include <aliceVision/system/Logger.hpp>

--- a/src/software/pipeline/main_panoramaPostProcessing.cpp
+++ b/src/software/pipeline/main_panoramaPostProcessing.cpp
@@ -5,7 +5,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // Image
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
+#include <aliceVision/image/dcp.hpp>
 
 // System
 #include <aliceVision/system/Logger.hpp>

--- a/src/software/pipeline/main_panoramaPrepareImages.cpp
+++ b/src/software/pipeline/main_panoramaPrepareImages.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>

--- a/src/software/pipeline/main_panoramaSeams.cpp
+++ b/src/software/pipeline/main_panoramaSeams.cpp
@@ -12,8 +12,9 @@
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
 // Image
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/imageAlgo.hpp>
+#include <aliceVision/image/io.hpp>
 
 // System
 #include <aliceVision/system/Logger.hpp>

--- a/src/software/pipeline/main_panoramaWarping.cpp
+++ b/src/software/pipeline/main_panoramaWarping.cpp
@@ -10,7 +10,8 @@
 #include <aliceVision/system/main.hpp>
 
 // Image related
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 
 // Sfmdata
 #include <aliceVision/sfmData/SfMData.hpp>

--- a/src/software/pipeline/main_photometricStereo.cpp
+++ b/src/software/pipeline/main_photometricStereo.cpp
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 
 // SFMData

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -6,7 +6,8 @@
 
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>

--- a/src/software/utils/main_colorCheckerCorrection.cpp
+++ b/src/software/utils/main_colorCheckerCorrection.cpp
@@ -4,7 +4,10 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/conversion.hpp>
+#include <aliceVision/image/conversionOpenCV.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>

--- a/src/software/utils/main_colorCheckerDetection.cpp
+++ b/src/software/utils/main_colorCheckerDetection.cpp
@@ -7,7 +7,10 @@
 #include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/conversionOpenCV.hpp>
+#include <aliceVision/image/io.hpp>
+
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/config.hpp>

--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -9,9 +9,9 @@
 #include <aliceVision/cmdline/cmdline.hpp>
 #include <aliceVision/system/main.hpp>
 #include <aliceVision/utils/filesIO.hpp>
+#include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/Sampler.hpp>
-
 #include <boost/program_options.hpp>
 
 // These constants define the current software version.

--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -4,7 +4,8 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 #include <aliceVision/keyframe/KeyframeSelector.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/cmdline/cmdline.hpp>

--- a/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
+++ b/src/software/utils/sfmColorHarmonize/colorHarmonizeEngineGlobal.cpp
@@ -17,7 +17,8 @@
 #include <aliceVision/sfm/sfm.hpp>
 #include <aliceVision/graph/graph.hpp>
 #include <aliceVision/config.hpp>
-#include <aliceVision/image/all.hpp>
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/io.hpp>
 // load features per view
 #include <aliceVision/sfm/pipeline/regionsIO.hpp>
 // feature matches


### PR DESCRIPTION
Reduce impact on compilation time when modifying image module