### PR TITLE
Update mask processing for single mask broadcasting

### DIFF
--- a/meshroom/aliceVision/MaskProcessing.py
+++ b/meshroom/aliceVision/MaskProcessing.py
@@ -43,7 +43,8 @@ class MaskProcessing(desc.AVCommandLineNode):
             ),
             name="inputs",
             label="Input Directories",
-            description="A set of directories containing masks with the same names.",
+            description="A set of directories containing masks with the same names.\n" 
+            "Any entry (except the first one) may be an image path. In this case, this mask will be used as an operand for each entry of the first directory.",
             exposed=True,
         ),
         desc.ChoiceParam(

--- a/src/software/utils/main_maskProcessing.cpp
+++ b/src/software/utils/main_maskProcessing.cpp
@@ -157,10 +157,19 @@ int aliceVision_main(int argc, char** argv)
             {
                 std::filesystem::path otherPath(directoryNames[otherDirIndex]);
 
-                std::filesystem::path otherMaskPath = otherPath / refpath.filename();
-                if (!std::filesystem::exists(otherMaskPath))
+                std::filesystem::path otherMaskPath;
+                if (std::filesystem::is_directory(otherPath))
                 {
-                    continue;
+                    otherMaskPath = otherPath / refpath.filename();
+                    if (!std::filesystem::exists(otherMaskPath))
+                    {
+                        continue;
+                    }
+                }
+                else 
+                {
+                    //Use the specified file directly
+                    otherMaskPath = otherPath;
                 }
 
                 image::Image<unsigned char> otherImg;


### PR DESCRIPTION
This pull request improves the flexibility of mask input handling in the mask processing workflow. The main change allows entries in the mask input list (except the first one) to be either directories or individual image files, enabling more versatile use cases.

**Enhancements to mask input handling:**

* Updated the `inputs` parameter description in `MaskProcessing.py` to clarify that entries (except the first) can be image paths, which will be used as operands for each entry in the first directory.
* Modified the mask file resolution logic in `main_maskProcessing.cpp` to check if an entry is a directory or a file; if it's a file, it uses the file directly as the mask operand.