### PR TITLE
Add tests for the temporal smoothness constraint

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -1,4 +1,4 @@
-__version__ = "2.3"
+__version__ = "2.4"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL

--- a/meshroom/aliceVision/TracksSimulating.py
+++ b/meshroom/aliceVision/TracksSimulating.py
@@ -43,6 +43,14 @@ class TracksSimulating(desc.AVCommandLineNode):
             invalidate=True,
             advanced=True,
         ),
+        desc.BoolParam(
+            name="randomNoiseVariancePerView",
+            label="Random Variance Per View",
+            description="Use different noise variance per view.",
+            value=False,
+            invalidate=True,
+            advanced=True,
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -160,6 +160,12 @@ alicevision_add_test(bundle/bundleAdjustment_Enhanced_test.cpp
           ${LEMON_LIBRARY}
 )
 
+alicevision_add_test(bundle/bundleAdjustment_temporalConstraint_test.cpp
+    NAME "sfm_bundleAdjustment_temporalConstraint"
+    LINKS aliceVision_sfm
+          aliceVision_track
+)
+
 alicevision_add_test(utils/alignment_test.cpp
     NAME "sfm_alignment"
     LINKS

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_temporalConstraint_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_temporalConstraint_test.cpp
@@ -1,0 +1,214 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#define BOOST_TEST_MODULE bundleAdjustment_temporalConstraint
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp>
+#include <aliceVision/sfmDataIO/sceneSample.hpp>
+#include <aliceVision/sfm/utils/poseNoise.hpp>
+#include <aliceVision/track/tracksUtils.hpp>
+
+#include <aliceVision/sfm/utils/statistics.hpp>
+#include <aliceVision/numeric/numeric.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+
+using namespace aliceVision;
+
+void computeTemporalSmoothness(const sfmData::SfMData& sfmData, double& diff0Mean, double& diff1Mean, double& diff2Mean,
+                               double& angleDiff0Mean, double& angleDiff1Mean, double& angleDiff2Mean)
+{
+    using namespace Eigen;
+    using namespace Eigen::indexing;
+
+    const int viewCount = sfmData.getViews().size();
+
+    MatrixXd viewCenters(3, viewCount);
+
+    int frameIdx = 0;
+    for (auto& [_, pose] : sfmData.getPoses().valueRange())
+        viewCenters.col(frameIdx++) = pose.getTransform().center();
+
+    Vector3d viewsCenter = viewCenters.rowwise().mean();
+
+    double radiusMean = (viewCenters.colwise() - viewsCenter).colwise().norm().mean();
+
+    diff0Mean = (viewCenters(all,seq(1, last)) - viewCenters(all,seq(0, last-1))).array().abs().mean();
+    diff0Mean = diff0Mean / radiusMean;
+
+    diff1Mean = (2. * viewCenters(all,seq(1, last-1))
+                    - viewCenters(all,seq(0, last-2))
+                    - viewCenters(all,seq(2, last))).array().abs().mean();
+    diff1Mean = diff1Mean / radiusMean;
+
+    diff2Mean = (3. * viewCenters(all,seq(1, last-2))
+               - 3. * viewCenters(all,seq(2, last-1))
+                    + viewCenters(all,seq(3, last))
+                    - viewCenters(all,seq(0, last-3))).array().abs().mean();
+    diff2Mean = diff2Mean / radiusMean;
+
+    MatrixXd angleDiff(3, viewCount-1);
+    MatrixXd quaterDiff(4, viewCount-1);
+
+    frameIdx = -1;
+    Quaterniond prevRot, currRot;
+    for (auto& [_, pose] : sfmData.getPoses().valueRange())
+    {
+        prevRot = currRot;
+        currRot = Quaterniond(pose.getTransform().rotation());
+        if (frameIdx == -1)
+        {
+            frameIdx++;
+            continue;
+        }
+        Quaterniond quatDiff = currRot * prevRot.conjugate();
+        quaterDiff.col(frameIdx) = quatDiff.coeffs();
+        AngleAxisd aa(quatDiff);
+        angleDiff.col(frameIdx++) = aa.angle() * aa.axis();
+    }
+
+    angleDiff0Mean = std::sqrt(angleDiff.array().pow(2).mean());
+
+    MatrixXd angleDiff1(3, viewCount-2);
+    MatrixXd quaterDiff1(4, viewCount-2);
+    for (frameIdx = 0; frameIdx < viewCount-2; frameIdx++)
+    {
+        Quaterniond quatDiff = Quaterniond(quaterDiff.col(frameIdx+1).data()) * Quaterniond(quaterDiff.col(frameIdx).data()).conjugate();
+        quaterDiff1.col(frameIdx) = quatDiff.coeffs();
+        AngleAxisd aa(quatDiff);
+        angleDiff1.col(frameIdx) = aa.angle() * aa.axis();
+    }
+
+    angleDiff1Mean = std::sqrt(angleDiff1.array().pow(2).mean());
+
+    MatrixXd angleDiff2(3, viewCount-3);
+    for (frameIdx = 0; frameIdx < viewCount-3; frameIdx++)
+    {
+        Quaterniond quatDiff = Quaterniond(quaterDiff1.col(frameIdx+1).data()) * Quaterniond(quaterDiff1.col(frameIdx).data()).conjugate();
+        AngleAxisd aa(quatDiff);
+        angleDiff2.col(frameIdx) = aa.angle() * aa.axis();
+    }
+
+    angleDiff2Mean = std::sqrt(angleDiff2.array().pow(2).mean());
+}
+
+BOOST_AUTO_TEST_CASE(BA_temporalConstraint)
+{
+    makeRandomOperationsReproducible();
+
+    sfmData::SfMData sfmData;
+    sfmDataIO::generateSphereScene(sfmData, 100, 240);
+
+    track::TracksMap mapTracks;
+    track::simulateTracks(sfmData, 20., 0., 0., false, mapTracks);
+    for (auto& [landmarkId, landmark] : sfmData.getLandmarks())
+    for (auto& [viewId, obs] : mapTracks[landmarkId].featPerView)
+        landmark.getObservations().at(viewId).setCoordinates(obs.coords);
+
+    double diff0MeanClean, diff1MeanClean, diff2MeanClean;
+    double angleDiff0MeanClean, angleDiff1MeanClean, angleDiff2MeanClean;
+    computeTemporalSmoothness(sfmData, diff0MeanClean, diff1MeanClean, diff2MeanClean,
+                              angleDiff0MeanClean, angleDiff1MeanClean, angleDiff2MeanClean);
+
+    sfm::addPoseNoise(sfmData, 0.3, 0.05);
+
+    double diff0MeanNoise, diff1MeanNoise, diff2MeanNoise;
+    double angleDiff0MeanNoise, angleDiff1MeanNoise, angleDiff2MeanNoise;
+    computeTemporalSmoothness(sfmData, diff0MeanNoise, diff1MeanNoise, diff2MeanNoise,
+                              angleDiff0MeanNoise, angleDiff1MeanNoise, angleDiff2MeanNoise);
+
+    BOOST_CHECK_LT(diff0MeanClean, diff0MeanNoise);
+    BOOST_CHECK_LT(diff1MeanClean, diff1MeanNoise);
+    BOOST_CHECK_LT(diff2MeanClean, diff2MeanNoise);
+
+    BOOST_CHECK_LT(angleDiff0MeanClean, angleDiff0MeanNoise);
+    BOOST_CHECK_LT(angleDiff1MeanClean, angleDiff1MeanNoise);
+    BOOST_CHECK_LT(angleDiff2MeanClean, angleDiff2MeanNoise);
+
+    sfm::BundleAdjustmentCeres::CeresOptions options;
+    sfm::BundleAdjustment::ERefineOptions refineOptions;
+    refineOptions = sfm::BundleAdjustment::REFINE_ROTATION
+                  | sfm::BundleAdjustment::REFINE_STRUCTURE
+                  | sfm::BundleAdjustment::REFINE_TRANSLATION
+                  | sfm::BundleAdjustment::REFINE_INTRINSICS_ALL;
+    options.summary = false;
+
+    // Bundle adjustment without temporal constraint
+    double rmseBeforeBA = sfm::RMSE(sfmData);
+    sfm::BundleAdjustmentCeres BA(options);
+    BA.adjust(sfmData, refineOptions);
+    double rmseAfterBA_noTC = sfm::RMSE(sfmData);
+    BOOST_CHECK_LT(rmseAfterBA_noTC, .5 * rmseBeforeBA);
+
+    double diff0MeanNoTC, diff1MeanNoTC, diff2MeanNoTC;
+    double angleDiff0MeanNoTC, angleDiff1MeanNoTC, angleDiff2MeanNoTC;
+    computeTemporalSmoothness(sfmData, diff0MeanNoTC, diff1MeanNoTC, diff2MeanNoTC,
+                              angleDiff0MeanNoTC, angleDiff1MeanNoTC, angleDiff2MeanNoTC);
+
+    BOOST_CHECK_LT(angleDiff0MeanNoTC, angleDiff0MeanNoise);
+    BOOST_CHECK_LT(angleDiff1MeanNoTC, angleDiff1MeanNoise);
+    BOOST_CHECK_LT(angleDiff2MeanNoTC, angleDiff2MeanNoise);
+
+    sfmData::SfMData sfmData_noTC = sfmData::SfMData(sfmData);
+
+    // Add the temporal constraint
+    refineOptions |= sfm::BundleAdjustment::REFINE_TEMPORAL_SMOOTHNESS_CONSTRAINT;
+    options.temporalConstraintParams.positionWeight = 10.;
+    options.temporalConstraintParams.c0positionWeight = 1.0;
+    options.temporalConstraintParams.orientationWeight = 0.;
+    BA = sfm::BundleAdjustmentCeres(options);
+
+    // Bundle adjustment with temporal constraint on positions
+    BA.adjust(sfmData, refineOptions);
+    double rmseAfterBA_TCP = sfm::RMSE(sfmData);
+    BOOST_CHECK_LT(rmseAfterBA_TCP, 1.2 * rmseAfterBA_noTC);
+
+    double diff0MeanTCP, diff1MeanTCP, diff2MeanTCP;
+    double angleDiff0MeanTCP, angleDiff1MeanTCP, angleDiff2MeanTCP;
+    computeTemporalSmoothness(sfmData, diff0MeanTCP, diff1MeanTCP, diff2MeanTCP,
+                              angleDiff0MeanTCP, angleDiff1MeanTCP, angleDiff2MeanTCP);
+
+    BOOST_CHECK_LT(diff0MeanTCP, 2. * diff0MeanClean);
+    BOOST_CHECK_LT(angleDiff0MeanTCP, 2. * angleDiff0MeanClean);
+
+    BOOST_CHECK_LT(diff1MeanTCP, .1 * diff1MeanNoTC);
+    BOOST_CHECK_LT(diff2MeanTCP, .1 * diff2MeanNoTC);
+
+    BOOST_CHECK_LT(angleDiff1MeanTCP, .9 * angleDiff1MeanNoTC);
+    BOOST_CHECK_LT(angleDiff2MeanTCP, .9 * angleDiff2MeanNoTC);
+
+    options.temporalConstraintParams.positionWeight = 0.;
+    options.temporalConstraintParams.orientationWeight = 10.;
+    BA = sfm::BundleAdjustmentCeres(options);
+
+    sfmData = sfmData::SfMData(sfmData_noTC);
+
+    // Bundle adjustment with temporal constraint on orientations
+    BA.adjust(sfmData, refineOptions);
+    double rmseAfterBA_TCO = sfm::RMSE(sfmData);
+    BOOST_CHECK_LT(rmseAfterBA_TCO, 1.2 * rmseAfterBA_noTC);
+
+    double diff0MeanTCO, diff1MeanTCO, diff2MeanTCO;
+    double angleDiff0MeanTCO, angleDiff1MeanTCO, angleDiff2MeanTCO;
+    computeTemporalSmoothness(sfmData, diff0MeanTCO, diff1MeanTCO, diff2MeanTCO,
+                              angleDiff0MeanTCO, angleDiff1MeanTCO, angleDiff2MeanTCO);
+
+    BOOST_CHECK_LT(diff0MeanTCO, 2. * diff0MeanClean);
+    BOOST_CHECK_LT(angleDiff0MeanTCO, 1.5 * angleDiff0MeanClean);
+
+    BOOST_CHECK_LT(diff1MeanTCO, .75 * diff1MeanNoTC);
+    BOOST_CHECK_LT(diff2MeanTCO, .75 * diff2MeanNoTC);
+
+    BOOST_CHECK_LT(angleDiff1MeanTCO, .9 * angleDiff1MeanNoTC);
+    BOOST_CHECK_LT(angleDiff2MeanTCO, .9 * angleDiff2MeanNoTC);
+
+    BOOST_CHECK_LT(diff1MeanTCP, .5 * diff1MeanTCO);
+    BOOST_CHECK_LT(diff2MeanTCP, .5 * diff2MeanTCO);
+
+    BOOST_CHECK_LT(angleDiff1MeanTCO, .9 * angleDiff1MeanTCP);
+    BOOST_CHECK_LT(angleDiff2MeanTCO, .9 * angleDiff2MeanTCP);
+}

--- a/src/aliceVision/sfm/bundle/costfunctions/temporalConstraint.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/temporalConstraint.hpp
@@ -52,69 +52,89 @@ struct TemporalConstraintFunctor
         const T* para2 = parameters[2];
         const T* para3 = parameters[3];
 
-        const auto viewPreProcess = [&](const T* angleAxis, const T* translation, T* viewCenter, T* quaternion, T* invQuaternion)
+        const auto quaternionConjugate = [&](const T* quaternion, T* invQuaternion)
         {
-            T invAngleAxis[3];
-            // Inverse the rotation to compute the camera position
-            invAngleAxis[0] = -angleAxis[0];
-            invAngleAxis[1] = -angleAxis[1];
-            invAngleAxis[2] = -angleAxis[2];
-            ceres::AngleAxisRotatePoint(invAngleAxis, translation, viewCenter);
+            invQuaternion[0] = quaternion[0];
+            invQuaternion[1] = -quaternion[1];
+            invQuaternion[2] = -quaternion[2];
+            invQuaternion[3] = -quaternion[3];
+        };
+
+        const auto viewPreProcess = [&](const T* angleAxis, const T* translation, T* viewCenter, T* quaternion)
+        {
+            T invQuaternion[4];
             ceres::AngleAxisToQuaternion(angleAxis, quaternion);
-            ceres::AngleAxisToQuaternion(invAngleAxis, invQuaternion);
+            // Inverse the rotation to compute the camera position
+            quaternionConjugate(quaternion, invQuaternion);
+            ceres::QuaternionRotatePoint(invQuaternion, translation, viewCenter);
         };
 
         T viewCenter0[3], viewCenter1[3], viewCenter2[3], viewCenter3[3];
         T quaternion0[4], quaternion1[4], quaternion2[4], quaternion3[4];
-        T invQuaternion0[4], invQuaternion1[4], invQuaternion2[4], invQuaternion3[4];
 
-        viewPreProcess(&para0[0], &para0[3], viewCenter0, quaternion0, invQuaternion0);
-        viewPreProcess(&para1[0], &para1[3], viewCenter1, quaternion1, invQuaternion1);
-        viewPreProcess(&para2[0], &para2[3], viewCenter2, quaternion2, invQuaternion2);
-        viewPreProcess(&para3[0], &para3[3], viewCenter3, quaternion3, invQuaternion3);
+        viewPreProcess(&para0[0], &para0[3], viewCenter0, quaternion0);
+        viewPreProcess(&para1[0], &para1[3], viewCenter1, quaternion1);
+        viewPreProcess(&para2[0], &para2[3], viewCenter2, quaternion2);
+        viewPreProcess(&para3[0], &para3[3], viewCenter3, quaternion3);
 
-        const auto computeAngleDiff = [&](const T* quaternionA, const T* invQuaternionB, T* angleAxisDiff)
+        const auto computeAngleDiff = [&](const T* quaternionA, const T* quaternionB, T* angleAxisDiff, T* quaternionDiff)
         {
-            T quaternionDiff[4];
+            T invQuaternionB[4];
+            quaternionConjugate(quaternionB, invQuaternionB);
             ceres::QuaternionProduct(quaternionA, invQuaternionB, quaternionDiff);
             ceres::QuaternionToAngleAxis(quaternionDiff, angleAxisDiff);
         };
 
-        T angleAxisDiff0[3], angleAxisDiff1[3], angleAxisDiff2[3];
+        T angleAxisDiff0_0[3], angleAxisDiff0_1[3], angleAxisDiff0_2[3];
+        T quaternionDiff0_0[4], quaternionDiff0_1[4], quaternionDiff0_2[4];
 
-        computeAngleDiff(quaternion1, invQuaternion0, angleAxisDiff0);
-        computeAngleDiff(quaternion2, invQuaternion1, angleAxisDiff1);
-        computeAngleDiff(quaternion3, invQuaternion2, angleAxisDiff2);
+        computeAngleDiff(quaternion1, quaternion0, angleAxisDiff0_0, quaternionDiff0_0);
+        computeAngleDiff(quaternion2, quaternion1, angleAxisDiff0_1, quaternionDiff0_1);
+        computeAngleDiff(quaternion3, quaternion2, angleAxisDiff0_2, quaternionDiff0_2);
 
         if (_boundaryCase == 2)
         {
-            residuals[0] = _c0oWeight * angleAxisDiff0[0];
-            residuals[1] = _c0oWeight * angleAxisDiff0[1];
-            residuals[2] = _c0oWeight * angleAxisDiff0[2];
+            residuals[0] = _c0oWeight * angleAxisDiff0_0[0];
+            residuals[1] = _c0oWeight * angleAxisDiff0_0[1];
+            residuals[2] = _c0oWeight * angleAxisDiff0_0[2];
         }
-        else if (_boundaryCase == 1)
+        else  // (_boundaryCase == 1 or 0)
         {
-            residuals[0] = _c0oWeight * angleAxisDiff1[0];
-            residuals[1] = _c0oWeight * angleAxisDiff1[1];
-            residuals[2] = _c0oWeight * angleAxisDiff1[2];
+            T angleAxisDiff1_0[3], angleAxisDiff1_1[3];
+            T quaternionDiff1_0[4], quaternionDiff1_1[4];
 
-            residuals[3] = _c1oWeight * (angleAxisDiff1[0] - angleAxisDiff0[0]);
-            residuals[4] = _c1oWeight * (angleAxisDiff1[1] - angleAxisDiff0[1]);
-            residuals[5] = _c1oWeight * (angleAxisDiff1[2] - angleAxisDiff0[2]);
-        }
-        else
-        {
-            residuals[0] = _c0oWeight * angleAxisDiff2[0];
-            residuals[1] = _c0oWeight * angleAxisDiff2[1];
-            residuals[2] = _c0oWeight * angleAxisDiff2[2];
+            computeAngleDiff(quaternionDiff0_1, quaternionDiff0_0, angleAxisDiff1_0, quaternionDiff1_0);
+            computeAngleDiff(quaternionDiff0_2, quaternionDiff0_1, angleAxisDiff1_1, quaternionDiff1_1);
 
-            residuals[3] = _c1oWeight * (angleAxisDiff2[0] - angleAxisDiff1[0]);
-            residuals[4] = _c1oWeight * (angleAxisDiff2[1] - angleAxisDiff1[1]);
-            residuals[5] = _c1oWeight * (angleAxisDiff2[2] - angleAxisDiff1[2]);
+            if (_boundaryCase == 1)
+            {
+                residuals[0] = _c0oWeight * angleAxisDiff0_1[0];
+                residuals[1] = _c0oWeight * angleAxisDiff0_1[1];
+                residuals[2] = _c0oWeight * angleAxisDiff0_1[2];
 
-            residuals[6] = _c2oWeight * (2. * angleAxisDiff1[0] - angleAxisDiff0[0] - angleAxisDiff2[0]);
-            residuals[7] = _c2oWeight * (2. * angleAxisDiff1[1] - angleAxisDiff0[1] - angleAxisDiff2[1]);
-            residuals[8] = _c2oWeight * (2. * angleAxisDiff1[2] - angleAxisDiff0[2] - angleAxisDiff2[2]);
+                residuals[3] = _c1oWeight * angleAxisDiff1_0[0];
+                residuals[4] = _c1oWeight * angleAxisDiff1_0[1];
+                residuals[5] = _c1oWeight * angleAxisDiff1_0[2];
+            }
+            else  // (_boundaryCase == 0)
+            {
+                residuals[0] = _c0oWeight * angleAxisDiff0_2[0];
+                residuals[1] = _c0oWeight * angleAxisDiff0_2[1];
+                residuals[2] = _c0oWeight * angleAxisDiff0_2[2];
+
+                residuals[3] = _c1oWeight * angleAxisDiff1_1[0];
+                residuals[4] = _c1oWeight * angleAxisDiff1_1[1];
+                residuals[5] = _c1oWeight * angleAxisDiff1_1[2];
+
+                T angleAxisDiff2_0[3];
+                T quaternionDiff2_0[4];
+
+                computeAngleDiff(quaternionDiff1_1, quaternionDiff1_0, angleAxisDiff2_0, quaternionDiff2_0);
+
+                residuals[6] = _c2oWeight * angleAxisDiff2_0[0];
+                residuals[7] = _c2oWeight * angleAxisDiff2_0[1];
+                residuals[8] = _c2oWeight * angleAxisDiff2_0[2];
+            }
         }
 
         if (_noPositionConstraint)
@@ -189,17 +209,17 @@ struct TemporalConstraintFunctor
         auto costFunction = new ceres::DynamicAutoDiffCostFunction<TemporalConstraintFunctor>
                             (
                                 new TemporalConstraintFunctor(
-                                    positionWeight, orientationWeight, 
-                                    c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight, 
+                                    positionWeight, orientationWeight,
+                                    c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight,
                                     boundaryCase
                                 )
-                            );  
+                            );
 
         costFunction->AddParameterBlock(6);
         costFunction->AddParameterBlock(6);
         costFunction->AddParameterBlock(6);
-        costFunction->AddParameterBlock(6); 
-        
+        costFunction->AddParameterBlock(6);
+
         if (boundaryCase == 2)
         {
             if (positionWeight != 0.)

--- a/src/aliceVision/sfmDataIO/sceneSample.cpp
+++ b/src/aliceVision/sfmDataIO/sceneSample.cpp
@@ -92,10 +92,10 @@ void generateCubeScene(sfmData::SfMData& output)
     const double offsetX = -26;
     const double offsetY = 16;
     output.getIntrinsics().emplace(
-      0, camera::createPinhole(camera::EDISTORTION::DISTORTION_NONE, camera::EUNDISTORTION::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, offsetX, offsetY));
+      0, camera::createPinhole(camera::DISTORTION_NONE, camera::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, offsetX, offsetY));
     output.getIntrinsics().emplace(
       1,
-      camera::createPinhole(camera::EDISTORTION::DISTORTION_RADIALK3, camera::EUNDISTORTION::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, offsetX, offsetY, {0.1, 0.05, -0.001}));
+      camera::createPinhole(camera::DISTORTION_RADIALK3, camera::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, offsetX, offsetY, {0.1, 0.05, -0.001}));
 
     // Generate poses on another cube
     IndexT idpose = 0;
