### PR TITLE
[meshroom] propagate node size from input sfmData

### DIFF
--- a/meshroom/aliceVision/GlobalPositionEstimating.py
+++ b/meshroom/aliceVision/GlobalPositionEstimating.py
@@ -6,6 +6,7 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class GlobalPositionEstimating(desc.AVCommandLineNode):
     commandLine = "aliceVision_globalPositionEstimating {allParams}"
+    size = desc.DynamicNodeSize("input")
 
     category = "Sparse Reconstruction"
     documentation = """Estimate the global translations and structure given tracks."""

--- a/meshroom/aliceVision/GlobalRotationEstimating.py
+++ b/meshroom/aliceVision/GlobalRotationEstimating.py
@@ -6,6 +6,7 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class GlobalRotationEstimating(desc.AVCommandLineNode):
     commandLine = "aliceVision_globalRotationEstimating {allParams}"
+    size = desc.DynamicNodeSize("input")
 
     category = "Sparse Reconstruction"
     documentation = """Estimate the global rotation given tracks."""

--- a/meshroom/aliceVision/PhotometricStereo.py
+++ b/meshroom/aliceVision/PhotometricStereo.py
@@ -5,6 +5,7 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class PhotometricStereo(desc.CommandLineNode):
     commandLine = "aliceVision_photometricStereo {allParams}"
+    size = desc.DynamicNodeSize("inputPath")
     category = "Photometric Stereo"
     documentation = """
 Reconstruction using Photometric Stereo.

--- a/meshroom/aliceVision/SfMChecking.py
+++ b/meshroom/aliceVision/SfMChecking.py
@@ -6,6 +6,7 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class SfMChecking(desc.Node):
 
+    size = desc.DynamicNodeSize("input")
     category = "Utils"
     documentation = """
 Check an input SfM for validity.

--- a/meshroom/aliceVision/SfMFilter.py
+++ b/meshroom/aliceVision/SfMFilter.py
@@ -6,6 +6,7 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class SfMFilter(desc.CommandLineNode):
     commandLine = "aliceVision_sfmFilter {allParams}"
+    size = desc.DynamicNodeSize("inputFile")
     category = "Utils"
     documentation = """This node allows select views from SfMData file using a regular expresion."""
 


### PR DESCRIPTION
Nodes processing an sfmData should propagate a size, so the following nodes using parallelization could correctly estimate the number of chunks.
