### PR TITLE
FIX: OpenCV SIFT API

### DIFF
--- a/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp
@@ -18,9 +18,9 @@
 namespace aliceVision {
 namespace feature {
 
-void SIFT_openCV_Params::setConfigurationPreset(EImageDescriberPreset preset)
+void SIFT_openCV_Params::setConfigurationPreset(ConfigurationPreset preset)
 {
-    switch (preset)
+    switch (preset.descPreset)
     {
         case EImageDescriberPreset::LOW:
             contrastThreshold = 0.01;
@@ -67,7 +67,7 @@ bool ImageDescriber_SIFT_openCV::describe(const image::Image<unsigned char>& ima
             maxDetect = _params.maxTotalKeypoints;
 
     cv::Ptr<cv::Feature2D> siftdetector =
-      cv::xfeatures2d::SIFT::create(maxDetect, _params.nOctaveLayers, _params.contrastThreshold, _params.edgeThreshold, _params.sigma);
+      cv::SIFT::create(maxDetect, _params.nOctaveLayers, _params.contrastThreshold, _params.edgeThreshold, _params.sigma);
 
     // Detect SIFT keypoints
     auto detect_start = std::chrono::steady_clock::now();

--- a/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.hpp
+++ b/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.hpp
@@ -30,7 +30,7 @@ class SIFT_openCV_Params
      * @param[in] preset The preset configuration
      * @return True if configuration succeed.
      */
-    void setConfigurationPreset(EImageDescriberPreset preset);
+    void setConfigurationPreset(ConfigurationPreset preset);
 
     /// Parameters
     std::size_t gridSize = 4;
@@ -84,7 +84,7 @@ class ImageDescriber_SIFT_openCV : public ImageDescriber
      * @param[in] preset The preset configuration
      * @return True if configuration succeed.
      */
-    void setConfigurationPreset(EImageDescriberPreset preset) override { _params.setConfigurationPreset(preset); }
+    void setConfigurationPreset(ConfigurationPreset preset) override { _params.setConfigurationPreset(preset); }
 
     /**
      * @brief Detect regions on the 8-bit image and compute their attributes (description)


### PR DESCRIPTION
This commit fixes some API changes likely introduced by switching to OpenCV 4 (namespace change for `SIFT`). Furthermore, this fixes a virtual function override mismatch, which caused a compiler error at least on macOS. As this only appears with `-DALICEVISION_USE_OCVSIFT=ON` (which is not the default), this was probably not caught in CI.

## Compiler error reference

```c++
In file included from AliceVision/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp:8:
AliceVision/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.hpp:87:63: error: non-virtual member function marked 'override' hides virtual member function
   87 |     void setConfigurationPreset(EImageDescriberPreset preset) override { _params.setConfigurationPreset(preset); }
      |                                                               ^
AliceVision/src/aliceVision/feature/ImageDescriber.hpp:215:18: note: hidden overloaded virtual function 'aliceVision::feature::ImageDescriber::setConfigurationPreset' declared here: type mismatch at 1st parameter ('ConfigurationPreset' vs 'EImageDescriberPreset')
  215 |     virtual void setConfigurationPreset(ConfigurationPreset preset) = 0;
      |                  ^
In file included from AliceVision/src/aliceVision/feature/ImageDescriber.cpp:27:
AliceVision/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.hpp:87:63: error: non-virtual member function marked 'override' hides virtual member function
   87 |     void setConfigurationPreset(EImageDescriberPreset preset) override { _params.setConfigurationPreset(preset); }
      |                                                               ^
AliceVision/src/aliceVision/feature/ImageDescriber.hpp:215:18: note: hidden overloaded virtual function 'aliceVision::feature::ImageDescriber::setConfigurationPreset' declared here: type mismatch at 1st parameter ('ConfigurationPreset' vs 'EImageDescriberPreset')
  215 |     virtual void setConfigurationPreset(ConfigurationPreset preset) = 0;
      |                  ^
AliceVision/src/aliceVision/feature/ImageDescriber.cpp:250:36: error: allocating an object of abstract class type 'ImageDescriber_SIFT_openCV'
  250 |             describerPtr.reset(new ImageDescriber_SIFT_openCV());
      |                                    ^
AliceVision/src/aliceVision/feature/ImageDescriber.hpp:215:18: note: unimplemented pure virtual method 'setConfigurationPreset' in 'ImageDescriber_SIFT_openCV'
  215 |     virtual void setConfigurationPreset(ConfigurationPreset preset) = 0;
      |                  ^
[ 26%] Building CXX object aliceVision/panorama/CMakeFiles/aliceVision_panorama.dir/coordinatesMap.cpp.o
2 errors generated.
make[5]: *** [aliceVision/feature/CMakeFiles/aliceVision_feature.dir/ImageDescriber.cpp.o] Error 1
make[5]: *** Waiting for unfinished jobs....
[ 26%] Building CXX object aliceVision/multiview/CMakeFiles/aliceVision_multiview.dir/essential.cpp.o
AliceVision/src/aliceVision/feature/openCV/ImageDescriber_SIFT_OCV.cpp:70:7: error: no member named 'SIFT' in namespace 'cv::xfeatures2d'; did you mean 'cv::SIFT'?
   70 |       cv::xfeatures2d::SIFT::create(maxDetect, _params.nOctaveLayers, _params.contrastThreshold, _params.edgeThreshold, _params.sigma);
      |       ^~~~~~~~~~~~~~~~~~~~~
      |       cv::SIFT
AliceVision/build/INSTALL_DEPS/include/opencv4/opencv2/features2d.hpp:266:20: note: 'cv::SIFT' declared here
  266 | class CV_EXPORTS_W SIFT : public Feature2D
      |
```