@@ -128,22 +128,13 @@ void generateCubeScene(sfmData::SfMData& output)
 void generateSphereScene(sfmData::SfMData& output, int pointsNb, int posesNb)
 {
     // Generate random points on a sphere
-    IndexT idpt = 0;
-    for (int pt = 0; pt < pointsNb; pt++)
-    {
-        Eigen::Vector3d point3D = Eigen::Vector3d::Random();
-        point3D = 1. * point3D / point3D.norm();
-
-        output.getLandmarks().emplace(idpt, sfmData::Landmark(point3D, feature::EImageDescriberType::UNKNOWN));
-        ++idpt;
-    }
 
     const int w = 4092;
     const int h = 2048;
-    const double focalLengthPixX = 1000.0;
-    const double focalLengthPixY = 2000.0;
+    const double focalLengthPixX = 10000.0;
+    const double focalLengthPixY = 20000.0;
     output.getIntrinsics().emplace(
-      0, camera::createPinhole(camera::EDISTORTION::DISTORTION_NONE, camera::EUNDISTORTION::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, 0, 0));
+      0, camera::createPinhole(camera::DISTORTION_NONE, camera::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, 0, 0));
 
     // Generate poses on a circle
     for (IndexT idPV = 0; idPV < posesNb; idPV++)
