### PR TITLE
Add depth to tracks

### DIFF
--- a/meshroom/aliceVision/DepthMapTracksInjecting.py
+++ b/meshroom/aliceVision/DepthMapTracksInjecting.py
@@ -1,0 +1,48 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class DepthMapTracksInjecting(desc.AVCommandLineNode):
+    commandLine = 'aliceVision_depthmapTracksInjecting {allParams}'
+
+    category = 'Utils'
+    documentation = '''Inject depth from depthmaps into tracks.'''
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input SfMData",
+            description="Input SfMData file.",
+            value="",
+        ),
+        desc.File(
+            name="tracksFilename",
+            label="Tracks File",
+            description="Tracks file.",
+            value="",
+        ),
+        desc.File(
+            name="depthSource",
+            label="Depth Source",
+            description="Directory containing depthMaps",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output Tracks File",
+            description="Output Tracks File with updated depth",
+            value="{nodeCacheFolder}/tracks.json",
+        ),
+    ]

--- a/src/aliceVision/sfm/sfmFilters.cpp
+++ b/src/aliceVision/sfm/sfmFilters.cpp
@@ -75,7 +75,13 @@ IndexT removeOutliersWithAngleError(sfmData::SfMData& sfmData, const double dMin
 #pragma omp parallel for
     for (int landmarkIndex = 0; landmarkIndex < vKeys.size(); ++landmarkIndex)
     {
-        const sfmData::Observations& observations = sfmData.getLandmarks().at(vKeys[landmarkIndex]).getObservations();
+        const sfmData::Landmark & landmark = sfmData.getLandmarks().at(vKeys[landmarkIndex]);
+        if (landmark.isParallaxRobust())
+        {
+            continue;
+        }
+
+        const sfmData::Observations& observations = landmark.getObservations();
 
         // create matrix for observation directions from camera to point
         Mat3X viewDirections(3, observations.size());

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -73,8 +73,21 @@ class Landmark
         }
     }
 
-  private:
+    /**
+     * @brief Is this landmark robustness independent of parallax
+     * @return true if this landmark has this special property
+    */
+    bool isParallaxRobust() const { return _parallaxRobust; }
+
+    /**
+    * @brief decide if this landmark is robust even if its parallax is low
+    * @param parallaxRobust True if robust to lack of parallax
+    */
+    void setParallaxRobust(bool parallaxRobust) { _parallaxRobust = parallaxRobust; }
+
+private:
     Observations _observations;
+    bool _parallaxRobust = false;
 };
 
 }  // namespace sfmData

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -396,6 +396,12 @@ class SfMData
      * @return the corresponding view reference
      */
     const View& getView(IndexT viewId) const { return *(_views.at(viewId)); }
+
+    /**
+     * @brief Gives the view of the input view id.
+     * @param[in] viewId The given view ID
+     * @return the corresponding view reference
+     */
     View& getView(IndexT viewId) { return *(_views.at(viewId)); }
 
     /**
@@ -404,6 +410,12 @@ class SfMData
      * @return the corresponding view ptr
      */
     const View::ptr getViewPtr(IndexT viewId) const { return _views.at(viewId).get(); }
