### PR TITLE
Remove direct access to landmark properties

### DIFF
--- a/pyTests/sfmData/test_landmark.py
+++ b/pyTests/sfmData/test_landmark.py
@@ -21,7 +21,7 @@ def test_landmark_default_constructor():
     """ Test creating a default Landmark object and checking its values are
     correctly initialized. """
     landmark = av.Landmark()
-    assert landmark.state == av.EEstimatorParameterState_REFINED
+    assert landmark.getState() == av.EEstimatorParameterState_REFINED
 
 
 @pytest.mark.skip(reason="feature::EImageDescriberType not binded")
@@ -46,7 +46,7 @@ def test_landmark_compare():
     assert landmark1 == landmark2
 
     # The "state" value is not taken into account when comparing Landmark objects
-    landmark1.state = av.EEstimatorParameterState_CONSTANT
+    landmark1.setState(av.EEstimatorParameterState_CONSTANT)
     assert landmark1 == landmark2, \
         "The two Landmark objects should be equal despite their different 'state' values"
 

--- a/src/aliceVision/depthMap/SgmDepthList.cpp
+++ b/src/aliceVision/depthMap/SgmDepthList.cpp
@@ -295,7 +295,7 @@ void SgmDepthList::getMinMaxMidNbDepthFromSfM(float& out_min, float& out_max, fl
     for (const auto& landmarkPair : _mp.getInputSfMData().getLandmarks())
     {
         const sfmData::Landmark& landmark = landmarkPair.second;
-        const Point3d point(landmark.X(0), landmark.X(1), landmark.X(2));
+        const Point3d point(landmark.getX()(0), landmark.getX()(1), landmark.getX()(2));
 
         // find rc observation
         const auto it = landmark.getObservations().find(viewId);
@@ -367,7 +367,7 @@ void SgmDepthList::getRcTcDepthRangeFromSfM(int tc, double& out_zmin, double& ou
     for (const auto& landmarkPair : _mp.getInputSfMData().getLandmarks())
     {
         const sfmData::Landmark& landmark = landmarkPair.second;
-        const Point3d point(landmark.X(0), landmark.X(1), landmark.X(2));
+        const Point3d point(landmark.getX()(0), landmark.getX()(1), landmark.getX()(2));
 
         // no tc observation
         if (landmark.getObservations().find(tcViewId) == landmark.getObservations().end())

--- a/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
+++ b/src/aliceVision/fuseCut/DelaunayGraphCut_test.cpp
@@ -200,7 +200,7 @@ SfMData generateSfm(const NViewDatasetConfigurator& config, const size_t size, c
     for (size_t i = 0; i < ptsSize; ++i)
     {
         Landmark landmark;
-        landmark.X = matPts.col(i);
+        landmark.setX(matPts.col(i));
         for (int j = 0; j < camsPts.size(); ++j)
         {
             const Vec2 pt = projectedPtsPerCam[j].col(i);

--- a/src/aliceVision/fuseCut/Fuser.cpp
+++ b/src/aliceVision/fuseCut/Fuser.cpp
@@ -360,7 +360,7 @@ float Fuser::computeAveragePixelSizeInHexahedron(Point3d* hexah, const sfmData::
     for (const auto& landmarkPair : sfmData.getLandmarks())
     {
         const sfmData::Landmark& landmark = landmarkPair.second;
-        const Point3d p(landmark.X(0), landmark.X(1), landmark.X(2));
+        const Point3d p(landmark.getX()(0), landmark.getX()(1), landmark.getX()(2));
 
         for (const auto& observationPair : landmark.getObservations())
         {
@@ -571,9 +571,9 @@ void Fuser::divideSpaceFromSfM(const sfmData::SfMData& sfmData, Point3d* hexah, 
         if (!checkLandmarkMinObservationAngle(sfmData, landmark, minObservationAngle))
             continue;
 
-        const double x = landmark.X(0);
-        const double y = landmark.X(1);
-        const double z = landmark.X(2);
+        const double x = landmark.getX()(0);
+        const double y = landmark.getX()(1);
+        const double z = landmark.getX()(2);
 
         accMinX(x);
         accMinY(y);

--- a/src/aliceVision/fuseCut/PointCloud.cpp
+++ b/src/aliceVision/fuseCut/PointCloud.cpp
@@ -610,7 +610,7 @@ void PointCloud::addPointsFromSfM(const Point3d hexah[8], const StaticVector<int
     for (std::size_t i = 0; i < nbPoints; ++i)
     {
         const sfmData::Landmark& landmark = landmarkIt->second;
-        const Point3d p(landmark.X(0), landmark.X(1), landmark.X(2));
+        const Point3d p(landmark.getX()(0), landmark.getX()(1), landmark.getX()(2));
 
         if (mvsUtils::isPointInHexahedron(p, hexah))
         {

--- a/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
+++ b/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
@@ -57,7 +57,7 @@ bool refinePoseAsItShouldbe(const Mat& pt3D,
     {
         const size_t idx = vec_inliers[i];
         Landmark landmark;
-        landmark.X = pt3D.col(idx);
+        landmark.setX(pt3D.col(idx));
         landmark.getObservations()[0] = Observation(pt2D.col(idx), UndefinedIndexT, unknownScale);
         sfm_data.getLandmarks()[i] = std::move(landmark);
     }

--- a/src/aliceVision/photometricStereo/normalIntegration.cpp
+++ b/src/aliceVision/photometricStereo/normalIntegration.cpp
@@ -541,7 +541,7 @@ void adjustScale(const sfmData::SfMData& sfmData, image::Image<float>& initDepth
     {
         size_t currentLandmarkIndex = visibleLandmarks.at(i);
         const sfmData::Landmark& currentLandmark = landmarks.at(currentLandmarkIndex);
-        knownDepths(i) = pose.depth(currentLandmark.X);
+        knownDepths(i) = pose.depth(currentLandmark.getX());
 
         sfmData::Observation observationInCurrentPicture = currentLandmark.getObservations().at(viewID);
 
@@ -583,7 +583,7 @@ void getZ0FromLandmarks(const sfmData::SfMData& sfmData,
 
         if (mask(rowInd, colInd) > 0.7)
         {
-            z0(rowInd, colInd) = pose.depth(currentLandmark.X);
+            z0(rowInd, colInd) = pose.depth(currentLandmark.getX());
             maskZ0(rowInd, colInd) = 1.0;
         }
     }

--- a/src/aliceVision/sfm/FrustumFilter.cpp
+++ b/src/aliceVision/sfm/FrustumFilter.cpp
@@ -170,7 +170,7 @@ void FrustumFilter::init_z_near_z_far_depth(const sfmData::SfMData& sfmData, con
         for (sfmData::Landmarks::const_iterator itL = sfmData.getLandmarks().begin(); itL != sfmData.getLandmarks().end(); ++itL)
         {
             const sfmData::Landmark& landmark = itL->second;
-            const Vec3& X = landmark.X;
+            const Vec3& X = landmark.getX();
             for (sfmData::Observations::const_iterator iterO = landmark.getObservations().begin(); iterO != landmark.getObservations().end(); ++iterO)
             {
                 const IndexT id_view = iterO->first;

--- a/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
+++ b/src/aliceVision/sfm/LocalBundleAdjustmentGraph.cpp
@@ -439,12 +439,12 @@ void LocalBundleAdjustmentGraph::convertDistancesToStates(sfmData::SfMData& sfmD
         if (!states.at(static_cast<std::size_t>(EEstimatorParameterState::REFINED)) ||
             states.at(static_cast<std::size_t>(EEstimatorParameterState::IGNORED)))
         {
-            itLandmark.second.state = EEstimatorParameterState::IGNORED;
+            itLandmark.second.setState(EEstimatorParameterState::IGNORED);
             _statePerLandmarkId[landmarkId] = EEstimatorParameterState::IGNORED;
         }
         else
         {
-            itLandmark.second.state = EEstimatorParameterState::REFINED;
+            itLandmark.second.setState(EEstimatorParameterState::REFINED);
             _statePerLandmarkId[landmarkId] = EEstimatorParameterState::REFINED;
         }
     }

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -529,7 +529,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
 
         // do not create a residual block if the landmark
         // have been set as Ignored by the Local BA strategy
-        if (landmark.state == EEstimatorParameterState::IGNORED)
+        if (landmark.getState() == EEstimatorParameterState::IGNORED)
         {
             _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::IGNORED);
             continue;
@@ -538,14 +538,14 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
         std::array<double, 3>& landmarkBlock = _landmarksBlocks[landmarkId];
         for (std::size_t i = 0; i < 3; ++i)
         {
-            landmarkBlock.at(i) = landmark.X(Eigen::Index(i));
+            landmarkBlock.at(i) = landmark.getX()(Eigen::Index(i));
         }
 
         //If the landmark has a referenceViewIndex set, then retrieve the reference pose
         double * referencePoseBlockPtr = nullptr;
-        if (landmark.referenceViewIndex != UndefinedIndexT)
+        if (landmark.getReferenceViewIndex() != UndefinedIndexT)
         {
-            const sfmData::View& refview = sfmData.getView(landmark.referenceViewIndex);
+            const sfmData::View& refview = sfmData.getView(landmark.getReferenceViewIndex());
             referencePoseBlockPtr = _posesBlocks.at(refview.getPoseId()).data();
         }
 
@@ -657,7 +657,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                 problem.AddResidualBlock(costFunction, nullptr, params);
             }
 
-            if (!refineStructure || landmark.state == EEstimatorParameterState::CONSTANT || landmark.isPrecise())
+            if (!refineStructure || landmark.getState() == EEstimatorParameterState::CONSTANT || landmark.isPrecise())
             {
                 // set the whole landmark parameter block as constant.
                 _statistics.addState(EParameter::LANDMARK, EEstimatorParameterState::CONSTANT);

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
@@ -108,7 +108,7 @@ void createScene(sfmData::SfMData& sfmData, const camera::IntrinsicBase& intrins
         int count = 0;
         for (auto& pl : sfmData.getLandmarks())
         {
-            const auto& pt = pl.second.X;
+            const auto& pt = pl.second.getX();
 
             Vec3 cpt = pose(pt);
             Vec3 dir = (cpt - origin).normalized();
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(test_landmarks)
         srand(0);
         for (auto& lpt : sfmData.getLandmarks())
         {
-            lpt.second.X += Eigen::Vector3d::Random() * 0.1;
+            lpt.second.setX(lpt.second.getX() + Eigen::Vector3d::Random() * 0.1);
         }
 
         sfm::BundleAdjustmentCeres::CeresOptions options;

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
@@ -343,7 +343,8 @@ SfMData getInputScene(const NViewDataSet& d, const NViewDatasetConfigurator& con
 
         if (config._useRelative)
         {
-            landmark.setReferenceViewIndex(nviews / 2);
+            sfmData::View::sptr refView = sfm_data.getViews().at(nviews / 2);
+            landmark.setReferenceView(refView);
             geometry::Pose3 p = sfm_data.getAbsolutePose(landmark.getReferenceViewIndex()).getTransform();
             landmark.setX(p(landmark.getX()));
         }

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_test.cpp
@@ -251,12 +251,12 @@ BOOST_AUTO_TEST_CASE(LOCAL_BUNDLE_ADJUSTMENT_EffectiveMinimization_Pinhole_Camer
                 sfmData_notRefined.getPose(*sfmData_notRefined.getViews().at(2).get()));  // v2 ignored
 
     // Check 3D points
-    BOOST_CHECK(sfmData.getLandmarks()[0].X != sfmData_notRefined.getLandmarks()[0].X);      // p0 refined
-    BOOST_CHECK(sfmData.getLandmarks()[1].X != sfmData_notRefined.getLandmarks()[1].X);      // p1 refined
-    BOOST_CHECK_EQUAL(sfmData.getLandmarks()[2].X, sfmData_notRefined.getLandmarks()[2].X);  // p2 ignored
+    BOOST_CHECK(sfmData.getLandmarks()[0].getX() != sfmData_notRefined.getLandmarks()[0].getX());      // p0 refined
+    BOOST_CHECK(sfmData.getLandmarks()[1].getX() != sfmData_notRefined.getLandmarks()[1].getX());      // p1 refined
+    BOOST_CHECK_EQUAL(sfmData.getLandmarks()[2].getX(), sfmData_notRefined.getLandmarks()[2].getX());  // p2 ignored
 
     // Not refined parameters:
-    BOOST_CHECK(sfmData.getLandmarks()[2].X == sfmData_notRefined.getLandmarks()[2].X);
+    BOOST_CHECK(sfmData.getLandmarks()[2].getX() == sfmData_notRefined.getLandmarks()[2].getX());
 
     const double dResidual_after = RMSE(sfmData);
     BOOST_CHECK_LT(dResidual_after, dResidual_before);
@@ -273,9 +273,9 @@ double RMSE(const SfMData& sfm_data)
 
         
         Pose3 world_T_reference;
-        if (landmark.referenceViewIndex != UndefinedIndexT)
+        if (landmark.getReferenceViewIndex() != UndefinedIndexT)
         {
-            const View & refView = sfm_data.getView(landmark.referenceViewIndex);
+            const View & refView = sfm_data.getView(landmark.getReferenceViewIndex());
             world_T_reference = sfm_data.getPose(refView).getTransform().inverse();
         }
 
@@ -285,7 +285,7 @@ double RMSE(const SfMData& sfm_data)
             const Pose3 camera_T_world = sfm_data.getPose(view).getTransform();
             const Pose3 camera_T_reference = camera_T_world * world_T_reference;
             const IntrinsicBase & intrinsic = sfm_data.getIntrinsic(view.getIntrinsicId());
-            const Vec2 residual = intrinsic.residual(camera_T_reference, landmark.X.homogeneous(), observation.getCoordinates());
+            const Vec2 residual = intrinsic.residual(camera_T_reference, landmark.getX().homogeneous(), observation.getCoordinates());
             
             vec.push_back(residual(0));
             vec.push_back(residual(1));
@@ -339,13 +339,13 @@ SfMData getInputScene(const NViewDataSet& d, const NViewDatasetConfigurator& con
     {
         // Collect the image of point i in each frame.
         Landmark landmark;
-        landmark.X = d._X.col(i);
+        landmark.setX(d._X.col(i));
 
         if (config._useRelative)
         {
-            landmark.referenceViewIndex = nviews / 2;
-            geometry::Pose3 p = sfm_data.getAbsolutePose(landmark.referenceViewIndex).getTransform();
-            landmark.X = p(landmark.X);
+            landmark.setReferenceViewIndex(nviews / 2);
+            geometry::Pose3 p = sfm_data.getAbsolutePose(landmark.getReferenceViewIndex()).getTransform();
+            landmark.setX(p(landmark.getX()));
         }
 
         for (int j = 0; j < nviews; ++j)

--- a/src/aliceVision/sfm/bundle/costfunctions/constraintPoint.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/constraintPoint.hpp
@@ -39,7 +39,7 @@ struct ConstraintPointErrorFunctor
     inline static ceres::CostFunction* createCostFunction(const sfmData::Landmark & landmark, const Vec3 & normal)
     {
         const double weight = 100.0;
-        auto costFunction = new ceres::DynamicAutoDiffCostFunction<ConstraintPointErrorFunctor>(new ConstraintPointErrorFunctor(weight, normal, landmark.X));
+        auto costFunction = new ceres::DynamicAutoDiffCostFunction<ConstraintPointErrorFunctor>(new ConstraintPointErrorFunctor(weight, normal, landmark.getX()));
 
         costFunction->AddParameterBlock(3);
         costFunction->SetNumResiduals(1);

--- a/src/aliceVision/sfm/generateReport.cpp
+++ b/src/aliceVision/sfm/generateReport.cpp
@@ -34,7 +34,7 @@ bool generateSfMReport(const sfmData::SfMData& sfmData, const std::string& htmlF
             const geometry::Pose3 pose = sfmData.getPose(*view).getTransform();
             const camera::IntrinsicBase* intrinsic = sfmData.getIntrinsics().at(view->getIntrinsicId()).get();
             // Use absolute values
-            const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X.homogeneous(), itObs->second.getCoordinates()).array().abs();
+            const Vec2 residual = intrinsic->residual(pose, iterTracks->second.getX().homogeneous(), itObs->second.getCoordinates()).array().abs();
             residuals_per_view[itObs->first].push_back(residual(0));
             residuals_per_view[itObs->first].push_back(residual(1));
             ++residualCount;

--- a/src/aliceVision/sfm/pipeline/ReconstructionEngine.cpp
+++ b/src/aliceVision/sfm/pipeline/ReconstructionEngine.cpp
@@ -53,12 +53,12 @@ void retrieveMarkersId(sfmData::SfMData& sfmData)
         auto& landmark = landmarkIt.second;
         if (landmark.getObservations().empty())
             continue;
-        if (markerDescTypes_set.find(landmark.descType) == markerDescTypes_set.end())
+        if (markerDescTypes_set.find(landmark.getDescType()) == markerDescTypes_set.end())
             continue;
-        landmark.rgb = image::BLACK;
+        landmark.setRgb(image::BLACK);
 
         const auto obs = landmark.getObservations().begin();
-        const feature::Regions& regions = regionPerView.getRegions(obs->first, landmark.descType);
+        const feature::Regions& regions = regionPerView.getRegions(obs->first, landmark.getDescType());
         const feature::CCTAG_Regions* cctagRegions = dynamic_cast<const feature::CCTAG_Regions*>(&regions);
         const feature::APRILTAG_Regions* apriltagRegions = dynamic_cast<const feature::APRILTAG_Regions*>(&regions);
         if (cctagRegions)
@@ -69,7 +69,7 @@ void retrieveMarkersId(sfmData::SfMData& sfmData)
                 if (d[i] == 255)
                 {
                     ALICEVISION_LOG_TRACE("Found cctag marker: " << i << " (landmarkId: " << landmarkIt.first << ").");
-                    landmark.rgb.r() = i;
+                    landmark.getRgb().r() = i;
                     break;
                 }
             }
@@ -82,7 +82,7 @@ void retrieveMarkersId(sfmData::SfMData& sfmData)
                 if (d[i] == 255)
                 {
                     ALICEVISION_LOG_TRACE("Found apriltag marker: " << i << " (landmarkId: " << landmarkIt.first << ").");
-                    landmark.rgb.r() = i;
+                    landmark.getRgb().r() = i;
                     break;
                 }
             }

--- a/src/aliceVision/sfm/pipeline/RigSequence.cpp
+++ b/src/aliceVision/sfm/pipeline/RigSequence.cpp
@@ -69,7 +69,7 @@ double computeCameraScore(const SfMData& sfmData, const track::TracksPerView& tr
 
         if (itObs != landmark.getObservations().end())
         {
-            const Vec2 residual = intrinsic->residual(pose, landmark.X.homogeneous(), itObs->second.getCoordinates());
+            const Vec2 residual = intrinsic->residual(pose, landmark.getX().homogeneous(), itObs->second.getCoordinates());
             score += std::min(1.0 / residual.norm(), 4.0);
         }
     }

--- a/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/Bootstrap.cpp
@@ -65,8 +65,8 @@ bool bootstrapBase(sfmData::SfMData & sfmData,
         }
 
         sfmData::Landmark landmark;
-        landmark.descType = track.descType;
-        landmark.X = X;
+        landmark.setDescType(track.descType);
+        landmark.setX(X);
         
         sfmData::Observation refObs;
         refObs.setFeatureId(refItem.featureId);
@@ -151,7 +151,7 @@ bool bootstrapMesh(sfmData::SfMData & sfmData,
         //Compute error
         const track::TrackItem & item = track.featPerView.at(viewId);
         const Vec2 pt = item.coords;
-        const Vec2 estpt = intrinsics->transformProject(pose3, landmark.X.homogeneous(), true);
+        const Vec2 estpt = intrinsics->transformProject(pose3, landmark.getX().homogeneous(), true);
         double err = (pt - estpt).norm();
 
         //If error is ok, then we add it to the sfmData
@@ -242,7 +242,7 @@ bool bootstrapDepth(sfmData::SfMData & sfmData,
         //Compute error
         const track::TrackItem & item = track.featPerView.at(nextViewId);
         const Vec2 pt = item.coords;
-        const Vec2 estpt = camNext->transformProject(pose3, landmark.X.homogeneous(), true);
+        const Vec2 estpt = camNext->transformProject(pose3, landmark.getX().homogeneous(), true);
         double err = (pt - estpt).norm();
 
         //If error is ok, then we add it to the sfmData

--- a/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.cpp
+++ b/src/aliceVision/sfm/pipeline/bootstrapping/TracksDepths.cpp
@@ -52,11 +52,11 @@ bool buildSfmDataFromDepthMap(sfmData::SfMData & output,
         const Vec2 meters = intrinsic.removeDistortion(intrinsic.ima2cam(feat.coords.cast<double>()));
         
         sfmData::Landmark & landmark = landmarks[trackId];
-        landmark.X.x() = meters.x() * Z;
-        landmark.X.y() = meters.y() * Z;
-        landmark.X.z() = Z;
+        landmark.getX().x() = meters.x() * Z;
+        landmark.getX().y() = meters.y() * Z;
+        landmark.getX().z() = Z;
 
-        landmark.descType = track.descType;
+        landmark.setDescType(track.descType);
 
         for (const auto & [otherViewId, otherFeat] : track.featPerView)
         {

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -421,7 +421,7 @@ void ExpansionChunk::setConstraints(sfmData::SfMData & sfmData, const track::Tra
         const Vec3 point = vecInfo[idBest].first;
         const Vec3 normal = vecInfo[idBest].second;
 
-        double dist = (point - landmark.X).norm();
+        double dist = (point - landmark.getX()).norm();
         if (dist > maxDistLandmark)
         {
             continue;

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
@@ -126,7 +126,7 @@ void ExpansionProcess::remapExistingLandmarks(sfmData::SfMData & sfmData, const 
 
         const IndexT firstViewId = landmarkPair.second.getObservations().begin()->first;
         const IndexT firstFeatureId = landmarkPair.second.getObservations().begin()->second.getFeatureId();
-        const feature::EImageDescriberType descType = landmarkPair.second.descType;
+        const feature::EImageDescriberType descType = landmarkPair.second.getDescType();
 
         obsToLandmark.emplace(ObsKey(firstViewId, firstFeatureId, descType), landmarkId);
     }

--- a/src/aliceVision/sfm/pipeline/expanding/LbaPolicyConnexity.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LbaPolicyConnexity.cpp
@@ -89,7 +89,7 @@ void LbaPolicyConnexity::upgradeSfmData(sfmData::SfMData & sfmData)
         //then obviously we want to ignore it (should be implicit in the bundle though)
         if ((!hasEstimated) || hasIgnored)
         {
-            landmark.state = EEstimatorParameterState::IGNORED;
+            landmark.setState(EEstimatorParameterState::IGNORED);
         }
     }
 }

--- a/src/aliceVision/sfm/pipeline/expanding/SfmResection.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmResection.cpp
@@ -78,7 +78,7 @@ bool SfmResection::processView(
         const auto & track = tracks.at(trackId);
 
         const feature::EImageDescriberType descType = track.descType;        
-        const Eigen::Vector3d X = sfmData.getLandmarks().at(trackId).X;
+        const Eigen::Vector3d X = sfmData.getLandmarks().at(trackId).getX();
         const Eigen::Vector2d x = track.featPerView.at(viewId).coords;
 
         structure.push_back(X);
@@ -174,7 +174,7 @@ bool SfmResection::internalRefinement(
         const std::size_t idx = inliers[i];
 
         sfmData::Landmark landmark;
-        landmark.X = structure[idx];
+        landmark.setX(structure[idx]);
         landmark.getObservations()[0] = sfmData::Observation(observations[idx], UndefinedIndexT, unknownScale);
         tinyScene.getLandmarks()[i] = std::move(landmark);
     }

--- a/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmTriangulation.cpp
@@ -178,8 +178,8 @@ bool SfmTriangulation::processTrack(
     homogeneousToEuclidean(X, X_euclidean); 
 
     //Create landmark from result
-    result.X = X_euclidean;
-    result.descType = track.descType;
+    result.setX(X_euclidean);
+    result.setDescType(track.descType);
 
     for (const std::size_t & i : inliers)
     {   
@@ -241,8 +241,8 @@ bool SfmTriangulation::processTrackWithPrior(
         //As it does not need parallax to estimate its depth
         sfmData::Landmark landmark;
         landmark.setParallaxRobust(true);
-        landmark.X = oX;
-        landmark.descType = track.descType;
+        landmark.setX(oX);
+        landmark.setDescType(track.descType);
 
         //Compute consensus for this depth
         for (auto viewId : viewIds)
@@ -342,8 +342,8 @@ bool SfmTriangulation::processTrackWithPointFetcher(
         //As it does not need parallax to estimate its depth
         sfmData::Landmark landmark;
         landmark.setParallaxRobust(true);
-        landmark.X = refpt;
-        landmark.descType = track.descType;
+        landmark.setX(refpt);
+        landmark.setDescType(track.descType);
         landmark.setIsPrecise(true);
 
         //For each observed view in the track
@@ -408,7 +408,7 @@ bool SfmTriangulation::checkChierality(const sfmData::SfMData & sfmData, const s
         const geometry::Pose3 & refPose = refCameraPose.getTransform();
 
         const Vec3 dir = intrinsic->toUnitSphere(intrinsic->removeDistortion(intrinsic->ima2cam(obs.getCoordinates())));
-        const Vec3 ldir = refPose(landmark.X).normalized();
+        const Vec3 ldir = refPose(landmark.getX()).normalized();
 
         if (dir.dot(ldir) < 0.0)
         {
@@ -442,7 +442,7 @@ double SfmTriangulation::getMaximalAngle(const sfmData::SfMData & sfmData, const
             const sfmData::View & nextView = sfmData.getView(nextViewId);
             const sfmData::CameraPose & nextCameraPose = sfmData.getAbsolutePose(nextView.getPoseId());
             const geometry::Pose3 & nextPose = nextCameraPose.getTransform();
-            double angle_deg = camera::angleBetweenRays(refPose, nextPose, landmark.X);
+            double angle_deg = camera::angleBetweenRays(refPose, nextPose, landmark.getX());
 
             max = std::max(max, angle_deg);
         }

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -300,7 +300,7 @@ bool ReconstructionEngine_globalSfM::computeInitialStructure(matching::PairwiseM
         {
             const Track& track = itTracks->second;
             Landmark& newLandmark = structure[idx];
-            newLandmark.descType = track.descType;
+            newLandmark.setDescType(track.descType);
             Observations& obs = newLandmark.getObservations();
             for (Track::TrackInfoPerView::const_iterator it = track.featPerView.begin(); it != track.featPerView.end(); ++it)
             {
@@ -601,9 +601,9 @@ void ReconstructionEngine_globalSfM::computeRelativeRotations(rotationAveraging:
                         obs[viewI->getViewId()] = Observation(x1_, match._i, scaleI);
                         obs[viewJ->getViewId()] = Observation(x2_, match._j, scaleJ);
                         Landmark& newLandmark = landmarks[landmarkId++];
-                        newLandmark.descType = descType;
+                        newLandmark.setDescType(descType);
                         newLandmark.getObservations() = obs;
-                        newLandmark.X = X;
+                        newLandmark.setX(X);
                     }
                 }
                 // - refine only Structure and Rotations & translations (keep intrinsic constant)

--- a/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
+++ b/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
@@ -207,7 +207,7 @@ bool SfMLocalizer::refinePose(camera::IntrinsicBase* intrinsics,
     {
         const std::size_t idx = matchingData.vec_inliers[i];
         sfmData::Landmark landmark;
-        landmark.X = matchingData.pt3D.col(idx);
+        landmark.setX(matchingData.pt3D.col(idx));
         landmark.getObservations()[0] = sfmData::Observation(matchingData.pt2D.col(idx), UndefinedIndexT, unknownScale);  // TODO-SCALE
         tinyScene.getLandmarks()[i] = std::move(landmark);
     }

--- a/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
+++ b/src/aliceVision/sfm/pipeline/panorama/ReconstructionEngine_panorama.cpp
@@ -928,10 +928,10 @@ bool ReconstructionEngine_panorama::buildLandmarks()
 
         // Store landmark
         Landmark l;
-        l.descType = c.descType;
+        l.setDescType(c.descType);
         l.getObservations()[c.ViewFirst] = c.ObservationFirst;
         l.getObservations()[c.ViewSecond] = c.ObservationSecond;
-        l.X = (wpt1 + wpt2) * 0.5;
+        l.setX((wpt1 + wpt2) * 0.5);
 
         _sfmData.getLandmarks()[count++] = l;
     }

--- a/src/aliceVision/sfm/pipeline/positioning/GlobalPositioning.cpp
+++ b/src/aliceVision/sfm/pipeline/positioning/GlobalPositioning.cpp
@@ -129,7 +129,7 @@ bool GlobalPositioning::createStructure(const sfmData::SfMData & sfmData, std::m
             //Initialize all scales to 1
             Pair pair = std::make_pair(idLandmark, poseId);
 
-            double norm = (landmark.X - pose.center()).norm();
+            double norm = (landmark.getX() - pose.center()).norm();
             if (norm < 1e-12) norm = 1.0;
             _scales[pair] = 1.0 /  norm;
 
@@ -211,7 +211,7 @@ void GlobalPositioning::updateSfmData(sfmData::SfMData & sfmData)
     sfmData::Landmarks & landmarks = sfmData.getLandmarks();
     for (auto & [idLandmark, vec] : _landmarks)
     {
-        landmarks[idLandmark].X = vec;
+        landmarks[idLandmark].setX(vec);
     }
 
 

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -1537,7 +1537,7 @@ bool ReconstructionEngine_sequentialSfM::computeResection(const IndexT viewId, R
          ++iterfeatId, ++iterTrackId, ++cpt)
     {
         const feature::EImageDescriberType descType = iterfeatId->first;
-        resectionData.pt3D.col(cpt) = _sfmData.getLandmarks().at(*iterTrackId).X;
+        resectionData.pt3D.col(cpt) = _sfmData.getLandmarks().at(*iterTrackId).getX();
         resectionData.pt2D.col(cpt) = _featuresPerView->getFeatures(viewId, descType)[iterfeatId->second].coords().cast<double>();
         resectionData.vec_descType.at(cpt) = descType;
     }
@@ -1619,7 +1619,7 @@ void ReconstructionEngine_sequentialSfM::updateScene(const IndexT viewIndex, con
             const IndexT idFeat = resectionData.featuresId[i].second;
             const double scale = (_params.featureConstraint == EFeatureConstraint::BASIC)
                                    ? 0.0
-                                   : _featuresPerView->getFeatures(viewIndex, landmark.descType)[idFeat].scale();
+                                   : _featuresPerView->getFeatures(viewIndex, landmark.getDescType())[idFeat].scale();
             // Inlier, add the point to the reconstructed track
             landmark.getObservations()[viewIndex] = Observation(x, idFeat, scale);
         }
@@ -1863,8 +1863,8 @@ void ReconstructionEngine_sequentialSfM::triangulateMultiViewsLORANSAC(SfMData& 
         if (isValidTrack)
         {
             Landmark landmark;
-            landmark.X = X_euclidean;
-            landmark.descType = track.descType;
+            landmark.setX(X_euclidean);
+            landmark.setDescType(track.descType);
             for (const IndexT& viewId : inliers)  // add inliers as observations
             {
                 const Vec2 x = _featuresPerView->getFeatures(viewId, track.descType)[track.featPerView.at(viewId).featureId].coords().cast<double>();
@@ -1974,12 +1974,12 @@ void ReconstructionEngine_sequentialSfM::triangulate2Views(SfMData& scene,
                         Landmark& landmark = scene.getLandmarks().at(trackId);
                         if (landmark.getObservations().count(I) == 0)
                         {
-                            const Vec2 residual = camI->residual(poseI, landmark.X.homogeneous(), xI);
+                            const Vec2 residual = camI->residual(poseI, landmark.getX().homogeneous(), xI);
                             // TODO: scale in residual
                             const auto& acThresholdIt = _map_ACThreshold.find(I);
                             // TODO assert(acThresholdIt != _map_ACThreshold.end());
                             const double acThreshold = (acThresholdIt != _map_ACThreshold.end()) ? acThresholdIt->second : 4.0;
-                            if (poseI.depth(landmark.X) > 0 && residual.norm() < std::max(4.0, acThreshold))
+                            if (poseI.depth(landmark.getX()) > 0 && residual.norm() < std::max(4.0, acThreshold))
                             {
                                 const double scale = (_params.featureConstraint == EFeatureConstraint::BASIC) ? 0.0 : featI.scale();
                                 landmark.getObservations()[I] = Observation(xI, track.featPerView.at(I).featureId, scale);
@@ -1988,11 +1988,11 @@ void ReconstructionEngine_sequentialSfM::triangulate2Views(SfMData& scene,
                         }
                         if (landmark.getObservations().count(J) == 0)
                         {
-                            const Vec2 residual = camJ->residual(poseJ, landmark.X.homogeneous(), xJ);
+                            const Vec2 residual = camJ->residual(poseJ, landmark.getX().homogeneous(), xJ);
                             const auto& acThresholdIt = _map_ACThreshold.find(J);
                             // TODO assert(acThresholdIt != _map_ACThreshold.end());
                             const double acThreshold = (acThresholdIt != _map_ACThreshold.end()) ? acThresholdIt->second : 4.0;
-                            if (poseJ.depth(landmark.X) > 0 && residual.norm() < std::max(4.0, acThreshold))
+                            if (poseJ.depth(landmark.getX()) > 0 && residual.norm() < std::max(4.0, acThreshold))
                             {
                                 const double scale = (_params.featureConstraint == EFeatureConstraint::BASIC) ? 0.0 : featJ.scale();
                                 landmark.getObservations()[J] = Observation(xJ, track.featPerView.at(J).featureId, scale);
@@ -2040,8 +2040,8 @@ void ReconstructionEngine_sequentialSfM::triangulate2Views(SfMData& scene,
                         {
                             // Add a new track
                             Landmark& landmark = scene.getLandmarks()[trackId];
-                            landmark.X = X_euclidean;
-                            landmark.descType = track.descType;
+                            landmark.setX(X_euclidean);
+                            landmark.setDescType(track.descType);
 
                             const double scaleI = (_params.featureConstraint == EFeatureConstraint::BASIC) ? 0.0 : featI.scale();
                             const double scaleJ = (_params.featureConstraint == EFeatureConstraint::BASIC) ? 0.0 : featJ.scale();

--- a/src/aliceVision/sfm/sfmFilters.cpp
+++ b/src/aliceVision/sfm/sfmFilters.cpp
@@ -35,7 +35,7 @@ IndexT removeOutliersWithPixelResidualError(sfmData::SfMData& sfmData,
             const geometry::Pose3 pose = sfmData.getPose(*view).getTransform();
             const camera::IntrinsicBase* intrinsic = sfmData.getIntrinsics().at(view->getIntrinsicId()).get();
 
-            Vec2 residual = intrinsic->residual(pose, iterTracks->second.X.homogeneous(), itObs->second.getCoordinates());
+            Vec2 residual = intrinsic->residual(pose, iterTracks->second.getX().homogeneous(), itObs->second.getCoordinates());
             if (featureConstraint == EFeatureConstraint::SCALE && itObs->second.getScale() > 0.0)
             {
                 // Apply the scale of the feature to get a residual value
@@ -43,7 +43,7 @@ IndexT removeOutliersWithPixelResidualError(sfmData::SfMData& sfmData,
                 residual /= itObs->second.getScale();
             }
 
-            if ((pose.depth(iterTracks->second.X) < 0) || (residual.norm() > dThresholdPixel))
+            if ((pose.depth(iterTracks->second.getX()) < 0) || (residual.norm() > dThresholdPixel))
             {
                 ++outlierCount;
                 itObs = observations.erase(itObs);
@@ -321,7 +321,7 @@ IndexT removeConstraints(sfmData::SfMData& sfmData, double maxDist)
             continue;
         }
     
-        const Vec3 & lpt = landmarkIt->second.X;
+        const Vec3 & lpt = landmarkIt->second.getX();
         double dist = (itConstraints->second.point - lpt).norm();
 
         //Remove if the landmark is too far away

--- a/src/aliceVision/sfm/sfmStatistics.cpp
+++ b/src/aliceVision/sfm/sfmStatistics.cpp
@@ -48,7 +48,7 @@ void computeResidualsHistogram(const sfmData::SfMData& sfmData,
             const sfmData::View& view = sfmData.getView(obs.first);
             const aliceVision::geometry::Pose3 pose = sfmData.getPose(view).getTransform();
             const std::shared_ptr<aliceVision::camera::IntrinsicBase> intrinsic = sfmData.getIntrinsics().find(view.getIntrinsicId())->second;
-            const Vec2 residual = intrinsic->residual(pose, track.second.X.homogeneous(), obs.second.getCoordinates());
+            const Vec2 residual = intrinsic->residual(pose, track.second.getX().homogeneous(), obs.second.getCoordinates());
             vecResiduals.push_back(residual.norm());
             // ALICEVISION_LOG_INFO("[AliceVision] sfmtstatistics::computeResidualsHistogram track: " << track.first << ", residual: " <<
             // residual.norm());
@@ -347,7 +347,7 @@ void computeResidualsPerView(const sfmData::SfMData& sfmData,
             const sfmData::View& view = sfmData.getView(obs.first);
             const aliceVision::geometry::Pose3 pose = sfmData.getPose(view).getTransform();
             const std::shared_ptr<aliceVision::camera::IntrinsicBase> intrinsic = sfmData.getIntrinsics().find(view.getIntrinsicId())->second;
-            const Vec2 residual = intrinsic->residual(pose, landmark.second.X.homogeneous(), obs.second.getCoordinates());
+            const Vec2 residual = intrinsic->residual(pose, landmark.second.getX().homogeneous(), obs.second.getCoordinates());
             residualsPerView[obs.first].push_back(residual.norm());
         }
     }

--- a/src/aliceVision/sfm/sfmTriangulation.cpp
+++ b/src/aliceVision/sfm/sfmTriangulation.cpp
@@ -81,7 +81,7 @@ void StructureComputationBlind::triangulate(sfmData::SfMData& sfmData, std::mt19
                 const Vec3 X = trianObj.compute();
                 if (trianObj.minDepth() > 0)  // Keep the point only if it have a positive depth
                 {
-                    iterTracks->second.X = X;
+                    iterTracks->second.setX(X);
                 }
                 else
                 {
@@ -132,11 +132,11 @@ void StructureComputationRobust::robustTriangulation(sfmData::SfMData& sfmData, 
             Vec3 X;
             if (robustTriangulation(sfmData, iterTracks->second.getObservations(), randomNumberGenerator, X))
             {
-                iterTracks->second.X = X;
+                iterTracks->second.setX(X);
             }
             else
             {
-                iterTracks->second.X = Vec3::Zero();
+                iterTracks->second.setX(Vec3::Zero());
 #pragma omp critical
                 {
                     rejectedId.push_front(iterTracks->first);

--- a/src/aliceVision/sfm/utils/alignment.cpp
+++ b/src/aliceVision/sfm/utils/alignment.cpp
@@ -446,9 +446,9 @@ std::map<std::pair<feature::EImageDescriberType, int>, IndexT> getUniqueMarkers(
 
     for (const auto& landmarkIt : sfmDataA.getLandmarks())
     {
-        if (isMarker(landmarkIt.second.descType))
+        if (isMarker(landmarkIt.second.getDescType()))
         {
-            const auto p = std::make_pair(landmarkIt.second.descType, landmarkIt.second.rgb.r());
+            const auto p = std::make_pair(landmarkIt.second.getDescType(), landmarkIt.second.getRgb().r());
             if (markers.find(p) == markers.end())
             {
                 markers[p] = landmarkIt.first;
@@ -511,8 +511,8 @@ bool computeSimilarityFromCommonMarkers(const sfmData::SfMData& sfmDataA,
     for (std::size_t i = 0; i < commonLandmarks.size(); ++i, ++it)
     {
         const std::pair<IndexT, IndexT>& commonLandmark = it->second;
-        xA.col(i) = sfmDataA.getLandmarks().at(commonLandmark.first).X;
-        xB.col(i) = sfmDataB.getLandmarks().at(commonLandmark.second).X;
+        xA.col(i) = sfmDataA.getLandmarks().at(commonLandmark.first).getX();
+        xB.col(i) = sfmDataB.getLandmarks().at(commonLandmark.second).getX();
     }
 
     if (commonLandmarks.size() == 1)
@@ -584,8 +584,8 @@ bool computeSimilarityFromCommonLandmarks(const sfmData::SfMData& sfmDataA,
     int count = 0;
     for (auto & pair : mapLandmarkAtoLandmarkB)
     {
-        xA.col(count) = sfmDataA.getLandmarks().at(pair.first).X;
-        xB.col(count) = sfmDataB.getLandmarks().at(pair.second).X;
+        xA.col(count) = sfmDataA.getLandmarks().at(pair.first).getX();
+        xB.col(count) = sfmDataB.getLandmarks().at(pair.second).getX();
         count++;
     }
 
@@ -700,8 +700,8 @@ bool computeNewCoordinateSystemFromPairs(const sfmData::SfMData& sfmDataA,
     int count = 0;
     for (auto & pair : mapLandmarkAtoLandmarkB)
     {
-        xA.col(count) = sfmDataA.getLandmarks().at(pair.first).X;
-        xB.col(count) = sfmDataB.getLandmarks().at(pair.second).X;
+        xA.col(count) = sfmDataA.getLandmarks().at(pair.first).getX();
+        xB.col(count) = sfmDataB.getLandmarks().at(pair.second).getX();
         count++;
     }
 
@@ -1054,11 +1054,11 @@ void computeNewCoordinateSystemFromLandmarks(const sfmData::SfMData& sfmData,
     for (const auto& landmark : sfmData.getLandmarks())
     {
         if (!imageDescriberTypes.empty() &&
-            std::find(imageDescriberTypes.begin(), imageDescriberTypes.end(), landmark.second.descType) == imageDescriberTypes.end())
+            std::find(imageDescriberTypes.begin(), imageDescriberTypes.end(), landmark.second.getDescType()) == imageDescriberTypes.end())
         {
             continue;
         }
-        const Vec3& position = landmark.second.X;
+        const Vec3& position = landmark.second.getX();
         vX.col(landmarksCount++) = position;
         meanPoints += position;
     }
@@ -1113,11 +1113,11 @@ bool computeNewCoordinateSystemFromSpecificMarkers(const sfmData::SfMData& sfmDa
     {
         if (landmarkIt.first > maxLandmarkIdx)
             maxLandmarkIdx = landmarkIt.first;
-        if (landmarkIt.second.descType != imageDescriberType)
+        if (landmarkIt.second.getDescType() != imageDescriberType)
             continue;
         for (int i = 0; i < markers.size(); ++i)
         {
-            if (landmarkIt.second.rgb.r() == markers[i].id)
+            if (landmarkIt.second.getRgb().r() == markers[i].id)
             {
                 landmarksIds[i] = landmarkIt.first;
             }
@@ -1138,7 +1138,7 @@ bool computeNewCoordinateSystemFromSpecificMarkers(const sfmData::SfMData& sfmDa
     Mat ptsDst = Mat3X(3, markers.size());
     for (std::size_t i = 0; i < markers.size(); ++i)
     {
-        ptsSrc.col(i) = sfmData.getLandmarks().at(landmarksIds[i]).X;
+        ptsSrc.col(i) = sfmData.getLandmarks().at(landmarksIds[i]).getX();
         ptsDst.col(i) = markers[i].coord;
     }
 
@@ -1293,7 +1293,7 @@ void computeNewCoordinateSystemGroundAuto(const sfmData::SfMData& sfmData, Vec3&
 
         // Filter out landmarks that lie above all the cameras that observe them
         // This filtering step assumes that cameras should not be underneath the ground level
-        const Vec3 X = plandmark.second.X;
+        const Vec3 X = plandmark.second.getX();
         bool foundUnder = false;
         for (const auto& pObs : plandmark.second.getObservations())
         {

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -164,7 +164,7 @@ inline void applyTransform(sfmData::SfMData& sfmData, const double S, const Mat3
 
     for (auto& landmark : sfmData.getLandmarks())
     {
-        landmark.second.X = S * R * landmark.second.X + t;
+        landmark.second.setX(S * R * landmark.second.getX() + t);
     }
 }
 

--- a/src/aliceVision/sfm/utils/alignment_test.cpp
+++ b/src/aliceVision/sfm/utils/alignment_test.cpp
@@ -180,7 +180,7 @@ SfMData getInputScene(const NViewDataSet& d, const NViewDatasetConfigurator& con
     {
         // Collect the image of point i in each frame.
         Landmark landmark;
-        landmark.X = d._X.col(i);
+        landmark.setX(d._X.col(i));
         for (int j = 0; j < nviews; ++j)
         {
             Vec2 pt = d._x[j].col(i);

--- a/src/aliceVision/sfm/utils/preprocess.cpp
+++ b/src/aliceVision/sfm/utils/preprocess.cpp
@@ -35,7 +35,7 @@ void remapLandmarkIdsToTrackIds(sfmData::SfMData& sfmData, const track::TracksMa
         const IndexT landmarkId = landmarkPair.first;
         const IndexT firstViewId = landmarkPair.second.getObservations().begin()->first;
         const IndexT firstFeatureId = landmarkPair.second.getObservations().begin()->second.getFeatureId();
-        const feature::EImageDescriberType descType = landmarkPair.second.descType;
+        const feature::EImageDescriberType descType = landmarkPair.second.getDescType();
 
         obsToLandmark.emplace(ObsKey(firstViewId, firstFeatureId, descType), landmarkId);
     }

--- a/src/aliceVision/sfm/utils/statistics.cpp
+++ b/src/aliceVision/sfm/utils/statistics.cpp
@@ -26,7 +26,7 @@ double RMSE(const sfmData::SfMData& sfmData)
             const sfmData::View* view = sfmData.getViews().find(itObs->first)->second.get();
             const geometry::Pose3 pose = sfmData.getPose(*view).getTransform();
             const std::shared_ptr<camera::IntrinsicBase> intrinsic = sfmData.getIntrinsics().at(view->getIntrinsicId());
-            const Vec2 residual = intrinsic->residual(pose, iterTracks->second.X.homogeneous(), itObs->second.getCoordinates());
+            const Vec2 residual = intrinsic->residual(pose, iterTracks->second.getX().homogeneous(), itObs->second.getCoordinates());
             vec.push_back(residual(0));
             vec.push_back(residual(1));
         }

--- a/src/aliceVision/sfm/utils/syntheticScene.cpp
+++ b/src/aliceVision/sfm/utils/syntheticScene.cpp
@@ -84,7 +84,7 @@ sfmData::SfMData getInputScene(const NViewDataSet& d, const NViewDatasetConfigur
     {
         // Collect the image of point i in each frame.
         sfmData::Landmark landmark;
-        landmark.X = d._X.col(i);
+        landmark.setX(d._X.col(i));
         for (int j = 0; j < nviews; ++j)
         {
             const Vec2 pt = d._x[j].col(i);
@@ -153,21 +153,21 @@ sfmData::SfMData getInputRigScene(const NViewDataSet& d, const NViewDatasetConfi
     {
         // Collect the image of point i in each frame.
         sfmData::Landmark landmark;
-        landmark.X = d._X.col(landmarkId);
+        landmark.setX(d._X.col(landmarkId));
         for (int viewId = 0; viewId < nbViews; ++viewId)
         {
             const sfmData::View& view = *sfmData.getViews().at(viewId);
             const geometry::Pose3 camPose = sfmData.getPose(view).getTransform();
 
-            std::shared_ptr<camera::IntrinsicBase> cam = sfmData.getIntrinsics().at(0);
-            std::shared_ptr<camera::Pinhole> camPinHole = std::dynamic_pointer_cast<camera::Pinhole>(cam);
+            const std::shared_ptr<camera::IntrinsicBase> intrinsicBase = sfmData.getIntrinsicSharedPtr(view.getIntrinsicId());
+            std::shared_ptr<camera::Pinhole> camPinHole = std::dynamic_pointer_cast<camera::Pinhole>(intrinsicBase);
             if (!camPinHole)
             {
                 ALICEVISION_LOG_ERROR("Camera is not pinhole in getInputRigScene");
                 continue;
             }
 
-            const Vec2 pt = project(camPinHole->getProjectiveEquivalent(camPose), landmark.X);
+            const Vec2 pt = project(camPinHole->getProjectiveEquivalent(camPose), landmark.getX());
             landmark.getObservations()[viewId] = sfmData::Observation(pt, landmarkId, unknownScale);
         }
         sfmData.getLandmarks()[landmarkId] = landmark;

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -24,6 +24,7 @@ set(sfmData_files_sources
     colorize.cpp
     exif.cpp
     ImageInfo.cpp
+    Landmark.cpp
     Observation.cpp
 )
 

--- a/src/aliceVision/sfmData/Landmark.cpp
+++ b/src/aliceVision/sfmData/Landmark.cpp
@@ -1,0 +1,24 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2025 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Landmark.hpp"
+#include "View.hpp"
+
+namespace aliceVision {
+namespace sfmData {
+
+IndexT Landmark::getReferenceViewIndex() const
+{
+    if (!_referenceView)
+    {
+        return UndefinedIndexT;
+    }
+
+    return _referenceView->getViewId();
+}
+
+}  // namespace sfmData
+}  // namespace aliceVision

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -14,8 +14,12 @@
 #include <aliceVision/types.hpp>
 #include <aliceVision/sfmData/Observation.hpp>
 
+#include <memory>
+
 namespace aliceVision {
 namespace sfmData {
+
+class View;
 
 /**
  * @brief Landmark is a 3D point with its 2d observations.
@@ -59,18 +63,18 @@ class Landmark
      * 
      * @return The index of the reference view, or UndefinedIndexT if not set
      */
-    IndexT getReferenceViewIndex() const { return _referenceViewIndex; }
+    IndexT getReferenceViewIndex() const;
 
     /**
-     * @brief Set the reference view index.
+     * @brief Set the reference view.
      * 
      * Sets the view that serves as the reference frame for this landmark's 3D position.
      * This is used in relative pose parameterization during bundle adjustment.
-     * Set to UndefinedIndexT to use absolute world coordinates.
+     * Set to nullptr to use absolute world coordinates.
      * 
-     * @param viewIndex The index of the reference view, or UndefinedIndexT for absolute coordinates
+     * @param view The reference view, or nullptr for absolute coordinates
      */
-    void setReferenceViewIndex(IndexT viewIndex) { _referenceViewIndex = viewIndex; }
+    void setReferenceView(std::shared_ptr<View> view) { _referenceView = view; }
 
     /**
      * @brief Equality operator
@@ -83,7 +87,7 @@ class Landmark
         && AreVecNearEqual(_rgb, other._rgb, 1e-3) 
         && _observations == other._observations 
         && _descType == other._descType
-        && _referenceViewIndex == other._referenceViewIndex;
+        && getReferenceViewIndex() == other.getReferenceViewIndex();
     }
 
     /**
@@ -225,7 +229,7 @@ private:
     bool _parallaxRobust = false;
     bool _isPrecise = false;
     image::RGBColor _rgb = image::WHITE;  //!> the color associated to the point
-    IndexT _referenceViewIndex = UndefinedIndexT;  //!> the index of the reference view for relative pose parameterization
+    std::shared_ptr<View> _referenceView;  //!> Reference view for relative pose parameterization
 };
 
 }  // namespace sfmData

--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -23,57 +23,173 @@ namespace sfmData {
 class Landmark
 {
   public:
+    /**
+     * @brief Default constructor
+     */
     Landmark() {}
 
+    /**
+     * @brief Constructor with image describer type
+     * @param descType The image describer type for this landmark
+     */
     explicit Landmark(feature::EImageDescriberType descType)
-      : descType(descType)
+      : _descType(descType)
     {}
 
+    /**
+     * @brief Constructor with 3D position, image describer type, and color
+     * @param pos3d The 3D position of the landmark
+     * @param descType The image describer type for this landmark
+     * @param color The RGB color associated with the landmark
+     */
     Landmark(const Vec3& pos3d,
              feature::EImageDescriberType descType = feature::EImageDescriberType::UNINITIALIZED,
              const image::RGBColor& color = image::WHITE)
-      : X(pos3d),
-        descType(descType),
-        rgb(color)
+      : _X(pos3d),
+        _descType(descType),
+        _rgb(color)
     {}
 
-    Vec3 X = { 0.0, 0.0, 0.0 };
-    feature::EImageDescriberType descType = feature::EImageDescriberType::UNINITIALIZED;
-    image::RGBColor rgb = image::WHITE;  //!> the color associated to the point
-    EEstimatorParameterState state = EEstimatorParameterState::REFINED;
-    IndexT referenceViewIndex = UndefinedIndexT;
+    /**
+     * @brief Get the reference view index.
+     * 
+     * The reference view index identifies the view that serves as the reference frame
+     * for this landmark's 3D position when using relative pose parameterization.
+     * When set to UndefinedIndexT, the landmark uses absolute world coordinates.
+     * 
+     * @return The index of the reference view, or UndefinedIndexT if not set
+     */
+    IndexT getReferenceViewIndex() const { return _referenceViewIndex; }
 
+    /**
+     * @brief Set the reference view index.
+     * 
+     * Sets the view that serves as the reference frame for this landmark's 3D position.
+     * This is used in relative pose parameterization during bundle adjustment.
+     * Set to UndefinedIndexT to use absolute world coordinates.
+     * 
+     * @param viewIndex The index of the reference view, or UndefinedIndexT for absolute coordinates
+     */
+    void setReferenceViewIndex(IndexT viewIndex) { _referenceViewIndex = viewIndex; }
+
+    /**
+     * @brief Equality operator
+     * @param other The landmark to compare with
+     * @return true if landmarks are equal, false otherwise
+     */
     bool operator==(const Landmark& other) const
     {
-        return AreVecNearEqual(X, other.X, 1e-3) 
-        && AreVecNearEqual(rgb, other.rgb, 1e-3) 
+        return AreVecNearEqual(_X, other._X, 1e-3) 
+        && AreVecNearEqual(_rgb, other._rgb, 1e-3) 
         && _observations == other._observations 
-        && descType == other.descType
-        && referenceViewIndex == other.referenceViewIndex;
+        && _descType == other._descType
+        && _referenceViewIndex == other._referenceViewIndex;
     }
 
+    /**
+     * @brief Inequality operator
+     * @param other The landmark to compare with
+     * @return true if landmarks are not equal, false otherwise
+     */
     inline bool operator!=(const Landmark& other) const { return !(*this == other); }
 
+    /**
+     * @brief Get the 3D position of the landmark (const version)
+     * @return Const reference to the 3D position vector
+     */
+    const Vec3& getX() const { return _X; }
+
+    /**
+     * @brief Get the 3D position of the landmark (non-const version)
+     * @return Reference to the 3D position vector
+     */
+    Vec3& getX() { return _X; }
+
+    /**
+     * @brief Set the 3D position of the landmark
+     * @param X The new 3D position vector
+     */
+    void setX(const Vec3& X) { _X = X; }
+
+    /**
+     * @brief Get the observations (const version)
+     * @return Const reference to the observations
+     */
     const Observations& getObservations() const { return _observations; }
 
+    /**
+     * @brief Get the observations (non-const version)
+     * @return Reference to the observations
+     */
     Observations& getObservations() { return _observations; }
 
+    /**
+     * @brief Get the estimator parameter state of the landmark
+     * @return The current state of the landmark
+     */
+    EEstimatorParameterState getState() const { return _state; }
+
+    /**
+     * @brief Set the estimator parameter state of the landmark
+     * @param state The new state for the landmark
+     */
+    void setState(EEstimatorParameterState state) { _state = state; }
+
+    /**
+     * @brief Get the image describer type of the landmark
+     * @return The image describer type
+     */
+    feature::EImageDescriberType getDescType() const { return _descType; }
+
+    /**
+     * @brief Set the image describer type of the landmark
+     * @param descType The new image describer type
+     */
+    void setDescType(feature::EImageDescriberType descType) { _descType = descType; }
+
+    /**
+     * @brief Get the RGB color of the landmark
+     * @return Const reference to the RGB color associated with the landmark
+     */
+    const image::RGBColor& getRgb() const { return _rgb; }
+
+    /**
+     * @brief Get the RGB color of the landmark (non-const version)
+     * @return Reference to the RGB color associated with the landmark
+     */
+    image::RGBColor& getRgb() { return _rgb; }
+
+    /**
+     * @brief Set the RGB color of the landmark
+     * @param rgb The new RGB color for the landmark
+     */
+    void setRgb(const image::RGBColor& rgb) { _rgb = rgb; }
+
+    /**
+     * @brief Get observations as a map
+     * @return Map of observations
+     */
     MapObservations getMapObservations() const 
     { 
         return MapObservations(_observations.begin(), _observations.end());;
     }
     
+    /**
+     * @brief Update the 3D position from estimator data
+     * @param data Array containing the new 3D coordinates [x, y, z]
+     * @note The landmark will only be updated if its state is REFINED
+     */
     inline void updateFromEstimator(const std::array<double, 3> & data)
     {
         // do not update a landmark set as Ignored or Constant in the Local strategy
-        if (state != EEstimatorParameterState::REFINED)
+        if (_state != EEstimatorParameterState::REFINED)
         {
             return;
         }
 
         for (std::size_t i = 0; i < 3; ++i)
         {
-            X(Eigen::Index(i)) = data.at(i);
+            _X(Eigen::Index(i)) = data.at(i);
         }
     }
 
@@ -102,9 +218,14 @@ class Landmark
     void setIsPrecise(bool isPrecise) { _isPrecise = isPrecise; }
 
 private:
+    Vec3 _X = { 0.0, 0.0, 0.0 };  //!> the 3D position of the landmark
     Observations _observations;
+    EEstimatorParameterState _state = EEstimatorParameterState::REFINED;
+    feature::EImageDescriberType _descType = feature::EImageDescriberType::UNINITIALIZED;
     bool _parallaxRobust = false;
     bool _isPrecise = false;
+    image::RGBColor _rgb = image::WHITE;  //!> the color associated to the point
+    IndexT _referenceViewIndex = UndefinedIndexT;  //!> the index of the reference view for relative pose parameterization
 };
 
 }  // namespace sfmData

--- a/src/aliceVision/sfmData/Landmark.i
+++ b/src/aliceVision/sfmData/Landmark.i
@@ -12,34 +12,45 @@
 // We don't want to have a direct access to rgb
 // It's easier to wrap it around a Vec3
 // As it's already binded to numpy
-%ignore aliceVision::sfmData::Landmark::rgb;
+%ignore aliceVision::sfmData::Landmark::_rgb;
+
+// Private members should not be directly accessible
+%ignore aliceVision::sfmData::Landmark::_state;
+%ignore aliceVision::sfmData::Landmark::_descType;
+%ignore aliceVision::sfmData::Landmark::_observations;
+%ignore aliceVision::sfmData::Landmark::_parallaxRobust;
+%ignore aliceVision::sfmData::Landmark::_isPrecise;
 
 //Add new swig only C++ code
 %extend aliceVision::sfmData::Landmark {
 
     // From RgbColor to Vec3
-    Vec3 getRgb() const {
+    Vec3 getRgbVec3() const {
         Vec3 ret;
 
-        ret.x() = $self->rgb.r();
-        ret.y() = $self->rgb.g();
-        ret.z() = $self->rgb.b();
+        ret.x() = $self->getRgb().r();
+        ret.y() = $self->getRgb().g();
+        ret.z() = $self->getRgb().b();
 
         return ret;
     }
     
     // From Vec3 to RgbColor
-    void setRgb(Vec3 value) {
-        $self->rgb.r() = value.x();
-        $self->rgb.g() = value.y();
-        $self->rgb.b() = value.z();
+    void setRgbVec3(Vec3 value) {
+        image::RGBColor color;
+        color.r() = value.x();
+        color.g() = value.y();
+        color.b() = value.z();
+        $self->setRgb(color);
     }
     
     // If the user asks for the rgb property
     // It is not a direct access to the rgb
     // variable but a getter/setter
     %pythoncode %{
-        rgb = property(getRgb, setRgb)
+        rgb = property(getRgbVec3, setRgbVec3)
+        state = property(getState, setState)
+        descType = property(getDescType, setDescType)
     %}
 }
 

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -57,7 +57,7 @@ SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eig
 
     for (const auto & pl : other._landmarks)
     {
-        const auto & pt = pl.second.X;
+        const auto & pt = pl.second.getX();
 
         if (pt.x() < bbMin.x()) continue;
         if (pt.y() < bbMin.y()) continue;
@@ -358,7 +358,7 @@ void SfMData::resetParameterStates()
 
     for (auto& pl : _landmarks)
     {
-        pl.second.state = EEstimatorParameterState::REFINED;
+        pl.second.setState(EEstimatorParameterState::REFINED);
     }
 
     for (auto& pi : _intrinsics)
@@ -374,7 +374,7 @@ void SfMData::getBoundingBox(Eigen::Vector3d & bbMin, Eigen::Vector3d & bbMax)
 
     for (const auto & pl : _landmarks)
     {
-        const auto & pt = pl.second.X;
+        const auto & pt = pl.second.getX();
 
         bbMin.x() = std::min(bbMin.x(), pt.x());
         bbMin.y() = std::min(bbMin.y(), pt.y());

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -491,7 +491,7 @@ class SfMData
         std::set<feature::EImageDescriberType> output;
         for (auto s : getLandmarks())
         {
-            output.insert(s.second.descType);
+            output.insert(s.second.getDescType());
         }
         return output;
     }
@@ -501,13 +501,13 @@ class SfMData
         std::map<feature::EImageDescriberType, int> output;
         for (auto s : getLandmarks())
         {
-            if (output.find(s.second.descType) == output.end())
+            if (output.find(s.second.getDescType()) == output.end())
             {
-                output[s.second.descType] = 1;
+                output[s.second.getDescType()] = 1;
             }
             else
             {
-                ++output[s.second.descType];
+                ++output[s.second.getDescType()];
             }
         }
         return output;

--- a/src/aliceVision/sfmData/colorize.cpp
+++ b/src/aliceVision/sfmData/colorize.cpp
@@ -114,7 +114,7 @@ void colorizeTracks(SfMData& sfmData)
                 // clamp the pixel position if the feature/marker center is outside the image.
                 pt.x() = clamp(pt.x(), 0.0, static_cast<double>(image.width() - 1));
                 pt.y() = clamp(pt.y(), 0.0, static_cast<double>(image.height() - 1));
-                landmark.rgb = image(pt.y(), pt.x());
+                landmark.setRgb(image(pt.y(), pt.x()));
             }
 
             progressDisplay += viewCardinal.landmarks.size();

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -520,14 +520,14 @@ void AlembicExporter::addLandmarks(const sfmData::Landmarks& landmarks,
     // For all the 3d points in the hash_map
     for (const auto& landmark : landmarks)
     {
-        const Vec3& pt = landmark.second.X;
-        const image::RGBColor& color = landmark.second.rgb;
+        const Vec3& pt = landmark.second.getX();
+        const image::RGBColor& color = landmark.second.getRgb();
         // convert position from computer vision convention to computer graphics (opengl-like)
         positions.emplace_back(pt[0], -pt[1], -pt[2]);
         colors.emplace_back(color.r() / 255.f, color.g() / 255.f, color.b() / 255.f);
-        descTypes.emplace_back(static_cast<Alembic::Util::uint8_t>(landmark.second.descType));
+        descTypes.emplace_back(static_cast<Alembic::Util::uint8_t>(landmark.second.getDescType()));
         isParallaxRobust.emplace_back(static_cast<Alembic::Util::bool_t>(landmark.second.isParallaxRobust()));
-        referenceViewIndices.emplace_back(landmark.second.referenceViewIndex);
+        referenceViewIndices.emplace_back(landmark.second.getReferenceViewIndex());
     }
 
     std::vector<Alembic::Util::uint64_t> ids(positions.size());

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -234,15 +234,15 @@ bool readPointCloud(const Version& abcVersion, IObject iObj, M44d mat, sfmData::
         if (sampleColors)
         {
             const P3fArraySamplePtr::element_type::value_type& color_i = sampleColors->get()[point3d_i];
-            landmark.rgb = image::RGBColor(static_cast<unsigned char>(color_i[0] * 255.0f),
-                                           static_cast<unsigned char>(color_i[1] * 255.0f),
-                                           static_cast<unsigned char>(color_i[2] * 255.0f));
+            landmark.setRgb(image::RGBColor(static_cast<unsigned char>(color_i[0] * 255.0f),
+                                            static_cast<unsigned char>(color_i[1] * 255.0f),
+                                            static_cast<unsigned char>(color_i[2] * 255.0f)));
         }
 
         if (sampleDescs)
         {
             const std::size_t descType_i = sampleDescs[point3d_i];
-            landmark.descType = static_cast<feature::EImageDescriberType>(descType_i);
+            landmark.setDescType(static_cast<feature::EImageDescriberType>(descType_i));
         }
 
         if (sampleIsParallaxRobust)
@@ -253,7 +253,7 @@ bool readPointCloud(const Version& abcVersion, IObject iObj, M44d mat, sfmData::
 
         if (sampleReferenceViewIndices)
         {
-            landmark.referenceViewIndex = sampleReferenceViewIndices[point3d_i];
+            landmark.setReferenceViewIndex(sampleReferenceViewIndices[point3d_i]);
         }
     }
 

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -253,7 +253,12 @@ bool readPointCloud(const Version& abcVersion, IObject iObj, M44d mat, sfmData::
 
         if (sampleReferenceViewIndices)
         {
-            landmark.setReferenceViewIndex(sampleReferenceViewIndices[point3d_i]);
+            IndexT referenceViewIndex = sampleReferenceViewIndices[point3d_i];
+            if (referenceViewIndex != UndefinedIndexT)
+            {
+                sfmData::View::sptr view = sfmdata.getViews().at(referenceViewIndex);
+                landmark.setReferenceView(view);
+            }
         }
     }
 

--- a/src/aliceVision/sfmDataIO/alembicIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/alembicIO_test.cpp
@@ -138,9 +138,9 @@ SfMData createTestScene(IndexT singleViewsCount, IndexT pointCount, IndexT rigCo
         observations[0] = Observation(Vec2(std::rand() % 10000, std::rand() % 10000), 0, unknownScale);
         observations[1] = Observation(Vec2(std::rand() % 10000, std::rand() % 10000), 1, unknownScale);
         sfm_data.getLandmarks()[i].getObservations() = observations;
-        sfm_data.getLandmarks()[i].X = Vec3(std::rand() % 10000, std::rand() % 10000, std::rand() % 10000);
-        sfm_data.getLandmarks()[i].rgb = image::RGBColor((std::rand() % 1000) / 1000.0, (std::rand() % 1000) / 1000.0, (std::rand() % 1000) / 1000.0);
-        sfm_data.getLandmarks()[i].descType = feature::EImageDescriberType::SIFT;
+        sfm_data.getLandmarks()[i].setX(Vec3(std::rand() % 10000, std::rand() % 10000, std::rand() % 10000));
+        sfm_data.getLandmarks()[i].setRgb(image::RGBColor((std::rand() % 1000) / 1000.0, (std::rand() % 1000) / 1000.0, (std::rand() % 1000) / 1000.0));
+        sfm_data.getLandmarks()[i].setDescType(feature::EImageDescriberType::SIFT);
 
         // Add control points
     }

--- a/src/aliceVision/sfmDataIO/bafIO.cpp
+++ b/src/aliceVision/sfmDataIO/bafIO.cpp
@@ -64,7 +64,7 @@ bool saveBAF(const sfmData::SfMData& sfmData, const std::string& filename, ESfMD
         {
             // Export visibility information
             // X Y Z #observations id_cam id_pose x y ...
-            const double* X = iterLandmarks->second.X.data();
+            const double* X = iterLandmarks->second.getX().data();
             std::copy(X, X + 3, std::ostream_iterator<double>(stream, " "));
             const sfmData::Observations& observations = iterLandmarks->second.getObservations();
             stream << observations.size() << " ";

--- a/src/aliceVision/sfmDataIO/colmap.cpp
+++ b/src/aliceVision/sfmDataIO/colmap.cpp
@@ -398,8 +398,8 @@ void generateColmapPoints3DTxtFile(const sfmData::SfMData& sfmData, const Compat
     for (const auto& iter : sfmData.getLandmarks())
     {
         const IndexT id = iter.first;
-        const Vec3 exportPoint = iter.second.X;
-        const auto pointColor = iter.second.rgb;
+        const Vec3 exportPoint = iter.second.getX();
+        const auto pointColor = iter.second.getRgb();
         outfile << id << " " << exportPoint.x() << " " << exportPoint.y() << " " << exportPoint.z() << " " << static_cast<int>(pointColor.r()) << " "
                 << static_cast<int>(pointColor.g()) << " " << static_cast<int>(pointColor.b()) << " ";
 

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -503,12 +503,12 @@ void saveLandmark(const std::string& name,
     bpt::ptree landmarkTree;
 
     landmarkTree.put("landmarkId", landmarkId);
-    landmarkTree.put("referenceViewIndex", landmark.referenceViewIndex);
-    landmarkTree.put("descType", feature::EImageDescriberType_enumToString(landmark.descType));
+    landmarkTree.put("referenceViewIndex", landmark.getReferenceViewIndex());
+    landmarkTree.put("descType", feature::EImageDescriberType_enumToString(landmark.getDescType()));
     landmarkTree.put("isParallaxRobust", landmark.isParallaxRobust());
     
-    saveMatrix("color", landmark.rgb, landmarkTree);
-    saveMatrix("X", landmark.X, landmarkTree);
+    saveMatrix("color", landmark.getRgb(), landmarkTree);
+    saveMatrix("X", landmark.getX(), landmarkTree);
 
     // observations
     if (saveObservations)
@@ -543,11 +543,11 @@ void saveLandmark(const std::string& name,
 void loadLandmark(IndexT& landmarkId, sfmData::Landmark& landmark, bpt::ptree& landmarkTree, bool loadObservations, bool loadFeatures)
 {
     landmarkId = landmarkTree.get<IndexT>("landmarkId");
-    landmark.descType = feature::EImageDescriberType_stringToEnum(landmarkTree.get<std::string>("descType"));
+    landmark.setDescType(feature::EImageDescriberType_stringToEnum(landmarkTree.get<std::string>("descType")));
     landmark.setParallaxRobust(landmarkTree.get<bool>("isParallaxRobust", false));
-    landmark.referenceViewIndex = landmarkTree.get<IndexT>("referenceViewIndex", UndefinedIndexT);
-    loadMatrix("color", landmark.rgb, landmarkTree);
-    loadMatrix("X", landmark.X, landmarkTree);
+    landmark.setReferenceViewIndex(landmarkTree.get<IndexT>("referenceViewIndex", UndefinedIndexT));
+    loadMatrix("color", landmark.getRgb(), landmarkTree);
+    loadMatrix("X", landmark.getX(), landmarkTree);
 
     // observations
     if (loadObservations)

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -540,12 +540,19 @@ void saveLandmark(const std::string& name,
     parentTree.push_back(std::make_pair(name, landmarkTree));
 }
 
-void loadLandmark(IndexT& landmarkId, sfmData::Landmark& landmark, bpt::ptree& landmarkTree, bool loadObservations, bool loadFeatures)
+void loadLandmark(sfmData::SfMData& sfmData, IndexT& landmarkId, sfmData::Landmark& landmark, bpt::ptree& landmarkTree, bool loadObservations, bool loadFeatures)
 {
     landmarkId = landmarkTree.get<IndexT>("landmarkId");
     landmark.setDescType(feature::EImageDescriberType_stringToEnum(landmarkTree.get<std::string>("descType")));
     landmark.setParallaxRobust(landmarkTree.get<bool>("isParallaxRobust", false));
-    landmark.setReferenceViewIndex(landmarkTree.get<IndexT>("referenceViewIndex", UndefinedIndexT));
+
+    IndexT referenceViewIndex = landmarkTree.get<IndexT>("referenceViewIndex", UndefinedIndexT);
+    if (referenceViewIndex != UndefinedIndexT)
+    {
+        sfmData::View::sptr view = sfmData.getViews().at(referenceViewIndex);
+        landmark.setReferenceView(view);
+    }
+
     loadMatrix("color", landmark.getRgb(), landmarkTree);
     loadMatrix("X", landmark.getX(), landmarkTree);
 
@@ -944,7 +951,7 @@ bool loadJSON(sfmData::SfMData& sfmData,
             IndexT landmarkId;
             sfmData::Landmark landmark;
 
-            loadLandmark(landmarkId, landmark, landmarkNode.second, loadObservations, loadFeatures);
+            loadLandmark(sfmData, landmarkId, landmark, landmarkNode.second, loadObservations, loadFeatures);
 
             structure.emplace(landmarkId, landmark);
         }

--- a/src/aliceVision/sfmDataIO/jsonIO.hpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.hpp
@@ -211,6 +211,7 @@ void saveLandmark(const std::string& name,
 
 /**
  * @brief Load a Landmark from a boost property tree.
+ * @param[in] sfmData The SfMData to which the landmark belongs
  * @param[out] landmarkId The output Landmark Id
  * @param[out] landmark The output Landmmark
  * @param[in,out] landmarkTree The input tree
@@ -219,7 +220,7 @@ void saveLandmark(const std::string& name,
  * @param[in] loadObservations Load landmark observations (default: true)
  * @param[in] loadFeatures Load landmark observations features (default: true)
  */
-void loadLandmark(IndexT& landmarkId, sfmData::Landmark& landmark, bpt::ptree& landmarkTree, bool loadObservations = true, bool loadFeatures = true);
+void loadLandmark(sfmData::SfMData& sfmData, IndexT& landmarkId, sfmData::Landmark& landmark, bpt::ptree& landmarkTree, bool loadObservations = true, bool loadFeatures = true);
 
 /**
  * @brief Save survey points in a boost property tree.

--- a/src/aliceVision/sfmDataIO/plyIO.cpp
+++ b/src/aliceVision/sfmDataIO/plyIO.cpp
@@ -89,13 +89,13 @@ bool savePLY(const sfmData::SfMData& sfmData, const std::string& filename, ESfMD
                 const auto& landmark = iterLandmarks->second;
                 if (b_binary)
                 {
-                    Vec3f point = landmark.X.cast<float>();
+                    Vec3f point = landmark.getX().cast<float>();
                     stream.write(reinterpret_cast<const char*>(&point), sizeof(float) * 3);
-                    stream.write(reinterpret_cast<const char*>(&landmark.rgb), sizeof(uint8_t) * 3);
+                    stream.write(reinterpret_cast<const char*>(&landmark.getRgb()), sizeof(uint8_t) * 3);
                 }
                 else
                 {
-                    stream << landmark.X.transpose() << " " << (int)landmark.rgb.r() << " " << (int)landmark.rgb.g() << " " << (int)landmark.rgb.b()
+                    stream << landmark.getX().transpose() << " " << (int)landmark.getRgb().r() << " " << (int)landmark.getRgb().g() << " " << (int)landmark.getRgb().b()
                            << "\n";
                 }
             }
@@ -140,16 +140,16 @@ bool loadPLY(sfmData::SfMData& sfmData, const std::string& filename)
 
                 sfmData::Landmark l;
 
-                l.X.x() = v.x;
-                l.X.y() = -v.y;
-                l.X.z() = -v.z;
+                l.getX().x() = v.x;
+                l.getX().y() = -v.y;
+                l.getX().z() = -v.z;
 
                 if (mesh->HasVertexColors(0))
                 {
                     const aiColor4D c = mesh->mColors[0][idPoint];
-                    l.rgb.r() = c.r * 255.0;
-                    l.rgb.g() = c.g * 255.0;
-                    l.rgb.b() = c.b * 255.0;
+                    l.getRgb().r() = c.r * 255.0;
+                    l.getRgb().g() = c.g * 255.0;
+                    l.getRgb().b() = c.b * 255.0;
                 }
 
                 landmarks[landmarks.size()] = l;

--- a/src/aliceVision/sfmDataIO/sfmDataIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/sfmDataIO_test.cpp
@@ -71,8 +71,8 @@ sfmData::SfMData createTestScene(std::size_t viewsCount = 2, std::size_t observa
     }
 
     sfmData.getLandmarks()[0].getObservations() = observations;
-    sfmData.getLandmarks()[0].X = Vec3(11, 22, 33);
-    sfmData.getLandmarks()[0].descType = feature::EImageDescriberType::SIFT;
+    sfmData.getLandmarks()[0].setX(Vec3(11, 22, 33));
+    sfmData.getLandmarks()[0].setDescType(feature::EImageDescriberType::SIFT);
 
     return sfmData;
 }

--- a/src/aliceVision/sfmMvsUtils/visibility.cpp
+++ b/src/aliceVision/sfmMvsUtils/visibility.cpp
@@ -33,7 +33,7 @@ void createRefMeshFromDenseSfMData(mesh::Mesh& refMesh, const sfmData::SfMData& 
             pointVisibility.push_back(mp.getIndexFromViewId(observationPair.first));
 
         refVisibilities.push_back(pointVisibility);
-        refMesh.pts.push_back(Point3d(landmark.X(0), landmark.X(1), landmark.X(2)));
+        refMesh.pts.push_back(Point3d(landmark.getX()(0), landmark.getX()(1), landmark.getX()(2)));
     }
 }
 

--- a/src/software/convert/main_convertSfMFormat.cpp
+++ b/src/software/convert/main_convertSfMFormat.cpp
@@ -183,7 +183,7 @@ int aliceVision_main(int argc, char** argv)
         std::vector<IndexT> toRemove;
         for (const auto& landmarkPair : sfmData.getLandmarks())
         {
-            if (std::find(imageDescriberTypes.begin(), imageDescriberTypes.end(), landmarkPair.second.descType) == imageDescriberTypes.end())
+            if (std::find(imageDescriberTypes.begin(), imageDescriberTypes.end(), landmarkPair.second.getDescType()) == imageDescriberTypes.end())
                 toRemove.push_back(landmarkPair.first);
         }
         for (const IndexT landmarkId : toRemove)

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -342,7 +342,7 @@ int aliceVision_main(int argc, char** argv)
     fuseCut::SimpleNode octree(bbmin, bbmax);
     for (const auto& pt : sfmData.getLandmarks())
     {
-        octree.store(pt.second.X);
+        octree.store(pt.second.getX());
     }
 
     // Now regroup cells as much as we can

--- a/src/software/export/main_exportMVE2.cpp
+++ b/src/software/export/main_exportMVE2.cpp
@@ -209,7 +209,7 @@ bool exportToMVE2Format(const SfMData& sfm_data,
 
         for (Landmarks::const_iterator iterLandmarks = landmarks.begin(); iterLandmarks != landmarks.end(); ++iterLandmarks)
         {
-            const Vec3 exportPoint = iterLandmarks->second.X;
+            const Vec3 exportPoint = iterLandmarks->second.getX();
             out << exportPoint.x() << " " << exportPoint.y() << " " << exportPoint.z() << "\n";
             out << 250 << " " << 100 << " " << 150 << "\n";  // Write arbitrary RGB color, see above note
 

--- a/src/software/export/main_exportMatlab.cpp
+++ b/src/software/export/main_exportMatlab.cpp
@@ -52,7 +52,7 @@ bool exportToMatlab(const SfMData& sfm_data, const std::string& outDirectory)
         {
             const IndexT landmarkId = s.first;
             const Landmark& landmark = s.second;
-            landmarksFile << landmarkId << " " << landmark.X[0] << " " << landmark.X[1] << " " << landmark.X[2] << "\n";
+            landmarksFile << landmarkId << " " << landmark.getX()[0] << " " << landmark.getX()[1] << " " << landmark.getX()[2] << "\n";
             for (const auto& obs : landmark.getObservations())
             {
                 const IndexT obsView = obs.first;  // The ID of the view that provides this 2D observation.

--- a/src/software/export/main_exportPMVS.cpp
+++ b/src/software/export/main_exportPMVS.cpp
@@ -280,7 +280,7 @@ bool exportToBundlerFormat(const SfMData& sfm_data,
         {
             const Landmark& landmark = iter->second;
             const Observations& observations = landmark.getObservations();
-            const Vec3& X = landmark.X;
+            const Vec3& X = landmark.getX();
             // X, color, obsCount
             os << X[0] << " " << X[1] << " " << X[2] << os.widen('\n') << "255 255 255" << os.widen('\n') << observations.size() << " ";
             for (Observations::const_iterator iterObs = observations.begin(); iterObs != observations.end(); ++iterObs)

--- a/src/software/pipeline/main_globalPositionEstimating.cpp
+++ b/src/software/pipeline/main_globalPositionEstimating.cpp
@@ -111,7 +111,7 @@ int aliceVision_main(int argc, char** argv)
             const track::TrackItem & trackItem = track.featPerView.at(idView);
             
             sfmData::Landmark & landmark = landmarks[idTrack];
-            landmark.descType = track.descType;
+            landmark.setDescType(track.descType);
             
             sfmData::Observation & obs = landmark.getObservations()[idView];
             obs.setCoordinates(trackItem.coords);

--- a/src/software/pipeline/main_meshing.cpp
+++ b/src/software/pipeline/main_meshing.cpp
@@ -462,7 +462,7 @@ int aliceVision_main(int argc, char* argv[])
         colors.resize(mesh->pts.size(), {0, 0, 0});
         for (std::size_t i = 0; i < mesh->pts.size(); ++i)
         {
-            const auto& c = landmarks.at(i).rgb;
+            const auto& c = landmarks.at(i).getRgb();
             colors[i] = {c.r(), c.g(), c.b()};
         }
     }

--- a/src/software/pipeline/main_nodalSfM.cpp
+++ b/src/software/pipeline/main_nodalSfM.cpp
@@ -127,7 +127,7 @@ void buildInitialWorld(sfmData::SfMData& sfmData,
         }
 
         sfmData::Landmark l(track.descType);
-        l.X = refP;
+        l.setX(refP);
         l.getObservations()[pair.reference] = sfmData::Observation(refV, refTrackItem.featureId, refTrackItem.scale);
         l.getObservations()[pair.next] = sfmData::Observation(nextV, nextTrackItem.featureId, nextTrackItem.scale);
 
@@ -208,7 +208,7 @@ bool localizeNext(sfmData::SfMData& sfmData,
         Vec2 nvV = trackItem.coords;
         Vec3 camP = newViewIntrinsics->toUnitSphere(newViewIntrinsics->ima2cam(newViewIntrinsics->getUndistortedPixel(nvV)));
 
-        refX.col(pos) = landmarks.at(trackId).X;
+        refX.col(pos) = landmarks.at(trackId).getX();
         newX.col(pos) = camP;
 
         pos++;
@@ -308,7 +308,7 @@ bool addPoints(sfmData::SfMData& sfmData,
             }
 
             sfmData::Landmark l(track.descType);
-            l.X = world_R_new * newP;
+            l.setX(world_R_new * newP);
             l.getObservations()[newViewId] = sfmData::Observation(newV, newTrackItem.featureId, newTrackItem.scale);
             l.getObservations()[pV.first] = sfmData::Observation(refV, refTrackItem.featureId, refTrackItem.scale);
 

--- a/src/software/pipeline/main_sfmBootstrapping.cpp
+++ b/src/software/pipeline/main_sfmBootstrapping.cpp
@@ -145,8 +145,8 @@ bool landmarksFromMesh(
 
             //Create a Landmark with a unique observation
             sfmData::Landmark l;
-            l.X = point;
-            l.descType = track.descType;
+            l.setX(point);
+            l.setDescType(track.descType);
             l.setParallaxRobust(true);
 
             sfmData::Observations & observations = l.getObservations();

--- a/src/software/utils/main_computeUncertainty.cpp
+++ b/src/software/utils/main_computeUncertainty.cpp
@@ -105,7 +105,7 @@ int aliceVision_main(int argc, char** argv)
         points3D.reserve(sfmData.getLandmarks().size() * 3);
         for (auto& landmarkIt : sfmData.getLandmarks())
         {
-            double* p = landmarkIt.second.X.data();
+            double* p = landmarkIt.second.getX().data();
             points3D.push_back(p[0]);
             points3D.push_back(p[1]);
             points3D.push_back(p[2]);

--- a/src/software/utils/main_sfmDistances.cpp
+++ b/src/software/utils/main_sfmDistances.cpp
@@ -102,13 +102,13 @@ void extractLandmarksPositions(std::vector<std::pair<std::string, Vec3>>& output
 
     for (const auto& landmarkIt : sfmData.getLandmarks())
     {
-        if (descTypes.count(landmarkIt.second.descType))
+        if (descTypes.count(landmarkIt.second.getDescType()))
         {
-            bool isMarker = isCCTag.count(landmarkIt.second.descType);
-            if (searchIdx.empty() || (isMarker ? searchIdx.count(landmarkIt.second.rgb.r()) : searchIdx.count(landmarkIt.first)))
+            bool isMarker = isCCTag.count(landmarkIt.second.getDescType());
+            if (searchIdx.empty() || (isMarker ? searchIdx.count(landmarkIt.second.getRgb().r()) : searchIdx.count(landmarkIt.first)))
             {
                 outputPositions.push_back(
-                  std::make_pair(std::to_string(isMarker ? landmarkIt.second.rgb.r() : landmarkIt.first), landmarkIt.second.X));
+                  std::make_pair(std::to_string(isMarker ? landmarkIt.second.getRgb().r() : landmarkIt.first), landmarkIt.second.getX()));
             }
         }
     }

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -290,8 +290,8 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
     int count = 0;
     for (auto & pair : landmarkPairs)
     {
-        xA.col(count) = sfmData1.getLandmarks().at(pair.first).X;
-        xB.col(count) = sfmData2.getLandmarks().at(pair.second).X;
+        xA.col(count) = sfmData1.getLandmarks().at(pair.first).getX();
+        xB.col(count) = sfmData2.getLandmarks().at(pair.second).getX();
         count++;
     }
 

--- a/src/software/utils/main_sfmTransform.cpp
+++ b/src/software/utils/main_sfmTransform.cpp
@@ -348,7 +348,7 @@ bool computeNewScaleFromDepths(const std::string & tracksFilename, sfmData::SfMD
             const sfmData::View & v = sfmData.getView(viewId);
             const sfmData::CameraPose cp = sfmData.getPose(v);
 
-            Vec3 pt = cp.getTransform()(landmark.X);
+            Vec3 pt = cp.getTransform()(landmark.getX());
             if (pt.z() < 1e-12)
             {
                 continue;
@@ -484,7 +484,7 @@ bool parseLineUp(const std::string & lineUpFilename, const std::string & tracksF
             continue;
         }
 
-        landmarkCoordinates.push_back(landmarks.at(trackId).X);
+        landmarkCoordinates.push_back(landmarks.at(trackId).getX());
         meshCoordinates.push_back(pt3d);
     }
 

--- a/src/software/utils/main_tracksSimulating.cpp
+++ b/src/software/utils/main_tracksSimulating.cpp
@@ -83,10 +83,10 @@ int aliceVision_main(int argc, char** argv)
 
     for (const auto & [landmarkId, landmark] : sfmData.getLandmarks())
     {
-        const Vec3 point = landmark.X;
+        const Vec3 point = landmark.getX();
 
         track::Track track;
-        track.descType = landmark.descType;
+        track.descType = landmark.getDescType();
 
         for (const auto & [viewId, observation] : landmark.getObservations())
         {


### PR DESCRIPTION
This pull request refactors the usage of the `Landmark` class throughout the codebase to consistently use getter and setter methods instead of direct access to member variables. This improves encapsulation and ensures that the internal state of `Landmark` objects is managed through their public API. The changes affect both C++ and Python test code, updating all relevant logic to use methods like `getX()`, `setX()`, `getState()`, `setState()`, `getReferenceViewIndex()`, `setReferenceView()`, `getDescType()`, and `setRgb()`.

The most important changes are:

**Encapsulation of Landmark Data:**

* Replaced direct access to `Landmark` members such as `X`, `state`, `referenceViewIndex`, `descType`, and `rgb` with their respective getter and setter methods (e.g., `getX()`, `setX()`, `getState()`, `setState()`, `getReferenceViewIndex()`, `setReferenceView()`, `getDescType()`, `setRgb()`, `getRgb()`) across the codebase, including in bundle adjustment, depth map, fuse cut, photometric stereo, and SfM pipeline modules. [[1]](diffhunk://#diff-134e8df13bbbe59a4f6c6f5b3e36682237ef5dec5eee2f6860831d759a762941L298-R298) [[2]](diffhunk://#diff-134e8df13bbbe59a4f6c6f5b3e36682237ef5dec5eee2f6860831d759a762941L370-R370) [[3]](diffhunk://#diff-9d9c499696c71aa78d351b3d5fc1a81cff07d3d13b62f798b4f18493627281dcL203-R203) [[4]](diffhunk://#diff-b64804156c078d29ff35c7a61d02c6a4278695b7bfc03a5785be25ef316ad888L363-R363) [[5]](diffhunk://#diff-b64804156c078d29ff35c7a61d02c6a4278695b7bfc03a5785be25ef316ad888L574-R576) [[6]](diffhunk://#diff-298dfaa62e6e33f1965d9e1a7d866717ec2c4341f8ac32e3075065ad93a3e4e4L613-R613) [[7]](diffhunk://#diff-b0ffc885563a368c662875c30631bce5597b7ef33f3aaf4868167d08482031e0L60-R60) [[8]](diffhunk://#diff-17a00a105ad993bba7657a56730d08012071fb044c95b7aa97da14a361b12aa4L544-R544) [[9]](diffhunk://#diff-17a00a105ad993bba7657a56730d08012071fb044c95b7aa97da14a361b12aa4L586-R586) [[10]](diffhunk://#diff-f2d5da6458167167d18fc522e52029cb4b483166ecf191846b7141bf429f63e3L173-R173) [[11]](diffhunk://#diff-b0f5d051f38306b5dfefc99936189ff80d9892a8ed2fbb3174aa1268a29d2bdbL442-R447) [[12]](diffhunk://#diff-6c41f29d2d32f1d6de3437051fcfcad3a72d5bc7777b3dee96bc1c4c185e6bdcL532-R532) [[13]](diffhunk://#diff-6c41f29d2d32f1d6de3437051fcfcad3a72d5bc7777b3dee96bc1c4c185e6bdcL541-R548) [[14]](diffhunk://#diff-6c41f29d2d32f1d6de3437051fcfcad3a72d5bc7777b3dee96bc1c4c185e6bdcL660-R660) [[15]](diffhunk://#diff-e85e4950f8c47b2f76919ba8625c15fcc1e8f7729595b011911e718aea7deb89L111-R111) [[16]](diffhunk://#diff-e85e4950f8c47b2f76919ba8625c15fcc1e8f7729595b011911e718aea7deb89L218-R218) [[17]](diffhunk://#diff-1acfcfb52480ebc6d34c59dcb94f88a68eea007d4819711b038f61fd5ebfcb53L254-R259) [[18]](diffhunk://#diff-1acfcfb52480ebc6d34c59dcb94f88a68eea007d4819711b038f61fd5ebfcb53L276-R278) [[19]](diffhunk://#diff-1acfcfb52480ebc6d34c59dcb94f88a68eea007d4819711b038f61fd5ebfcb53L288-R288) [[20]](diffhunk://#diff-1acfcfb52480ebc6d34c59dcb94f88a68eea007d4819711b038f61fd5ebfcb53L342-R349) [[21]](diffhunk://#diff-478115f70aec40def6e5077160dd64cc589c6a5c4823433d7a130e539dbd86a0L42-R42) [[22]](diffhunk://#diff-589f556a87852aba89afb91ac7fa404aa15ddce5b3e8cde80e1d552698540b81L37-R37) [[23]](diffhunk://#diff-719f4937a4a6cc824f2a33089af48d3f6a79816911e013ca3bbcd21ef76f24ffL56-R61) [[24]](diffhunk://#diff-719f4937a4a6cc824f2a33089af48d3f6a79816911e013ca3bbcd21ef76f24ffL72-R72) [[25]](diffhunk://#diff-719f4937a4a6cc824f2a33089af48d3f6a79816911e013ca3bbcd21ef76f24ffL85-R85)

**Python Bindings and Tests:**

* Updated Python tests to use `getState()` and `setState()` instead of direct access to the `state` attribute, ensuring consistency with the new encapsulation in the C++ API. [[1]](diffhunk://#diff-ad76f49d0ceac9b2ce9446eb262ea75fbb98d7cd12db1e818c5ae61a7acd22c6L24-R24) [[2]](diffhunk://#diff-ad76f49d0ceac9b2ce9446eb262ea75fbb98d7cd12db1e818c5ae61a7acd22c6L49-R49)

**Consistency and Robustness:**

* Ensured all code paths, including test utilities and report generation, now use the public API for `Landmark` objects, reducing the risk of bugs from direct member access and making future changes to the internal representation of `Landmark` safer and easier. [[1]](diffhunk://#diff-1acfcfb52480ebc6d34c59dcb94f88a68eea007d4819711b038f61fd5ebfcb53L342-R349) [[2]](diffhunk://#diff-1acfcfb52480ebc6d34c59dcb94f88a68eea007d4819711b038f61fd5ebfcb53L276-R278) [[3]](diffhunk://#diff-1acfcfb52480ebc6d34c59dcb94f88a68eea007d4819711b038f61fd5ebfcb53L288-R288) [[4]](diffhunk://#diff-589f556a87852aba89afb91ac7fa404aa15ddce5b3e8cde80e1d552698540b81L37-R37)

These changes collectively improve code maintainability, safety, and clarity by enforcing encapsulation for the `Landmark` class.