### PR TITLE
New node to erode masks' valid regions

### DIFF
--- a/meshroom/aliceVision/MaskEroding.py
+++ b/meshroom/aliceVision/MaskEroding.py
@@ -1,0 +1,58 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
+
+import os.path
+
+
+class MaskEroding(desc.AVCommandLineNode):
+    commandLine = "aliceVision_maskEroding {allParams}"
+
+    size = desc.DynamicNodeSize("input")
+    parallelization = desc.Parallelization(blockSize=50)
+    commandLineRange = "--rangeIteration {rangeIteration} --rangeBlocksCount {rangeBlocksCount}"
+
+    category = "Utils"
+    documentation = """ Assumes the inputs are binary masks. 
+    Erode the valid part of the mask such that a new pixel is valid if and only if the input region is fully valid. """
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input Directory",
+            description="A directory with a set of mask.",
+            value="",
+        ),
+        desc.IntParam(
+            name="radius",
+            label="Radius of erosion",
+            description="Radius of the erosion filter",
+            value=5,
+            range=None,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        )
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="Path to the output directory.",
+            value="{nodeCacheFolder}",
+        ),
+        desc.File(
+            name="masks",
+            label="Masks",
+            description="Processed masks.",
+            semantic="imageList",
+            value= "{nodeCacheFolder}/*.exr",
+            group="",
+        ),
+    ]

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -62,6 +62,15 @@ if (ALICEVISION_BUILD_SFM)
               ${Boost_LIBRARIES}
     )
 
+    alicevision_add_software(aliceVision_maskEroding 
+        SOURCE main_maskEroding.cpp
+        FOLDER ${FOLDER_SOFTWARE_UTILS}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_image
+              ${Boost_LIBRARIES}
+    )
+
     # Track builder
     alicevision_add_software(aliceVision_tracksSimulating
         SOURCE main_tracksSimulating.cpp

--- a/src/software/utils/main_maskEroding.cpp
+++ b/src/software/utils/main_maskEroding.cpp
@@ -1,0 +1,184 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/image/io.hpp>
+#include <aliceVision/system/Parallelization.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <string>
+#include <sstream>
+#include <random>
+#include <filesystem>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+/**
+@brief Each pixel (x,y) in integralCount is the count of non-zero pixel 
+in the input mask's sub rectangle (0->x; 0->y).
+@param integralCount the output integral image
+@param mask the input mask
+*/
+void computeIntegralMask(image::Image<unsigned long> & integralCount, const image::Image<unsigned char> & mask)
+{
+    integralCount.resize(mask.width(), mask.height());
+
+    //Bootstrap first row
+    int countFirstRow = 0;
+    for (int j = 0; j < mask.width(); j++)
+    {
+        if (mask(0, j))
+        {
+            countFirstRow++;
+            integralCount(0, j) = countFirstRow;
+        }
+    }
+
+    //For all next rows
+    for (int i = 1; i < mask.height(); i++)
+    {
+        int countRow = 0;
+        for (int j = 0; j < mask.width(); j++)
+        {
+            if (mask(i, j))
+            {
+                countRow++;
+            }
+
+            integralCount(i, j) = integralCount(i - 1, j) + countRow;
+        }
+    }
+}
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string directoryName;
+    std::string outDirectory;
+    int rangeIteration = 0;
+    int rangeBlocksCount = 1;
+    int radius = 5;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&directoryName)->required(),
+         "Path to directories to process.")
+        ("output,o", po::value<std::string>(&outDirectory)->required(),
+         "Output directory.");
+        
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("radius", po::value<int>(&radius)->default_value(radius), "")
+        ("rangeIteration", po::value<int>(&rangeIteration)->default_value(rangeIteration), "Chunk id.")
+        ("rangeBlocksCount", po::value<int>(&rangeBlocksCount)->default_value(rangeBlocksCount), "Chunk count.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision maskEroding");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    std::vector<std::filesystem::path> paths;
+    for (auto &p : std::filesystem::recursive_directory_iterator(directoryName))
+    {
+        const std::filesystem::path path = p.path();
+        if (path.extension() != ".exr")
+        {
+            continue;
+        }
+
+        paths.push_back(path);
+    }
+
+    int rangeStart, rangeEnd;
+    if (!rangeComputation(rangeStart, rangeEnd, rangeIteration, rangeBlocksCount, paths.size()))
+    {
+        ALICEVISION_LOG_ERROR("Problem computing chunks.");
+        return EXIT_FAILURE;
+    }
+
+    #pragma omp parallel for schedule(dynamic)
+    for (int pid = rangeStart; pid < rangeEnd; pid++)
+    {
+        const auto & path = paths[pid];
+
+        ALICEVISION_LOG_INFO("Processing " << path.string());
+
+        std::filesystem::path outputDirectoryPath(outDirectory);
+        std::filesystem::path outputPath = outputDirectoryPath / path.filename();
+
+
+        image::Image<unsigned char> img;
+        aliceVision::image::readImage(path.string(), img, image::EImageColorSpace::NO_CONVERSION);
+
+        image::Image<unsigned long> integral;
+        computeIntegralMask(integral, img);
+
+        image::Image<unsigned char> out(img.width(), img.height());
+        for (int i = 0; i < img.height(); i++)
+        {
+            int mini = std::max(i - radius, 0);
+            int maxi = std::min(i + radius, img.height() - 1);
+            int si = maxi - mini + 1;
+
+            for (int j = 0; j < img.width(); j++)
+            {
+                int minj = std::max(j - radius, 0);
+                int maxj = std::min(j + radius, img.width() - 1);
+                int sj = maxj - minj + 1;
+
+                //A B
+                //C D
+                //"CD" = D - V)
+                long A = 0;
+                long B = 0;
+                long C = 0;
+                long D = integral(maxi, maxj);
+
+                if (minj > 0)
+                {
+                    C = integral(maxi, minj - 1);
+                }
+                if (mini > 0)
+                {
+                    B = integral(mini - 1, maxj);
+
+                    if (minj > 0)
+                    {
+                        A = integral(mini - 1, minj - 1);
+                    }
+                }
+
+                //Are all the pixels valid ?
+                long sub = D - C - B + A;
+                out(i, j) = (sub == (si * sj))?255:0;
+            }
+        }
+        
+        aliceVision::image::ImageWriteOptions wopt;
+        aliceVision::image::writeImage(outputPath.string(), out, wopt);
+    }    
+    
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
This pull request introduces a new mask erosion utility to the AliceVision project, enabling users to process binary mask images by eroding their valid regions. The main changes add the `aliceVision_maskEroding` command-line tool, integrate it into the build system, and expose it as a node in the Meshroom pipeline.

**New mask erosion feature:**

* Added `aliceVision_maskEroding` command-line tool for eroding binary mask images, including implementation of the mask erosion algorithm using integral images and parallel processing (`src/software/utils/main_maskEroding.cpp`).

**Build system integration:**

* Registered the new `aliceVision_maskEroding` tool in the CMake build system, ensuring it is built and linked with the required dependencies (`src/software/utils/CMakeLists.txt`).

**Meshroom node integration:**

* Introduced a new Meshroom node `MaskEroding` that wraps the mask erosion functionality, defines its inputs/outputs, and exposes parameters such as erosion radius and verbosity (`meshroom/aliceVision/MaskEroding.py`).