### PR TITLE
Split `ExportAnimatedCamera` using modern pipelines

### DIFF
--- a/meshroom/aliceVision/ExportAlembic.py
+++ b/meshroom/aliceVision/ExportAlembic.py
@@ -1,0 +1,47 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class ExportAlembic(desc.AVCommandLineNode):
+    commandLine = "aliceVision_exportAlembic {allParams}"
+    size = desc.DynamicNodeSize("input")
+
+    category = "Export"
+    documentation = """
+Convert cameras from an SfM scene into an animated cameras in Alembic file format.
+Based on the input image filenames, it will recognize the input video sequence to create an animated camera.
+"""
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input SfMData",
+            description="SfMData file containing a complete SfM.",
+            value="",
+        ),
+        desc.FloatParam(
+            name="frameRate",
+            label="Camera Frame Rate",
+            description="Define the camera's Frames per second.",
+            value=24.0,
+            range=(1.0, 60.0, 1.0),
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Alembic Filename",
+            description="Output alembic filename.",
+            value="{nodeCacheFolder}/animated.abc",
+        )
+    ]

--- a/meshroom/aliceVision/ExportImages.py
+++ b/meshroom/aliceVision/ExportImages.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -43,6 +43,13 @@ For example, the target intrinsics may be the same without the distortion.
             description="Apply a correction on images' exposure value.",
             value=False,
             advanced=True,
+        ),
+        desc.BoolParam(
+            name="exportFullROD",
+            label="Export Full ROD",
+            description="Export images with the full Region of Definition (ROD). Only supported by the EXR file format.",
+            value=False,
+            enabled=lambda node: node.outputFileType.value == "exr"
         ),
         desc.ChoiceParam(
             name="namingMode",

--- a/meshroom/aliceVision/IntrinsicsTransforming.py
+++ b/meshroom/aliceVision/IntrinsicsTransforming.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -39,6 +39,12 @@ class IntrinsicsTransforming(desc.AVCommandLineNode):
             description="If the input intrinsic is not a pinhole but the output is, what is the virtual FOV requested.",
             value=90.0,
             range=(1.0, 179.0, 0.1),
+        ),
+        desc.BoolParam(
+            name="correctPrincipalPoint",
+            label="Correct Principal Point",
+            description="Force principal point to image center.",
+            value=False,
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/src/software/export/CMakeLists.txt
+++ b/src/software/export/CMakeLists.txt
@@ -20,6 +20,21 @@ if (ALICEVISION_BUILD_SFM)
         )
     endif()
 
