### PR TITLE
Triangulation from depth priors

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -1,4 +1,4 @@
-__version__ = "2.1"
+__version__ = "2.2"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -51,7 +51,19 @@ class SfMExpanding(desc.AVCommandLineNode):
             range=(0.0, 100.0, 0.1),
             advanced=True,
         ),
-       desc.BoolParam(
+        desc.BoolParam(
+            name="enableDepthPrior",
+            label="Use Depth Prior",
+            description="If available in the tracks, use the depth prior to help the structure estimation.",
+            value=True,
+        ),
+        desc.BoolParam(
+            name="ignoreMultiviewOnPrior",
+            label="Ignore Multiview On Prior",
+            description="Favour the prior based 3d reconstruction over the multiview reconstruction.",
+            value=False,
+        ),
+        desc.BoolParam(
             name="lockScenePreviouslyReconstructed",
             label="Lock Previously Reconstructed Scene",
             description="Lock previously reconstructed poses and intrinsics.\n"

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -177,50 +177,99 @@ bool ExpansionChunk::triangulate(sfmData::SfMData & sfmData, const track::Tracks
     ALICEVISION_LOG_INFO("ExpansionChunk::triangulate start");
     SfmTriangulation triangulation(_triangulationMinPoints, _maxTriangulationError);
 
-    std::set<IndexT> evaluatedTracks;
-    std::map<IndexT, sfmData::Landmark> outputLandmarks;
+    
+    const bool enableMultiviewTriangulation = true;
 
-    std::mt19937 randomNumberGenerator;
-    if (!triangulation.process(sfmData, tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
-                                randomNumberGenerator, viewIds, 
-                                evaluatedTracks, outputLandmarks))
+    if (enableMultiviewTriangulation)
     {
-        return false;
+        std::set<IndexT> evaluatedTracks;
+        std::map<IndexT, sfmData::Landmark> outputLandmarks;
+        std::mt19937 randomNumberGenerator;
+        if (!triangulation.process(sfmData, tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
+                                    randomNumberGenerator, viewIds, 
+                                    evaluatedTracks, outputLandmarks, false))
+        {
+            return false;
+        }
+
+        auto & landmarks = sfmData.getLandmarks();
+        ALICEVISION_LOG_INFO("Existing landmarks : " << landmarks.size());
+
+        for (const auto & pl : outputLandmarks)
+        {
+            const auto & landmark = pl.second;
+
+            if (landmarks.find(pl.first) != landmarks.end())
+            {
+                landmarks.erase(pl.first);
+            }
+
+            if (landmark.getObservations().size() < _triangulationMinPoints)
+            {
+                continue;
+            }
+
+            if (!SfmTriangulation::checkChierality(sfmData, landmark))
+            {
+                continue;
+            }
+
+            double maxAngle = SfmTriangulation::getMaximalAngle(sfmData, landmark);
+            if (maxAngle < _minTriangulationAngleDegrees)
+            {
+                continue;
+            }
+
+            landmarks.insert(pl);
+        }
+
+        ALICEVISION_LOG_INFO("New landmarks count : " << landmarks.size());
+        ALICEVISION_LOG_INFO("ExpansionChunk::triangulate end");
     }
 
-    auto & landmarks = sfmData.getLandmarks();
-    ALICEVISION_LOG_INFO("Existing landmarks : " << landmarks.size());
-
-    for (const auto & pl : outputLandmarks)
+    if (_enableDepthPrior)
     {
-        const auto & landmark = pl.second;
-
-        if (landmarks.find(pl.first) != landmarks.end())
+        std::set<IndexT> evaluatedTracks;
+        std::map<IndexT, sfmData::Landmark> outputLandmarks;
+        std::mt19937 randomNumberGenerator;
+        if (!triangulation.process(sfmData, tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
+                                    randomNumberGenerator, viewIds, 
+                                    evaluatedTracks, outputLandmarks, true))
         {
-            landmarks.erase(pl.first);
+            return false;
         }
 
-        if (landmark.getObservations().size() < _triangulationMinPoints)
+        auto & landmarks = sfmData.getLandmarks();
+        ALICEVISION_LOG_INFO("Existing landmarks : " << landmarks.size());
+
+        for (const auto & pl : outputLandmarks)
         {
-            continue;
+            const auto & landmark = pl.second;
+
+            if (landmarks.find(pl.first) != landmarks.end())
+            {
+                if (!_ignoreMultiviewOnPrior)
+                {
+                    continue;
+                }
+            }
+
+            if (landmark.getObservations().size() < _triangulationMinPoints)
+            {
+                continue;
+            }
+
+            if (!SfmTriangulation::checkChierality(sfmData, landmark))
+            {
+                continue;
+            }
+
+            landmarks.insert(pl);
         }
 
-        if (!SfmTriangulation::checkChierality(sfmData, landmark))
-        {
-            continue;
-        }
-
-        double maxAngle = SfmTriangulation::getMaximalAngle(sfmData, landmark);
-        if (maxAngle < _minTriangulationAngleDegrees)
-        {
-            continue;
-        }
-
-        landmarks.insert(pl);
+        ALICEVISION_LOG_INFO("New landmarks count : " << landmarks.size());
+        ALICEVISION_LOG_INFO("ExpansionChunk::triangulate end");
     }
-
-    ALICEVISION_LOG_INFO("New landmarks count : " << landmarks.size());
-    ALICEVISION_LOG_INFO("ExpansionChunk::triangulate end");
 
     return true;
 }

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
@@ -112,6 +112,24 @@ public:
         return _ignoredViews;
     }
 
+     /**
+     * @brief Are the optional depths priors used ?
+     * @param flag boolean to set value to
+    */
+    void setEnableDepthPrior(bool flag)
+    {
+        _enableDepthPrior = flag;
+    }
+
+    /**
+     * @brief Do we prefer prior depth over estimated multiview depth ?
+     * @param flag boolean to set value to
+    */
+    void setIgnoreMultiviewOnPrior(bool flag)
+    {
+        _ignoreMultiviewOnPrior = flag;
+    }
+
 private:
 
     /**
@@ -150,6 +168,8 @@ private:
     double _minTriangulationAngleDegrees = 3.0;
     double _maxTriangulationError = 8.0;
     size_t _weakResectionSize = 100;
+    bool _enableDepthPrior = true;
+    bool _ignoreMultiviewOnPrior = false;
 };
 
 } // namespace sfm

--- a/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
@@ -33,7 +33,8 @@ bool SfmTriangulation::process(
             std::mt19937 &randomNumberGenerator,
             const std::set<IndexT> &viewIds,
             std::set<IndexT> & evaluatedTracks,
-            std::map<IndexT, sfmData::Landmark> & outputLandmarks
+            std::map<IndexT, sfmData::Landmark> & outputLandmarks,
+            bool useDepthPrior
         )
 {
     evaluatedTracks.clear();
@@ -83,9 +84,19 @@ bool SfmTriangulation::process(
         }
 
         sfmData::Landmark result;
-        if (!processTrack(sfmData, track, randomNumberGenerator, trackViewsFiltered, result))
+        if (useDepthPrior)
         {
-            continue;
+            if (!processTrackWithPrior(sfmData, track, randomNumberGenerator, trackViewsFiltered, result))
+            {
+                continue;
+            }
+        }
+        else 
+        {
+            if (!processTrack(sfmData, track, randomNumberGenerator, trackViewsFiltered, result))
+            {
+                continue;
+            }
         }
 
         #pragma omp critical
@@ -173,6 +184,100 @@ bool SfmTriangulation::processTrack(
         o.setFeatureId(trackItem.featureId);
         o.setScale(trackItem.scale);
         o.setCoordinates(trackItem.coords);
+    }
+
+    return true;
+}
+
+bool SfmTriangulation::processTrackWithPrior(
+            const sfmData::SfMData & sfmData,
+            const track::Track & track,
+            std::mt19937 &randomNumberGenerator,
+            const std::set<IndexT> & viewIds,
+            sfmData::Landmark & result
+        )
+{
+    size_t bestInliersCount = 0;
+
+    //For each observed view in the track
+    for (auto referenceViewId : viewIds)
+    {   
+        if (track.featPerView.find(referenceViewId) == track.featPerView.end())
+        {
+            continue;
+        }
+
+        //Look if this observation has an associated depth
+        const auto & refTrackItem = track.featPerView.at(referenceViewId);
+        if (refTrackItem.depth < 0.0)
+        {
+            continue;
+        }
+
+        //Retrieve pose and feature coordinates for this observation
+        const sfmData::View & rView = sfmData.getView(referenceViewId);
+        const camera::IntrinsicBase & rIntrinsic = sfmData.getIntrinsic(rView.getIntrinsicId());
+        const geometry::Pose3 rPose = sfmData.getPose(rView).getTransform();        
+
+        //Compute 3D point in camera space
+        const double Z = refTrackItem.depth;
+        const Vec2 meters = rIntrinsic.removeDistortion(rIntrinsic.ima2cam(refTrackItem.coords.cast<double>()));
+        Vec3 cX = Z * meters.homogeneous();
+
+        //Transform 3D point in world space
+        const Vec3 oX = rPose.inverse()(cX);
+        
+        //Make sure this point is not dependent on parallax 
+        //As it does not need parallax to estimate its depth
+        sfmData::Landmark landmark;
+        landmark.setParallaxRobust(true);
+        landmark.X = oX;
+        landmark.descType = track.descType;
+
+        //Compute consensus for this depth
+        for (auto viewId : viewIds)
+        {
+            if (track.featPerView.find(viewId) == track.featPerView.end())
+            {
+                continue;
+            }
+
+            const auto & trackItem = track.featPerView.at(viewId);
+
+            const sfmData::View & view = sfmData.getView(viewId);
+            const camera::IntrinsicBase & intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
+            const geometry::Pose3 pose = sfmData.getPose(view).getTransform();    
+
+            const Vec2 est = intrinsic.transformProject(pose, oX.homogeneous(), true);
+            const Vec2 mes = trackItem.coords.cast<double>();
+            double err = (est - mes).norm() / trackItem.scale;
+
+            //Use _maxError as threshold for inliers/outlier detection
+            if (err > _maxError)
+            {
+                continue;
+            }
+
+            //Create and associated an observation to the landmark
+            sfmData::Observation & o = landmark.getObservations()[viewId];
+            o.setFeatureId(trackItem.featureId);
+            o.setScale(trackItem.scale);
+            o.setCoordinates(trackItem.coords);
+        }
+
+        //Store the landmark if it's better than the previously estimated one
+        int count = landmark.getObservations().size();
+        if (count > bestInliersCount)
+        {
+            bestInliersCount = count;
+            result = landmark;
+        }
+    }
+
+    //One inlier is the reference, so we need at least 2 inliers
+    if (bestInliersCount < 2)
+    {
+        return false;
     }
 
     return true;

--- a/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp
@@ -36,6 +36,7 @@ public:
      * @param viewIds the set of view ids to process. Only tracks observed in these views will be considered
      * @param evaluatedTracks output list of track ids which were evaluated (Not necessarily with success)
      * @param outputLandmarks a set of generated landmarks indexed by their landmark id (the associated track id)
+     * @param useDepthPrior use depth prior found in tracks
      * @return false if a critical error occurred
     */
     bool process(
@@ -45,7 +46,8 @@ public:
             std::mt19937 &randomNumberGenerator,
             const std::set<IndexT> & viewIds,
             std::set<IndexT> & evaluatedTracks,
-            std::map<IndexT, sfmData::Landmark> & outputLandmarks
+            std::map<IndexT, sfmData::Landmark> & outputLandmarks,
+            bool useDepthPrior
         );
 
 public:
@@ -82,6 +84,23 @@ private:
             const std::set<IndexT> & viewIds,
             sfmData::Landmark & result
         );  