@@ -156,6 +147,25 @@ void generateSphereScene(sfmData::SfMData& output, int pointsNb, int posesNb)
         output.getPoses().assign(idPV, sfmData::CameraPose(pose));
         output.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, w, h));
         output.getView(idPV).setFrameId(idPV);
+    }
+
+    // Generate random points on a sphere and corresponding observations in each view
+    const double arbitraryScale = 1.0;
+    for (int landmarkId = 0; landmarkId < pointsNb; landmarkId++)
+    {
+        Eigen::Vector3d point3D = Eigen::Vector3d::Random();
+        point3D = point3D / point3D.norm();
+
+        sfmData::Landmark landmark(point3D, feature::EImageDescriberType::UNKNOWN);
+        for (int viewId = 0; viewId < posesNb; viewId++)
+        {
+            const sfmData::View& view = output.getView(viewId);
+            const geometry::Pose3 pose = output.getPose(view).getTransform();
+            const camera::IntrinsicBase& intrinsic = output.getIntrinsic(0);
+            const Eigen::Vector2d pt = intrinsic.transformProject(pose, landmark.getX().homogeneous(), true);
+            landmark.getObservations().emplace(viewId, sfmData::Observation(pt, landmarkId, arbitraryScale));
+        }
+        output.getLandmarks().emplace(landmarkId, landmark);
     }
 }
 

