### PR TITLE
ExportAlembic has an option to export point cloud

### DIFF
--- a/meshroom/aliceVision/ExportAlembic.py
+++ b/meshroom/aliceVision/ExportAlembic.py
@@ -28,6 +28,12 @@ Based on the input image filenames, it will recognize the input video sequence t
             value=24.0,
             range=(1.0, 60.0, 1.0),
         ),
+        desc.BoolParam(
+            name="exportLandmarks",
+            label="Export Landmarks",
+            description="If true, export SfM landmarks.",
+            value=False,
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/meshroom/aliceVision/ExportMaya.py
+++ b/meshroom/aliceVision/ExportMaya.py
@@ -154,7 +154,13 @@ This script, executed inside Maya, will gather the Meshroom computed elements.
         abcString = f'AbcImport -mode open -fitTimeRange "{alembic}";'
 
         mesh = chunk.node.mesh.value
-        objString = f'file -import -type "OBJ"  -ignoreVersion -ra true -mbl true -mergeNamespacesOnClash false -namespace "mesh" -options "mo=1"  -pr  -importTimeRange "combine" "{mesh}";'
+        objString = ''
+        if len(mesh) > 0:
+            if mesh.lower().endswith('.obj'):
+                objString = f'file -import -type "OBJ"  -ignoreVersion -ra true -mbl true -mergeNamespacesOnClash false -namespace "mesh" -options "mo=1"  -pr  -importTimeRange "combine" "{mesh}";'
+            else:
+                chunk.logger.error("Undefined mesh format for maya import")
+            
 
         framePath = chunk.node.images.value.replace('<INTRINSIC_ID>', str(minIntrinsicId)).replace('<FILESTEM>', minFrameName)
 

--- a/src/software/export/main_exportAlembic.cpp
+++ b/src/software/export/main_exportAlembic.cpp
@@ -34,6 +34,7 @@ int aliceVision_main(int argc, char** argv)
 
     // User optional parameters
     double frameRate = 24.0;
+    bool exportLandmarks = false;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -46,7 +47,9 @@ int aliceVision_main(int argc, char** argv)
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
         ("frameRate", po::value<double>(&frameRate)->default_value(frameRate),
-         "Define the camera's Frames per seconds.");
+         "Define the camera's Frames per seconds.")
+        ("exportLandmarks", po::value<bool>(&exportLandmarks)->default_value(exportLandmarks),
+         "Are the landmarks exported ?.");
     // clang-format on
 
     CmdLine cmdline("AliceVision exportAnimatedCamera");
@@ -178,6 +181,12 @@ int aliceVision_main(int argc, char** argv)
 
             exporter.addCameraKeyframe(pose.getTransform(), cam, imagePath, view.getViewId(), view.getIntrinsicId());
         }
+    }
+
+    if (exportLandmarks)
+    {
+        sfmData::LandmarksUncertainty emptyUncertainty;
+        exporter.addLandmarks(sfmData.getLandmarks(), emptyUncertainty, false, false);
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
This pull request introduces support for exporting Structure-from-Motion (SfM) landmarks in the Alembic export pipeline, along with some improvements to mesh format handling in the Maya export process. The most significant changes are the addition of an `exportLandmarks` parameter throughout the Alembic export workflow and improved error handling for mesh imports in Maya.

**Alembic Export Enhancements:**

* Added a new boolean parameter `exportLandmarks` to the Alembic export node in the UI, allowing users to choose whether to export SfM landmarks (`ExportAlembic.py`).
* Updated the Alembic export command-line tool to accept an `--exportLandmarks` option, wiring it through the argument parser and main logic (`main_exportAlembic.cpp`). [[1]](diffhunk://#diff-97e2ff871275679e34707444e3cfcdccdbd64103409a8a667964904ecfc69d5aR37) [[2]](diffhunk://#diff-97e2ff871275679e34707444e3cfcdccdbd64103409a8a667964904ecfc69d5aL49-R52)
* Implemented logic to export landmarks when the `exportLandmarks` flag is set, invoking the appropriate exporter method (`main_exportAlembic.cpp`).

**Maya Export Improvements:**

* Improved mesh format handling in the Maya export process by checking if the mesh file ends with `.obj` (case-insensitive) before importing, and logging an error for undefined formats (`ExportMaya.py`).