+    
+    /**
+     * Process triangulation of a track with depth prior enabled
+     * @param sfmData the actual state of the sfm
+     * @param track the track of interest
+     * @param randomNumberGenerator random number generator object
+     * @param viewIds the set of view ids to process. Only tracks observed in these views will be considered
+     * @param result the output landmark
+     * @return false if a critical error occurred
+    */
+    bool processTrackWithPrior(
+            const sfmData::SfMData & sfmData,
+            const track::Track & track,
+            std::mt19937 &randomNumberGenerator,
+            const std::set<IndexT> & viewIds,
+            sfmData::Landmark & result
+        ); 
 
 private:
     const size_t _minObservations;

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -28,7 +28,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 2
 
 using namespace aliceVision;
 
@@ -104,6 +104,8 @@ int aliceVision_main(int argc, char** argv)
     bool useRigConstraint = true;
     int minNbCamerasForRigCalibration = 20;
     int weakResectionSize = 100;
+    bool enableDepthPrior = true;
+    bool ignoreMultiviewOnPrior = false;
 
     int randomSeed = std::mt19937::default_seed;
 
@@ -119,6 +121,8 @@ int aliceVision_main(int argc, char** argv)
     ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).")
     ("localizerEstimatorMaxIterations", po::value<std::size_t>(&localizerEstimatorMaxIterations)->default_value(localizerEstimatorMaxIterations), "Maximum number of RANSAC iterations.")
     ("localizerEstimatorError", po::value<double>(&localizerEstimatorError)->default_value(0.0), "Reprojection error threshold (in pixels) for the localizer estimator (0 for default value according to the estimator).")