--- a/src/aliceVision/track/tracksUtils.cpp
+++ b/src/aliceVision/track/tracksUtils.cpp
@@ -6,6 +6,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "tracksUtils.hpp"
+#include <aliceVision/sfmData/SfMData.hpp>
 
 #include <iterator>
 
@@ -286,6 +287,84 @@ void computeCovisibility(std::map<Pair, unsigned int>& covisibility, const track
                 }
             }
         }
+    }
+}
+
+void simulateTracks(const sfmData::SfMData& sfmData, double sigmaNoise, double outlierRatio, double outlierEpipolarRatio, bool randomNoiseVariancePerView, TracksMap &mapTracks)
+{
+    std::mt19937 generator;
+    std::uniform_real_distribution<double> rand(0, 1);
+    std::uniform_real_distribution<double> randDepth(0.1, 100.0);
+    std::normal_distribution<double> randNoise(0.0, sigmaNoise);
+
+    std::map<IndexT, std::normal_distribution<double>> viewRandNoise;
+    if (randomNoiseVariancePerView)
+    {
+        for (const auto viewId : sfmData.getViewsKeys())
+        {
+            double viewSigma = std::abs(randNoise(generator));
+            viewRandNoise.emplace(viewId, std::normal_distribution<double>(0.0, viewSigma));
+        }
+    }
+
+    for (const auto & [landmarkId, landmark] : sfmData.getLandmarks())
+    {
+        const Vec3 point = landmark.getX();
+
+        track::Track track;
+        track.descType = landmark.getDescType();
+
+        for (const auto & [viewId, observation] : landmark.getObservations())
+        {
+            const auto & view = sfmData.getView(viewId);
+            const auto & intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
+            const auto & pose = sfmData.getAbsolutePose(view.getPoseId());
+
+            Vec2 obs;
+
+            if (rand(generator) < outlierRatio)
+            {
+                //This is an outlier
+                if (rand(generator) < outlierEpipolarRatio)
+                {
+                    //Outlier but on the epipolar line
+                    Vec3 fakePoint = point * randDepth(generator) / point(2);
+                    obs = intrinsic.transformProject(pose.getTransform(), fakePoint.homogeneous(), true);
+                }
+                else
+                {
+                    std::uniform_real_distribution<double> randWidth(0.0, intrinsic.w());
+                    std::uniform_real_distribution<double> randHeight(0.0, intrinsic.h());
+
+                    obs.x() = randWidth(generator);
+                    obs.y() = randHeight(generator);
+                }
+            }
+            else
+            {
+                obs = intrinsic.transformProject(pose.getTransform(), point.homogeneous(), true);
+            }
+
+            if (randomNoiseVariancePerView)
+            {
+                obs.x() += viewRandNoise.at(viewId)(generator);
+                obs.y() += viewRandNoise.at(viewId)(generator);
+            }
+            else
+            {
+                obs.x() += randNoise(generator);
+                obs.y() += randNoise(generator);
+            }
+
+            TrackItem item;
+            item.coords = obs;
+            item.featureId = observation.getFeatureId();
+            item.scale = observation.getScale();
+
+            track.featPerView[viewId] = item;
+        }
+
+        mapTracks[landmarkId] = track;
     }
 }
 

