### PR TITLE
Fix refineOptions initialization in SfmBundle

### DIFF
--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -19,7 +19,7 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
     ALICEVISION_LOG_INFO("SfmBundle::process start");
 
     BundleAdjustmentCeres::CeresOptions options;
-    BundleAdjustment::ERefineOptions refineOptions;
+    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_NONE;
 
     refineOptions |= BundleAdjustment::REFINE_ROTATION;
     refineOptions |= BundleAdjustment::REFINE_TRANSLATION;


### PR DESCRIPTION
This pull request introduces a minor change to the initialization of the `refineOptions` variable in the `SfmBundle::process` function. The change ensures that `refineOptions` is explicitly initialized to `BundleAdjustment::REFINE_NONE` before enabling specific refinement options.

* Explicitly initializes `refineOptions` to `BundleAdjustment::REFINE_NONE`, ensuring a clear starting state before setting refinement flags. Previously uninitialized, risking undefined behavior.