### PR TITLE
[meshroom] Update experimental pipelines to use ExportImages

### DIFF
--- a/meshroom/aliceVision/ExportImages.py
+++ b/meshroom/aliceVision/ExportImages.py
@@ -100,7 +100,7 @@ For example, the target intrinsics may be the same without the distortion.
             label="Undistorted Images",
             description="List of undistorted images.",
             semantic="image",
-            value="{nodeCacheFolder}/<VIEW_ID>.{outputFileTypeValue}",
+            value=lambda attr: getUndistortedPath(attr.node.namingMode.value),
             group="",
             advanced=True,
         ),
@@ -111,3 +111,14 @@ For example, the target intrinsics may be the same without the distortion.
             value="{nodeCacheFolder}/sfm.abc",
         ),
     ]
+
+def getUndistortedPath(namingMode):
+    
+    replacement = "<FILESTEM>"
+    if (namingMode == "viewid"):
+        replacement = "<VIEW_ID>"
+    elif (namingMode == "frameid"):
+        replacement = "<FRAME_ID>"
+
+    return "{nodeCacheFolder}/" + replacement + ".{outputFileTypeValue}"
+                    

--- a/meshroom/cameraTrackingExperimental.mg
+++ b/meshroom/cameraTrackingExperimental.mg
@@ -1,6 +1,6 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
@@ -11,27 +11,27 @@
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.0",
-            "ExportAnimatedCamera": "2.0",
+            "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
-            "ExportImages": "1.0",
+            "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
             "ImageSegmentationBox": "0.3",
-            "IntrinsicsTransforming": "1.0",
+            "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "RelativePoseEstimating": "3.0",
+            "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
             "SfMBootStrapping": "4.1",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.1",
+            "SfMExpanding": "2.2",
             "SfMTransfer": "2.1",
-            "SfMTransform": "3.1",
+            "SfMTransform": "3.2",
             "SfMTriangulation": "1.0",
             "Texturing": "6.0",
             "TracksBuilding": "1.0",
@@ -99,7 +99,7 @@
                 219
             ],
             "inputs": {
-                "input": "{ExportAnimatedCamera_1.input}",
+                "input": "{SfMColorizing_2.output}",
                 "fileExt": "json",
                 "describerTypes": "{TracksBuilding_2.describerTypes}",
                 "structure": false,
@@ -107,6 +107,22 @@
             },
             "internalInputs": {
                 "color": "#4c594c"
+            }
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                5079,
+                119
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{Texturing_1.output}",
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{ExportAlembic_1.output}",
+                    "{ExportImages_2.output}"
+                ]
             }
         },
         "DepthMapFilter_1": {
@@ -152,15 +168,14 @@
                 "color": "#302e2e"
             }
         },
-        "ExportAnimatedCamera_1": {
-            "nodeType": "ExportAnimatedCamera",
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
             "position": [
-                3083,
-                203
+                3456,
+                206
             ],
             "inputs": {
-                "input": "{SfMColorizing_2.output}",
-                "exportUndistortedImages": true
+                "input": "{ExportImages_2.outputSfMData}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -195,6 +210,21 @@
             },
             "internalInputs": {
                 "color": "#3f3138"
+            }
+        },
+        "ExportImages_2": {
+            "nodeType": "ExportImages",
+            "position": [
+                3250,
+                194
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_2.input}",
+                "target": "{IntrinsicsTransforming_2.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
             }
         },
         "FeatureExtraction_1": {
@@ -360,6 +390,19 @@
                 "color": "#3f3138"
             }
         },
