### PR TITLE
Fix sfm bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,7 @@ Production
 **/.vscode
 **/.vs
 
-vcpkg_installed/
-export/
+/vcpkg_installed/
+/export/
+/.cache/
+/compile_commands.json

--- a/meshroom/aliceVision/RelativePoseEstimating.py
+++ b/meshroom/aliceVision/RelativePoseEstimating.py
@@ -1,4 +1,4 @@
-__version__ = "3.0"
+__version__ = "3.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
@@ -46,6 +46,14 @@ class RelativePoseEstimating(desc.AVCommandLineNode):
             description="Minimal allowed inliers in two view relationship.",
             value=35,
             range=(1, 1000, 1),
+            advanced=True,
+        ),
+        desc.FloatParam(
+            name="distanceThreshold",
+            label="Distance Threshold",
+            description="Threshold on geometric distance (epipolar distance or reprojection distance for pure rotation)",
+            value=4.0,
+            range=(0.0, 50.0, 1.0),
             advanced=True,
         ),
         desc.File(

--- a/src/aliceVision/multiview/triangulation/triangulationDLT.cpp
+++ b/src/aliceVision/multiview/triangulation/triangulationDLT.cpp
@@ -34,22 +34,63 @@ void TriangulateDLT(const Mat34& P1, const Vec2& x1, const Mat34& P2, const Vec2
     homogeneousToEuclidean(X_homogeneous, X_euclidean);
 }
 
-// Solve:
-// [cross(x0,P0) X = 0]
-// [cross(x1,P1) X = 0]
+/**
+* let v = R.transpose() * x; (to get a world coordinates direction)
+* then lambda * v = X - center
+* (v) cross (X - center) = 0
+* [v]x*X - [V]x*center) = 0
+*/
 void TriangulateSphericalDLT(const Mat4& T1, const Vec3& x1, const Mat4& T2, const Vec3& x2, Vec4& X_homogeneous)
 {
-    Mat design(6, 4);
-    for (int i = 0; i < 4; ++i)
-    {
-        design(0, i) = -x1[2] * T1(1, i) + x1[1] * T1(2, i);
-        design(1, i) = x1[2] * T1(0, i) - x1[0] * T1(2, i);
-        design(2, i) = -x1[1] * T1(0, i) + x1[0] * T1(1, i);
+    const Mat3 R1 = T1.block<3, 3>(0, 0);
+    const Mat3 R2 = T2.block<3, 3>(0, 0);
+    const Vec3 t1 = T1.block<3, 1>(0, 3);
+    const Vec3 t2 = T2.block<3, 1>(0, 3);
+    const Vec3 c1 = -R1.transpose() * t1;
+    const Vec3 c2 = -R2.transpose() * t2;
 
-        design(3, i) = -x2[2] * T2(1, i) + x2[1] * T2(2, i);
-        design(4, i) = x2[2] * T2(0, i) - x2[0] * T2(2, i);
-        design(5, i) = -x2[1] * T2(0, i) + x2[0] * T2(1, i);
-    }
+    const Vec3 v1 = R1.transpose() * x1;
+    const Vec3 v2 = R2.transpose() * x2;
+
+    Mat4 design;
+    
+    //We keep last 2 rows of the equation for each point
+    // [ 0  -z   y]
+    // [ z   0  -x]
+    // [-y   x   0]
+    // --> 
+    // [ z   0  -x]
+    // [-y   x   0]
+
+    // [ z   0  -x] * [cx cy cz]^t = z * cx - x * cz
+    // [-y   x   0] * [cx cy cz]^t = -y * cx + x * cy
+
+    //[v]x
+    design(0, 0) = v1.z();
+    design(0, 1) = 0;
+    design(0, 2) = -v1.x();    
+    design(1, 0) = - v1.y();
+    design(1, 1) = v1.x();
+    design(1, 2) = 0;
+
+    //-[V]x*center
+    design(0, 3) = - (v1.z() * c1.x() - v1.x() * c1.z());
+    design(1, 3) = - (-v1.y() * c1.x() + v1.x() * c1.y());
+
+    //[v]x
+    design(2, 0) = v2.z();
+    design(2, 1) = 0;
+    design(2, 2) = -v2.x();    
+    design(3, 0) = - v2.y();
+    design(3, 1) = v2.x();
+    design(3, 2) = 0;
+
+    //-[V]x*center
+    design(2, 3) = - (v2.z() * c2.x() - v2.x() * c2.z());
+    design(3, 3) = - (-v2.y() * c2.x() + v2.x() * c2.y());
+
+    // Solve AX=0, where X is the homogeneous coordinates vector of the 3d point
+    // in the reference frame
     Nullspace(design, X_homogeneous);
 }
 

--- a/src/aliceVision/multiview/triangulation/triangulationDLT.hpp
+++ b/src/aliceVision/multiview/triangulation/triangulationDLT.hpp
@@ -50,9 +50,9 @@ void TriangulateSphericalDLT(const Mat4& T1, const Vec3& x1, const Mat4& T2, con
  * Triangulate a point given a set of bearing vectors
  * and associated projection matrices (in meters)
  * @param T1 a projection matrix (R | t)
- * @param x1 a unit bearing vector
+ * @param x1 a unit bearing vector (on the unit sphere)
  * @param T2 a projection matrix K (R | t)
- * @param x2 a unit bearing vector
+ * @param x2 a unit bearing vector (on the unit sphere)
  * @param X_homogeneous a 3d point
  */
 void TriangulateSphericalDLT(const Mat4& T1, const Vec3& x1, const Mat4& T2, const Vec3& x2, Vec3& X_euclidean);

--- a/src/aliceVision/multiview/triangulation/triangulationDLT_test.cpp
+++ b/src/aliceVision/multiview/triangulation/triangulationDLT_test.cpp
@@ -9,6 +9,7 @@
 #include <aliceVision/numeric/projection.hpp>
 #include <aliceVision/multiview/NViewDataSet.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
+#include <aliceVision/geometry/lie.hpp>
 
 #define BOOST_TEST_MODULE triangulationDLT
 
@@ -31,4 +32,46 @@ BOOST_AUTO_TEST_CASE(Triangulation_TriangulateDLT)
         multiview::TriangulateDLT(d.P(0), x1, d.P(1), x2, X_estimated);
         BOOST_CHECK_SMALL(DistanceLInfinity(X_estimated, X_gt), 1e-8);
     }
+}
+
+BOOST_AUTO_TEST_CASE(Triangulation_TriangulateSphericalDLT_base)
+{
+    Vec3 X_gt;
+
+    X_gt << 2, -3, 4;
+
+    Mat4 T1 = Mat4::Identity();
+    Mat4 T2 = Mat4::Identity();
+
+    T1.block<3, 3>(0, 0) = SO3::expm({0.1, 0.2, -0.5});
+    T2.block<3, 3>(0, 0) = SO3::expm({0.01, -0.3, -0.2});
+    T1.block<3, 1>(0, 3) << 0.5, 0.6, -0.2;
+    T2.block<3, 1>(0, 3) << -0.1, 1.6, 2.2;
+
+    Vec3 x1 = (T1 * X_gt.homogeneous()).head(3).normalized();
+    Vec3 x2 = (T2 * X_gt.homogeneous()).head(3).normalized();
+
+    Vec3 X_estimated;
+    multiview::TriangulateSphericalDLT(T1, x1, T2, x2, X_estimated);
+
+    BOOST_CHECK_SMALL(DistanceLInfinity(X_estimated, X_gt), 1e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Triangulation_TriangulateSphericalDLT_Zero)
+{
+    Vec3 X_gt;
+
+    X_gt << 2, -3, 4;
+
+    Mat4 T1 = Mat4::Identity();
+    Mat4 T2 = Mat4::Identity();
+
+    Vec3 x1 = (T1 * X_gt.homogeneous()).head(3).normalized();
+    Vec3 x2 = (T2 * X_gt.homogeneous()).head(3).normalized();
+
+    Vec3 X_estimated;
+    multiview::TriangulateSphericalDLT(T1, x1, T2, x2, X_estimated);
+    
+    //Result should be null vector
+    BOOST_CHECK(X_estimated.norm() < 1e-3);
 }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/EstimateAngle.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/EstimateAngle.cpp
@@ -16,6 +16,7 @@ bool estimatePairAngle(const sfmData::SfMData & sfmData,
                        const IndexT referenceViewId,
                        const IndexT otherViewId,
                        const geometry::Pose3 & otherTreference,
+                       const double & errorMax,
                        const track::TracksMap& tracksMap, 
                        const track::TracksPerView & tracksPerView, 
                        double & resultAngle, 
@@ -33,7 +34,9 @@ bool estimatePairAngle(const sfmData::SfMData & sfmData,
     track::getCommonTracksInImagesFast({referenceViewId, otherViewId}, tracksMap, tracksPerView, mapTracksCommon);
 
     const Mat4 T1 = Eigen::Matrix4d::Identity();
-    const Mat4 T2 = otherTreference.getHomogeneous();
+    Mat4 T2 = otherTreference.getHomogeneous();
+    const Mat3 R2 = otherTreference.rotation();
+    const Mat3 E = CrossProductMatrix(otherTreference.translation()) * R2;
     
     const Eigen::Vector3d c = otherTreference.center();
 
@@ -51,6 +54,13 @@ bool estimatePairAngle(const sfmData::SfMData & sfmData,
         
         const Vec3 pt3d1 = refIntrinsics->toUnitSphere(refIntrinsics->removeDistortion(refIntrinsics->ima2cam(refpt)));
         const Vec3 pt3d2 = nextIntrinsics->toUnitSphere(nextIntrinsics->removeDistortion(nextIntrinsics->ima2cam(nextpt)));
+
+        const Vec3 x = (E * pt3d1).normalized();
+        double error = std::abs(std::asin(pt3d2.dot(x)));
+        if (error > errorMax)
+        {
+            continue;
+        }
 
         
         Vec3 X;

--- a/src/aliceVision/sfm/pipeline/bootstrapping/EstimateAngle.hpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/EstimateAngle.hpp
@@ -18,6 +18,7 @@ namespace sfm {
  * @param referenceViewId the reference view id
  * @param otherViewId the other view id
  * @param otherTreference the relative pose
+ * @param errorMax the maximal tolerated error
  * @param tracksMap the input map of tracks
  * @param tracksPerView tracks grouped by views
  * @param resultAngle the output median angle
@@ -28,6 +29,7 @@ bool estimatePairAngle(const sfmData::SfMData & sfmData,
                        const IndexT referenceViewId,
                        const IndexT otherViewId,
                        const geometry::Pose3 & otherTreference,
+                       const double & errorMax,
                        const track::TracksMap& tracksMap, 
                        const track::TracksPerView & tracksPerView, 
                        double & resultAngle, 

--- a/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.cpp
@@ -70,7 +70,7 @@ IndexT findBestPair(const sfmData::SfMData & sfmData,
         
         double angle = 0.0;
         std::vector<size_t> usedTracks;
-        if (!sfm::estimatePairAngle(sfmData, pair.reference, pair.next, pair.pose, tracksMap, tracksPerView, angle, usedTracks))
+        if (!sfm::estimatePairAngle(sfmData, pair.reference, pair.next, pair.pose, pair.errorMax, tracksMap, tracksPerView, angle, usedTracks))
         {
             continue;
         }

--- a/src/aliceVision/sfm/pipeline/relativePoses.hpp
+++ b/src/aliceVision/sfm/pipeline/relativePoses.hpp
@@ -20,6 +20,7 @@ struct ReconstructedPair
     IndexT next;
     geometry::Pose3 pose;
     double score;
+    double errorMax;
 };
 
 void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, sfm::ReconstructedPair const& input)
@@ -28,7 +29,9 @@ void tag_invoke(const boost::json::value_from_tag&, boost::json::value& jv, sfm:
           {"next", input.next},
           {"R", boost::json::value_from(SO3::logm(input.pose.rotation()))},
           {"t", boost::json::value_from(input.pose.translation())},
-          {"score", boost::json::value_from(input.score)}};
+          {"score", boost::json::value_from(input.score)},
+          {"errorMax", boost::json::value_from(input.errorMax)}
+          };
 }
 
 ReconstructedPair tag_invoke(boost::json::value_to_tag<ReconstructedPair>, boost::json::value const& jv)
@@ -42,6 +45,7 @@ ReconstructedPair tag_invoke(boost::json::value_to_tag<ReconstructedPair>, boost
     ret.pose.setRotation(SO3::expm(boost::json::value_to<Vec3>(obj.at("R"))));
     ret.pose.setTranslation(boost::json::value_to<Vec3>(obj.at("t")));
     ret.score = boost::json::value_to<double>(obj.at("score"));
+    ret.errorMax = boost::json::value_to<double>(obj.at("errorMax"));
 
     return ret;
 }

--- a/src/software/pipeline/main_relativePoseEstimating.cpp
+++ b/src/software/pipeline/main_relativePoseEstimating.cpp
@@ -55,6 +55,7 @@ namespace po = boost::program_options;
  * @brief Estimate the relative essential matrix between two cameras
  * @param E the output Essential matrix
  * @param vecInliers the input list of inliers (set of indices in the coordinates vectors)
+ * @param errorMax the allowed error for an inlier
  * @param cam1 the first camera intrinsic object
  * @param cam2 the second camera intrinsic object
  * @param x1 the observed points coordinates in the first camera
@@ -66,6 +67,7 @@ namespace po = boost::program_options;
 */
 bool robustEssential(Mat3& E,
                      std::vector<size_t>& vecInliers,
+                     double & errorMax,
                      const camera::IntrinsicBase & cam1,
                      const camera::IntrinsicBase & cam2,
                      const std::vector<Vec2>& x1,
@@ -90,6 +92,8 @@ bool robustEssential(Mat3& E,
 
     E = model.getMatrix();
 
+    errorMax = acRansacOut.first;
+
     return true;
 }
 
@@ -97,6 +101,7 @@ bool robustEssential(Mat3& E,
  * @brief Estimate the relative rortation matrix between two cameras
  * @param R the output Rotation matrix
  * @param vecInliers the input list of inliers (set of indices in the coordinates vectors)
+ * @param errorMax the allowed error for an inlier
  * @param cam1 the first camera intrinsic object
  * @param cam2 the second camera intrinsic object
  * @param x1 the observed points coordinates in the first camera
@@ -108,6 +113,7 @@ bool robustEssential(Mat3& E,
 */
 bool robustRotation(Mat3& R,
                     std::vector<size_t>& vecInliers,
+                    double & errorMax,
                      const camera::IntrinsicBase & cam1,
                      const camera::IntrinsicBase & cam2,
                      const std::vector<Vec2>& x1,
@@ -131,6 +137,8 @@ bool robustRotation(Mat3& R,
     }
 
     R = model.getMatrix();
+
+    errorMax = acRansacOut.first;
 
     return true;
 }
@@ -298,6 +306,7 @@ int aliceVision_main(int argc, char** argv)
 
         std::vector<size_t> vecInliers;
         sfm::ReconstructedPair reconstructed;
+        double errorMax = 0.0;
 
         if (enforcePureRotation)
         {
@@ -305,6 +314,7 @@ int aliceVision_main(int argc, char** argv)
             Mat3 R;
             const bool relativeSuccess = robustRotation(R, 
                                                         vecInliers, 
+                                                        errorMax,
                                                         *refIntrinsics,
                                                         *nextIntrinsics, 
                                                         refpts, 
@@ -320,6 +330,7 @@ int aliceVision_main(int argc, char** argv)
             reconstructed.reference = refImage;
             reconstructed.next = nextImage;
             reconstructed.pose.setRotation(R);
+            reconstructed.errorMax = errorMax;
         }
         else
         {
@@ -328,6 +339,7 @@ int aliceVision_main(int argc, char** argv)
             std::vector<size_t> inliers;
             const bool essentialSuccess = robustEssential(E,
                                                           inliers,
+                                                          errorMax,
                                                           *refIntrinsics,
                                                           *nextIntrinsics,
                                                           refpts,
@@ -343,6 +355,7 @@ int aliceVision_main(int argc, char** argv)
             std::vector<Vec3> structure;
             reconstructed.reference = refImage;
             reconstructed.next = nextImage;
+            reconstructed.errorMax = errorMax;
 
             Mat4 T;
             if (!estimateTransformStructureFromEssential(T, structure, vecInliers, E, inliers, 

--- a/src/software/pipeline/main_relativePoseEstimating.cpp
+++ b/src/software/pipeline/main_relativePoseEstimating.cpp
@@ -44,7 +44,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
@@ -63,6 +63,7 @@ namespace po = boost::program_options;
  * @param randomNumberGenerator a random number generator object shared among objects
  * @param maxIterationsCount how many iterations are allowed during ransac
  * @param minInliers what is the minimal number of inliers required to consider the estimation successful
+ * @param distanceThreshold minimal distance allowed for epipolar line to point distance in pixels
  * @return true if estimation succeeded
 */
 bool robustEssential(Mat3& E,
@@ -74,16 +75,31 @@ bool robustEssential(Mat3& E,
                      const std::vector<Vec2>& x2,
                      std::mt19937& randomNumberGenerator,
                      const size_t maxIterationCount,
-                     const size_t minInliers)
+                     const size_t minInliers,
+                     const double distanceThreshold)
 {
     multiview::relativePose::RelativeSphericalKernel kernel(cam1, cam2, x1, x2);
+
+    double threshold = std::numeric_limits<double>::infinity();
+    if (distanceThreshold > 0.0)
+    {
+        //From pixel distance to angular error
+        double angularError1 = cam1.getHorizontalFov() * distanceThreshold / cam1.w();
+        double angularError2 = cam2.getHorizontalFov() * distanceThreshold / cam2.w();
+        threshold = std::max(angularError1, angularError2);
+    }
 
     robustEstimation::Mat3Model model;
     vecInliers.clear();
 
     // robustly estimation of the Essential matrix and its precision
     const std::pair<double, double> acRansacOut =
-      robustEstimation::NACRANSAC(kernel, randomNumberGenerator, vecInliers, maxIterationCount, &model);
+      robustEstimation::NACRANSAC(kernel, 
+                                randomNumberGenerator, 
+                                vecInliers, 
+                                maxIterationCount, 
+                                &model, 
+                                threshold);
 
     if (vecInliers.size() < minInliers)
     {
@@ -109,6 +125,7 @@ bool robustEssential(Mat3& E,
  * @param randomNumberGenerator a random number generator object shared among objects
  * @param maxIterationsCount how many iterations are allowed during ransac
  * @param minInliers what is the minimal number of inliers required to consider the estimation successful
+ * @param distanceThreshold minimal distance allowed to reprojection
  * @return true if estimation succeeded
 */
 bool robustRotation(Mat3& R,
@@ -120,16 +137,31 @@ bool robustRotation(Mat3& R,
                      const std::vector<Vec2>& x2,
                      std::mt19937& randomNumberGenerator,
                      const size_t maxIterationCount,
-                     const size_t minInliers)
+                     const size_t minInliers,
+                     const double distanceThreshold)
 {
     multiview::relativePose::RotationSphericalKernel kernel(cam1, cam2, x1, x2);
+
+    double threshold = std::numeric_limits<double>::infinity();
+    if (distanceThreshold > 0.0)
+    {
+        //From pixel distance to angular error
+        double angularError1 = cam1.getHorizontalFov() * distanceThreshold / cam1.w();
+        double angularError2 = cam2.getHorizontalFov() * distanceThreshold / cam2.w();
+        threshold = std::max(angularError1, angularError2);
+    }
 
     robustEstimation::Mat3Model model;
     vecInliers.clear();
 
     // robustly estimation of the Essential matrix and its precision
     const std::pair<double, double> acRansacOut =
-      robustEstimation::NACRANSAC(kernel, randomNumberGenerator, vecInliers, maxIterationCount, &model);
+      robustEstimation::NACRANSAC(kernel,
+                                randomNumberGenerator, 
+                                vecInliers, 
+                                maxIterationCount, 
+                                &model, 
+                                threshold);
 
     if (vecInliers.size() < minInliers)
     {
@@ -155,6 +187,7 @@ int aliceVision_main(int argc, char** argv)
     bool enforcePureRotation = false;
     size_t countIterations = 1024;
     std::vector<std::string> predefinedPairList;
+    double distanceThreshold = 4.0;
 
     // user optional parameters
     std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
@@ -173,6 +206,7 @@ int aliceVision_main(int argc, char** argv)
         ("enforcePureRotation,e", po::value<bool>(&enforcePureRotation)->default_value(enforcePureRotation), "Enforce pure rotation in estimation.")
         ("countIterations", po::value<size_t>(&countIterations)->default_value(countIterations), "Maximal number of iterations.")
         ("minInliers", po::value<size_t>(&minInliers)->default_value(minInliers), "Minimal number of inliers for a valid ransac.")
+        ("distanceThreshold", po::value<double>(&distanceThreshold)->default_value(distanceThreshold), "Threshold on geometric distance (epipolar distance or reprojection distance for pure rotation)")
         ("imagePairsList,l", po::value<std::vector<std::string>>(&predefinedPairList)->multitoken(),
          "Path(s) to one or more files which contain the list of image pairs to match.")
         ("rangeIteration", po::value<int>(&rangeIteration)->default_value(rangeIteration), "Chunk id.")
@@ -321,7 +355,8 @@ int aliceVision_main(int argc, char** argv)
                                                         nextpts, 
                                                         randomNumberGenerator, 
                                                         countIterations, 
-                                                        minInliers);
+                                                        minInliers,
+                                                        distanceThreshold);
             if (!relativeSuccess)
             {
                 continue;
@@ -346,7 +381,8 @@ int aliceVision_main(int argc, char** argv)
                                                           nextpts,
                                                           randomNumberGenerator,
                                                           countIterations,
-                                                          minInliers);
+                                                          minInliers,
+                                                          distanceThreshold);
             if (!essentialSuccess)
             {
                 continue;

--- a/src/software/pipeline/main_relativePoseEstimating.cpp
+++ b/src/software/pipeline/main_relativePoseEstimating.cpp
@@ -226,7 +226,13 @@ int aliceVision_main(int argc, char** argv)
     HardwareContext hwc = cmdline.getHardwareContext();
     omp_set_num_threads(hwc.getMaxThreads());
 
-    std::mt19937 randomNumberGenerator(randomSeed);
+    // Generate one number generator per thread to enable repetability
+    // Without thread concurrency
+    std::vector<std::mt19937> randomNumberGenerators;
+    for (int i = 0; i < omp_get_max_threads(); i++)
+    {
+        randomNumberGenerators.emplace_back(randomSeed);
+    }
 
     // load input SfMData scene
     sfmData::SfMData sfmData;
@@ -303,11 +309,13 @@ int aliceVision_main(int argc, char** argv)
     std::ofstream of(ss.str());
 
     // For each covisible pair
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for //schedule(dynamic)
     for (int posPairs = chunkStart; posPairs < chunkEnd; posPairs++)
     {
         auto iterPairs = covisibility.begin();
         std::advance(iterPairs, posPairs);
+
+        std::mt19937 & randomNumberGenerator = randomNumberGenerators[omp_get_thread_num()];
 
         // Retrieve pair information
         IndexT refImage = iterPairs->first.first;


### PR DESCRIPTION
- Rewrite DLT triangulation method for bearing vectors.
- Store found ACRansac threshold in the relative poses file.
- Read and use this threshold in sfm bootstraping.
- Add a threshold parameter to relativeposeEstimating that will be used in RANSAC for inlier testing.