+
+    /**
+     * @brief Gives the view of the input view id.
+     * @param[in] viewId The given view ID
+     * @return the corresponding view ptr
+     */
     View::ptr getViewPtr(IndexT viewId) { return _views.at(viewId).get(); }
 
     /**

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -510,8 +510,10 @@ void AlembicExporter::addLandmarks(const sfmData::Landmarks& landmarks,
     std::vector<V3f> positions;
     std::vector<Imath::C3f> colors;
     std::vector<Alembic::Util::uint32_t> descTypes;
+    std::vector<Alembic::Util::bool_t> isParallaxRobust;
     positions.reserve(landmarks.size());
     descTypes.reserve(landmarks.size());
+    isParallaxRobust.reserve(landmarks.size());
 
     // For all the 3d points in the hash_map
     for (const auto& landmark : landmarks)
@@ -522,6 +524,7 @@ void AlembicExporter::addLandmarks(const sfmData::Landmarks& landmarks,
         positions.emplace_back(pt[0], -pt[1], -pt[2]);
         colors.emplace_back(color.r() / 255.f, color.g() / 255.f, color.b() / 255.f);
         descTypes.emplace_back(static_cast<Alembic::Util::uint8_t>(landmark.second.descType));
+        isParallaxRobust.emplace_back(static_cast<Alembic::Util::bool_t>(landmark.second.isParallaxRobust()));
     }
 
     std::vector<Alembic::Util::uint64_t> ids(positions.size());
@@ -544,6 +547,7 @@ void AlembicExporter::addLandmarks(const sfmData::Landmarks& landmarks,
     OCompoundProperty userProps = pSchema.getUserProperties();
 
     OUInt32ArrayProperty(userProps, "mvg_describerType").set(descTypes);
+    OBoolArrayProperty(userProps, "mvg_isParallaxRobust").set(isParallaxRobust);
 
     if (withVisibility)
     {

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -188,6 +188,19 @@ bool readPointCloud(const Version& abcVersion, IObject iObj, M44d mat, sfmData::
         }
     }
 
+    BoolArraySamplePtr sampleIsParallaxRobust;
+    if (userProps && userProps.getPropertyHeader("mvg_isParallaxRobust"))
+    {
+        IBoolArrayProperty propIsParallaxRobust(userProps, "mvg_isParallaxRobust");
+        propIsParallaxRobust.get(sampleIsParallaxRobust);
+
+        if (sampleIsParallaxRobust->size() != positions->size())
+        {
+            ALICEVISION_LOG_WARNING("[Alembic Importer] isParallaxRobust property will be ignored.");
+            sampleIsParallaxRobust->reset();
+        }
+    }
+
     // Number of points before adding the Alembic data
     const std::size_t nbPointsInit = sfmdata.getLandmarks().size();
     for (std::size_t point3d_i = 0; point3d_i < positions->size(); ++point3d_i)
@@ -218,6 +231,12 @@ bool readPointCloud(const Version& abcVersion, IObject iObj, M44d mat, sfmData::
         {
             const std::size_t descType_i = sampleDescs[point3d_i];
             landmark.descType = static_cast<feature::EImageDescriberType>(descType_i);
+        }
+
+        if (sampleIsParallaxRobust)
+        {
+            const bool isParallaxRobust = sampleIsParallaxRobust->get()[point3d_i];
+            landmark.setParallaxRobust(isParallaxRobust);
         }
     }
 

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -504,7 +504,8 @@ void saveLandmark(const std::string& name,
 
     landmarkTree.put("landmarkId", landmarkId);
     landmarkTree.put("descType", feature::EImageDescriberType_enumToString(landmark.descType));
-
+    landmarkTree.put("isParallaxRobust", landmark.isParallaxRobust());
+    
     saveMatrix("color", landmark.rgb, landmarkTree);
     saveMatrix("X", landmark.X, landmarkTree);
 
@@ -541,7 +542,8 @@ void loadLandmark(IndexT& landmarkId, sfmData::Landmark& landmark, bpt::ptree& l
 {
     landmarkId = landmarkTree.get<IndexT>("landmarkId");
     landmark.descType = feature::EImageDescriberType_stringToEnum(landmarkTree.get<std::string>("descType"));
-
+    landmark.setParallaxRobust(landmarkTree.get<bool>("isParallaxRobust", false));
+    
     loadMatrix("color", landmark.rgb, landmarkTree);
     loadMatrix("X", landmark.X, landmarkTree);
 

--- a/src/aliceVision/track/Track.hpp
+++ b/src/aliceVision/track/Track.hpp
@@ -61,6 +61,7 @@ struct TrackItem
     std::size_t featureId;
     Vec2 coords;
     double scale;
+    double depth;
 };
 
 /**

--- a/src/aliceVision/track/TracksBuilder.cpp
+++ b/src/aliceVision/track/TracksBuilder.cpp
@@ -214,6 +214,7 @@ void TracksBuilder::exportToSTL(TracksMap& allTracks, const feature::FeaturesPer
 
                 item.coords = feature.coords().cast<double>();
                 item.scale = feature.scale();
+                item.depth = -1.0;
             }
         }
     }

--- a/src/aliceVision/track/trackIO.cpp
+++ b/src/aliceVision/track/trackIO.cpp
@@ -17,6 +17,7 @@ void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, alic
       {"featureId", boost::json::value_from(input.featureId)},
       {"coords", boost::json::value_from(input.coords)},
       {"scale", boost::json::value_from(input.scale)},
+      {"depth", boost::json::value_from(input.depth)},
     };
 }
 
@@ -27,7 +28,24 @@ aliceVision::track::TrackItem tag_invoke(boost::json::value_to_tag<aliceVision::
     aliceVision::track::TrackItem ret;
     ret.featureId = boost::json::value_to<std::size_t>(obj.at("featureId"));
     ret.coords = boost::json::value_to<Vec2>(obj.at("coords"));
-    ret.scale = boost::json::value_to<double>(obj.at("scale"));
+
+    if (obj.contains("scale"))
+    {
+        ret.scale = boost::json::value_to<double>(obj.at("scale"));
+    }
+    else
+    {
+        ret.scale = 1.0;
+    }
+
+    if (obj.contains("depth"))
+    {
+        ret.depth = boost::json::value_to<double>(obj.at("depth"));
+    }
+    else 
+    {
+        ret.depth = -1.0;
+    }
 
     return ret;
 }

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -76,6 +76,21 @@ if (ALICEVISION_BUILD_SFM)
               Boost::json
     )
 
+
+    # Track from depthmap
+    alicevision_add_software(aliceVision_depthmapTracksInjecting
+        SOURCE main_depthmapTracksInjecting.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              aliceVision_track
+              aliceVision_image
+              Boost::program_options
+              Boost::json
+    )
+
     if (ALICEVISION_HAVE_OPENCV)
         target_link_libraries(aliceVision_imageProcessing_exe PRIVATE ${OpenCV_LIBS})
     endif()

--- a/src/software/utils/main_depthmapTracksInjecting.cpp
+++ b/src/software/utils/main_depthmapTracksInjecting.cpp
@@ -1,0 +1,131 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/types.hpp>
+#include <aliceVision/config.hpp>
+
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+
+#include <aliceVision/image/io.hpp>
+#include <aliceVision/image/Image.hpp>
+
+#include <aliceVision/track/trackIO.hpp>
+#include <aliceVision/track/TracksHandler.hpp>
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+
+#include <filesystem>
+
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string tracksInputFilename;
+    std::string tracksOutputFilename;
+    std::string depthSource;
+    
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+    ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
+    ("tracksFilename", po::value<std::string>(&tracksInputFilename)->required(), "Tracks input file.")
+    ("output,o", po::value<std::string>(&tracksOutputFilename)->required(), "Tracks output file.")
+    ("depthSource", po::value<std::string>(&depthSource)->required(), "Depth Source directory.");
+
+    CmdLine cmdline("AliceVision DepthMapTracksInjecting");
+
+    cmdline.add(requiredParams);
+    if(!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    // Load input scene
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::VIEWS))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read");
+        return EXIT_FAILURE;
+    }
+
+    // Load tracks
+    ALICEVISION_LOG_INFO("Load tracks");
+    track::TracksHandler tracksHandler;
+    if (!tracksHandler.load(tracksInputFilename, sfmData.getViewsKeys()))
+    {
+        ALICEVISION_LOG_ERROR("The input tracks file '" + tracksInputFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    const auto & tracksPerView = tracksHandler.getTracksPerView();
+    auto & tracks = tracksHandler.getAllTracksMutable();
+
+    for (const auto & [idView, view]: sfmData.getViews())
+    {
+        if (tracksPerView.find(idView) == tracksPerView.end())
+        {
+            continue;
+        }
+
+        fs::path path(view->getImage().getImagePath());
+        std::string depthPath = depthSource + "/depth_" + path.stem().string() + ".exr";
+
+        image::Image<float> depthImg;
+
+        try
+        {
+            image::readImage(depthPath, depthImg, image::EImageColorSpace::NO_CONVERSION);
+        }
+        catch(...)
+        {
+            continue;
+        }
+
+        ALICEVISION_LOG_INFO("Injecting from " << depthPath);
+        for (const auto & trackId: tracksPerView.at(idView))
+        {
+            track::Track & track = tracks[trackId];
+
+            auto & feature = track.featPerView.at(idView);
+            
+            int ix = int(feature.coords.x());
+            int iy = int(feature.coords.y());
+
+            if (ix < 0 || ix >= depthImg.width()) continue;
+            if (iy < 0 || iy >= depthImg.height()) continue;
+
+            feature.depth = depthImg(iy, ix);
+        }
+    }
+
+    // Save tracks
+    ALICEVISION_LOG_INFO("Saving to " << tracksOutputFilename);
+    ALICEVISION_LOG_INFO("File has " << tracksHandler.getAllTracks().size() << " tracks.");
+    if (!track::saveTracks(tracksHandler.getAllTracks(), tracksOutputFilename))
+    {
+        ALICEVISION_LOG_ERROR("Failed to save file");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull request introduces support for injecting depth information from depth maps into tracks within the AliceVision pipeline. The main changes add a new utility for this purpose, extend the `TrackItem` structure to store depth, and update serialization logic to handle the new field.