### PR TITLE
Bootstrap with injected depths from Depthmaps

### DIFF
--- a/meshroom/aliceVision/SfmBootstrapping.py
+++ b/meshroom/aliceVision/SfmBootstrapping.py
@@ -18,6 +18,13 @@ class SfMBootStrapping(desc.AVCommandLineNode):
             description="SfMData file.",
             value="",
         ),
+        desc.ChoiceParam(
+            name="method",
+            label="Method",
+            description="Bootstrapping method: classic (epipolar geometry), mesh (3D mesh constraints), or depth (depth map information).",
+            values=["classic", "mesh", "depth"],
+            value="classic",
+        ),
         desc.File(
             name="tracksFilename",
             label="Tracks File",
@@ -29,6 +36,7 @@ class SfMBootStrapping(desc.AVCommandLineNode):
             label="Mesh File",
             description="Mesh file (*.obj).",
             value="",
+            enabled=lambda node: node.method.value == "mesh"
         ),
         desc.File(
             name="pairs",

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -27,6 +27,7 @@ set(sfm_files_headers
     pipeline/bootstrapping/EstimateAngle.hpp
     pipeline/bootstrapping/PairsScoring.hpp
     pipeline/bootstrapping/Bootstrap.hpp
+    pipeline/bootstrapping/TracksDepths.hpp
     pipeline/expanding/SfmTriangulation.hpp
     pipeline/expanding/SfmResection.hpp
     pipeline/expanding/SfmBundle.hpp
@@ -74,6 +75,7 @@ set(sfm_files_sources
     pipeline/bootstrapping/EstimateAngle.cpp
     pipeline/bootstrapping/PairsScoring.cpp
     pipeline/bootstrapping/Bootstrap.cpp
+    pipeline/bootstrapping/TracksDepths.cpp
     pipeline/expanding/SfmTriangulation.cpp
     pipeline/expanding/SfmResection.cpp
     pipeline/expanding/SfmBundle.cpp

--- a/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
 #include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
 #include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp>
+#include <aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp>
 #include <vector>
 #include <random>
 
@@ -167,6 +168,103 @@ bool bootstrapMesh(sfmData::SfMData & sfmData,
 
             //Add observation to landmark
             sfmData::Observations & observations = outLandmarks[landmarkId].getObservations();
+            observations[nextViewId] = obs;
+        }
+    }
+
+    return true;
+}
+
+bool bootstrapDepth(sfmData::SfMData & sfmData, 
+                    const IndexT referenceViewId,
+                    const IndexT nextViewId,
+                    const track::TracksMap& tracksMap, 
+                    const track::TracksPerView & tracksPerView)
+{
+    std::mt19937 randomNumberGenerator;
+
+    const sfmData::View & viewReference = sfmData.getView(referenceViewId);
+    const sfmData::View & viewNext = sfmData.getView(nextViewId);
+
+    camera::IntrinsicBase::sptr camReference = sfmData.getIntrinsicSharedPtr(viewReference.getIntrinsicId());
+    camera::IntrinsicBase::sptr camNext = sfmData.getIntrinsicSharedPtr(viewNext.getIntrinsicId());
+
+    sfmData::CameraPose & poseReference = sfmData.getPoses()[viewReference.getPoseId()];
+    sfmData::CameraPose & poseNext = sfmData.getPoses()[viewNext.getPoseId()];
+
+
+    sfmData::SfMData miniSfm;
+    if (!buildSfmDataFromDepthMap(miniSfm, sfmData, tracksMap, tracksPerView, referenceViewId))
+    {
+        return false;
+    }
+
+    //Compute resection for selected view
+    sfm::LocalizationValidationPolicy::uptr resectionValidationPolicy = std::make_unique<sfm::LocalizationValidationPolicyLegacy>();
+
+    sfm::SfmResection resection;
+    resection.setMaxIterations(50000);
+    resection.setResectionMaxError(std::numeric_limits<double>::infinity());
+    resection.setValidationPolicy(resectionValidationPolicy);
+
+    Eigen::Matrix4d pose;
+    double newThreshold;
+    size_t inliersCount;
+
+    if (!resection.processView(miniSfm, 
+                            tracksMap, tracksPerView, 
+                            randomNumberGenerator,
+                            nextViewId, pose, newThreshold, inliersCount))
+    {
+        return false;
+    }
+
+
+    geometry::Pose3 pose3(pose);
+    poseNext.setTransform(pose3);
+
+    const auto & landmarks = miniSfm.getLandmarks();
+    auto & outLandmarks = sfmData.getLandmarks();
+
+    for (const auto & [landmarkId, landmark] : landmarks)
+    {
+        //Retrieve track object
+        const auto & track = tracksMap.at(landmarkId);
+
+        const track::TrackItem & itemReference = track.featPerView.at(referenceViewId);
+
+        //Maybe this track is not observed in the next view
+        if (track.featPerView.find(nextViewId) == track.featPerView.end())
+        {
+            continue;
+        }
+
+        //Compute error
+        const track::TrackItem & item = track.featPerView.at(nextViewId);
+        const Vec2 pt = item.coords;
+        const Vec2 estpt = camNext->transformProject(pose3, landmark.X.homogeneous(), true);
+        double err = (pt - estpt).norm();
+
+        //If error is ok, then we add it to the sfmData
+        if (err <= newThreshold)
+        {
+            sfmData::Observation obs;
+            obs.setFeatureId(item.featureId);
+            obs.setScale(item.scale);
+            obs.setCoordinates(item.coords);
+
+            sfmData::Observation obsReference;
+            obsReference.setFeatureId(itemReference.featureId);
+            obsReference.setScale(itemReference.scale);
+            obsReference.setCoordinates(itemReference.coords);
+
+            //Add landmark to sfmData
+            outLandmarks[landmarkId] = landmark;
+            outLandmarks[landmarkId].setParallaxRobust(true);
+
+            //Add observation to landmark
+            sfmData::Observations & observations = outLandmarks[landmarkId].getObservations();
+            observations[referenceViewId] = obsReference;
             observations[nextViewId] = obs;
         }
     }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.hpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.hpp
@@ -46,5 +46,20 @@ bool bootstrapMesh(sfmData::SfMData & sfmData,
                     const track::TracksMap& tracksMap, 
                     const track::TracksPerView & tracksPerView);
 
+/**
+ * @brief Create a minimal SfmData with poses and landmarks for two views
+ * @param sfmData the input sfmData which contains camera information
+ * @param referenceViewId the reference view id
+ * @param otherViewId the other view id
+ * @param tracksMap the input map of tracks
+ * @param tracksPerView tracks grouped by views
+ * @return true
+*/
+bool bootstrapDepth(sfmData::SfMData & sfmData, 
+                    const IndexT referenceViewId,
+                    const IndexT otherViewId,
+                    const track::TracksMap& tracksMap, 
+                    const track::TracksPerView & tracksPerView);
+
 }
 }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.cpp
