### PR TITLE
[utils] Fix `exportImages` parallelization

### DIFF
--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -315,7 +315,7 @@ bool process(const sfmData::SfMData & input,
     // for exposure correction
     const double medianCameraExposure = input.getMedianCameraExposureSetting().getExposure(); 
 
-    for (int posImage = rangeStart; posImage < rangeEnd; posImage++)
+    for (int posImage = 0; posImage < countElements; posImage++)
     {
         auto viewsIt = input.getViews().begin();
         std::advance(viewsIt, posImage);
@@ -345,7 +345,8 @@ bool process(const sfmData::SfMData & input,
         std::string outFileName = namingFunction(view);
         outputView.getImage().setImagePath(outFileName);
 
-        if (posImage < rangeStart && posImage >= rangeEnd)
+        //Real processing is ignored if we are not in the chunk
+        if (posImage < rangeStart || posImage >= rangeEnd)
         {
             continue;
         }


### PR DESCRIPTION
Fix export image parallelization to fill all paths in the sfmData for ALL chunks.

However we only do the image transformation for the chunk items.