+    ("enableDepthPrior", po::value<bool>(&enableDepthPrior)->default_value(enableDepthPrior),"If available in the tracks, use the depth prior.")
+    ("ignoreMultiviewOnPrior", po::value<bool>(&ignoreMultiviewOnPrior)->default_value(ignoreMultiviewOnPrior),"Favour the prior based 3d reconstruction over the multiview reconstruction.")
     ("lockScenePreviouslyReconstructed", po::value<bool>(&lockScenePreviouslyReconstructed)->default_value(lockScenePreviouslyReconstructed),"Lock/Unlock scene previously reconstructed.")
     ("useLocalBA,l", po::value<bool>(&useLocalBA)->default_value(useLocalBA), "Enable/Disable the Local bundle adjustment strategy.\n It reduces the reconstruction time, especially for big datasets (500+ images).")
     ("localBAGraphDistance", po::value<int>(&lbaDistanceLimit)->default_value(lbaDistanceLimit), "Graph-distance limit setting the Active region in the Local Bundle Adjustment strategy.")
@@ -257,6 +261,8 @@ int aliceVision_main(int argc, char** argv)
     expansionChunk->setResectionHandler(sfmResectionHandler);
     expansionChunk->setTriangulationMaxError(maxTriangulationError);
     expansionChunk->setTriangulationMinPoints(minNbObservationsForTriangulation);
