### PR TITLE
[utils] ExportImages: Add ranges for parallelization

### DIFF
--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -315,7 +315,7 @@ bool process(const sfmData::SfMData & input,
     // for exposure correction
     const double medianCameraExposure = input.getMedianCameraExposureSetting().getExposure(); 
 
-    for (int posImage = 0; posImage < countElements; posImage++)
+    for (int posImage = rangeStart; posImage < rangeEnd; posImage++)
     {
         auto viewsIt = input.getViews().begin();
         std::advance(viewsIt, posImage);


### PR DESCRIPTION
ExportImages is parallelizing computations among chunks.

Before this PR all chunks will erroneously compute all images instead of their own subset of images.