+        "IntrinsicsTransforming_2": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                3050,
+                194
+            ],
+            "inputs": {
+                "input": "{SfMColorizing_2.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
         "KeyframeSelection_1": {
             "nodeType": "KeyframeSelection",
             "position": [
@@ -421,21 +464,6 @@
                 "color": "#3f3138"
             }
         },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                5079,
-                119
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{ExportAnimatedCamera_1.output}",
-                    "{Texturing_1.output}",
-                    "{ScenePreview_1.output}",
-                    "{ExportDistortion_1.output}"
-                ]
-            }
-        },
         "RelativePoseEstimating_1": {
             "nodeType": "RelativePoseEstimating",
             "position": [
@@ -462,7 +490,7 @@
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
-                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "undistortedImages": "{ExportImages_2.output}",
                 "masks": "{ImageSegmentationBox_1.output}"
             },
             "internalInputs": {

--- a/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
@@ -1,6 +1,6 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
@@ -10,27 +10,27 @@
             "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "ExportAnimatedCamera": "2.0",
+            "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
-            "ExportImages": "1.0",
+            "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
             "ImageSegmentationBox": "0.3",
-            "IntrinsicsTransforming": "1.0",
+            "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "RelativePoseEstimating": "3.0",
+            "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
             "SfMBootStrapping": "4.1",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.1",
+            "SfMExpanding": "2.2",
             "SfMTransfer": "2.1",
-            "SfMTransform": "3.1",
+            "SfMTransform": "3.2",
             "SfMTriangulation": "1.0",
             "Texturing": "6.0",
             "TracksBuilding": "1.0",
@@ -79,11 +79,11 @@
         "ConvertSfMFormat_1": {
             "nodeType": "ConvertSfMFormat",
             "position": [
-                4245,
+                4585,
                 200
             ],
             "inputs": {
-                "input": "{ExportAnimatedCamera_1.input}",
+                "input": "{SfMColorizing_2.output}",
                 "fileExt": "json",
                 "describerTypes": "{TracksBuilding_2.describerTypes}",
                 "structure": false,
@@ -91,6 +91,22 @@
             },
             "internalInputs": {
                 "color": "#4c594c"
+            }
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                5228,
+                100
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{Texturing_1.output}",
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{ExportAlembic_1.output}",
+                    "{ExportImages_2.output}"
+                ]
             }
         },
         "DepthMapFilter_1": {
@@ -122,15 +138,14 @@
                 "color": "#3f3138"
             }
         },
-        "ExportAnimatedCamera_1": {
-            "nodeType": "ExportAnimatedCamera",
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
             "position": [
-                3216,
-                198
+                3465.0,
+                191.0
             ],
             "inputs": {
-                "input": "{SfMColorizing_2.output}",
-                "exportUndistortedImages": true
+                "input": "{ExportImages_2.outputSfMData}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -163,6 +178,21 @@
             },
             "internalInputs": {
                 "color": "#3f3138"
+            }
+        },
+        "ExportImages_2": {
+            "nodeType": "ExportImages",
+            "position": [
+                3259.0,
+                179.0
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_2.input}",
+                "target": "{IntrinsicsTransforming_2.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
             }
         },
         "FeatureExtraction_1": {
@@ -328,6 +358,19 @@
                 "color": "#3f3138"
             }
         },
