### PR TITLE
Enable decimation of output images in the exportImages/IntrinsicsTransforming pipeline

### DIFF
--- a/meshroom/aliceVision/ExportImages.py
+++ b/meshroom/aliceVision/ExportImages.py
@@ -1,7 +1,7 @@
 __version__ = "1.1"
 
 from meshroom.core import desc
-from meshroom.core.utils import VERBOSE_LEVEL
+from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
 
 
 class ExportImages(desc.AVCommandLineNode):
@@ -28,6 +28,17 @@ For example, the target intrinsics may be the same without the distortion.
             label="Target SfMData",
             description="This SfMData file contains the required intrinsics for the output images.",
             value="",
+        ),
+        desc.ListAttribute(
+            elementDesc=desc.File(
+                name="masksFolder",
+                label="Masks Folder",
+                description="",
+                value="",
+            ),
+            name="masksFolders",
+            label="Masks Folders",
+            description="Use masks from specific folder(s). Filename should be the same or the image UID.",
         ),
         desc.ChoiceParam(
             name="outputFileType",
@@ -61,23 +72,24 @@ For example, the target intrinsics may be the same without the distortion.
             value="viewid",
             values=["viewid", "frameid", "keep"],
         ),
-        desc.ListAttribute(
-            elementDesc=desc.File(
-                name="masksFolder",
-                label="Masks Folder",
-                description="",
-                value="",
-            ),
-            name="masksFolders",
-            label="Masks Folders",
-            description="Use masks from specific folder(s). Filename should be the same or the image UID.",
-        ),
         desc.ChoiceParam(
             name="maskExtension",
             label="Mask Extension",
             description="File extension for the masks to use.",
             value="png",
             values=["exr", "jpg", "png"],
+        ),
+        desc.ChoiceParam(
+            name="storageDataType",
+            label="Storage Data Type",
+            description="Storage image data type:\n"
+                        " - float: Use full floating point (32 bits per channel).\n"
+                        " - half: Use half float (16 bits per channel).\n"
+                        " - halfFinite: Use half float, but clamp values to avoid non-finite values.\n"
+                        " - auto: Use half float if all values can fit, else use full float.",
+            values=EXR_STORAGE_DATA_TYPE,
+            value="halfFinite",
+            enabled=lambda node: node.outputFileType.value == "exr"
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/aliceVision/ExportImages.py
+++ b/meshroom/aliceVision/ExportImages.py
@@ -39,6 +39,7 @@ For example, the target intrinsics may be the same without the distortion.
             name="masksFolders",
             label="Masks Folders",
             description="Use masks from specific folder(s). Filename should be the same or the image UID.",
+            exposed=True
         ),
         desc.ChoiceParam(
             name="outputFileType",

--- a/meshroom/aliceVision/IntrinsicsTransforming.py
+++ b/meshroom/aliceVision/IntrinsicsTransforming.py
@@ -40,6 +40,14 @@ class IntrinsicsTransforming(desc.AVCommandLineNode):
             value=90.0,
             range=(1.0, 179.0, 0.1),
         ),
