### PR TITLE
Node to remap landmarks to tracks

### DIFF
--- a/meshroom/aliceVision/SfmLandmarksRemapping.py
+++ b/meshroom/aliceVision/SfmLandmarksRemapping.py
@@ -1,0 +1,45 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class SfMLandmarksRemapping(desc.AVCommandLineNode):
+    commandLine = "aliceVision_sfmLandmarksRemapping {allParams}"
+    size = desc.DynamicNodeSize("input")
+
+    category = "Utils"
+    documentation = """
+    A landmark is created using a track. Both have ids. It is assumed in many nodes that the source track id is the landmark id.
+    In this node, we update the landmark id to match its track id. It may have change over operations on tracks.
+    """
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="SfMData file.",
+            value="",
+        ),
+        desc.File(
+            name="tracksFilename",
+            label="Tracks File",
+            description="Tracks file.",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfMData",
+            description="Path to the output SfMData file.",
+            value="{nodeCacheFolder}/sfmData.sfm",
+        )
+    ]

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -320,7 +320,7 @@ if (ALICEVISION_BUILD_SFM)
               Boost::program_options
               Boost::json
     )
-
+    
     # SfM Survey Injecting
     alicevision_add_software(aliceVision_sfmSurveyInjecting
         SOURCE main_sfmSurveyInjecting.cpp
@@ -342,6 +342,20 @@ if (ALICEVISION_BUILD_SFM)
               aliceVision_cmdline
               aliceVision_sfmData
               aliceVision_sfmDataIO
+              aliceVision_sfm
+              Boost::program_options
+              Boost::json
+    )
+
+    # Track from depthmap
+    alicevision_add_software(aliceVision_sfmLandmarksRemapping
+        SOURCE main_sfmLandmarksRemapping.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              aliceVision_track
               aliceVision_sfm
               Boost::program_options
               Boost::json

--- a/src/software/utils/main_sfmLandmarksRemapping.cpp
+++ b/src/software/utils/main_sfmLandmarksRemapping.cpp
@@ -1,0 +1,81 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/types.hpp>
+#include <aliceVision/config.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfm/pipeline/expanding/ExpansionProcess.hpp>
+#include <aliceVision/track/TracksHandler.hpp>
+
+#include <boost/program_options.hpp>
+#include <boost/json.hpp>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+namespace po = boost::program_options;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string sfmDataOutputFilename;
+    std::string tracksFilename;
+    
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(),
+         "Input SfMData file.")
+        ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(),
+         "SfMData output file with the remapped landmarks.")
+        ("tracksFilename,t", po::value<std::string>(&tracksFilename)->required(), "Tracks file.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision Landmarks Remapping");
+
+    cmdline.add(requiredParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // Set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    // Load input SfMData scene
+    ALICEVISION_LOG_INFO("Load SfmData from " << sfmDataFilename);
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_LOG_INFO("Load tracks");
+    track::TracksHandler tracksHandler;
+    if (!tracksHandler.load(tracksFilename, sfmData.getViewsKeys()))
+    {
+        ALICEVISION_LOG_ERROR("The input tracks file '" + tracksFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    ALICEVISION_LOG_INFO("Remap landmarks");
+    sfm::ExpansionProcess::remapExistingLandmarks(sfmData, tracksHandler);
+
+    ALICEVISION_LOG_INFO("Save SfmData to " << sfmDataOutputFilename);
+    sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData::ALL);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull request introduces a new utility for remapping SfM (Structure-from-Motion) landmarks to ensure their IDs are compatible with a given track map. It adds a new command-line tool, integrates it into the build system, and refactors related API in the expansion pipeline. The main changes are grouped as follows:

**New utility for landmark remapping:**

* Added a new command-line tool `aliceVision_sfmLandmarksRemapping` with its main implementation in `main_sfmLandmarksRemapping.cpp`. This tool loads an SfMData file and a tracks file, remaps the landmarks to match the track IDs, and saves the updated SfMData.
* Integrated the new utility into the build system by updating `CMakeLists.txt` to build and link the new executable with the necessary dependencies.
* Added a corresponding Meshroom node definition in `SfmLandmarksRemapping.py` to expose this tool in the Meshroom pipeline, including input/output parameters and documentation stubs.

**API and pipeline refactoring:**

* Refactored the `ExpansionProcess` class in the SfM expansion pipeline to expose `remapExistingLandmarks` as a static method, making it directly callable from the new utility and clarifying the separation between remapping and preparation steps.