### PR TITLE
Replace Segmentation model in pipelines

### DIFF
--- a/meshroom/cameraTrackingDepthExperimental.mg
+++ b/meshroom/cameraTrackingDepthExperimental.mg
@@ -17,10 +17,9 @@
             "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
-            "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
-            "ImageSegmentationBox": "0.3",
+            "ImageSegmentationSam3": "0.1",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
@@ -29,9 +28,9 @@
             "MoGe": "1.0",
             "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
-            "SfMBootStrapping": "4.1",
+            "SfMBootStrapping": "4.2",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.2",
+            "SfMExpanding": "2.3",
             "SfMFilter": "2.0",
             "SfMTransfer": "2.1",
             "SfMTransform": "3.2",
@@ -237,7 +236,7 @@
                 "input": "{IntrinsicsTransforming_1.input}",
                 "target": "{IntrinsicsTransforming_1.output}",
                 "masksFolders": [
-                    "{ImageSegmentationBox_1.output}"
+                    "{ImageSegmentationSam3_1.output}"
                 ],
                 "maskExtension": "exr"
             },
@@ -268,7 +267,7 @@
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
-                "masksFolder": "{ImageSegmentationBox_1.output}",
+                "masksFolder": "{ImageSegmentationSam3_1.output}",
                 "maskExtension": "exr"
             },
             "internalInputs": {
@@ -323,19 +322,6 @@
             "internalInputs": {
                 "label": "FeatureMatchingFramesToKeyframes",
                 "color": "#80766f"
-            }
-        },
-        "ImageDetectionPrompt_1": {
-            "nodeType": "ImageDetectionPrompt",
-            "position": [
-                0,
-                200
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#575963"
             }
         },
         "ImageMatchingMultiSfM_1": {
@@ -394,15 +380,14 @@
                 "color": "#80766f"
             }
         },
-        "ImageSegmentationBox_1": {
-            "nodeType": "ImageSegmentationBox",
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
             "position": [
-                200,
-                200
+                199,
+                201
             ],
             "inputs": {
-                "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "input": "{CameraInit_1.output}",
                 "maskInvert": true,
                 "keepFilename": true
             },
@@ -539,7 +524,7 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
                 "undistortedImages": "{ExportImages_2.output}",
-                "masks": "{ImageSegmentationBox_1.output}"
+                "masks": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#4c594c"

--- a/meshroom/cameraTrackingExperimental.mg
+++ b/meshroom/cameraTrackingExperimental.mg
@@ -16,10 +16,9 @@
             "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
-            "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
-            "ImageSegmentationBox": "0.3",
+            "ImageSegmentationSam3": "0.1",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
@@ -27,9 +26,9 @@
             "Meshing": "7.0",
             "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
-            "SfMBootStrapping": "4.1",
+            "SfMBootStrapping": "4.2",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.2",
+            "SfMExpanding": "2.3",
             "SfMTransfer": "2.1",
             "SfMTransform": "3.2",
             "SfMTriangulation": "1.0",
@@ -204,7 +203,7 @@
                 "input": "{IntrinsicsTransforming_1.input}",
                 "target": "{IntrinsicsTransforming_1.output}",
                 "masksFolders": [
-                    "{ImageSegmentationBox_1.output}"
+                    "{ImageSegmentationSam3_1.output}"
                 ],
                 "maskExtension": "exr"
             },
@@ -235,7 +234,7 @@
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
-                "masksFolder": "{ImageSegmentationBox_1.output}",
+                "masksFolder": "{ImageSegmentationSam3_1.output}",
                 "maskExtension": "exr"
             },
             "internalInputs": {
@@ -290,19 +289,6 @@
             "internalInputs": {
                 "label": "FeatureMatchingFramesToKeyframes",
                 "color": "#80766f"
-            }
-        },
-        "ImageDetectionPrompt_1": {
-            "nodeType": "ImageDetectionPrompt",
-            "position": [
-                0,
-                200
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#575963"
             }
         },
         "ImageMatchingMultiSfM_1": {
@@ -361,15 +347,14 @@
                 "color": "#80766f"
             }
         },
-        "ImageSegmentationBox_1": {
-            "nodeType": "ImageSegmentationBox",
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
             "position": [
-                200,
-                200
+                197.0,
+                201.0
             ],
             "inputs": {
-                "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "input": "{CameraInit_1.output}",
                 "maskInvert": true,
                 "keepFilename": true
             },
@@ -491,7 +476,7 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
                 "undistortedImages": "{ExportImages_2.output}",
-                "masks": "{ImageSegmentationBox_1.output}"
+                "masks": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#4c594c"

--- a/meshroom/cameraTrackingRomaExperimental.mg
+++ b/meshroom/cameraTrackingRomaExperimental.mg
@@ -13,8 +13,7 @@
             "ExportDistortion": "2.0",
             "ExportImages": "1.1",
             "GeometricFilterEstimating": "1.0",
-            "ImageDetectionPrompt": "0.2",
-            "ImageSegmentationBox": "0.3",
+            "ImageSegmentationSam3": "0.1",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MatchMasking": "1.0",
@@ -23,9 +22,9 @@
             "RomaReducer": "1.0",
             "RomaSampler": "1.0",
             "ScenePreview": "2.0",
-            "SfMBootStrapping": "4.1",
+            "SfMBootStrapping": "4.2",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.2",
+            "SfMExpanding": "2.3",
             "SfMTransform": "3.2",
             "StarListing": "1.0",
             "TracksBuilding": "1.0"
@@ -192,28 +191,14 @@
                 "color": "#575963"
             }
         },
