### PR TITLE
feat(sensorDB): Add Nikon Z 6_2 camera entry to database

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -3859,6 +3859,7 @@ Nikon;Nikon Z50;23.5;digicamdb
 Nikon;Nikon Z6;35.9;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Z6 II;35.9;digicamdb
 Nikon;Nikon Z6II;35.9;dxomark
+Nikon;Nikon Z 6_2;35.9;dpreview,digicamdb,imaging-resource
 Nikon;Nikon Z7;35.9;digicamdb,dpreview,imaging-resource
 Nikon;Nikon Z7 II;35.9;digicamdb
 Nikon;Nikon Z7II;35.9;dxomark


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description

The existing entries did not work for my Z II. 


## Features list

Adding `Nikon;Nikon Z 6_2;35.9;dpreview,digicamdb,imaging-resource` to the db

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

