### PR TITLE
Fix Bug in tracksMerger

### DIFF
--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
@@ -152,6 +152,13 @@ void ExpansionProcess::remapExistingLandmarks(sfmData::SfMData & sfmData, const 
             }
 
             auto landmarkPair = landmarks.find(it->second);
+
+            // This should not happen if each feature is associated to only one track
+            if (landmarkPair == landmarks.end())
+            {
+                continue;
+            }
+
             sfmData::Landmark l = landmarkPair->second;
             landmarks.erase(landmarkPair->first);
 

--- a/src/aliceVision/track/TracksMerger.cpp
+++ b/src/aliceVision/track/TracksMerger.cpp
@@ -13,24 +13,48 @@ namespace track
 
 bool TracksMerger::addTrackMap(const track::TracksMap & inputTracks)
 {
+    // Loop over the tracks to add 
     for (const auto & [idTrack, track]: inputTracks)
     {
-        IndexT foundTrack = UndefinedIndexT;
-        size_t newSize = track.featPerView.size();
-        
+        std::map<IndexT, size_t> candidates;
+
+        // Find if one of the features already exists in a track
+        // In this case we would like to merge both tracks instead of adding a track
         for (const auto & [idView, feat]: track.featPerView)
         {
             TuplePoint tp = std::make_tuple(track.descType, idView, feat.featureId);
-            auto it = _existingTracks.find(tp);
-            if (it != _existingTracks.end())
+            if (_existingTracks.find(tp) == _existingTracks.end())
             {
-                foundTrack = it->second;
-                break;
+                // This feature is not present in the existing tracks
+                continue;
+            }
+
+            // Compute stats on best target to use
+            IndexT target = _existingTracks[tp];
+            if (candidates.find(target) == candidates.end())
+            {
+                candidates[target] = _tracks[target].featPerView.size();
+            }
+            else 
+            {
+                candidates[target]++;
             }
         }
-        
+
+        // Select the largest track solution
+        size_t bestSize = 0;
+        IndexT foundTrack = UndefinedIndexT;
+        for (const auto [trackId, size] : candidates)
+        {
+            if (size > bestSize)
+            {
+                foundTrack = trackId;
+                bestSize = size;
+            }
+        }
+
         if (foundTrack == UndefinedIndexT)
-        {   
+        {
             //Simply add track
             foundTrack = _lastIndex;
             _lastIndex++;
@@ -40,25 +64,18 @@ bool TracksMerger::addTrackMap(const track::TracksMap & inputTracks)
         auto & outputTrack = _tracks[foundTrack];
         outputTrack.descType = track.descType;
 
-        //Previous Size is either 0 if new track, or the size of the matching track
-        size_t oldSize = outputTrack.featPerView.size();
-        
-        //Append all features from existing track
+        // Merge both tracks
         for (const auto & [idView, feat]: track.featPerView)
         {
             TuplePoint tp = std::make_tuple(track.descType, idView, feat.featureId);
-            _existingTracks[tp] = foundTrack;
-
-            // Replace only if the new tracks is longer than the old one.
-            if (outputTrack.featPerView.find(idView) != outputTrack.featPerView.end())
+            // Ignore any track item that disagrees with the retargeting
+            if (_existingTracks.find(tp) != _existingTracks.end())
             {
-                if (newSize < oldSize)
-                {
-                    continue;
-                }
-            } 
-            
+                continue;
+            }
+
             outputTrack.featPerView[idView] = feat;
+            _existingTracks[tp] = foundTrack;
         }
     }
 

--- a/src/aliceVision/track/TracksMerger.hpp
+++ b/src/aliceVision/track/TracksMerger.hpp
@@ -20,6 +20,7 @@ class TracksMerger
 public:
     //viewId, featureId is a unique identifier for an observation
     using TuplePoint = std::tuple<feature::EImageDescriberType, IndexT, std::size_t>;
+
 public:
 
     /**


### PR DESCRIPTION
This pull request updates the logic for merging tracks in the `TracksMerger::addTrackMap` method, with a focus on improving how features are added and merged when tracks overlap. The changes clarify the merging process and ensure that feature replacement is handled more intelligently.

**Track merging logic improvements:**

* Added comments to clarify the process of looping over input tracks and the rationale for merging tracks if features already exist, making the code easier to understand and maintain.
* Updated the feature replacement logic to only replace an existing feature in a track if the input track is larger than the existing one, and added comments explaining this decision.

**Feature tracking and updating:**

* Moved the storage of feature information (`TuplePoint` in `_existingTracks`) to after the replacement logic and added explanatory comments, ensuring that the tracking of existing features is accurate and up-to-date.