-        "ImageDetectionPrompt_1": {
-            "nodeType": "ImageDetectionPrompt",
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
             "position": [
-                0,
-                200
+                205.0,
+                210.0
             ],
             "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#575963"
-            }
-        },
-        "ImageSegmentationBox_1": {
-            "nodeType": "ImageSegmentationBox",
-            "position": [
-                200,
-                200
-            ],
-            "inputs": {
-                "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "input": "{CameraInit_1.output}",
                 "maskInvert": true,
                 "keepFilename": true
             },
@@ -260,7 +245,7 @@
                 "imagePairsList": "{RomaMatcher_1.imagePairsList}",
                 "warpFolder": "{RomaMatcher_1.outputWarpFolder}",
                 "certaintyFolder": "{RomaMatcher_1.outputCertaintyFolder}",
-                "masksFolder": "{ImageSegmentationBox_1.output}"
+                "masksFolder": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#575963"
@@ -377,7 +362,7 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{ConvertSfMFormat_1.input}",
                 "undistortedImages": "{ExportImages_1.output}",
-                "masks": "{ImageSegmentationBox_1.output}"
+                "masks": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#4c594c"

--- a/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationExperimental.mg
@@ -15,10 +15,9 @@
             "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
-            "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
-            "ImageSegmentationBox": "0.3",
+            "ImageSegmentationSam3": "0.1",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
@@ -26,9 +25,9 @@
             "Meshing": "7.0",
             "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
-            "SfMBootStrapping": "4.1",
+            "SfMBootStrapping": "4.2",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.2",
+            "SfMExpanding": "2.3",
             "SfMTransfer": "2.1",
             "SfMTransform": "3.2",
             "SfMTriangulation": "1.0",
@@ -203,7 +202,7 @@
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
-                "masksFolder": "{ImageSegmentationBox_1.output}",
+                "masksFolder": "{ImageSegmentationSam3_1.output}",
                 "maskExtension": "exr"
             },
             "internalInputs": {
@@ -258,19 +257,6 @@
             "internalInputs": {
                 "label": "FeatureMatchingFramesToKeyframes",
                 "color": "#80766f"
-            }
-        },
-        "ImageDetectionPrompt_1": {
-            "nodeType": "ImageDetectionPrompt",
-            "position": [
-                0,
-                200
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#575963"
             }
         },
         "ImageMatchingMultiSfM_1": {
@@ -329,15 +315,14 @@
                 "color": "#80766f"
             }
         },
-        "ImageSegmentationBox_1": {
-            "nodeType": "ImageSegmentationBox",
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
             "position": [
-                200,
-                200
+                197.0,
+                201.0
             ],
             "inputs": {
-                "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "input": "{CameraInit_1.output}",
                 "maskInvert": true,
                 "keepFilename": true
             },
@@ -459,7 +444,7 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
                 "undistortedImages": "{ExportImages_2.output}",
-                "masks": "{ImageSegmentationBox_1.output}"
+                "masks": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#4c594c"

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -14,9 +14,8 @@
             "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
-            "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
-            "ImageSegmentationBox": "0.3",
+            "ImageSegmentationSam3": "0.1",
             "IntrinsicsTransforming": "1.1",
             "NodalSfM": "2.0",
             "RelativePoseEstimating": "3.1",
@@ -173,7 +172,7 @@
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
-                "masksFolder": "{ImageSegmentationBox_1.output}"
+                "masksFolder": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -195,19 +194,6 @@
                 "color": "#80766f"
             }
         },
-        "ImageDetectionPrompt_1": {
-            "nodeType": "ImageDetectionPrompt",
-            "position": [
-                0,
-                200
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#80766f"
-            }
-        },
         "ImageMatching_1": {
             "nodeType": "ImageMatching",
             "position": [
@@ -224,15 +210,14 @@
                 "color": "#80766f"
             }
         },
