### PR TITLE
Wrap Rgb in landmark for swig

### DIFF
--- a/src/aliceVision/sfmData/Landmark.i
+++ b/src/aliceVision/sfmData/Landmark.i
@@ -8,6 +8,41 @@
 %eigen_typemaps(Vec3)
 
 %include <aliceVision/sfmData/Observation.i>
+
+// We don't want to have a direct access to rgb
+// It's easier to wrap it around a Vec3
+// As it's already binded to numpy
+%ignore aliceVision::sfmData::Landmark::rgb;
+
+//Add new swig only C++ code
+%extend aliceVision::sfmData::Landmark {
+
+    // From RgbColor to Vec3
+    Vec3 getRgb() const {
+        Vec3 ret;
+
+        ret.x() = $self->rgb.r();
+        ret.y() = $self->rgb.g();
+        ret.z() = $self->rgb.b();
+
+        return ret;
+    }
+    
+    // From Vec3 to RgbColor
+    void setRgb(Vec3 value) {
+        $self->rgb.r() = value.x();
+        $self->rgb.g() = value.y();
+        $self->rgb.b() = value.z();
+    }
+    
+    // If the user asks for the rgb property
+    // It is not a direct access to the rgb
+    // variable but a getter/setter
+    %pythoncode %{
+        rgb = property(getRgb, setRgb)
+    %}
+}
+
 %include <aliceVision/sfmData/Landmark.hpp>
 
 %{


### PR DESCRIPTION
This pull request improves the Python bindings for the `Landmark` class in the Structure-from-Motion (SfM) data module by providing a more Pythonic and safer interface for accessing and modifying the `rgb` color property. Instead of exposing the internal `rgb` member directly, it wraps the RGB color as a `Vec3`, which is already compatible with numpy, and provides getter and setter methods.

Key changes:

**Python Binding Improvements:**

* The direct access to the `rgb` member of `aliceVision::sfmData::Landmark` is now ignored in the SWIG interface to prevent unsafe or unintended usage.
* Getter (`getRgb`) and setter (`setRgb`) methods are added to expose the RGB color as a `Vec3`, making it easier to work with in Python and ensuring compatibility with numpy.
* A Python property named `rgb` is defined, which uses the new getter and setter, allowing users to access and modify the RGB color in a Pythonic way (e.g., `landmark.rgb = np.array([r, g, b])`).