### PR TITLE
Fix bug in remap

### DIFF
--- a/src/aliceVision/image/remap.hpp
+++ b/src/aliceVision/image/remap.hpp
@@ -163,10 +163,6 @@ void remapInter(const Image<P> & source, const Image<Vec2> & map, const P& fillC
                         const P & pix = source(by, bx);
                         double weight = yocc * xocc;
                         
-                        if constexpr (std::is_same<P, RGBAfColor>())
-                        {   
-                            weight *= pix.a();
-                        }
 
                         sum += pix * weight;
                         wsum += weight;


### PR DESCRIPTION
Remap was zeroing rgb values when alpha was zero. We want to keep the masked values but only mask it with alpha = 0.