### PR TITLE
Checking depth coming from depthmaps

### DIFF
--- a/src/software/utils/main_depthmapTracksInjecting.cpp
+++ b/src/software/utils/main_depthmapTracksInjecting.cpp
@@ -127,7 +127,10 @@ int aliceVision_main(int argc, char** argv)
             if (ix < 0 || ix >= depthImg.width()) continue;
             if (iy < 0 || iy >= depthImg.height()) continue;
 
-            feature.depth = depthImg(iy, ix);
+            double Z = depthImg(iy, ix);
+            if (!std::isfinite(Z)) continue;
+	
+            feature.depth = Z;
         }
     }
 


### PR DESCRIPTION
This pull request introduces a small but important improvement to the way depth values are assigned to features in `main_depthmapTracksInjecting.cpp`. Now, the code checks that the depth value is finite before assigning it, which helps prevent invalid or corrupted data from propagating.

- Depth value validation:
  * In `aliceVision_main`, before assigning a depth from `depthImg` to `feature.depth`, the code now checks that the value is finite using `std::isfinite`. This prevents non-finite values (like NaN or Inf) from being assigned.