### PR TITLE
Upgrade landmark code for swig compatibility

### DIFF
--- a/src/aliceVision/sfmData/Landmark.hpp
+++ b/src/aliceVision/sfmData/Landmark.hpp
@@ -107,7 +107,9 @@ class Landmark
      * @brief Get the 3D position of the landmark (non-const version)
      * @return Reference to the 3D position vector
      */
+    #ifndef SWIG
     Vec3& getX() { return _X; }
+    #endif
 
     /**
      * @brief Set the 3D position of the landmark
@@ -161,7 +163,9 @@ class Landmark
      * @brief Get the RGB color of the landmark (non-const version)
      * @return Reference to the RGB color associated with the landmark
      */
+    #ifndef SWIG
     image::RGBColor& getRgb() { return _rgb; }
+    #endif
 
     /**
      * @brief Set the RGB color of the landmark

--- a/src/aliceVision/sfmData/Landmark.i
+++ b/src/aliceVision/sfmData/Landmark.i
@@ -20,6 +20,7 @@
 %ignore aliceVision::sfmData::Landmark::_observations;
 %ignore aliceVision::sfmData::Landmark::_parallaxRobust;
 %ignore aliceVision::sfmData::Landmark::_isPrecise;
+%ignore aliceVision::sfmData::Landmark::_X;
 
 //Add new swig only C++ code
 %extend aliceVision::sfmData::Landmark {
@@ -51,6 +52,7 @@
         rgb = property(getRgbVec3, setRgbVec3)
         state = property(getState, setState)
         descType = property(getDescType, setDescType)
+        X = property(getX, setX)
     %}
 }
 


### PR DESCRIPTION
This pull request updates the `Landmark` class to improve its compatibility and encapsulation when used with SWIG (Simplified Wrapper and Interface Generator) for language bindings. The main changes ensure that internal data members are properly hidden from SWIG while still providing controlled access via properties.

**SWIG compatibility and encapsulation improvements:**

* Wrapped the non-const getter methods `getX()` and `getRgb()` in `#ifndef SWIG` guards in `Landmark.hpp` to prevent SWIG from exposing direct references to internal members. [[1]](diffhunk://#diff-6ec344065b38431bd66c4f849b324c5e3385cb229c32fed8ff99401aa440118fR110-R112) [[2]](diffhunk://#diff-6ec344065b38431bd66c4f849b324c5e3385cb229c32fed8ff99401aa440118fR166-R168)
* Added `%ignore aliceVision::sfmData::Landmark::_X;` in `Landmark.i` to explicitly hide the `_X` member from SWIG-generated bindings.

**SWIG interface enhancements:**

* Added a SWIG property `X` using `getX` and `setX` to allow controlled access to the landmark's 3D position in language bindings, without exposing the internal member directly.