+        desc.FloatParam(
+            name="scaleFactor",
+            label="Scale Factor",
+            description="Rescale the size of the images in the sfmData description",
+            value=1.0,
+            range=(0.0, 1.0, 0.1),
+            enabled=lambda node: node.type.value == "pinhole"
+        ),
         desc.BoolParam(
             name="correctPrincipalPoint",
             label="Correct Principal Point",

--- a/src/aliceVision/camera/IntrinsicScaleOffsetDisto.cpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffsetDisto.cpp
@@ -16,6 +16,11 @@ std::shared_ptr<IntrinsicScaleOffsetDisto> IntrinsicScaleOffsetDisto::cast(std::
 
 bool IntrinsicScaleOffsetDisto::operator==(const IntrinsicBase& otherBase) const
 {
+    return equalTo(otherBase, false);
+}
+
+bool IntrinsicScaleOffsetDisto::equalTo(const IntrinsicBase& otherBase, bool ignoreDistortion) const
+{
     if (!IntrinsicScaleOffset::operator==(otherBase))
     {
         return false;
@@ -24,6 +29,11 @@ bool IntrinsicScaleOffsetDisto::operator==(const IntrinsicBase& otherBase) const
     if (typeid(*this) != typeid(otherBase))
     {
         return false;
+    }
+
+    if (ignoreDistortion)
+    {
+        return true;
     }
 
     const IntrinsicScaleOffsetDisto& other = static_cast<const IntrinsicScaleOffsetDisto&>(otherBase);

--- a/src/aliceVision/camera/IntrinsicScaleOffsetDisto.hpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffsetDisto.hpp
@@ -63,7 +63,20 @@ class IntrinsicScaleOffsetDisto : public IntrinsicScaleOffset
 
     void assign(const IntrinsicBase& other) override { *this = dynamic_cast<const IntrinsicScaleOffsetDisto&>(other); }
 
+    /**
+    * @brief compare to another intrinsic object
+    * @param otherBase an intrinsic object to compare to.
+    * @return true if both objects are considered equal
+    */
     bool operator==(const IntrinsicBase& otherBase) const override;
+
+    /**
+    * @brief compare to another intrinsic object
+    * @param otherBase an intrinsic object to compare to.
+    * @param ignoreDistortion ignore difference in distortion.
+    * @return true if both objects are considered equal
+    */
+    bool equalTo(const IntrinsicBase& otherBase, bool ignoreDistortion) const;
 
     void setDistortionObject(std::shared_ptr<Distortion> object) { _pDistortion = object; }
 

--- a/src/aliceVision/image/CMakeLists.txt
+++ b/src/aliceVision/image/CMakeLists.txt
@@ -19,6 +19,7 @@ set(image_files_headers
     pixelTypes.hpp
     Rgb.hpp
     Sampler.hpp
+    remap.hpp
     cache.hpp
 )
 
@@ -31,6 +32,7 @@ set(image_files_sources
     io.cpp
     imageAlgo.cpp
     jetColorMap.cpp
+    remap.cpp
     cache.cpp
 )
 

--- a/src/aliceVision/image/remap.cpp
+++ b/src/aliceVision/image/remap.cpp
@@ -1,0 +1,15 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/image/remap.hpp>
+
+namespace aliceVision {
+namespace image {
+
+
+
+}  // namespace image
+}  // namespace aliceVision

--- a/src/aliceVision/image/remap.hpp
+++ b/src/aliceVision/image/remap.hpp
@@ -1,0 +1,200 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/image/Image.hpp>
+#include <aliceVision/image/Sampler.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <type_traits>
+
+namespace aliceVision {
+namespace image {
+
+/**
+ * @brief Fill pixels of an image such that dest(i, j) = input(map(i, j).y, map(i, j).x)
+ * @param[in] src source image (of size H1,W1) to remap
+ * @param[in] map image (of size H2, W2) containing coordinates in the source image
+ * @param[in] fillColor the default pixel value if not possible to remap
+ * @param[out] output image to store the result (will be resized to size H2, W2)
+ */
+template <typename P>
+void remap(const Image<P> & source, const Image<Vec2> & map, const P & fillColor, Image<P> & output)
+{
+    if (output.width() != map.width() || output.height() != map.height())
+    {
+        output.resize(map.width(), map.height());
+    }
+
+    const image::Sampler2d<image::SamplerLinear> sampler;
+
+    for (int i = 0; i < map.height(); i++)
+    {
+        for (int j = 0; j < map.width(); j++)
+        {
+            const Vec2 & coord = map(i, j);
+
+            const double & x = coord.x();
+            const double & y = coord.y();
+
+            // pick pixel if it is in the image domain
+            if (source.contains(y, x))
+            {
+                output(i, j) = sampler(source, y, x);
+            }
+            else 
+            {
+                output(i, j) = fillColor;
+            }
+        }
+    }
+}
+
+/**
+ * @brief Fill pixels of an image such that dest(i, j) = input(map(i, j).y, map(i, j).x)
+ * @param[in] src source image (of size H1,W1) to remap
+ * @param[in] map image (of size H2, W2) containing coordinates in the source image
+ * @param[in] fillColor the default pixel value if not possible to remap
+ * @param[out] output image to store the result (will be resized to size H2, W2)
+ */
+template <typename P>
+void remapInter(const Image<P> & source, const Image<Vec2> & map, const P& fillColor, Image<P> & output)
+{
+    if (output.width() != map.width() || output.height() != map.height())
+    {
+        output.resize(map.width(), map.height());
+    }
+
+    int srcWidth = source.width();
+    int srcHeight = source.height();
+
+    const image::Sampler2d<image::SamplerLinear> sampler;
+
+    for (int i = 0; i < map.height(); i++)
+    {
+        for (int j = 0; j < map.width(); j++)
+        {
+            const Vec2 & coord = map(i, j);
+
+            const double & x = coord.x();
+            const double & y = coord.y();
+            
+            double scaleX = 1.0;
+            if (j < map.width() - 1 && j > 0) 
+            {
+                scaleX = std::abs(map(i, j + 1).x() - map(i, j - 1).x()) * 0.5;
+            } 
+            else if (j < map.width() - 1) 
+            {
+                scaleX = std::abs(map(i, j + 1).x() - x);
+            } 
+            else if (j > 0) 
+            {
+                scaleX = std::abs(x - map(i, j - 1).x());
+            }
+            
+            double scaleY = 1.0;
+            if (i < map.height() - 1 && i > 0) 
+            {
+                scaleY = std::abs(map(i + 1, j).y() - map(i - 1, j).y()) * 0.5;
+            } 
+            else if (i < map.height() - 1) 
+            {
+                scaleY = std::abs(map(i + 1, j).y() - y);
+            } 
+            else if (i > 0) 
+            {
+                scaleY = std::abs(y - map(i - 1, j).y());
+            }
+        
+            const double max_scale = std::max(scaleX, scaleY);
+            if (scaleX > 1.0 && scaleY > 1.0)
+            {
+                //We are doing downsampling here.
+                //Use area interpolation to avoid aliasing
+
+                double halfWidth = scaleX * 0.5;
+                double halfHeight = scaleY * 0.5;
+
+                double x1 = coord.x() - halfWidth;
+                double x2 = coord.x() + halfWidth;
+                double y1 = coord.y() - halfHeight;
+                double y2 = coord.y() + halfHeight;
+
+                int ix1 = static_cast<int>(x1);
+                int ix2 = static_cast<int>(std::ceil(x2));
+                int iy1 = static_cast<int>(y1);
+                int iy2 = static_cast<int>(std::ceil(y2));
+
+                //Not using sampler as the neigborhood size is dynamic
+
+                P sum(0.0);
+                double wsum = 0.0;
+
+                for (int by = iy1; by < iy2; by++)
+                {
+                    if (by < 0 || by >= srcHeight)
+                    {
+                        continue;
+                    }
+
+                    //Compute vertical occupancy
+                    // (by + 1) - y1
+                    // or y2 - by
+                    double yocc = std::max(0.0, std::min(double(by + 1), y2) - std::max(double(by), y1));
+
+                    for (int bx = ix1; bx < ix2; bx++)
+                    {
+                        if (bx < 0 || bx >= srcWidth)
+                        {
+                            continue;
+                        }
+
+                        //Compute horizontal occupancy
+                        // (bx + 1) - x1
+                        // or x2 - bx
+                        double xocc = std::max(0.0, std::min(double(bx + 1), x2) - std::max(double(bx), x1));
+                        double weight = yocc * xocc;
+
+                        sum += source(by, bx) * weight;
+                        wsum += weight;
+                    }
+                }
+
+                //Output pixel is the weighted mean of the 
+                //Source pixels in the area covered by the output pixel.
+                if (wsum > 0.0)
+                {
+                    sum /= wsum;
+
+                    if constexpr (std::is_same<P, RGBAfColor>())
+                    {
+                        sum.a() = 1.0;
+                    }
+                }
+
+                output(i, j) = sum;
+            }
+            else 
+            {
+                // Not downsampling, do bilinear interpolation
+
+                // pick pixel if it is in the image domain
+                if (source.contains(y, x))
+                {
+                    output(i, j) = sampler(source, y, x);
+                }
+                else 
+                {
+                    output(i, j) = fillColor;
+                }
+            }
+        }
+    }
+}
+
+}  // namespace image
+}  // namespace aliceVision

--- a/src/aliceVision/image/remap.hpp
+++ b/src/aliceVision/image/remap.hpp
@@ -131,7 +131,9 @@ void remapInter(const Image<P> & source, const Image<Vec2> & map, const P& fillC
 
                 //Not using sampler as the neigborhood size is dynamic
 
-                P sum(0.0);
+                P sum;
+                sum.fill(0.0);
+
                 double wsum = 0.0;
 
                 for (int by = iy1; by < iy2; by++)
@@ -157,9 +159,16 @@ void remapInter(const Image<P> & source, const Image<Vec2> & map, const P& fillC
                         // (bx + 1) - x1
                         // or x2 - bx
                         double xocc = std::max(0.0, std::min(double(bx + 1), x2) - std::max(double(bx), x1));
+                        
+                        const P & pix = source(by, bx);
                         double weight = yocc * xocc;
+                        
+                        if constexpr (std::is_same<P, RGBAfColor>())
+                        {   
+                            weight *= pix.a();
+                        }
 
-                        sum += source(by, bx) * weight;
+                        sum += pix * weight;
                         wsum += weight;
                     }
                 }
@@ -169,11 +178,6 @@ void remapInter(const Image<P> & source, const Image<Vec2> & map, const P& fillC
                 if (wsum > 0.0)
                 {
                     sum /= wsum;
-
-                    if constexpr (std::is_same<P, RGBAfColor>())
-                    {
-                        sum.a() = 1.0;
-                    }
                 }
 
                 output(i, j) = sum;

--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -202,6 +202,7 @@ void ImageRemoveDistortion(const image::Image<T>& imageIn,
  * @param medianCameraExposure median camera exposure for the sfmData
  * @param masksFolders the mask folders list
  * @param maskExtension the mask extension
+ * @param storageDatatype output image storage data type
  * @return false on error
 */
 bool processImage(const std::string& dstFileName,
@@ -214,7 +215,8 @@ bool processImage(const std::string& dstFileName,
              double cameraExposure,
              double medianCameraExposure,
              const std::vector<std::string> & masksFolders,
-             const std::string & maskExtension)
+             const std::string & maskExtension,
+             const image::EStorageDataType & storageDataType)
 {
     image::Image<image::RGBAfColor> image;
     image::Image<image::RGBAfColor> image_ud;
@@ -304,7 +306,9 @@ bool processImage(const std::string& dstFileName,
     //Write the result
     try
     {
-        writeImage(dstFileName, image_ud, image::ImageWriteOptions(), metadata, roi);
+        image::ImageWriteOptions writeOptions;
+        writeOptions.storageDataType(storageDataType);
+        writeImage(dstFileName, image_ud, writeOptions, metadata, roi);
     }
     catch (...)
     {
@@ -324,6 +328,7 @@ bool processImage(const std::string& dstFileName,
  * @param exportFullRod do we export the full rod or not
  * @param masksFolders the mask folders list
  * @param maskExtension the mask extension
+ * @param storageDatatype output image storage data type
  * @param rangeStart the initial view index to process (range selection)
  * @param rangeEnd the last view index to process (range selection)
 */
@@ -334,6 +339,7 @@ bool process(const sfmData::SfMData & input,
              bool exportFullRod,
              const std::vector<std::string> & masksFolders,
              const std::string & maskExtension,
+             const image::EStorageDataType & storageDataType,
              size_t rangeStart,
              size_t rangeEnd)
 {
@@ -391,7 +397,8 @@ bool process(const sfmData::SfMData & input,
                     view.getImage().getCameraExposureSetting().getExposure(),
                     medianCameraExposure,
                     masksFolders,
-                    maskExtension);
+                    maskExtension,
+                    storageDataType);
     }
 
     return true;
@@ -413,6 +420,7 @@ int aliceVision_main(int argc, char* argv[])
     int rangeSize = 1;
     bool evCorrection = false;
     bool exportFullROD = false;
+    image::EStorageDataType storageDataType = image::EStorageDataType::HalfFinite;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -443,7 +451,9 @@ int aliceVision_main(int argc, char* argv[])
          "Use masks from specific folder(s).\n"
          "Filename should be the same or the image UID.")
         ("maskExtension", po::value<std::string>(&maskExtension)->default_value(maskExtension),
-         "File extension of the masks to use.");
+         "File extension of the masks to use.")
+        ("storageDataType", po::value<image::EStorageDataType>(&storageDataType)->default_value(storageDataType),
+         ("Storage data type: " + image::EStorageDataType_informations()).c_str());
     // clang-format on
 
     CmdLine cmdline("AliceVision prepareDenseScene");
@@ -561,6 +571,7 @@ int aliceVision_main(int argc, char* argv[])
                 exportFullROD,
                 masksFolders, 
                 maskExtension,
+                storageDataType,
                 rangeStart, 
                 rangeEnd))
     {

--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -12,6 +12,8 @@
 #include <aliceVision/image/Image.hpp>
 #include <aliceVision/image/io.hpp>
 #include <aliceVision/image/Sampler.hpp>
+#include <aliceVision/image/remap.hpp>
+#include <aliceVision/camera/IntrinsicScaleOffsetDisto.hpp>
 #include <boost/program_options.hpp>
 
 // These constants define the current software version.
@@ -96,8 +98,7 @@ void ImageIntrinsicsTransform(const image::Image<T>& imageIn,
         yOffset = roi.ybegin;
     }
 
-    image_ud.resize(widthRoi, heightRoi, true, fillcolor);
-    const image::Sampler2d<image::SamplerLinear> sampler;
+    image::Image<Vec2> map(widthRoi, heightRoi);
 
 #pragma omp parallel for
     for (int y = 0; y < heightRoi; ++y)
@@ -108,15 +109,41 @@ void ImageIntrinsicsTransform(const image::Image<T>& imageIn,
 
             // compute coordinates with distortion
             const Vec3 intermediate = intrinsicOutput.backProjectUnit(undisto_pix);
-            const Vec2 disto_pix = intrinsicSource.project(intermediate.homogeneous(), true);
-
-            // pick pixel if it is in the image domain
-            if (imageIn.contains(disto_pix(1), disto_pix(0)))
-            {
-                image_ud(y, x) = sampler(imageIn, disto_pix(1), disto_pix(0));
-            }
+            map(y, x) = intrinsicSource.project(intermediate.homogeneous(), true);
         }
     }
+
+    remapInter(imageIn, map, fillcolor, image_ud);
+}
+
+bool isFullComputeNeeded(const camera::IntrinsicBase & source, const camera::IntrinsicBase & dest)
+{
+    // Is the output undistorted
+    if (dest.hasDistortion())
+    {
+        return true;
+    }
+    
+    // Do we need to cast to a different intrinsic type ?
+    if (source.getType() != dest.getType())
+    {
+        return true;
+    }
+
+    // Are the "non distortion" parameters equal ?
+    try
+    {
+        const auto& isod = dynamic_cast<const camera::IntrinsicScaleOffsetDisto&>(source);
+        if (!isod.equalTo(dest, true))
+        {
+            return true;
+        }
+    }
+    catch (const std::bad_cast& e)
+    {
+    }
+                
+    return false;
 }
 
 template<typename T>
@@ -260,17 +287,18 @@ bool processImage(const std::string& dstFileName,
         roi = convertRodToRoi(outputIntrinsic, rod);
     }
     
-    bool shortCut = (sourceIntrinsic.getType() == outputIntrinsic.getType()) &&
-                    (outputIntrinsic.hasDistortion() == false);
-    if (shortCut)
+    // Guess if we can accelerate stuff
+    if (isFullComputeNeeded(sourceIntrinsic, outputIntrinsic))
     {
-        // undistort the image and save it
-        ImageRemoveDistortion(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0), rod);
+        // Transform the image and save it
+        ALICEVISION_LOG_INFO("Using full complex transform.");
+        ImageIntrinsicsTransform(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0), rod);
     }
     else 
     {
-        // Transform the image and save it
-        ImageIntrinsicsTransform(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0), rod);
+        // undistort the image and save it
+        ALICEVISION_LOG_INFO("Using Simplified undistortion transform.");
+        ImageRemoveDistortion(image, sourceIntrinsic, outputIntrinsic, image_ud, image::RGBAfColor(0.0), rod);
     }
 
     //Write the result

--- a/src/software/utils/main_intrinsicsTransforming.cpp
+++ b/src/software/utils/main_intrinsicsTransforming.cpp
@@ -31,13 +31,29 @@ namespace fs = std::filesystem;
  * @param sfmData the original sfmData
  * @param outputSfmData the result sfmData
  * @param fakeFov if one intrinsic is non pinhole, what is the required fov for the "fake" camera
+ * @param scaleFactor the scale factor of all intrinsics
  * @return true if everything worked
 */
 bool convertToPinhole(const sfmData::SfMData & sfmData, 
                     sfmData::SfMData & outputSfmData,
-                    double fakeFov)
+                    double fakeFov,
+                    double scaleFactor)
 {
     outputSfmData.getIntrinsics().clear();
+    
+    if (scaleFactor != 1.0)
+    {
+        // Rescale the views
+        for (auto & [idView, view] : outputSfmData.getViews().valueRange())
+        {
+            int w = view.getImage().getWidth();
+            int h = view.getImage().getHeight();
+            w = int(std::round(double(w) * scaleFactor));
+            h = int(std::round(double(h) * scaleFactor));
+            view.getImage().setWidth(w);
+            view.getImage().setHeight(h);
+        }
+    }
 
     // Loop over all input intrinsics
     for (const auto & [intrinsicId, intrinsicPtr] : sfmData.getIntrinsics())
@@ -63,12 +79,21 @@ bool convertToPinhole(const sfmData::SfMData & sfmData,
             cy = pinhole.getOffset().y();
         }
 
+        // Apply scale factor to all values
+        int w = intrinsicPtr->w();
+        int h = intrinsicPtr->h();
+        w = int(std::round(double(w) * scaleFactor));
+        h = int(std::round(double(h) * scaleFactor));
+        fx = fx * scaleFactor;
+        fy = fy * scaleFactor;
+        cx = cx * scaleFactor;
+        cy = cy * scaleFactor;
+
         std::shared_ptr<camera::IntrinsicBase> fakecam = camera::createIntrinsic(
                                                 camera::EINTRINSIC::PINHOLE_CAMERA, 
                                                 camera::DISTORTION_NONE, 
                                                 camera::UNDISTORTION_NONE, 
-                                                intrinsicPtr->w(), 
-                                                intrinsicPtr->h(),
+                                                w, h,
                                                 fx, fy, cx, cy
                                                 );
 
@@ -229,6 +254,7 @@ int aliceVision_main(int argc, char* argv[])
     std::string outputTracksFilename;
     std::string cameraTypeStr;
     double fakeFov = 90.0;
+    double scaleFactor = 1.0;
     bool correctPrincipalPoint = false;
 
     // clang-format off
@@ -243,6 +269,8 @@ int aliceVision_main(int argc, char* argv[])
     optionalParams.add_options()
         ("fakeFov", po::value<double>(&fakeFov)->default_value(fakeFov),
          "Virtual FOV if output is pinhole and input is not.")
+        ("scaleFactor", po::value<double>(&scaleFactor)->default_value(scaleFactor),
+         "Rescale the size of the images in the sfmData description.")
         ("type", po::value<std::string>(&cameraTypeStr)->default_value(cameraTypeStr),
          "Default camera model type (pinhole, equidistant, equirectangular).")
         ("correctPrincipalPoint", po::value<bool>(&correctPrincipalPoint)->default_value(correctPrincipalPoint),
@@ -282,7 +310,7 @@ int aliceVision_main(int argc, char* argv[])
     sfmData::SfMData outputSfmData(inputSfmData);
     if (cameraType == camera::EINTRINSIC::PINHOLE_CAMERA)
     {
-        if (!convertToPinhole(inputSfmData, outputSfmData, fakeFov))
+        if (!convertToPinhole(inputSfmData, outputSfmData, fakeFov, scaleFactor))
         {
             ALICEVISION_LOG_ERROR("There was an error converting intrinsics");
             return EXIT_FAILURE;


### PR DESCRIPTION
This pull request introduces improvements to image transformation functionality, particularly around intrinsic parameter handling and image remapping. The most significant changes include adding a scale factor parameter to intrinsic transformations, implementing advanced image remapping functions, and improving efficiency by distinguishing between full and simplified transformation paths.

### Intrinsic transformation and scaling enhancements

* Added a `scaleFactor` parameter to the `IntrinsicsTransforming` node and command-line options, allowing users to rescale image sizes during intrinsic conversion. This parameter is also propagated through the `convertToPinhole` function and applied to both view and intrinsic parameters. [[1]](diffhunk://#diff-97379217d0e750eff791d4440a591ec6044991e8568f1d5a86b83f66b255091dR43-R50) [[2]](diffhunk://#diff-9525a2efc3c7f57977e06a2ca0280ea627815e1fd6491d192daccb0de1b492b6R34-R57) [[3]](diffhunk://#diff-9525a2efc3c7f57977e06a2ca0280ea627815e1fd6491d192daccb0de1b492b6R82-R96) [[4]](diffhunk://#diff-9525a2efc3c7f57977e06a2ca0280ea627815e1fd6491d192daccb0de1b492b6R257) [[5]](diffhunk://#diff-9525a2efc3c7f57977e06a2ca0280ea627815e1fd6491d192daccb0de1b492b6R272-R273) [[6]](diffhunk://#diff-9525a2efc3c7f57977e06a2ca0280ea627815e1fd6491d192daccb0de1b492b6L285-R313)

### Image remapping functionality

* Implemented new `remap` and `remapInter` template functions in `remap.hpp`/`remap.cpp`, supporting both bilinear and area interpolation for resampling images according to a coordinate map. These functions are now used in image transformation workflows. [[1]](diffhunk://#diff-108593c4b254d9c08e21a594d10c4d9576c273599b025ecd8fc5e1b35af293c1R22) [[2]](diffhunk://#diff-108593c4b254d9c08e21a594d10c4d9576c273599b025ecd8fc5e1b35af293c1R35) [[3]](diffhunk://#diff-f0e10387abc7030bae0ffc1afa72831efedf875149167592846ebcac25291a8eR1-R200) [[4]](diffhunk://#diff-2e6f7518a4897919cd4fb2c3c5ef224d17c6b1464ed50aa4590fa21a20efb60fR1-R17) [[5]](diffhunk://#diff-dcc1984d7e2d60dbe9c726fdd0a34fd4dda0ddabb566005cbc341a32175f65a1R15-R16) [[6]](diffhunk://#diff-dcc1984d7e2d60dbe9c726fdd0a34fd4dda0ddabb566005cbc341a32175f65a1L99-R101) [[7]](diffhunk://#diff-dcc1984d7e2d60dbe9c726fdd0a34fd4dda0ddabb566005cbc341a32175f65a1L111-R146)

### Transformation efficiency improvements

* Added the `isFullComputeNeeded` function to determine whether a full intrinsic transformation is required or a simplified undistortion is sufficient, based on distortion presence, intrinsic type, and parameter equality. The main image processing logic now chooses the optimal transformation path accordingly, logging the chosen method. [[1]](diffhunk://#diff-dcc1984d7e2d60dbe9c726fdd0a34fd4dda0ddabb566005cbc341a32175f65a1L111-R146) [[2]](diffhunk://#diff-dcc1984d7e2d60dbe9c726fdd0a34fd4dda0ddabb566005cbc341a32175f65a1L263-R301)

### Intrinsic comparison logic

* Enhanced the intrinsic comparison functionality by adding the `equalTo` method to `IntrinsicScaleOffsetDisto`, allowing for optional ignoring of distortion parameters. Updated equality operator logic to use this method, improving flexibility in intrinsic comparisons. [[1]](diffhunk://#diff-bb0272344ea8d0d14611db64e1fee26a98c4757b8981fc3e0130c2e1bc11f4ecR66-R80) [[2]](diffhunk://#diff-b46d45e90501c2a7b6bc484c26d186440bfa7c4110eeeeae4759df7dbb132576R18-R22) [[3]](diffhunk://#diff-b46d45e90501c2a7b6bc484c26d186440bfa7c4110eeeeae4759df7dbb132576R34-R38)