--- a/src/aliceVision/track/tracksUtils.hpp
+++ b/src/aliceVision/track/tracksUtils.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <aliceVision/track/Track.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
 
 namespace aliceVision {
 namespace track {
@@ -147,6 +148,17 @@ void imageIdInTracks(const TracksMap& tracks, std::set<std::size_t>& imagesId);
  * @param mapTracks the input tracks map
  */
 void computeCovisibility(std::map<Pair, unsigned int>& covisibility, const track::TracksMap& mapTracks);
+
+/**
+ * @brief Generate noisy tracks
+ * @param[in] sfmData the input SfMData file
+ * @param[in] sigmaNoise the variance (in pixels) of the Gaussian noise added to the observation coordinates
+ * @param[in] outlierRatio the ratio of outliers with respect to the observations count
+ * @param[in] outlierEpipolarRatio the proportion of outliers which are still respecting the epipolar constraint
+ * @param[in] randomNoiseVariancePerView specify whether to use different noise variance per view
+ * @param[out] mapTracks the output tracks map
+ */
+void simulateTracks(const sfmData::SfMData& sfmData, double sigmaNoise, double outlierRatio, double outlierEpipolarRatio, bool randomNoiseVariancePerView, TracksMap& mapTracks);
 
 }  // namespace track
 }  // namespace aliceVision

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -29,7 +29,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 3
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 4
 
 using namespace aliceVision;
 