@@ -8,6 +8,9 @@
 #include <aliceVision/sfm/pipeline/bootstrapping/EstimateAngle.hpp>
 #include <aliceVision/sfm/pipeline/expanding/ExpansionPolicyLegacy.hpp>
 #include <aliceVision/multiview/triangulation/triangulationDLT.hpp>
+#include <aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp>
+#include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
+#include <aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicyLegacy.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -113,6 +116,111 @@ IndexT findBestPair(const sfmData::SfMData & sfmData,
         }
     }
     
+    return bestPair;
+}
+
+sfm::ReconstructedPair findBestPairFromTrackDepths(const sfmData::SfMData & sfmData, 
+                                    const std::vector<sfm::ReconstructedPair> & pairs,
+                                    const track::TracksMap& tracksMap, 
+                                    const track::TracksPerView & tracksPerView,
+                                    std::mt19937 & randomNumberGenerator)
+{
+    //Create set of unique view ids
+    std::set<IndexT> views;
+    for (IndexT pairId = 0; pairId < pairs.size(); pairId++)
+    {
+        views.insert(pairs[pairId].reference);
+        views.insert(pairs[pairId].next);
+    }
+
+    sfm::ReconstructedPair bestPair;
+    bestPair.reference = UndefinedIndexT;
+    size_t bestCount = 0;
+
+    sfm::LocalizationValidationPolicy::uptr resectionValidationPolicy = std::make_unique<sfm::LocalizationValidationPolicyLegacy>();
+
+    sfm::SfmResection resection;
+    resection.setMaxIterations(1024);
+    resection.setResectionMaxError(std::numeric_limits<double>::infinity());
+    resection.setValidationPolicy(resectionValidationPolicy);
+
+    //Loop over all views relatively located to another view
+    for (const auto & idView: views)
+    {
+        //Build a local sfm where the landmarks are the points on the depthmap
+        sfmData::SfMData miniSfm;
+        if (!buildSfmDataFromDepthMap(miniSfm, sfmData, tracksMap, tracksPerView, idView))
+        {
+            continue;
+        }
+        
+        sfm::ReconstructedPair bestPairLocal;
+        size_t maxInliers = 0;
+        size_t totalInliers = 0;
+
+        //Loop over all other views which are linked to this view
+        for (IndexT pairId = 0; pairId < pairs.size(); pairId++)
+        {
+            const auto & pairSource = pairs[pairId];
+            sfm::ReconstructedPair pair;
+            pair.reference = idView;
+
+
+            // Create the correct pair with order
+            if (pairSource.reference == idView)
+            {
+                pair.next = pairSource.next;
+            }
+            else if (pairSource.next == idView)
+            {
+                pair.next = pairSource.reference;
+            }
+            else
+            {
+                continue;
+            }
+
+            //Make sure the local sfm has this view
+            if (miniSfm.getViews().find(pair.next) == miniSfm.getViews().end())
+            {
+                continue;
+            }
+
+            //Try to locate this view in the local sfm
+            Eigen::Matrix4d pose;
+            double newThreshold;
+            size_t inliersCount;
+            if (!resection.processView(miniSfm, 
+                                    tracksMap, 
+                                    tracksPerView, 
+                                    randomNumberGenerator,
+                                    pair.next, 
+                                    pose, newThreshold, inliersCount))
+            {
+                continue;
+            }    
+
+            //Keep the best second view
+            pair.pose = geometry::Pose3(pose);
+            pair.score = inliersCount;
+            if (inliersCount > maxInliers)
+            {
+                maxInliers = inliersCount;
+                bestPairLocal = pair;
+            }
+
+            totalInliers += inliersCount;
+        }
+
+        //Keep the best pair
+        if (totalInliers > bestCount)
+        {
+            bestPair = bestPairLocal;
+            bestCount = totalInliers;
+        }
+    }
+
+
     return bestPair;
 }
 