+    expansionChunk->setEnableDepthPrior(enableDepthPrior);
+    expansionChunk->setIgnoreMultiviewOnPrior(ignoreMultiviewOnPrior);
     expansionChunk->setMinAngleTriangulation(minAngleForTriangulation);
     expansionChunk->setPointFetcherHandler(pointFetcherHandler);
     expansionChunk->setWeakResectionSize(weakResectionSize);


### PR DESCRIPTION
This pull request adds support for using depth priors in the structure-from-motion (SfM) expanding pipeline, allowing for improved 3D reconstruction when depth information is available in the tracks. It introduces new parameters to control the use of depth priors and the preference between prior-based and multiview-based reconstruction. The changes affect both the command-line interface and the core triangulation logic, ensuring that depth priors are properly integrated into the triangulation process.

**Depth Prior Integration and Control:**

* Added two new boolean parameters, `enableDepthPrior` and `ignoreMultiviewOnPrior`, to the `SfMExpanding` node, the command-line interface, and the `ExpansionChunk` class, allowing users to enable depth prior usage and control whether prior-based reconstruction is favored over multiview reconstruction. [[1]](diffhunk://#diff-b36f82a55bf559f41f08693e937a475c92ba4afd6f83c9b2e3ecde2de7c06843R54-R65) [[2]](diffhunk://#diff-d8298c7c2cc5697417d7ca897442abd96d187627a8b6ca351064cec20d453e3cR115-R132) [[3]](diffhunk://#diff-d8298c7c2cc5697417d7ca897442abd96d187627a8b6ca351064cec20d453e3cR171-R172) [[4]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R107-R108) [[5]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R124-R125) [[6]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R264-R265)

* Updated the `ExpansionChunk::triangulate` method to perform triangulation using both multiview and depth prior information, applying the new parameters to determine the reconstruction strategy and how landmarks are updated or replaced. [[1]](diffhunk://#diff-6902bad577d70b0956f4bc732cc25ddd47181aadd05ab0cea7a3cbac271a44f8R180-R190) [[2]](diffhunk://#diff-6902bad577d70b0956f4bc732cc25ddd47181aadd05ab0cea7a3cbac271a44f8R228-R272)

**Triangulation Logic Enhancements:**

* Extended the `SfmTriangulation::process` method and its interface to accept a `useDepthPrior` flag, enabling the selection between standard triangulation and depth-prior-based triangulation for each track. [[1]](diffhunk://#diff-a2a9b3c04247091efb91870d626265a6d8663377f1e3d00b20ab448fde680920L36-R37) [[2]](diffhunk://#diff-8923fb5ac3fde9c6e4ed746569392de39ff33c493e565177de4ad33d083adb71R39) [[3]](diffhunk://#diff-8923fb5ac3fde9c6e4ed746569392de39ff33c493e565177de4ad33d083adb71L48-R50)

* Implemented the `SfmTriangulation::processTrackWithPrior` method, which reconstructs 3D points directly from available depth priors in the tracks, bypassing the need for parallax and multiview triangulation when the prior is available and enabled. [[1]](diffhunk://#diff-a2a9b3c04247091efb91870d626265a6d8663377f1e3d00b20ab448fde680920R87-R100) [[2]](diffhunk://#diff-a2a9b3c04247091efb91870d626265a6d8663377f1e3d00b20ab448fde680920R192-R284) [[3]](diffhunk://#diff-8923fb5ac3fde9c6e4ed746569392de39ff33c493e565177de4ad33d083adb71R88-R104)

**Version Updates:**

* Bumped the version numbers in both the Python node (`meshroom/aliceVision/SfmExpanding.py`) and the C++ pipeline (`main_sfmExpanding.cpp`) to reflect the new features and interface changes. [[1]](diffhunk://#diff-b36f82a55bf559f41f08693e937a475c92ba4afd6f83c9b2e3ecde2de7c06843L1-R1) [[2]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2L31-R31)