### PR TITLE
exportImages: load full sfm on the chunk where we export the sfm

### DIFF
--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -446,7 +446,9 @@ int aliceVision_main(int argc, char* argv[])
                 sfmDataIO::ESfMData::VIEWS | 
                 sfmDataIO::ESfMData::INTRINSICS | 
                 sfmDataIO::ESfMData::EXTRINSICS
-            );
+    );
+    if (rangeStart == 0)
+        flagsPart = sfmDataIO::ESfMData::ALL;
 
     // Read the input SfM scene
     sfmData::SfMData inputSfmData;


### PR DESCRIPTION
Like the PR title says