+        "IntrinsicsTransforming_2": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                3059.0,
+                179.0
+            ],
+            "inputs": {
+                "input": "{SfMColorizing_2.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
         "KeyframeSelection_1": {
             "nodeType": "KeyframeSelection",
             "position": [
@@ -389,21 +432,6 @@
                 "color": "#3f3138"
             }
         },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                5228,
-                100
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{ExportAnimatedCamera_1.output}",
-                    "{Texturing_1.output}",
-                    "{ScenePreview_1.output}",
-                    "{ExportDistortion_1.output}"
-                ]
-            }
-        },
         "RelativePoseEstimating_1": {
             "nodeType": "RelativePoseEstimating",
             "position": [
@@ -430,7 +458,7 @@
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
-                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "undistortedImages": "{ExportImages_2.output}",
                 "masks": "{ImageSegmentationBox_1.output}"
             },
             "internalInputs": {

--- a/meshroom/photogrammetryAndCameraTrackingExperimental.mg
+++ b/meshroom/photogrammetryAndCameraTrackingExperimental.mg
@@ -1,6 +1,6 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
@@ -11,27 +11,27 @@
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.0",
-            "ExportAnimatedCamera": "2.0",
+            "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
-            "ExportImages": "1.0",
+            "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
             "ImageSegmentationBox": "0.3",
-            "IntrinsicsTransforming": "1.0",
+            "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "RelativePoseEstimating": "3.0",
+            "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
             "SfMBootStrapping": "4.1",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.1",
+            "SfMExpanding": "2.2",
             "SfMTransfer": "2.1",
-            "SfMTransform": "3.1",
+            "SfMTransform": "3.2",
             "Texturing": "6.0",
             "TracksBuilding": "1.0",
             "TracksMerging": "3.0"
@@ -107,11 +107,11 @@
         "ConvertSfMFormat_1": {
             "nodeType": "ConvertSfMFormat",
             "position": [
-                4333,
-                201
+                4802,
+                171
             ],
             "inputs": {
-                "input": "{ExportAnimatedCamera_1.input}",
+                "input": "{SfMTransfer_1.output}",
                 "fileExt": "sfm",
                 "describerTypes": "{TracksBuilding_3.describerTypes}",
                 "structure": false,
@@ -119,6 +119,22 @@
             },
             "internalInputs": {
                 "color": "#4c594c"
+            }
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                5368,
+                -145
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{Texturing_2.output}",
+                    "{ExportImages_2.output}",
+                    "{ExportAlembic_1.output}"
+                ]
             }
         },
         "DepthMapFilter_2": {
@@ -163,15 +179,14 @@
                 "color": "#302e2e"
             }
         },
-        "ExportAnimatedCamera_1": {
-            "nodeType": "ExportAnimatedCamera",
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
             "position": [
-                4126,
-                158
+                4522.0,
+                218.0
             ],
             "inputs": {
-                "input": "{SfMTransfer_1.output}",
-                "exportUndistortedImages": true
+                "input": "{ExportImages_2.outputSfMData}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -203,6 +218,21 @@
             },
             "internalInputs": {
                 "color": "#384a55"
+            }
+        },
+        "ExportImages_2": {
+            "nodeType": "ExportImages",
+            "position": [
+                4316.0,
+                206.0
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_2.input}",
+                "target": "{IntrinsicsTransforming_2.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
             }
         },
         "FeatureExtraction_1": {
@@ -447,6 +477,19 @@
                 "color": "#384a55"
             }
         },
