### PR TITLE
Fix sfmTransform frame

### DIFF
--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -217,6 +217,13 @@ static void parseManualTransform(const std::string& manualTransform, double& S, 
         rotateMat = quaternion.matrix();
     }
     R = rotateMat;  // Assign Rotation
+
+    Eigen::Matrix3d M = Eigen::Matrix3d::Identity();
+    M(1, 1) = -1;
+    M(2, 2) = -1;
+
+    R = M * R * M;
+    t = M * t;
 }
 
 }  // namespace


### PR DESCRIPTION
- Meshroom is directly reading and interpreting the transform with CG convention (Computer Graphics)
- AliceVision is using another code to interpret the transform with CV convention (Computer Vision)
There was a discrepancy between both.

Here we correct that by aligning aliceVision TO meshroom.
So even if internally AliceVision is using CV convention, the input transform is now considered in CG convention.
