### PR TITLE
[utils] KeyframeSelection: Exit if there is not output extension for videos

### DIFF
--- a/src/software/utils/main_keyframeSelection.cpp
+++ b/src/software/utils/main_keyframeSelection.cpp
@@ -224,6 +224,22 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    if (outputExtension == "none")
+    {
+        for (std::size_t i = 0; i < nbCameras; i++)
+        {
+            const std::string ext = fs::path(inputPaths.at(i)).extension().string();
+            if (image::isVideoExtension(ext))
+            {
+                ALICEVISION_LOG_ERROR("At least one input path (" << inputPaths.at(i) << ") is a video. "
+                    << "The output extension being set to '" << outputExtension
+                    << "', the selected keyframes will not be written on disk, meaning the SfMData "
+                    << "file for the keyframes cannot be written. An output extension is needed for video inputs.");
+                return EXIT_FAILURE;
+            }
+        }
+    }
+
     brands.resize(nbCameras);
     models.resize(nbCameras);
     mmFocals.resize(nbCameras);


### PR DESCRIPTION
## Description

For input videos, frames are not already available on disk, meaning the output SfMData files cannot be written unless the selected frames are also written on disk. By default, the `outputExtension` parameter is set to `none`, meaning that the selected frames are not going to be written on disk.

Prior to this pull request, the video would be fully processed, and an error would only be raised at the very end of the process, when attempting to write the SfMData files. With it, the check is performed beforehand, and the program immediately exits before starting to process the video if the output extension is set to `none`.