+        "IntrinsicsTransforming_2": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                4116.0,
+                206.0
+            ],
+            "inputs": {
+                "input": "{SfMTransfer_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
         "KeyframeSelection_1": {
             "nodeType": "KeyframeSelection",
             "position": [
@@ -503,21 +546,6 @@
                 "color": "#384a55"
             }
         },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                4725,
-                -186
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{ExportAnimatedCamera_1.output}",
-                    "{ScenePreview_1.output}",
-                    "{ExportDistortion_1.output}",
-                    "{Texturing_2.output}"
-                ]
-            }
-        },
         "RelativePoseEstimating_1": {
             "nodeType": "RelativePoseEstimating",
             "position": [
@@ -537,13 +565,13 @@
         "ScenePreview_1": {
             "nodeType": "ScenePreview",
             "position": [
-                4526,
-                158
+                4991,
+                150
             ],
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
-                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "undistortedImages": "{ExportImages_2.output}",
                 "masks": "{ImageSegmentationBox_2.output}"
             },
             "internalInputs": {


### PR DESCRIPTION
This pull request updates the experimental camera tracking and photogrammetry pipelines and enhances the `ExportImages` node logic to provide more flexible naming of undistorted images. The changes modernize the pipeline structure, replace deprecated nodes, and improve compatibility with newer workflows.

**Pipeline and Node Structure Updates:**

* Replaced `ExportAnimatedCamera` nodes with `ExportAlembic` nodes in all experimental pipeline `.mg` files, updating their connections accordingly. (`meshroom/cameraTrackingExperimental.mg`, `meshroom/cameraTrackingWithoutCalibrationExperimental.mg`, `meshroom/photogrammetryAndCameraTrackingExperimental.mg`) [[1]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3L14-R34) [[2]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeL13-R33) [[3]](diffhunk://#diff-22f09bda154cbc23de672162f3b478878d7d1f37c54b2ff3ecb303a4e2623795L14-R34) [[4]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3L155-R178) [[5]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeL125-R148) [[6]](diffhunk://#diff-22f09bda154cbc23de672162f3b478878d7d1f37c54b2ff3ecb303a4e2623795L166-R189)
* Updated node versions and release version metadata to reflect the new pipeline structure and node versions. (`meshroom/cameraTrackingExperimental.mg`, `meshroom/cameraTrackingWithoutCalibrationExperimental.mg`, `meshroom/photogrammetryAndCameraTrackingExperimental.mg`) [[1]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3L3-R3) [[2]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeL3-R3) [[3]](diffhunk://#diff-22f09bda154cbc23de672162f3b478878d7d1f37c54b2ff3ecb303a4e2623795L3-R3)

**ExportImages Node Improvements:**

* Added a new `getUndistortedPath` function in `ExportImages.py` to dynamically determine the naming pattern for undistorted images based on the `namingMode` parameter, and updated the corresponding attribute to use this function. (`meshroom/aliceVision/ExportImages.py`) [[1]](diffhunk://#diff-e166e29f8beddde6aefbfe8c0cdd2909eb23f30cc9daab2f33b0904a2f5d6db4L103-R103) [[2]](diffhunk://#diff-e166e29f8beddde6aefbfe8c0cdd2909eb23f30cc9daab2f33b0904a2f5d6db4R114-R124)
* Updated all pipelines to use the new `ExportImages_2` node (version 1.1) with explicit `namingMode` and connections to `IntrinsicsTransforming_2`, ensuring undistorted images are generated and used downstream. (`meshroom/cameraTrackingExperimental.mg`, `meshroom/cameraTrackingWithoutCalibrationExperimental.mg`, `meshroom/photogrammetryAndCameraTrackingExperimental.mg`) [[1]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3R215-R229) [[2]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeR183-R197) [[3]](diffhunk://#diff-22f09bda154cbc23de672162f3b478878d7d1f37c54b2ff3ecb303a4e2623795R223-R237)

**Pipeline Output and File Management:**

* Added or updated `CopyFiles_1` nodes in all pipelines to collect outputs from `ExportImages_2`, `ExportAlembic_1`, and other key nodes, ensuring all important results are gathered at the end of the pipeline. (`meshroom/cameraTrackingExperimental.mg`, `meshroom/cameraTrackingWithoutCalibrationExperimental.mg`, `meshroom/photogrammetryAndCameraTrackingExperimental.mg`) [[1]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3R112-R127) [[2]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3L424-L438) [[3]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeR96-R111) [[4]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeL392-L406) [[5]](diffhunk://#diff-22f09bda154cbc23de672162f3b478878d7d1f37c54b2ff3ecb303a4e2623795R124-R139)

**Pipeline Connection Adjustments:**

* Updated references throughout the pipelines to use outputs from the new nodes (e.g., `ExportImages_2.output` instead of `ExportAnimatedCamera_1.outputUndistorted`, and new connections for `ConvertSfMFormat_1` and `undistortedImages` inputs). (`meshroom/cameraTrackingExperimental.mg`, `meshroom/cameraTrackingWithoutCalibrationExperimental.mg`, `meshroom/photogrammetryAndCameraTrackingExperimental.mg`) [[1]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3L102-R102) [[2]](diffhunk://#diff-0706abe1e9e76d8a76cb2d77ba60cf6b9c643b10911ede29fc9cb511d0f15bd3L465-R493) [[3]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeL82-R86) [[4]](diffhunk://#diff-e497cb88006224aeac2bdfeb5d0372725fcf55975180b0fe2b61e4370d8d99aeL433-R461) [[5]](diffhunk://#diff-22f09bda154cbc23de672162f3b478878d7d1f37c54b2ff3ecb303a4e2623795L110-R114)

These changes collectively modernize the pipelines, improve output management, and make the `ExportImages` node more flexible and maintainable.