--- a/src/software/utils/main_tracksSimulating.cpp
+++ b/src/software/utils/main_tracksSimulating.cpp
@@ -14,6 +14,7 @@
 #include <aliceVision/config.hpp>
 #include <aliceVision/track/Track.hpp>
 #include <aliceVision/track/trackIO.hpp>
+#include <aliceVision/track/tracksUtils.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -76,83 +77,8 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    std::mt19937 generator;
-    std::uniform_real_distribution<double> rand(0, 1);
-    std::uniform_real_distribution<double> randDepth(0.1, 100.0);
-    std::normal_distribution<double> randNoise(0.0, sigmaNoise);
-
-    std::map<IndexT, std::normal_distribution<double>> viewRandNoise;
-    if (randomNoiseVariancePerView)
-    {
-        for (const auto viewId : sfmData.getViewsKeys())
-        {
-            double viewSigma = std::abs(randNoise(generator));
-            viewRandNoise.emplace(viewId, std::normal_distribution<double>(0.0, viewSigma));
-            ALICEVISION_LOG_INFO("View Random Noise Sigma : " << viewSigma);
-        }
-    }
-
     track::TracksMap mapTracks;
-
-    for (const auto & [landmarkId, landmark] : sfmData.getLandmarks())
-    {
-        const Vec3 point = landmark.getX();
-
-        track::Track track;
-        track.descType = landmark.getDescType();
-
-        for (const auto & [viewId, observation] : landmark.getObservations())
-        {
-            const auto & view = sfmData.getView(viewId);
-            const auto & intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
-            const auto & pose = sfmData.getAbsolutePose(view.getPoseId());
-
-            Vec2 obs;
-
-            if (rand(generator) < outlierRatio)
-            {
-                //This is an outlier
-                if (rand(generator) < outlierEpipolarRatio)
-                {
-                    //Outlier but on the epipolar line
-                    Vec3 fakePoint = point * randDepth(generator) / point(2);
-                    obs = intrinsic.transformProject(pose.getTransform(), fakePoint.homogeneous(), true);
-                }
-                else
-                {
-                    std::uniform_real_distribution<double> randWidth(0.0, intrinsic.w());
-                    std::uniform_real_distribution<double> randHeight(0.0, intrinsic.h());
-
-                    obs.x() = randWidth(generator);
-                    obs.y() = randHeight(generator);
-                }
-            }
-            else
-            {
-                obs = intrinsic.transformProject(pose.getTransform(), point.homogeneous(), true);
-            }
-
-            if (randomNoiseVariancePerView)
-            {
-                obs.x() += viewRandNoise.at(viewId)(generator);
-                obs.y() += viewRandNoise.at(viewId)(generator);
-            }
-            else
-            {
-                obs.x() += randNoise(generator);
-                obs.y() += randNoise(generator);
-            }
-
-            track::TrackItem item;
-            item.coords = obs;
-            item.featureId = observation.getFeatureId();
-            item.scale = observation.getScale();
-
-            track.featPerView[viewId] = item;
-        }
-
-        mapTracks[landmarkId] = track;
-    }
+    track::simulateTracks(sfmData, sigmaNoise, outlierRatio, outlierEpipolarRatio, randomNoiseVariancePerView, mapTracks);
 
      // write the json file
     ALICEVISION_LOG_INFO("Export to file");