+    # Export an alembic animated camera from a SfMData file
+    if (ALICEVISION_HAVE_ALEMBIC)
+        alicevision_add_software(aliceVision_exportAlembic
+            SOURCE main_exportAlembic.cpp
+            FOLDER ${FOLDER_SOFTWARE_EXPORT}
+            LINKS aliceVision_system
+                  aliceVision_cmdline
+                  aliceVision_sfmData
+                  aliceVision_sfmDataIO
+                  Boost::program_options
+                  Boost::boost
+                  Boost::timer
+        )
+    endif()
+
     # Export view extracted keypoints
     alicevision_add_software(aliceVision_exportKeypoints
         SOURCE main_exportKeypoints.cpp

--- a/src/software/export/main_exportAlembic.cpp
+++ b/src/software/export/main_exportAlembic.cpp
@@ -1,0 +1,184 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/system/Timer.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfmDataIO/AlembicExporter.hpp>
+#include <aliceVision/sfmDataIO/viewIO.hpp>
+
+#include <boost/program_options.hpp>
+
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+
+int aliceVision_main(int argc, char** argv)
+{
+    // Command-line parameters
+    std::string sfmDataFilename;
+    std::string outputFilename;
+
+    // User optional parameters
+    double frameRate = 24.0;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(),
+         "SfMData file containing a complete SfM.")
+        ("output,o", po::value<std::string>(&outputFilename)->required(),
+         "Output Alembic.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("frameRate", po::value<double>(&frameRate)->default_value(frameRate),
+         "Define the camera's Frames per seconds.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision exportAnimatedCamera");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+   
+    // Load SfMData files
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    if (sfmData.getViews().empty())
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' is empty.");
+        return EXIT_FAILURE;
+    }
+
+
+    std::map<std::string, std::map<std::size_t, IndexT>> videoViewPerFrame;
+    std::map<std::string, std::vector<std::pair<std::size_t, IndexT>>> dslrViewPerKey;
+
+    //Discriminate sequences and image sets
+    for (const auto& [viewId, view] : sfmData.getViews().valueRange())
+    {
+        if (!sfmData.isPoseAndIntrinsicDefined(view))
+        {
+            continue;
+        }
+
+        std::string cameraName = view.getImage().getMetadataMake() 
+                                + "_" + view.getImage().getMetadataModel();
+
+        IndexT frameN = 0;
+        bool isSequence = false;
+
+        if (view.isPartOfRig())
+        {
+            cameraName += std::string("_") + std::to_string(view.getSubPoseId());
+        }
+
+        std::string prefix;
+        std::string suffix;
+        const std::string imagePathStem = fs::path(view.getImage().getImagePath()).stem().string();
+        if (sfmDataIO::extractNumberFromFileStem(imagePathStem, frameN, prefix, suffix))
+        {
+            if (prefix.empty() && suffix.empty())
+            {
+                cameraName = std::string("Undefined") + "_" + cameraName;
+            }
+            else
+            {
+                cameraName = prefix + "frame" + suffix + "_" + cameraName;
+            }
+
+            isSequence = true;
+        }
+
+        if (isSequence)  // Video
+        {
+            const std::size_t frame = frameN;
+            videoViewPerFrame[cameraName][frame] = view.getViewId();
+        }
+        else if (view.getImage().hasMetadataDateTimeOriginal())  // Picture
+        {
+            const std::size_t key = view.getImage().getMetadataDateTimestamp();
+            dslrViewPerKey[cameraName].push_back({key, view.getViewId()});
+        }
+        else  // No time or sequence information
+        {
+            dslrViewPerKey[cameraName].push_back({0, view.getViewId()});
+        }
+    }
+
+
+    sfmDataIO::AlembicExporter exporter(outputFilename);
+
+    for (const auto& [cameraName, frameToView] : videoViewPerFrame)
+    {
+        const std::size_t firstFrame = frameToView.begin()->first;
+        const std::size_t lastFrame = frameToView.rbegin()->first;
+
+        exporter.initAnimatedCamera(cameraName, firstFrame, frameRate);
+
+        for (std::size_t frame = firstFrame; frame <= lastFrame; ++frame)
+        {
+            const auto findFrameIt = frameToView.find(frame);
+
+            if (findFrameIt != frameToView.end())
+            {
+                const IndexT viewId = findFrameIt->second;
+
+                const sfmData::View & view = sfmData.getView(viewId);
+                const IndexT intrinsicId = view.getIntrinsicId();
+                const camera::Pinhole * cam = dynamic_cast<camera::Pinhole*>(sfmData.getIntrinsicPtr(intrinsicId));
+                const sfmData::CameraPose pose = sfmData.getPose(view);
+                const std::string& imagePath = view.getImage().getImagePath();
+
+                exporter.addCameraKeyframe(pose.getTransform(), cam, imagePath, viewId, intrinsicId);
+            }
+            else
+            {
+                exporter.jumpKeyframe(std::to_string(frame));
+            }
+        }
+    }
+
+    for (auto& [cameraName, views] : dslrViewPerKey)
+    {
+        exporter.initAnimatedCamera(cameraName);
+
+        //Sort views by timestamp
+        std::sort(views.begin(), views.end());
+
+        //Loop over images
+        for (const auto& [key, id] : views)
+        {
+            const sfmData::View& view = sfmData.getView(id);
+            const camera::Pinhole* cam = dynamic_cast<camera::Pinhole*>(sfmData.getIntrinsicPtr(view.getIntrinsicId()));
+            const sfmData::CameraPose pose = sfmData.getPose(view);
+            const std::string& imagePath = view.getImage().getImagePath();
+
+            exporter.addCameraKeyframe(pose.getTransform(), cam, imagePath, view.getViewId(), view.getIntrinsicId());
+        }
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -17,7 +17,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
@@ -26,6 +26,55 @@ namespace fs = std::filesystem;
 
 using NameFunction = std::function<std::string(const sfmData::View &)>;
 
+oiio::ROI computeRod(const camera::IntrinsicBase & source, const camera::IntrinsicBase & dest)
+{
+    //Build the 4 corners of the source image
+    std::vector<Vec2> pointToBeChecked;
+    pointToBeChecked.push_back(Vec2(0, 0));
+    pointToBeChecked.push_back(Vec2(source.w() - 1, 0));
+    pointToBeChecked.push_back(Vec2(0, source.h() - 1));
+    pointToBeChecked.push_back(Vec2(source.w() - 1, source.h() - 1));
+
+    const Vec2 center(source.w() * 0.5, source.h() * 0.5);
+
+    //Add the middle of the edges
+    pointToBeChecked.push_back(Vec2(center.x(), 0));
+    pointToBeChecked.push_back(Vec2(center.x(), source.h() - 1));
+    pointToBeChecked.push_back(Vec2(0, center.y()));
+    pointToBeChecked.push_back(Vec2(source.w() - 1, center.y()));
+
+    //Undistort all points
+    double minx = std::numeric_limits<double>::max();
+    double miny = std::numeric_limits<double>::max();
+    double maxx = std::numeric_limits<double>::lowest();
+    double maxy = std::numeric_limits<double>::lowest();
+
+    for (const Vec2& n : pointToBeChecked)
+    {
+        // compute every source pixel into the new destination camera
+        const Vec3 intermediate = source.backProjectUnit(n);
+        const Vec2 undisto_pix = dest.project(intermediate.homogeneous(), true);
+ 
+        minx = std::min(minx, undisto_pix.x());
+        miny = std::min(miny, undisto_pix.y());
+        maxx = std::max(maxx, undisto_pix.x());
+        maxy = std::max(maxy, undisto_pix.y());
+    }
+
+    oiio::ROI rod(minx, maxx + 1, miny, maxy + 1);
+        
+    return rod;
+}
+
+oiio::ROI convertRodToRoi(const camera::IntrinsicBase & intrinsic, const oiio::ROI& rod)
+{
+    const int xOffset = rod.xbegin;
+    const int yOffset = rod.ybegin;
+
+    const oiio::ROI roi(-xOffset, intrinsic.w() - xOffset, -yOffset, intrinsic.h() - yOffset);
+
+    return roi;
+}
 
 template<typename T>
 void ImageIntrinsicsTransform(const image::Image<T>& imageIn,
@@ -121,6 +170,7 @@ void ImageRemoveDistortion(const image::Image<T>& imageIn,
  * @param viewId the image view Id
  * @param srcFileName the initial image file path
  * @param evCorrection do we apply exposure compensation
+ * @param exportFullRod do we export the full rod or not
  * @param cameraExposure current image camera exposure
  * @param medianCameraExposure median camera exposure for the sfmData
  * @param masksFolders the mask folders list
@@ -133,6 +183,7 @@ bool processImage(const std::string& dstFileName,
              const IndexT & viewId,
              const std::string& srcFileName,
              bool evCorrection,
+             bool exportFullRod,
              double cameraExposure,
              double medianCameraExposure,
              const std::vector<std::string> & masksFolders,
@@ -201,24 +252,31 @@ bool processImage(const std::string& dstFileName,
             image(pix)[2] *= exposureCompensation;
         }
     }
+
+    oiio::ROI roi, rod;
+    if (exportFullRod)
+    {
+        rod = computeRod(sourceIntrinsic, outputIntrinsic);
+        roi = convertRodToRoi(outputIntrinsic, rod);
+    }
     
     bool shortCut = (sourceIntrinsic.getType() == outputIntrinsic.getType()) &&
                     (outputIntrinsic.hasDistortion() == false);
     if (shortCut)
     {
         // undistort the image and save it
-        ImageRemoveDistortion(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0));
+        ImageRemoveDistortion(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0), rod);
     }
     else 
     {
         // Transform the image and save it
-        ImageIntrinsicsTransform(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0));
+        ImageIntrinsicsTransform(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0), rod);
     }
 
     //Write the result
     try
     {
-        writeImage(dstFileName, image_ud, image::ImageWriteOptions(), metadata);
+        writeImage(dstFileName, image_ud, image::ImageWriteOptions(), metadata, roi);
     }
     catch (...)
     {
@@ -235,6 +293,7 @@ bool processImage(const std::string& dstFileName,
  * @param target the transformed sfmData which will be used for intrinsics properties
  * @param namingFunction function which defines how is the image named given the view object
  * @param evCorrection do we correct the exposure
+ * @param exportFullRod do we export the full rod or not
  * @param masksFolders the mask folders list
  * @param maskExtension the mask extension
  * @param rangeStart the initial view index to process (range selection)
@@ -244,6 +303,7 @@ bool process(const sfmData::SfMData & input,
              sfmData::SfMData & target, 
              const NameFunction & namingFunction,
              bool evCorrection,
+             bool exportFullRod,
              const std::vector<std::string> & masksFolders,
              const std::string & maskExtension,
              size_t rangeStart,
@@ -298,6 +358,7 @@ bool process(const sfmData::SfMData & input,
                     viewId,
                     srcFileName,
                     evCorrection,
+                    exportFullRod,
                     view.getImage().getCameraExposureSetting().getExposure(),
                     medianCameraExposure,
                     masksFolders,
@@ -322,6 +383,7 @@ int aliceVision_main(int argc, char* argv[])
     int rangeStart = -1;
     int rangeSize = 1;
     bool evCorrection = false;
+    bool exportFullROD = false;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -344,6 +406,8 @@ int aliceVision_main(int argc, char* argv[])
          "Range size.")
         ("evCorrection", po::value<bool>(&evCorrection)->default_value(evCorrection),
          "Correct exposure value.")
+        ("exportFullROD", po::value<bool>(&exportFullROD)->default_value(exportFullROD),
+         "Export undistorted images with the full Region of Definition (RoD). Only supported by the EXR image file format.")
         ("namingMode", po::value<std::string>(&namingMode)->default_value(namingMode),
          "naming mode.")
         ("masksFolders", po::value<std::vector<std::string>>(&masksFolders)->multitoken(),
@@ -363,6 +427,13 @@ int aliceVision_main(int argc, char* argv[])
 
     // set output file type
     image::EImageFileType outputFileType = image::EImageFileType_stringToEnum(outImageFileTypeName);
+
+    // Check compatibility
+    if (exportFullROD && outputFileType != image::EImageFileType::EXR)
+    {
+        ALICEVISION_LOG_ERROR("Export full RoD (Region Of Definition) is only possible in EXR file format and not in '" << outputFileType << "'.");
+        return EXIT_FAILURE;
+    }
 
     // Create output dir
     if (!utils::exists(outFolder))
@@ -455,7 +526,8 @@ int aliceVision_main(int argc, char* argv[])
     if (!process(inputSfmData, 
                 targetSfmData, 
                 namingFunction, 
-                evCorrection, 
+                evCorrection,
+                exportFullROD,
                 masksFolders, 
                 maskExtension,
                 rangeStart, 

--- a/src/software/utils/main_intrinsicsTransforming.cpp
+++ b/src/software/utils/main_intrinsicsTransforming.cpp
@@ -18,7 +18,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
@@ -209,6 +209,16 @@ bool convertTracks(const sfmData::SfMData & inputSfmData,
     return true;
 }
 
+void resetOffset(sfmData::SfMData & sfmData)
+{
+    for (auto & [_, intrinsic] : sfmData.getIntrinsics().valueRange())
+    {
+        camera::IntrinsicScaleOffset & iso = dynamic_cast<camera::IntrinsicScaleOffset&>(intrinsic);
+        
+        iso.setOffset(Vec2::Zero());
+    }
+}
+
 int aliceVision_main(int argc, char* argv[])
 {
     // command-line parameters
@@ -219,6 +229,7 @@ int aliceVision_main(int argc, char* argv[])
     std::string outputTracksFilename;
     std::string cameraTypeStr;
     double fakeFov = 90.0;
+    bool correctPrincipalPoint = false;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -234,6 +245,8 @@ int aliceVision_main(int argc, char* argv[])
          "Virtual FOV if output is pinhole and input is not.")
         ("type", po::value<std::string>(&cameraTypeStr)->default_value(cameraTypeStr),
          "Default camera model type (pinhole, equidistant, equirectangular).")
+        ("correctPrincipalPoint", po::value<bool>(&correctPrincipalPoint)->default_value(correctPrincipalPoint),
+         "Force principal point to image center.")
         ("inputTracks", po::value<std::string>(&inputTracksFilename)->required(),
          "Input Tracks file.")
         ("outputTracks", po::value<std::string>(&outputTracksFilename)->required(),
@@ -287,6 +300,12 @@ int aliceVision_main(int argc, char* argv[])
     {
         ALICEVISION_LOG_ERROR("Invalid camera model");
         return EXIT_FAILURE;
+    }
+
+    if (correctPrincipalPoint)
+    {
+        //Set all intrinsics to zero offset
+        resetOffset(outputSfmData);
     }
 
     if (!convertObservations(inputSfmData, outputSfmData))


### PR DESCRIPTION
`ExportAnimatedCamera` is splitted into

- `IntrinsicsTransforming`
- `ExportImages`
- `ExportAlembic`

Both first and second nodes already exists. The Alembic export from `ExportAnimatedCamera` is moved into the new node `ExportAlembic`. This will be seconded by `ExportUSD` in a future PR.

`IntrinsicsTransforming` is also modified to be able to cancel the principal point and assume the new camera has a perfectly centered principal point.

`Export Images` is modified to be able to export the full ROD in EXR images.

I kept ExportAnimatedCamera for the moment and the pipelines are still to be upgraded to use that