-        "ImageSegmentationBox_1": {
-            "nodeType": "ImageSegmentationBox",
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
             "position": [
-                200,
-                200
+                -2.0,
+                148.0
             ],
             "inputs": {
-                "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "input": "{CameraInit_1.output}",
                 "maskInvert": true,
                 "keepFilename": true
             },
@@ -294,7 +279,7 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{NodalSfM_1.output}",
                 "undistortedImages": "{ExportImages_1.output}",
-                "masks": "{ImageSegmentationBox_1.output}",
+                "masks": "{ImageSegmentationSam3_1.output}",
                 "pointCloudParams": {
                     "particleSize": 0.001,
                     "particleColor": "Red"

--- a/meshroom/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/nodalCameraTrackingWithoutCalibration.mg
@@ -12,9 +12,8 @@
             "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
-            "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
-            "ImageSegmentationBox": "0.3",
+            "ImageSegmentationSam3": "0.1",
             "IntrinsicsTransforming": "1.1",
             "NodalSfM": "2.0",
             "RelativePoseEstimating": "3.1",
@@ -27,8 +26,8 @@
         "CameraInit_1": {
             "nodeType": "CameraInit",
             "position": [
-                -400,
-                0
+                -220,
+                2
             ],
             "inputs": {},
             "internalInputs": {
@@ -126,11 +125,11 @@
             "nodeType": "FeatureExtraction",
             "position": [
                 200,
-                0
+                2
             ],
             "inputs": {
-                "input": "{ImageSegmentationBox_1.input}",
-                "masksFolder": "{ImageSegmentationBox_1.output}"
+                "input": "{ImageSegmentationSam3_1.input}",
+                "masksFolder": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#80766f"
@@ -152,19 +151,6 @@
                 "color": "#80766f"
             }
         },
-        "ImageDetectionPrompt_1": {
-            "nodeType": "ImageDetectionPrompt",
-            "position": [
-                -200,
-                0
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#80766f"
-            }
-        },
         "ImageMatching_1": {
             "nodeType": "ImageMatching",
             "position": [
@@ -181,15 +167,14 @@
                 "color": "#80766f"
             }
         },
-        "ImageSegmentationBox_1": {
-            "nodeType": "ImageSegmentationBox",
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
             "position": [
-                0,
-                0
+                -10,
+                2
             ],
             "inputs": {
-                "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "input": "{CameraInit_1.output}",
                 "maskInvert": true,
                 "keepFilename": true
             },
@@ -251,7 +236,7 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{NodalSfM_1.output}",
                 "undistortedImages": "{ExportImages_1.output}",
-                "masks": "{ImageSegmentationBox_1.output}",
+                "masks": "{ImageSegmentationSam3_1.output}",
                 "pointCloudParams": {
                     "particleSize": 0.001,
                     "particleColor": "Red"

--- a/meshroom/photogrammetryAndCameraTrackingExperimental.mg
+++ b/meshroom/photogrammetryAndCameraTrackingExperimental.mg
@@ -16,10 +16,9 @@
             "ExportImages": "1.1",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
-            "ImageDetectionPrompt": "0.2",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.0",
-            "ImageSegmentationBox": "0.3",
+            "ImageSegmentationSam3": "0.1",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",
@@ -27,9 +26,9 @@
             "Meshing": "7.0",
             "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
-            "SfMBootStrapping": "4.1",
+            "SfMBootStrapping": "4.2",
             "SfMColorizing": "1.0",
-            "SfMExpanding": "2.2",
+            "SfMExpanding": "2.3",
             "SfMTransfer": "2.1",
             "SfMTransform": "3.2",
             "Texturing": "6.0",
@@ -243,7 +242,7 @@
             ],
             "inputs": {
                 "input": "{ApplyCalibration_1.output}",
-                "masksFolder": "{ImageSegmentationBox_2.output}",
+                "masksFolder": "{ImageSegmentationSam3_1.output}",
                 "maskExtension": "exr"
             },
             "internalInputs": {
@@ -345,19 +344,6 @@
                 "color": "#575963"
             }
         },
-        "ImageDetectionPrompt_1": {
-            "nodeType": "ImageDetectionPrompt",
-            "position": [
-                0,
-                200
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}"
-            },
-            "internalInputs": {
-                "color": "#575963"
-            }
-        },
         "ImageMatchingMultiSfM_1": {
             "nodeType": "ImageMatchingMultiSfM",
             "position": [
@@ -448,15 +434,14 @@
                 "color": "#384a55"
             }
         },
-        "ImageSegmentationBox_2": {
-            "nodeType": "ImageSegmentationBox",
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
             "position": [
-                200,
-                200
+                200.0,
+                200.0
             ],
             "inputs": {
-                "input": "{ImageDetectionPrompt_1.input}",
-                "bboxFolder": "{ImageDetectionPrompt_1.output}",
+                "input": "{CameraInit_1.output}",
                 "maskInvert": true,
                 "keepFilename": true
             },
@@ -572,7 +557,7 @@
                 "cameras": "{ConvertSfMFormat_1.output}",
                 "model": "{MeshDecimate_1.output}",
                 "undistortedImages": "{ExportImages_2.output}",
-                "masks": "{ImageSegmentationBox_2.output}"
+                "masks": "{ImageSegmentationSam3_1.output}"
             },
             "internalInputs": {
                 "color": "#4c594c"


### PR DESCRIPTION
This pull request updates all experimental camera tracking pipeline configuration files to replace the use of the `ImageDetectionPrompt` and `ImageSegmentationBox` nodes with the new `ImageSegmentationSam3` node. It also updates the relevant version numbers for several nodes. The changes ensure that all mask-related dependencies and references now use `ImageSegmentationSam3`, simplifying the pipeline and removing the now-obsolete nodes.