--- a/src/software/utils/main_tracksSimulating.cpp
+++ b/src/software/utils/main_tracksSimulating.cpp
@@ -36,6 +36,7 @@ int aliceVision_main(int argc, char** argv)
     double sigmaNoise = 0.0;
     double outlierRatio = 0.0;
     double outlierEpipolarRatio = 0.2;
+    bool randomNoiseVariancePerView = false;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -49,8 +50,9 @@ int aliceVision_main(int argc, char** argv)
     optionalParams.add_options()
         ("sigmaNoise", po::value<double>(&sigmaNoise)->default_value(sigmaNoise))
         ("outlierRatio", po::value<double>(&outlierRatio)->default_value(outlierRatio))
-        ("outlierEpipolarRatio", po::value<double>(&outlierEpipolarRatio)->default_value(outlierEpipolarRatio));
-        
+        ("outlierEpipolarRatio", po::value<double>(&outlierEpipolarRatio)->default_value(outlierEpipolarRatio))
+        ("randomNoiseVariancePerView", po::value<bool>(&randomNoiseVariancePerView)->default_value(randomNoiseVariancePerView), "Use different noise variance per view.");
+
     // clang-format on
 
     CmdLine cmdline("AliceVision tracksSimulating");
@@ -78,7 +80,18 @@ int aliceVision_main(int argc, char** argv)
     std::uniform_real_distribution<double> rand(0, 1);
     std::uniform_real_distribution<double> randDepth(0.1, 100.0);
     std::normal_distribution<double> randNoise(0.0, sigmaNoise);