--- a/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.hpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/PairsScoring.hpp
@@ -37,5 +37,20 @@ IndexT findBestPair(const sfmData::SfMData & sfmData,
                     double softMinAngle,
                     double maxAngle);
 
+/**
+* @brief Get best pair from track Depths with highest score
+* @param sfmData the input sfmData which contains camera information
+* @param pairs the input list of reconstructed pairs
+* @param tracksMap the input map of tracks
+* @param tracksPerView tracks grouped by views
+* @param randomNumberGenerator the random number generator used for drawing numbers
+* @return The best pair (pair.reference is UndefinedIndexT if nothing found)
+*/
+sfm::ReconstructedPair findBestPairFromTrackDepths(const sfmData::SfMData & sfmData, 
+                            const std::vector<sfm::ReconstructedPair> & pairs,
+                            const track::TracksMap& tracksMap, 
+                            const track::TracksPerView & tracksPerView,
+                            std::mt19937 & randomNumberGenerator);
+
 }
 }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.cpp
@@ -1,0 +1,82 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+bool buildSfmDataFromDepthMap(sfmData::SfMData & output,
+                            const sfmData::SfMData & sfmData, 
+                            const track::TracksMap& tracksMap, 
+                            const track::TracksPerView & tracksPerView, 
+                            IndexT viewId)
+{
+    output.clear();
+
+    const sfmData::View & view = sfmData.getView(viewId);
+    const camera::IntrinsicBase & intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
+
+    if (tracksPerView.find(viewId) == tracksPerView.end())
+    {
+        return false;
+    }
+
+    sfmData::Landmarks & landmarks = output.getLandmarks();
+
+    //Copy all intrinsics, because it's light.
+    for (const auto & [intrinsicId, intrinsic] : sfmData.getIntrinsics())
+    {
+        output.getIntrinsics().insert(
+            std::make_pair(intrinsicId, 
+                camera::IntrinsicBase::sptr(intrinsic->clone()))
+            );
+    }
+
+    std::set<IndexT> usedViewIds;
+    const auto & trackIds = tracksPerView.at(viewId);
+    for (const auto & trackId : trackIds)
+    {
+        const auto & track = tracksMap.at(trackId);
+        const auto & feat = track.featPerView.at(viewId);
+        const double & Z = feat.depth;
+
+        if (Z <= 0.0)
+        {
+            continue;
+        }
+        
+        const Vec2 meters = intrinsic.removeDistortion(intrinsic.ima2cam(feat.coords.cast<double>()));
+        
+        sfmData::Landmark & landmark = landmarks[trackId];
+        landmark.X.x() = meters.x() * Z;
+        landmark.X.y() = meters.y() * Z;
+        landmark.X.z() = Z;
+
+        landmark.descType = track.descType;
+
+        for (const auto & [otherViewId, otherFeat] : track.featPerView)
+        {
+            usedViewIds.insert(otherViewId);
+        }
+    }
+
+    // Copy only used views
+    for (const auto & usedViewId : usedViewIds)
+    {
+        const auto & iview = sfmData.getViewSharedPtr(usedViewId);
+
+        output.getViews().insert(
+            std::make_pair(usedViewId, 
+                sfmData::View::sptr(iview->clone()))
+            );
+    }
+
+    return true;
+}
+
+}
+}

