### PR TITLE
[meshroom] Update pipeline templates

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,10 +147,24 @@ jobs:
           cd mrBlenderSfmRenderer
           mrBlenderSfmRenderer_avBranch=$(git ls-remote --heads https://github.com/meshroomHub/mrBlenderSfmRenderer.git $GITHUB_HEAD_REF | cut -f 1)
           if [ $mrBlenderSfmRenderer_avBranch != "" ]; then git checkout $mrBlenderSfmRenderer_avBranch; echo "Use mrBlenderSfmRenderer/$GITHUB_HEAD_REF"; fi
+          cd ..
+
+          # Clone and checkout mrIntrinsicImageDecomposition, align the branch if necessary
+          git clone https://github.com/meshroomHub/mrIntrinsicImageDecomposition.git
+          cd mrIntrinsicImageDecomposition
+          mrIntrinsicImageDecomposition_avBranch=$(git ls-remote --heads https://github.com/meshroomHub/mrIntrinsicImageDecomposition.git $GITHUB_HEAD_REF | cut -f 1)
+          if [ $mrIntrinsicImageDecomposition_avBranch != "" ]; then git checkout $mrIntrinsicImageDecomposition_avBranch; echo "Use mrIntrinsicImageDecomposition/$GITHUB_HEAD_REF"; fi
+          cd ..
+
+          # Clone and checkout mrRoma, align the branch if necessary
+          git clone https://github.com/meshroomHub/mrRoma.git
+          cd mrRoma
+          mrRoma_avBranch=$(git ls-remote --heads https://github.com/meshroomHub/mrRoma $GITHUB_HEAD_REF | cut -f 1)
+          if [ $mrRoma_avBranch != "" ]; then git checkout $mrRoma_avBranch; echo "Use mrRoma/$GITHUB_HEAD_REF"; fi
           cd ../Meshroom/
 
           export MESHROOM_INSTALL_DIR=$PWD
-          export MESHROOM_NODES_PATH=${MESHROOM_NODES_PATH}:${ALICEVISION_ROOT}/share/meshroom:$PWD/../mrSegmentation/meshroom:$PWD/../mrBlenderSfmRenderer/meshroom
+          export MESHROOM_NODES_PATH=${MESHROOM_NODES_PATH}:${ALICEVISION_ROOT}/share/meshroom:$PWD/../mrSegmentation/meshroom:$PWD/../mrBlenderSfmRenderer/meshroom:$PWD/../mrIntrinsicImageDecomposition/meshroom:$PWD/../mrRoma/meshroom
           export MESHROOM_PIPELINE_TEMPLATES_PATH=${MESHROOM_PIPELINE_TEMPLATES_PATH}:${ALICEVISION_ROOT}/share/meshroom
           export PYTHONPATH=$PWD:${ALICEVISION_ROOT}/lib64/python:${ALICEVISION_ROOT}/lib/python:${PYTHONPATH}
           export PATH=$PATH:${ALICEVISION_ROOT}/bin

--- a/meshroom/cameraTrackingDepthExperimental.mg
+++ b/meshroom/cameraTrackingDepthExperimental.mg
@@ -1,0 +1,752 @@
+{
+    "header": {
+        "releaseVersion": "2026.1.0+develop",
+        "fileVersion": "2.0",
+        "nodesVersions": {
+            "ApplyCalibration": "1.0",
+            "CameraInit": "12.0",
+            "CheckerboardDetection": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
+            "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "DepthMapTracksInjecting": "1.0",
+            "DistortionCalibration": "6.0",
+            "ExportAlembic": "1.0",
+            "ExportDistortion": "2.0",
+            "ExportImages": "1.1",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.0",
+            "ImageDetectionPrompt": "0.2",
+            "ImageMatching": "2.0",
+            "ImageMatchingMultiSfM": "1.0",
+            "ImageSegmentationBox": "0.3",
+            "IntrinsicsTransforming": "1.1",
+            "KeyframeSelection": "5.0",
+            "MeshDecimate": "1.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
+            "MoGe": "1.0",
+            "RelativePoseEstimating": "3.1",
+            "ScenePreview": "2.0",
+            "SfMBootStrapping": "4.1",
+            "SfMColorizing": "1.0",
+            "SfMExpanding": "2.2",
+            "SfMFilter": "1.0",
+            "SfMTransfer": "2.1",
+            "SfMTransform": "3.2",
+            "SfMTriangulation": "1.0",
+            "Texturing": "6.0",
+            "TracksBuilding": "1.0",
+            "TracksMerging": "3.0"
+        },
+        "template": true
+    },
+    "graph": {
+        "ApplyCalibration_1": {
+            "nodeType": "ApplyCalibration",
+            "position": [
+                0,
+                0
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "calibration": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                -200,
+                0
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_2": {
+            "nodeType": "CameraInit",
+            "position": [
+                -600,
+                -160
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "label": "CameraInitLensGrid",
+                "color": "#302e2e"
+            }
+        },
+        "CheckerboardDetection_1": {
+            "nodeType": "CheckerboardDetection",
+            "position": [
+                -400,
+                -160
+            ],
+            "inputs": {
+                "input": "{CameraInit_2.output}",
+                "useNestedGrids": true,
+                "exportDebugImages": true
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ConvertSfMFormat_1": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                5087,
+                225
+            ],
+            "inputs": {
+                "input": "{SfMColorizing_2.output}",
+                "fileExt": "json",
+                "describerTypes": "{TracksBuilding_2.describerTypes}",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                5487,
+                125
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{Texturing_1.output}",
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{ExportAlembic_1.output}",
+                    "{ExportImages_2.output}"
+                ]
+            }
+        },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [
+                4487,
+                25
+            ],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "DepthMapTracksInjecting_1": {
+            "nodeType": "DepthMapTracksInjecting",
+            "position": [
+                998,
+                8
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "tracksFilename": "{TracksBuilding_1.output}",
+                "depthSource": "{MoGe_1.output}"
+            },
+            "internalInputs": {
+                "color": "#ff7000"
+            }
+        },
+        "DepthMapTracksInjecting_2": {
+            "nodeType": "DepthMapTracksInjecting",
+            "position": [
+                2626.0,
+                217.0
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_2.input}",
+                "tracksFilename": "{TracksMerging_1.output}",
+                "depthSource": "{MoGe_1.output}"
+            },
+            "internalInputs": {
+                "color": "#ff7000"
+            }
+        },
+        "DepthMap_1": {
+            "nodeType": "DepthMap",
+            "position": [
+                4287,
+                25
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_1.output}",
+                "imagesFolder": "{ExportImages_1.output}",
+                "downscale": 1
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "DistortionCalibration_1": {
+            "nodeType": "DistortionCalibration",
+            "position": [
+                -200,
+                -160
+            ],
+            "inputs": {
+                "input": "{CheckerboardDetection_1.input}",
+                "checkerboards": "{CheckerboardDetection_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
+            "position": [
+                3864,
+                212
+            ],
+            "inputs": {
+                "input": "{ExportImages_2.outputSfMData}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                0,
+                -160
+            ],
+            "inputs": {
+                "input": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ExportImages_1": {
+            "nodeType": "ExportImages",
+            "position": [
+                4083,
+                23
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_1.input}",
+                "target": "{IntrinsicsTransforming_1.output}",
+                "masksFolders": [
+                    "{ImageSegmentationBox_1.output}"
+                ],
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "ExportImages_2": {
+            "nodeType": "ExportImages",
+            "position": [
+                3658,
+                200
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_2.input}",
+                "target": "{IntrinsicsTransforming_2.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                400,
+                200
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "masksFolder": "{ImageSegmentationBox_1.output}",
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                600,
+                0
+            ],
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                2027,
+                415
+            ],
+            "inputs": {
+                "input": "{ImageMatching_2.input}",
+                "featuresFolders": "{ImageMatching_2.featuresFolders}",
+                "imagePairsList": "{ImageMatching_2.output}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingAllFrames",
+                "color": "#80766f"
+            }
+        },
+        "FeatureMatching_3": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                2027,
+                215
+            ],
+            "inputs": {
+                "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
+                "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}",
+                "imagePairsList": "{ImageMatchingMultiSfM_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingFramesToKeyframes",
+                "color": "#80766f"
+            }
+        },
+        "ImageDetectionPrompt_1": {
+            "nodeType": "ImageDetectionPrompt",
+            "position": [
+                0,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageMatchingMultiSfM_1": {
+            "nodeType": "ImageMatchingMultiSfM",
+            "position": [
+                1827,
+                215
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "inputB": "{SfMExpanding_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "VocabularyTree",
+                "matchingMode": "a/b",
+                "nbMatches": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                400,
+                0
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Exhaustive"
+            },
+            "internalInputs": {
+                "label": "ImageMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "ImageMatching_2": {
+            "nodeType": "ImageMatching",
+            "position": [
+                1827,
+                415
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Sequential",
+                "nbNeighbors": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageSegmentationBox_1": {
+            "nodeType": "ImageSegmentationBox",
+            "position": [
+                200,
+                200
+            ],
+            "inputs": {
+                "input": "{ImageDetectionPrompt_1.input}",
+                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "maskInvert": true,
+                "keepFilename": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "IntrinsicsTransforming_1": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                3882,
+                23
+            ],
+            "inputs": {
+                "input": "{SfMTriangulation_1.output}"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "IntrinsicsTransforming_2": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                3458,
+                200
+            ],
+            "inputs": {
+                "input": "{SfMColorizing_2.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "KeyframeSelection_1": {
+            "nodeType": "KeyframeSelection",
+            "position": [
+                200,
+                0
+            ],
+            "inputs": {
+                "inputPaths": [
+                    "{ApplyCalibration_1.output}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "MeshDecimate_1": {
+            "nodeType": "MeshDecimate",
+            "position": [
+                5087,
+                25
+            ],
+            "inputs": {
+                "input": "{MeshFiltering_1.outputMesh}",
+                "simplificationFactor": 0.05
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "MeshFiltering_1": {
+            "nodeType": "MeshFiltering",
+            "position": [
+                4887,
+                25
+            ],
+            "inputs": {
+                "inputMesh": "{Meshing_1.outputMesh}",
+                "filterLargeTrianglesFactor": 10.0
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [
+                4687,
+                25
+            ],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}",
+                "estimateSpaceFromSfM": false,
+                "minStep": 1,
+                "fullWeight": 10.0,
+                "saveRawDensePointCloud": true
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "MoGe_1": {
+            "nodeType": "MoGe",
+            "position": [
+                600,
+                -157
+            ],
+            "inputs": {
+                "inputImages": "{SfMFilter_1.outputSfMData_selected}",
+                "foVEstimationMode": "Metadata",
+                "outputNormals": false
+            },
+            "internalInputs": {
+                "color": "#ff7000"
+            }
+        },
+        "RelativePoseEstimating_1": {
+            "nodeType": "RelativePoseEstimating",
+            "position": [
+                1201,
+                6
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "tracksFilename": "{DepthMapTracksInjecting_1.output}",
+                "countIterations": 50000,
+                "minInliers": 100,
+                "imagePairsList": "{FeatureMatching_1.imagePairsList}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ScenePreview_1": {
+            "nodeType": "ScenePreview",
+            "position": [
+                5287,
+                225
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_1.output}",
+                "model": "{MeshDecimate_1.output}",
+                "undistortedImages": "{ExportImages_2.output}",
+                "masks": "{ImageSegmentationBox_1.output}"
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "SfMBootStrapping_1": {
+            "nodeType": "SfMBootStrapping",
+            "position": [
+                1401,
+                6
+            ],
+            "inputs": {
+                "input": "{RelativePoseEstimating_1.input}",
+                "method": "depth",
+                "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
+                "pairs": "{RelativePoseEstimating_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "SfMColorizing_2": {
+            "nodeType": "SfMColorizing",
+            "position": [
+                3220.5,
+                208.0
+            ],
+            "inputs": {
+                "input": "{SfMTransform_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "SfMExpanding_1": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                1601,
+                6
+            ],
+            "inputs": {
+                "input": "{SfMBootStrapping_1.output}",
+                "tracksFilename": "{SfMBootStrapping_1.tracksFilename}",
+                "meshFilename": "{SfMBootStrapping_1.meshFilename}",
+                "ignoreMultiviewOnPrior": true,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the keyframes.",
+                "label": "SfMExpandingKeys",
+                "color": "#575963"
+            }
+        },
+        "SfMExpanding_2": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                2828,
+                215
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_2.input}",
+                "tracksFilename": "{DepthMapTracksInjecting_2.output}",
+                "meshFilename": "{SfMExpanding_1.meshFilename}",
+                "ignoreMultiviewOnPrior": true,
+                "nbFirstUnstableCameras": 0,
+                "maxImagesPerGroup": 0,
+                "bundleAdjustmentMaxOutliers": 5000000,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
+                "label": "SfMExpandingAll",
+                "color": "#80766f"
+            }
+        },
+        "SfMFilter_1": {
+            "nodeType": "SfMFilter",
+            "position": [
+                409,
+                -138
+            ],
+            "inputs": {
+                "inputFile": "{KeyframeSelection_1.outputSfMDataKeyframes}"
+            },
+            "internalInputs": {
+                "color": "#ff7000"
+            }
+        },
+        "SfMTransfer_1": {
+            "nodeType": "SfMTransfer",
+            "position": [
+                3485,
+                28
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "reference": "{SfMColorizing_2.output}",
+                "transferLandmarks": false
+            },
+            "internalInputs": {
+                "comment": "Transfer pose from final camera tracking into the keyframes-only scene.",
+                "color": "#3f3138"
+            }
+        },
+        "SfMTransform_1": {
+            "nodeType": "SfMTransform",
+            "position": [
+                3031.5,
+                210.0
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_2.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "SfMTriangulation_1": {
+            "nodeType": "SfMTriangulation",
+            "position": [
+                3685,
+                28
+            ],
+            "inputs": {
+                "input": "{SfMTransfer_1.output}",
+                "featuresFolders": "{TracksBuilding_1.featuresFolders}",
+                "matchesFolders": "{TracksBuilding_1.matchesFolders}",
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "Texturing_1": {
+            "nodeType": "Texturing",
+            "position": [
+                5287,
+                25
+            ],
+            "inputs": {
+                "input": "{Meshing_1.output}",
+                "imagesFolder": "{ExportImages_1.output}",
+                "inputMesh": "{MeshDecimate_1.output}"
+            },
+            "internalInputs": {
+                "color": "#3f3138"
+            }
+        },
+        "TracksBuilding_1": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                800,
+                0
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}"
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}",
+                "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "TracksBuilding_2": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                2227,
+                215
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_3.input}",
+                "featuresFolders": "{FeatureMatching_3.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_2.output}",
+                    "{FeatureMatching_3.output}"
+                ],
+                "describerTypes": "{FeatureMatching_3.describerTypes}",
+                "minInputTrackLength": 5,
+                "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "TracksMerging_1": {
+            "nodeType": "TracksMerging",
+            "position": [
+                2427,
+                215
+            ],
+            "inputs": {
+                "inputs": [
+                    "{TracksBuilding_2.output}",
+                    "{SfMExpanding_1.tracksFilename}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        }
+    }
+}

--- a/meshroom/cameraTrackingRomaExperimental.mg
+++ b/meshroom/cameraTrackingRomaExperimental.mg
@@ -1,0 +1,484 @@
+{
+    "header": {
+        "releaseVersion": "2026.1.0+develop",
+        "fileVersion": "2.0",
+        "nodesVersions": {
+            "ApplyCalibration": "1.0",
+            "CameraInit": "12.0",
+            "CheckerboardDetection": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
+            "DistortionCalibration": "6.0",
+            "ExportAlembic": "1.0",
+            "ExportDistortion": "2.0",
+            "ExportImages": "1.1",
+            "GeometricFilterEstimating": "1.0",
+            "ImageDetectionPrompt": "0.2",
+            "ImageSegmentationBox": "0.3",
+            "IntrinsicsTransforming": "1.1",
+            "KeyframeSelection": "5.0",
+            "MatchMasking": "1.0",
+            "RelativePoseEstimating": "3.1",
+            "RomaMatcher": "1.0",
+            "RomaReducer": "1.0",
+            "RomaSampler": "1.0",
+            "ScenePreview": "2.0",
+            "SfMBootStrapping": "4.1",
+            "SfMColorizing": "1.0",
+            "SfMExpanding": "2.2",
+            "SfMTransform": "3.2",
+            "StarListing": "1.0",
+            "TracksBuilding": "1.0"
+        },
+        "template": true
+    },
+    "graph": {
+        "ApplyCalibration_1": {
+            "nodeType": "ApplyCalibration",
+            "position": [
+                -6,
+                34
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "calibration": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                -216,
+                34
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "CameraInit_2": {
+            "nodeType": "CameraInit",
+            "position": [
+                -600,
+                -160
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "label": "CameraInitLensGrid",
+                "color": "#302e2e"
+            }
+        },
+        "CheckerboardDetection_1": {
+            "nodeType": "CheckerboardDetection",
+            "position": [
+                -400,
+                -160
+            ],
+            "inputs": {
+                "input": "{CameraInit_2.output}",
+                "useNestedGrids": true,
+                "exportDebugImages": true
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ConvertSfMFormat_1": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                3564,
+                34
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_1.input}",
+                "fileExt": "json",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                4033,
+                -1
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{ExportAlembic_1.output}",
+                    "{ExportImages_1.output}"
+                ]
+            }
+        },
+        "DistortionCalibration_1": {
+            "nodeType": "DistortionCalibration",
+            "position": [
+                -200,
+                -160
+            ],
+            "inputs": {
+                "input": "{CheckerboardDetection_1.input}",
+                "checkerboards": "{CheckerboardDetection_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
+            "position": [
+                3791,
+                -78
+            ],
+            "inputs": {
+                "input": "{ExportImages_1.outputSfMData}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                0,
+                -160
+            ],
+            "inputs": {
+                "input": "{DistortionCalibration_1.output}"
+            },
+            "internalInputs": {
+                "color": "#302e2e"
+            }
+        },
+        "ExportImages_1": {
+            "nodeType": "ExportImages",
+            "position": [
+                3569,
+                -102
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_1.input}",
+                "target": "{IntrinsicsTransforming_1.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "GeometricFilterEstimating_1": {
+            "nodeType": "GeometricFilterEstimating",
+            "position": [
+                1464,
+                34
+            ],
+            "inputs": {
+                "input": "{RomaReducer_1.inputSfMData}",
+                "featuresFolders": [
+                    "{RomaReducer_1.featuresFolder}"
+                ],
+                "matchesFolders": [
+                    "{RomaReducer_1.matchesFolder}"
+                ],
+                "describerTypes": "{RomaReducer_1.describerTypes}",
+                "geometricError": 16.0
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageDetectionPrompt_1": {
+            "nodeType": "ImageDetectionPrompt",
+            "position": [
+                0,
+                200
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ImageSegmentationBox_1": {
+            "nodeType": "ImageSegmentationBox",
+            "position": [
+                200,
+                200
+            ],
+            "inputs": {
+                "input": "{ImageDetectionPrompt_1.input}",
+                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "maskInvert": true,
+                "keepFilename": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "IntrinsicsTransforming_1": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                3354,
+                34
+            ],
+            "inputs": {
+                "input": "{SfMColorizing_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "KeyframeSelection_1": {
+            "nodeType": "KeyframeSelection",
+            "position": [
+                204,
+                34
+            ],
+            "inputs": {
+                "inputPaths": [
+                    "{ApplyCalibration_1.output}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "MatchMasking_1": {
+            "nodeType": "MatchMasking",
+            "position": [
+                834,
+                34
+            ],
+            "inputs": {
+                "inputSfMData": "{RomaMatcher_1.inputSfMData}",
+                "imagePairsList": "{RomaMatcher_1.imagePairsList}",
+                "warpFolder": "{RomaMatcher_1.outputWarpFolder}",
+                "certaintyFolder": "{RomaMatcher_1.outputCertaintyFolder}",
+                "masksFolder": "{ImageSegmentationBox_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "RelativePoseEstimating_1": {
+            "nodeType": "RelativePoseEstimating",
+            "position": [
+                2304,
+                34
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "tracksFilename": "{TracksBuilding_1.output}",
+                "countIterations": 50000,
+                "minInliers": 100,
+                "distanceThreshold": 0.0,
+                "imagePairsList": "{RomaReducer_2.imagePairsList}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "RomaMatcher_1": {
+            "nodeType": "RomaMatcher",
+            "position": [
+                624,
+                34
+            ],
+            "inputs": {
+                "inputSfMData": "{StarListing_1.inputSfMData}",
+                "imagePairsList": "{StarListing_1.imagePairsList}",
+                "checkLoops": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "RomaReducer_1": {
+            "nodeType": "RomaReducer",
+            "position": [
+                1254,
+                34
+            ],
+            "inputs": {
+                "inputSfMData": "{RomaSampler_1.inputSfMData}",
+                "imagePairsList": "{RomaSampler_1.imagePairsList}",
+                "samplesFolder": "{RomaSampler_1.samplesFolder}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "RomaReducer_2": {
+            "nodeType": "RomaReducer",
+            "position": [
+                1884,
+                34
+            ],
+            "inputs": {
+                "inputSfMData": "{RomaSampler_2.inputSfMData}",
+                "imagePairsList": "{RomaSampler_2.imagePairsList}",
+                "samplesFolder": "{RomaSampler_2.samplesFolder}",
+                "describerTypes": "{RomaSampler_2.describerTypes}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "RomaSampler_1": {
+            "nodeType": "RomaSampler",
+            "position": [
+                1044,
+                34
+            ],
+            "inputs": {
+                "inputSfMData": "{MatchMasking_1.inputSfMData}",
+                "imagePairsList": "{MatchMasking_1.imagePairsList}",
+                "warpFolder": "{MatchMasking_1.warpFolder}",
+                "certaintyFolder": "{MatchMasking_1.outputCertaintyFolder}",
+                "maxMatches": 5000
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "RomaSampler_2": {
+            "nodeType": "RomaSampler",
+            "position": [
+                1674,
+                34
+            ],
+            "inputs": {
+                "inputSfMData": "{GeometricFilterEstimating_1.input}",
+                "imagePairsList": "{RomaReducer_1.imagePairsList}",
+                "warpFolder": "{RomaSampler_1.warpFolder}",
+                "certaintyFolder": "{RomaSampler_1.certaintyFolder}",
+                "maxMatches": 2500,
+                "minCertainty": 0.0,
+                "filtersFolder": "{GeometricFilterEstimating_1.output}",
+                "describerTypes": "{GeometricFilterEstimating_1.describerTypes}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ScenePreview_1": {
+            "nodeType": "ScenePreview",
+            "position": [
+                3793,
+                10
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_1.output}",
+                "model": "{ConvertSfMFormat_1.input}",
+                "undistortedImages": "{ExportImages_1.output}",
+                "masks": "{ImageSegmentationBox_1.output}"
+            },
+            "internalInputs": {
+                "color": "#4c594c"
+            }
+        },
+        "SfMBootStrapping_1": {
+            "nodeType": "SfMBootStrapping",
+            "position": [
+                2514,
+                34
+            ],
+            "inputs": {
+                "input": "{RelativePoseEstimating_1.input}",
+                "tracksFilename": "{RelativePoseEstimating_1.tracksFilename}",
+                "pairs": "{RelativePoseEstimating_1.output}"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "SfMColorizing_1": {
+            "nodeType": "SfMColorizing",
+            "position": [
+                3144,
+                34
+            ],
+            "inputs": {
+                "input": "{SfMTransform_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "SfMExpanding_1": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                2724,
+                34
+            ],
+            "inputs": {
+                "input": "{SfMBootStrapping_1.output}",
+                "tracksFilename": "{SfMBootStrapping_1.tracksFilename}",
+                "meshFilename": "{SfMBootStrapping_1.meshFilename}",
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5,
+                "maxReprojectionError": 16.0
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the keyframes.",
+                "label": "SfMExpandingKeys",
+                "color": "#575963"
+            }
+        },
+        "SfMTransform_1": {
+            "nodeType": "SfMTransform",
+            "position": [
+                2934,
+                34
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "StarListing_1": {
+            "nodeType": "StarListing",
+            "position": [
+                414,
+                34
+            ],
+            "inputs": {
+                "inputSfMData": "{KeyframeSelection_1.inputPaths[0]}",
+                "keySfMData": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "radiusKeyFrames": 5
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "TracksBuilding_1": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                2094,
+                34
+            ],
+            "inputs": {
+                "input": "{RomaReducer_2.inputSfMData}",
+                "featuresFolders": [
+                    "{RomaReducer_2.featuresFolder}"
+                ],
+                "matchesFolders": [
+                    "{RomaReducer_2.matchesFolder}"
+                ],
+                "describerTypes": "{RomaReducer_2.describerTypes}",
+                "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        }
+    }
+}

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -1,6 +1,6 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
@@ -9,15 +9,17 @@
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
             "DistortionCalibration": "6.0",
-            "ExportAnimatedCamera": "2.0",
+            "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
+            "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageSegmentationBox": "0.3",
+            "IntrinsicsTransforming": "1.1",
             "NodalSfM": "2.0",
-            "RelativePoseEstimating": "3.0",
+            "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"
         },
@@ -79,8 +81,8 @@
         "ConvertSfMFormat_1": {
             "nodeType": "ConvertSfMFormat",
             "position": [
-                1600,
-                200
+                1593,
+                141
             ],
             "inputs": {
                 "input": "{NodalSfM_1.output}",
@@ -90,6 +92,21 @@
             },
             "internalInputs": {
                 "color": "#4c594c"
+            }
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                2171,
+                7
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{ExportImages_1.output}",
+                    "{ExportAlembic_1.output}"
+                ]
             }
         },
         "DistortionCalibration_1": {
@@ -106,15 +123,14 @@
                 "color": "#302e2e"
             }
         },
-        "ExportAnimatedCamera_1": {
-            "nodeType": "ExportAnimatedCamera",
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
             "position": [
-                1600,
-                0
+                1980,
+                6
             ],
             "inputs": {
-                "input": "{NodalSfM_1.output}",
-                "exportUndistortedImages": true
+                "input": "{ExportImages_1.target}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -131,6 +147,22 @@
             },
             "internalInputs": {
                 "color": "#302e2e"
+            }
+        },
+        "ExportImages_1": {
+            "nodeType": "ExportImages",
+            "position": [
+                1791,
+                3
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_1.input}",
+                "target": "{IntrinsicsTransforming_1.output}",
+                "outputFileType": "jpg",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
             }
         },
         "FeatureExtraction_1": {
@@ -208,6 +240,19 @@
                 "color": "#80766f"
             }
         },
+        "IntrinsicsTransforming_1": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                1596,
+                3
+            ],
+            "inputs": {
+                "input": "{NodalSfM_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
         "NodalSfM_1": {
             "nodeType": "NodalSfM",
             "position": [
@@ -221,20 +266,6 @@
             },
             "internalInputs": {
                 "color": "#80766f"
-            }
-        },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                2000,
-                0
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{ExportAnimatedCamera_1.output}",
-                    "{ScenePreview_1.output}",
-                    "{ExportDistortion_1.output}"
-                ]
             }
         },
         "RelativePoseEstimating_1": {
@@ -256,13 +287,13 @@
         "ScenePreview_1": {
             "nodeType": "ScenePreview",
             "position": [
-                1800,
-                200
+                1991,
+                180
             ],
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{NodalSfM_1.output}",
-                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "undistortedImages": "{ExportImages_1.output}",
                 "masks": "{ImageSegmentationBox_1.output}",
                 "pointCloudParams": {
                     "particleSize": 0.001,

--- a/meshroom/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/nodalCameraTrackingWithoutCalibration.mg
@@ -1,21 +1,23 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "ExportAnimatedCamera": "2.0",
+            "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
+            "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageSegmentationBox": "0.3",
+            "IntrinsicsTransforming": "1.1",
             "NodalSfM": "2.0",
-            "RelativePoseEstimating": "3.0",
+            "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"
         },
@@ -36,11 +38,11 @@
         "ConvertDistortion_1": {
             "nodeType": "ConvertDistortion",
             "position": [
-                1600,
-                0
+                1616,
+                4
             ],
             "inputs": {
-                "input": "{ExportAnimatedCamera_1.input}"
+                "input": "{NodalSfM_1.output}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -62,15 +64,29 @@
                 "color": "#4c594c"
             }
         },
-        "ExportAnimatedCamera_1": {
-            "nodeType": "ExportAnimatedCamera",
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
             "position": [
-                1400,
-                0
+                2100,
+                100
             ],
             "inputs": {
-                "input": "{NodalSfM_1.output}",
-                "exportUndistortedImages": true
+                "inputFiles": [
+                    "{ScenePreview_1.output}",
+                    "{ExportDistortion_1.output}",
+                    "{ExportAlembic_1.output}",
+                    "{ExportImages_1.output}"
+                ]
+            }
+        },
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
+            "position": [
+                1807.0,
+                -129.5
+            ],
+            "inputs": {
+                "input": "{ExportImages_1.target}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -85,6 +101,22 @@
             "inputs": {
                 "input": "{ConvertDistortion_1.output}",
                 "exportLensGridsUndistorted": false
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportImages_1": {
+            "nodeType": "ExportImages",
+            "position": [
+                1618.0,
+                -132.5
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_1.input}",
+                "target": "{IntrinsicsTransforming_1.output}",
+                "outputFileType": "jpg",
+                "namingMode": "keep"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -165,6 +197,19 @@
                 "color": "#80766f"
             }
         },
+        "IntrinsicsTransforming_1": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                1423.0,
+                -132.5
+            ],
+            "inputs": {
+                "input": "{NodalSfM_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
         "NodalSfM_1": {
             "nodeType": "NodalSfM",
             "position": [
@@ -178,20 +223,6 @@
             },
             "internalInputs": {
                 "color": "#80766f"
-            }
-        },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                2100,
-                100
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{ExportAnimatedCamera_1.output}",
-                    "{ScenePreview_1.output}",
-                    "{ExportDistortion_1.output}"
-                ]
             }
         },
         "RelativePoseEstimating_1": {
@@ -213,13 +244,13 @@
         "ScenePreview_1": {
             "nodeType": "ScenePreview",
             "position": [
-                1600,
-                200
+                1799,
+                185
             ],
             "inputs": {
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{NodalSfM_1.output}",
-                "undistortedImages": "{ExportAnimatedCamera_1.outputUndistorted}",
+                "undistortedImages": "{ExportImages_1.output}",
                 "masks": "{ImageSegmentationBox_1.output}",
                 "pointCloudParams": {
                     "particleSize": 0.001,


### PR DESCRIPTION
- Updates both `nodalCameraTracking.mg` and `nodalCameraTrackingWithoutCalibration.mg` workflows to modernize the pipeline, replacing the `ExportAnimatedCamera` node with new nodes and introducing additional export and transformation steps. The changes improve output flexibility by exporting images and Alembic files, and add an explicit camera intrinsics transformation step. Node positions and inputs are also updated to reflect the new workflow.

- Add a new camera tracking pipeline with monocular depth estimation to be used on low parallax problems.

- Add a new camera tracking pipeline with RoMa and simple keyframe approach.