-    
+
+    std::map<IndexT, std::normal_distribution<double>> viewRandNoise;
+    if (randomNoiseVariancePerView)
+    {
+        for (const auto viewId : sfmData.getViewsKeys())
+        {
+            double viewSigma = std::abs(randNoise(generator));
+            viewRandNoise.emplace(viewId, std::normal_distribution<double>(0.0, viewSigma));
+            ALICEVISION_LOG_INFO("View Random Noise Sigma : " << viewSigma);
+        }
+    }
+
     track::TracksMap mapTracks;
 
     for (const auto & [landmarkId, landmark] : sfmData.getLandmarks())
@@ -105,7 +118,7 @@ int aliceVision_main(int argc, char** argv)
                     Vec3 fakePoint = point * randDepth(generator) / point(2);
                     obs = intrinsic.transformProject(pose.getTransform(), fakePoint.homogeneous(), true);
                 }
-                else 
+                else
                 {
                     std::uniform_real_distribution<double> randWidth(0.0, intrinsic.w());
                     std::uniform_real_distribution<double> randHeight(0.0, intrinsic.h());
@@ -114,19 +127,27 @@ int aliceVision_main(int argc, char** argv)
                     obs.y() = randHeight(generator);
                 }
             }
-            else 
+            else
             {
                 obs = intrinsic.transformProject(pose.getTransform(), point.homogeneous(), true);
             }
 
-            obs.x() += randNoise(generator);
-            obs.y() += randNoise(generator);
+            if (randomNoiseVariancePerView)
+            {
+                obs.x() += viewRandNoise.at(viewId)(generator);
+                obs.y() += viewRandNoise.at(viewId)(generator);
+            }
+            else
+            {
+                obs.x() += randNoise(generator);
+                obs.y() += randNoise(generator);
+            }
 
             track::TrackItem item;
             item.coords = obs;
             item.featureId = observation.getFeatureId();
             item.scale = observation.getScale();
-            
+
             track.featPerView[viewId] = item;
         }
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to the structure-from-motion (SfM) pipeline, focusing on enhancing temporal smoothness constraints in bundle adjustment, improving test coverage, and refining simulation utilities. The most significant changes include the addition of a comprehensive test for temporal constraints in bundle adjustment, a major refactor and improvement in the temporal constraint cost function, and enhancements to synthetic scene and track simulation utilities.

**Bundle Adjustment & Temporal Constraint Improvements:**

* Added a new test `bundleAdjustment_temporalConstraint_test.cpp` to rigorously validate temporal smoothness constraints in bundle adjustment, including both position and orientation smoothing. This test checks the effectiveness of the constraints and ensures that the optimization behaves as expected under various settings. [[1]](diffhunk://#diff-12596bdd70cd7ac93a41cac3172c49f1a61ddb5af4342e7beffb0a4aa3874d60R1-R214) [[2]](diffhunk://#diff-50e7fbc9016bb0b9a8dd173a6937d28a10a4b4c50dd20686b9ca7213c62f07e5R163-R168)
* Refactored the `TemporalConstraintFunctor` in `temporalConstraint.hpp` to improve angle difference computation using quaternions, leading to more accurate and robust temporal orientation constraints in bundle adjustment.

**Synthetic Data Generation and Simulation Enhancements:**

* Improved the `generateSphereScene` utility to generate both 3D points and their corresponding 2D observations for each view, ensuring consistency and realism in synthetic SfM datasets. Also updated camera intrinsics for better test coverage. [[1]](diffhunk://#diff-84d01fbfa77e0d7b497280bfcb15f8ae81d995fd7e516fe6462db479c126b589L131-R137) [[2]](diffhunk://#diff-84d01fbfa77e0d7b497280bfcb15f8ae81d995fd7e516fe6462db479c126b589R151-R169)
* Updated `generateCubeScene` and `generateSphereScene` to use simplified enum names for camera distortion/undistortion types, improving code clarity and maintainability.

**Track Simulation Utility:**

* Added a new `simulateTracks` function in `tracksUtils.cpp` that can simulate tracks with configurable noise, outlier ratios, and per-view noise variance, supporting more realistic and flexible synthetic experiments. [[1]](diffhunk://#diff-3487887ddcf5530418e62e8b1628e5b3e9f4409de52660d88d5c91cc03a4d4cfR293-R370) [[2]](diffhunk://#diff-3487887ddcf5530418e62e8b1628e5b3e9f4409de52660d88d5c91cc03a4d4cfR9)

**Miscellaneous:**

* Bumped the `SfmExpanding.py` module version to 2.4 to reflect the new features and improvements.
* Added a new boolean parameter `randomNoiseVariancePerView` to the `TracksSimulating` node, enabling per-view noise variance in track simulation.