### PR TITLE
Add an option to disable structure refinement

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -1,4 +1,4 @@
-__version__ = "2.2"
+__version__ = "2.3"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -173,6 +173,12 @@ class SfMExpanding(desc.AVCommandLineNode):
                         "principal point, distortion if any) constant during the reconstruction.\n"
                         "This may be helpful if the input cameras are already fully calibrated.",
             value=False,
+        ),
+        desc.BoolParam(
+            name="enableStructureRefinement",
+            label="Enable Structure Refinement",
+            description="Bundle adjustment will try to optimize the landmarks positions.",
+            value=True,
         ),
         desc.IntParam(
             name="minNbCamerasToRefinePrincipalPoint",

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -22,7 +22,12 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
 
     refineOptions |= BundleAdjustment::REFINE_ROTATION; 
     refineOptions |= BundleAdjustment::REFINE_TRANSLATION;
-    refineOptions |= BundleAdjustment::REFINE_STRUCTURE;
+
+    if (_isStructureRefinementEnabled)
+    {
+        refineOptions |= BundleAdjustment::REFINE_STRUCTURE;
+    }
+
     refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;
 
     options.setSparseBA();

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
@@ -72,6 +72,15 @@ public:
         _minNbCamerasToRefinePrincipalPoint = count;
     }
 
+    /**
+     * @brief Set whether to enable structure refinement in bundle adjustment
+     * @param flag true to enable structure refinement, false to disable it
+    */
+    void setIsStructureRefinementEnabled(bool flag)
+    {
+        _isStructureRefinementEnabled = flag;
+    }
+
 private:
     /**
      * Initialize bundle properties
@@ -105,6 +114,7 @@ private:
     size_t _minNbCamerasLBA = 100;
     size_t _LBAGraphDistanceLimit = 1;
     size_t _LBAMinNbOfMatches = 50;
+    bool _isStructureRefinementEnabled = true;
 };
 
 } // namespace sfm

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -28,7 +28,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 2
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 3
 
 using namespace aliceVision;
 
@@ -100,6 +100,7 @@ int aliceVision_main(int argc, char** argv)
     double maxReprojectionError = 4.0;
     double maxTriangulationError = 8.0;
     bool lockAllIntrinsics = false;
+    bool enableStructureRefinement = true;
     int minNbCamerasToRefinePrincipalPoint = 3;
     bool useRigConstraint = true;
     int minNbCamerasForRigCalibration = 20;
@@ -146,9 +147,10 @@ int aliceVision_main(int argc, char** argv)
     ("maxTriangulationError", po::value<double>(&maxTriangulationError)->default_value(maxTriangulationError), "Maximum reprojection error in the triangulation process.")
     ("maxReprojectionError", po::value<double>(&maxReprojectionError)->default_value(maxReprojectionError), "Maximum reprojection error in the bundle verification step.")
     ("lockAllIntrinsics", po::value<bool>(&lockAllIntrinsics)->default_value(lockAllIntrinsics), "Force lock of all camera intrinsic parameters, so they will not be refined during Bundle Adjustment.")
+    ("enableStructureRefinement", po::value<bool>(&enableStructureRefinement)->default_value(enableStructureRefinement), "Bundle adjustment will try to optimize the landmarks positions.")
     ("minNbCamerasToRefinePrincipalPoint", po::value<int>(&minNbCamerasToRefinePrincipalPoint)->default_value(minNbCamerasToRefinePrincipalPoint),
          "Minimal number of cameras to refine the principal point of the cameras (one of the intrinsic parameters of the camera). "
-         "If we do not have enough cameras, the principal point in consider is considered in the center of the image. "
+         "If we do not have enough cameras, the principal point is considered in the center of the image. "
          "If minNbCamerasToRefinePrincipalPoint<=0, the principal point is never refined. "
          "If minNbCamerasToRefinePrincipalPoint==1, the principal point is always refined.")
     ("useRigConstraint", po::value<bool>(&useRigConstraint)->default_value(useRigConstraint), "Enable/Disable rig constraint.")
@@ -233,6 +235,7 @@ int aliceVision_main(int argc, char** argv)
     sfmBundle->setMinAngleLandmark(minAngleForLandmark);
     sfmBundle->setMaxReprojectionError(maxReprojectionError);
     sfmBundle->setMinNbCamerasToRefinePrincipalPoint(minNbCamerasToRefinePrincipalPoint);
+    sfmBundle->setIsStructureRefinementEnabled(enableStructureRefinement);
 
     sfm::PointFetcher::uptr pointFetcherHandler;
     if (!meshFilename.empty())


### PR DESCRIPTION
This pull request adds support for enabling or disabling structure refinement (landmark position optimization) during bundle adjustment in the SfM Expanding pipeline. It introduces a new parameter to the user interface and command line, updates the core logic to respect this setting, and increments the software version to reflect the new feature.

**New Feature: Structure Refinement Control**
- Added a new boolean parameter, `enableStructureRefinement`, to the `SfMExpanding` node in the UI and command line, allowing users to control whether bundle adjustment optimizes landmark positions. The default value is `False` in the UI and `True` in the command line. [[1]](diffhunk://#diff-b36f82a55bf559f41f08693e937a475c92ba4afd6f83c9b2e3ecde2de7c06843R177-R182) [[2]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R103) [[3]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R150)

**Core Logic Updates**
- Modified the `SfmBundle` class to store and use the `enableStructureRefinement` flag, and updated the bundle adjustment process to conditionally refine structure based on this setting. [[1]](diffhunk://#diff-96a08aeb5178f0dbeeccdb2f60f6481b7ede09373e813cfe0397072b67240b7fR75-R83) [[2]](diffhunk://#diff-96a08aeb5178f0dbeeccdb2f60f6481b7ede09373e813cfe0397072b67240b7fR117) [[3]](diffhunk://#diff-096633d8d9d01c7d41501b6d3c0ec2ad9fb599a6167bad9123d7e69483ce759aR25-R30)
- Passed the new parameter from the main pipeline to the `SfmBundle` instance.

**Version Update**
- Incremented the software version from 2.2 to 2.3 in both the Python and C++ components to reflect the addition of this feature. [[1]](diffhunk://#diff-b36f82a55bf559f41f08693e937a475c92ba4afd6f83c9b2e3ecde2de7c06843L1-R1) [[2]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2L31-R31)