### PR TITLE
[meshroom] `CameraInit`: Remove `_cmdVars`

### DIFF
--- a/meshroom/aliceVision/CameraInit.py
+++ b/meshroom/aliceVision/CameraInit.py
@@ -671,7 +671,7 @@ The needed metadata are:
                 "featureFolder": "",
                 "matchingFolder": "",
             }
-            node.viewpointsFile = os.path.join(node.internalFolder, 'viewpoints.sfm').format(**node._cmdVars)
+            node.viewpointsFile = os.path.join(node.internalFolder, 'viewpoints.sfm')
             with open(node.viewpointsFile, 'w') as f:
                 json.dump(sfmData, f, indent=4)
 


### PR DESCRIPTION
## Description

As a consequence of https://github.com/alicevision/Meshroom/pull/2888, `_cmdVars`, which was used in `CameraInit`, does not exist anymore and `node.internalFolder` now contains the resolved path. There is thus no need to format it anymore.

`.format(**node._cmdVars)` is thus fully removed.