### PR TITLE
Enable access to aliceVision logger initialization in python

### DIFF
--- a/src/aliceVision/__init__.py
+++ b/src/aliceVision/__init__.py
@@ -20,6 +20,10 @@ if hasattr(os, "add_dll_directory"):
         os.add_dll_directory(p)
 
 #Enforce loading order
+from . import system
 from . import geometry
 from . import sfmData
 from . import sfmDataIO
+
+#initialize logger
+system.initialize_alicevision_logger("info")

--- a/src/aliceVision/system/System.i
+++ b/src/aliceVision/system/System.i
@@ -9,3 +9,15 @@
 %include <aliceVision/global.i>
 %include <aliceVision/system/ProgressDisplay.i>
 
+
+%{
+#include <aliceVision/system/Logger.hpp>
+
+void initialize_alicevision_logger(const std::string & verboseLevel)
+{
+    // set verbose level
+    aliceVision::system::Logger::get()->setLogLevel(verboseLevel);
+}
+%}
+
+void initialize_alicevision_logger(const std::string & verboseLevel);


### PR DESCRIPTION
This pull request introduces logging initialization for the AliceVision Python bindings, ensuring that the logger is set up at module import. The main changes are centered around exposing the logger configuration to Python and initializing it with a default verbosity.

**Logging integration and initialization:**

* Exposed a new function `initialize_alicevision_logger` to Python via SWIG, allowing the log verbosity level to be set from Python (`src/aliceVision/system/System.i`).
* Called `system.initialize_alicevision_logger("info")` during module initialization in `src/aliceVision/__init__.py` to set the default logging level and print a confirmation message.