--- a/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.hpp
@@ -1,0 +1,30 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+#pragma once
+
+#include <aliceVision/track/Track.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+/**
+ * @brief Create a new sfmData cleared from any existing landmarks and poses
+ * But with new landmarks created from tracks if depth exists
+ * @param output the result sfmData
+ * @param sfmData the input sfmData, used for views and intrinsics
+ * @param tracksMap the input map of tracks
+ * @param tracksPerView tracks grouped by views 
+ * @param viewId the view of interest identifier
+ * @return false if an error occured
+*/
+bool buildSfmDataFromDepthMap(sfmData::SfMData & output,
+                            const sfmData::SfMData & sfmData, 
+                            const track::TracksMap& tracksMap, 
+                            const track::TracksPerView & tracksPerView, 
+                            IndexT viewId);
+}
+}

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -426,6 +426,13 @@ class SfMData
     View::sptr getViewSharedPtr(IndexT viewId) { return _views.at(viewId); }
 
     /**
+     * @brief Gives the view of the input view id.
+     * @param[in] viewId The given view ID
+     * @return the corresponding view ptr
+     */
+    const View::sptr getViewSharedPtr(IndexT viewId) const { return _views.at(viewId); }
+
+    /**
      * @brief Retrieve the view id in the sfmData from the image filename.
      * @param[in] name the image name to find (uid or filename or path)
      * @return a view Id if a view is found or UndefinedIndexT

--- a/src/software/pipeline/main_sfmBootstrapping.cpp
+++ b/src/software/pipeline/main_sfmBootstrapping.cpp
@@ -51,6 +51,36 @@ using namespace aliceVision;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
+enum EBOOTSTRAPMETHOD
+{
+    CLASSIC = (1u << 0),
+    MESH = (1u << 1),
+    DEPTH = (1u << 2)
+};
+
+inline EBOOTSTRAPMETHOD EBOOTSTRAPMETHOD_stringToEnum(const std::string& method)
+{
+    std::string type = method;
+    std::transform(type.begin(), type.end(), type.begin(), ::tolower);  // tolower
+
+    if (type == "classic")
+    {
+        return EBOOTSTRAPMETHOD::CLASSIC;
+    }
+
+    if (type == "mesh")
+    {
+        return EBOOTSTRAPMETHOD::MESH;
+    }
+
+    if (type == "depth")
+    {
+        return EBOOTSTRAPMETHOD::DEPTH;
+    }
+
+    throw std::out_of_range(method);
+}
+
 /**
  * @brief build an initial set of landmarks from a view and a mesh object
  * @param sfmData the input/output sfmData
@@ -76,6 +106,12 @@ bool landmarksFromMesh(
     
     for (const auto referenceViewId: referenceViewIds)
     {
+        //Ignore views without poses and intrinsics
+        if (!sfmData.isPoseAndIntrinsicDefined(referenceViewId))
+        {
+            continue;
+        }
+        
         const sfmData::View & v = sfmData.getView(referenceViewId);
         const sfmData::CameraPose & cpose = sfmData.getAbsolutePose(v.getPoseId());
         const camera::IntrinsicBase & intrinsic = sfmData.getIntrinsic(v.getIntrinsicId());
@@ -94,12 +130,14 @@ bool landmarksFromMesh(
             const std::size_t featureId = track.featPerView.at(referenceViewId).featureId;
             const double scale = track.featPerView.at(referenceViewId).scale;
 
+            //Get interpolated 3d point on mesh
             Vec3 point;
             if (!mi.pickPoint(point, intrinsic, refpt))
             {
                 continue;
             }
 
+            //Create a Landmark with a unique observation
             sfmData::Landmark l;
             l.X = point;
             l.descType = feature::EImageDescriberType::SIFT;
@@ -126,15 +164,170 @@ void showStatsAngles(const sfmData::SfMData & sfmData)
     ALICEVISION_LOG_INFO(histo.ToString());
 }
 
+bool processClassic(sfmData::SfMData & sfmData, 
+                const track::TracksHandler & tracksHandler, 
+                const std::vector<sfm::ReconstructedPair> &reconstructedPairs,
+                double minAngleHard, 
+                double minAngleSoft, 
+                double maxAngle)
+{
+
+    if (sfmData.getValidViews().size() >= 2)
+    {
+        ALICEVISION_LOG_INFO("SfmData has already an initialization");
+        return false;
+    }
+
+    //Check all pairs
+    ALICEVISION_LOG_INFO("Give a score to all pairs");
+    int count = 0;
+
+    double bestScore = std::numeric_limits<double>::lowest();
+    sfm::ReconstructedPair bestPair;
+    bestPair.reference = UndefinedIndexT;
+    std::vector<std::size_t> bestUsedTracks;
+
+    std::set<IndexT> filterIn;
+    std::set<IndexT> filterOut;
+
+    IndexT bestPairId = findBestPair(sfmData, reconstructedPairs,  
+                            tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
+                            filterIn, filterOut,
+                            minAngleHard, minAngleSoft, maxAngle);
+
+    if (bestPairId == UndefinedIndexT)
+    {
+        ALICEVISION_LOG_INFO("No valid pair");
+        return false;
+    }
+    
+    bestPair = reconstructedPairs[bestPairId];
+    if (!sfm::bootstrapBase(sfmData, 
+                    bestPair.reference, bestPair.next, 
+                    bestPair.pose, 
+                    tracksHandler.getAllTracks(), tracksHandler.getTracksPerView()))
+    {
+        return false;
+    }
+
+    ALICEVISION_LOG_INFO("Best selected pair is : ");
+    ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.reference).getImage().getImagePath());
+    ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.next).getImage().getImagePath());
+    ALICEVISION_LOG_INFO("Landmarks count : " << sfmData.getLandmarks().size());
+
+    return true;
+}
+
+bool processMesh(sfmData::SfMData & sfmData, 
+                const track::TracksHandler & tracksHandler, 
+                const std::vector<sfm::ReconstructedPair> &reconstructedPairs,
+                const std::set<IndexT> & firstViewFilters,
+                const std::string & meshFilename,
+                double minAngleHard, 
+                double minAngleSoft, 
+                double maxAngle)
+{
+    //Load mesh in the mesh intersection object
+    if (meshFilename.empty())
+    {
+        ALICEVISION_LOG_ERROR("No mesh file given");
+        return false;
+    } 
+    
+    if (!firstViewFilters.empty())
+    {        
+        ALICEVISION_LOG_ERROR("No known pose for mesh");
+        return false;
+    }
+
+    sfmData::Landmarks landmarks;
+    if (!landmarksFromMesh(landmarks, sfmData, meshFilename, firstViewFilters, tracksHandler))
+    {
+        return false;
+    }
+
+    //Check all pairs
+    ALICEVISION_LOG_INFO("Give a score to all pairs");
+    int count = 0;
+
+    sfm::ReconstructedPair bestPair;
+    std::set<IndexT> filterIn;
+    std::set<IndexT> filterOut;
+
+    IndexT bestPairId = findBestPair(sfmData, reconstructedPairs,  
+                            tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
+                            filterIn, filterOut,
+                            minAngleHard, minAngleSoft, maxAngle);
+
+    if (bestPairId == UndefinedIndexT)
+    {
+        ALICEVISION_LOG_INFO("No valid pair");
+        return false;
+    }
+    
+    bestPair = reconstructedPairs[bestPairId];
+
+    ALICEVISION_LOG_INFO("Bootstrap with mesh");
+    if (!sfm::bootstrapMesh(sfmData, 
+                        landmarks,
+                        bestPair.reference, bestPair.next, 
+                        tracksHandler.getAllTracks(), tracksHandler.getTracksPerView()))
+    {
+        return false;
+    }
+
+    ALICEVISION_LOG_INFO("Best selected pair is : ");
+    ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.reference).getImage().getImagePath());
+    ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.next).getImage().getImagePath());
+    ALICEVISION_LOG_INFO("Landmarks count : " << sfmData.getLandmarks().size());
+
+    return true;
+}
+
+bool processDepth(sfmData::SfMData & sfmData, 
+                const track::TracksHandler & tracksHandler, 
+                const std::vector<sfm::ReconstructedPair> &reconstructedPairs,
+                double minAngleHard, 
+                double minAngleSoft, 
+                double maxAngle)
+{
+    //Check all pairs
+    ALICEVISION_LOG_INFO("Find best pair");
+    std::mt19937 randomNumberGenerator;
+    sfm::ReconstructedPair bestPair;
+    bestPair = sfm::findBestPairFromTrackDepths(sfmData, 
+                                                reconstructedPairs,
+                                                tracksHandler.getAllTracks(), 
+                                                tracksHandler.getTracksPerView(),
+                                                randomNumberGenerator);
+
+    if (bestPair.reference == UndefinedIndexT)
+    {
+        ALICEVISION_LOG_INFO("No valid pair using depth prior based algorithm.");
+        return false;
+    }
+    
+    if (!sfm::bootstrapDepth(sfmData, 
+                bestPair.reference, bestPair.next, 
+                tracksHandler.getAllTracks(), tracksHandler.getTracksPerView()))
+    {
+        ALICEVISION_LOG_INFO("Failed to create initial sfmData.");
+        return false;
+    }
+
+    return true;
+}
+
 int aliceVision_main(int argc, char** argv)
 {
     // command-line parameters
     std::string sfmDataFilename;
     std::string sfmDataOutputFilename;
     std::string tracksFilename;
-    std::string meshFilename;
     std::string pairsDirectory;
     std::string outputSfMViewsAndPoses;
+    std::string methodString;
+    std::string meshFilename = "";
 
     // user optional parameters
     const double maxEpipolarDistance = 4.0;
@@ -142,6 +335,7 @@ int aliceVision_main(int argc, char** argv)
     double minAngleSoft = 5.0;
     double maxAngle = 40.0;
     std::pair<std::string, std::string> initialPairString("", "");
+    
     
     std::set<IndexT> firstViewFilters;
     IndexT secondViewFilter = UndefinedIndexT;
@@ -152,16 +346,17 @@ int aliceVision_main(int argc, char** argv)
     requiredParams.add_options()
     ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
     ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(), "SfMData output file.")
+    ("method", po::value<std::string>(&methodString)->required(), "Bootstrapping method: classic (epipolar geometry), mesh (3D mesh constraints), or depth (depth map information).")
     ("tracksFilename,t", po::value<std::string>(&tracksFilename)->required(), "Tracks file.")
     ("pairs,p", po::value<std::string>(&pairsDirectory)->required(), "Path to the pairs directory.");
 
-    po::options_description optionalParams("Required parameters");
+    po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
     ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).")
     ("minAngleSoftInitialPair", po::value<double>(&minAngleSoft)->default_value(minAngleSoft), "Minimum angle for the initial pair (Score is downgraded heavily if angle is under this value).")
     ("minAngleHardInitialPair", po::value<double>(&minAngleHard)->default_value(minAngleHard), "Minimum angle for the initial pair validation.")
     ("maxAngleInitialPair", po::value<double>(&maxAngle)->default_value(maxAngle), "Maximum angle for the initial pair.")
-    ("meshFilename,t", po::value<std::string>(&meshFilename)->required(), "Mesh object file.")
+    ("meshFilename,t", po::value<std::string>(&meshFilename)->default_value(meshFilename), "Mesh object file.")
     ("initialPairA", po::value<std::string>(&initialPairString.first)->default_value(initialPairString.first), "UID or filepath or filename of the first image.")
     ("initialPairB", po::value<std::string>(&initialPairString.second)->default_value(initialPairString.second), "UID or filepath or filename of the second image.");
 
@@ -177,6 +372,8 @@ int aliceVision_main(int argc, char** argv)
     // set maxThreads
     HardwareContext hwc = cmdline.getHardwareContext();
     omp_set_num_threads(hwc.getMaxThreads());
+
+    EBOOTSTRAPMETHOD method = EBOOTSTRAPMETHOD_stringToEnum(methodString);
     
     // load input SfMData scene
     sfmData::SfMData sfmData;
@@ -185,16 +382,14 @@ int aliceVision_main(int argc, char** argv)
         ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilename + "' cannot be read.");
         return EXIT_FAILURE;
     }
-    
 
-
-    if (sfmData.getValidViews().size() >= 2 && meshFilename.empty())
+    ALICEVISION_LOG_INFO("Load tracks");
+    track::TracksHandler tracksHandler;
+    if (!tracksHandler.load(tracksFilename, sfmData.getViewsKeys()))
     {
-        ALICEVISION_LOG_INFO("SfmData has already an initialization");
-        return EXIT_SUCCESS;
+        ALICEVISION_LOG_ERROR("The input tracks file '" + tracksFilename + "' cannot be read.");
+        return EXIT_FAILURE;
     }
-    
-
 
     if (!initialPairString.first.empty() || !initialPairString.second.empty())
     {
@@ -252,27 +447,6 @@ int aliceVision_main(int argc, char** argv)
         ALICEVISION_LOG_INFO("Secondary view filter : " << secondViewFilter);
     }
 
-    ALICEVISION_LOG_INFO("Load tracks");
-    track::TracksHandler tracksHandler;
-    if (!tracksHandler.load(tracksFilename, sfmData.getViewsKeys()))
-    {
-        ALICEVISION_LOG_ERROR("The input tracks file '" + tracksFilename + "' cannot be read.");
-        return EXIT_FAILURE;
-    }
-
-
-    //Load mesh in the mesh intersection object
-    bool useMesh = false;
-    sfmData::Landmarks landmarks;
-    if (!meshFilename.empty() && !firstViewFilters.empty())
-    {        
-        if (!landmarksFromMesh(landmarks, sfmData, meshFilename, firstViewFilters, tracksHandler))
-        {
-            return EXIT_FAILURE;
-        }
-            
-        useMesh = true;
-    }
 
     //Result of pair estimations are stored in multiple files
     std::vector<sfm::ReconstructedPair> reconstructedPairs;
@@ -291,7 +465,7 @@ int aliceVision_main(int argc, char** argv)
         for (const boost::json::value & value : values)
         {
             std::vector<sfm::ReconstructedPair> localVector = boost::json::value_to<std::vector<sfm::ReconstructedPair>>(value);
-          
+        
             for (const auto & pair: localVector)
             {
                 // One of the view must match one of the first view filters
@@ -331,64 +505,34 @@ int aliceVision_main(int argc, char** argv)
 
     ALICEVISION_LOG_INFO("Pairs to process : " << reconstructedPairs.size());
 
-    //Check all pairs
-    ALICEVISION_LOG_INFO("Give a score to all pairs");
-    int count = 0;
+    
+    bool ret;
 
-    double bestScore = std::numeric_limits<double>::lowest();
-    sfm::ReconstructedPair bestPair;
-    bestPair.reference = UndefinedIndexT;
-    std::vector<std::size_t> bestUsedTracks;
-
-    std::set<IndexT> filterIn;
-    std::set<IndexT> filterOut;
-
-    IndexT bestPairId = findBestPair(sfmData, reconstructedPairs,  
-                            tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
-                            filterIn, filterOut,
-                            minAngleHard, minAngleSoft, maxAngle);
-
-    if (bestPairId == UndefinedIndexT)
+    switch (method)
     {
-        ALICEVISION_LOG_INFO("No valid pair");
+    case MESH:
+        ret = processMesh(sfmData, tracksHandler, reconstructedPairs, 
+                        firstViewFilters, meshFilename,
+                        minAngleHard, minAngleSoft, maxAngle);
+        break;
+    case DEPTH:
+        ret = processDepth(sfmData, tracksHandler, reconstructedPairs,  
+                        minAngleHard, minAngleSoft, maxAngle);
+        break;
+    default:
+        ret = processClassic(sfmData, tracksHandler, reconstructedPairs,  
+                        minAngleHard, minAngleSoft, maxAngle);
+        break;
+    }
+
+    if (!ret)
+    {
         return EXIT_FAILURE;
     }
     
-    bestPair = reconstructedPairs[bestPairId];
-
-    if (useMesh)
-    {
-        if (!sfm::bootstrapMesh(sfmData, 
-                        landmarks,
-                        bestPair.reference, bestPair.next, 
-                        tracksHandler.getAllTracks(), tracksHandler.getTracksPerView()))
-        {
-            return EXIT_FAILURE;
-        }
-    }
-    else 
-    {
-        if (!sfm::bootstrapBase(sfmData, 
-                        bestPair.reference, bestPair.next, 
-                        bestPair.pose, 
-                        tracksHandler.getAllTracks(), tracksHandler.getTracksPerView()))
-        {
-            return EXIT_FAILURE;
-        }
-    }
-
-
-    ALICEVISION_LOG_INFO("Best selected pair is : ");
-    ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.reference).getImage().getImagePath());
-    ALICEVISION_LOG_INFO(" - " << sfmData.getView(bestPair.next).getImage().getImagePath());
-    ALICEVISION_LOG_INFO("Landmarks count : " << sfmData.getLandmarks().size());
-
     showStatsAngles(sfmData);
     
-    
-
     sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData::ALL);
-
     if (!outputSfMViewsAndPoses.empty())
     {   
         sfmDataIO::save(sfmData, outputSfMViewsAndPoses, 


### PR DESCRIPTION
This is a first bootstrapping solution for depthmaps. It is very basic at the moment and should be improved over time !

This pull request introduces a new "depth" bootstrapping method to the Structure-from-Motion (SfM) pipeline, alongside the existing "classic" and "mesh" methods. It adds the necessary infrastructure to handle depth-based bootstrapping, including new C++ logic, Python interface updates, and supporting utilities for constructing SfM data from depth maps. The changes are grouped below by theme.

**New bootstrapping method: "depth"**

* Added a new parameter `method` (choices: "classic", "mesh", "depth") to the `SfMBootStrapping` node in the Python interface, allowing users to select the bootstrapping approach. The mesh file parameter is now only enabled if the "mesh" method is selected. [[1]](diffhunk://#diff-b8c6c6c7956d292ce6942a1b475914a28c1cbda786ae8e561e4fcd8d568c51e7R21-R27) [[2]](diffhunk://#diff-b8c6c6c7956d292ce6942a1b475914a28c1cbda786ae8e561e4fcd8d568c51e7R39)
* Introduced an enum `EBOOTSTRAPMETHOD` and a string-to-enum conversion utility to handle the new method in the C++ pipeline entry point.

**Depth-based bootstrapping implementation**

* Added the `bootstrapDepth` function, which constructs initial camera poses and landmarks using depth information from tracks, and integrates it into the bootstrapping pipeline. [[1]](diffhunk://#diff-24ebc2e866c4bcc7c920013f96e2f47e1dc81c9e3ef84a7064d41a52c58c959aR178-R274) [[2]](diffhunk://#diff-72bc172a6e0415d65752e56c58a22f8dc0b17ce6ea14c31c110b1522c4e08ab1R49-R64)
* Implemented `buildSfmDataFromDepthMap` in new files `TracksDepths.cpp` and `TracksDepths.hpp`, providing utilities to build minimal SfMData objects from depth maps for a given view. [[1]](diffhunk://#diff-c03a243bf9fbfc6aa05c30ed666480fc55e3f672321bcb855d131efcdb5fabccR1-R83) [[2]](diffhunk://#diff-3a1d3d9f6ee229bd96beb78da5352acd8c3119ff88c265971197d6c42fb24329R1-R30)
* Updated CMake and includes to register and use the new depth-based files and logic. [[1]](diffhunk://#diff-50e7fbc9016bb0b9a8dd173a6937d28a10a4b4c50dd20686b9ca7213c62f07e5R30) [[2]](diffhunk://#diff-50e7fbc9016bb0b9a8dd173a6937d28a10a4b4c50dd20686b9ca7213c62f07e5R78) [[3]](diffhunk://#diff-24ebc2e866c4bcc7c920013f96e2f47e1dc81c9e3ef84a7064d41a52c58c959aR13) [[4]](diffhunk://#diff-960f96052a08fa517213099baae7edd33d6db51329955625b321573c43fd2772R11-R13)

**Pair selection using depth information**

* Added `findBestPairFromTrackDepths` to select the best initial image pair using depth information, with supporting documentation and logic. [[1]](diffhunk://#diff-960f96052a08fa517213099baae7edd33d6db51329955625b321573c43fd2772R122-R226) [[2]](diffhunk://#diff-bb7162161f7fb47c7cd3569815f31a97e2b1e5ef93deb5b94488e84c65afae63R40-R54)

**Supporting API improvements**

* Added a const overload for `getViewSharedPtr` in `SfMData` to facilitate safe access during depth-based operations.