### PR TITLE
Management of "version" metadata for exr images

### DIFF
--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -1066,6 +1066,7 @@ void writeImage(const std::string& path,
     auto itversion = metadata.find("version");
     if (isEXR && itversion != metadata.end())
     {
+        // The "version" metadata of exr images must be an integer, otherwise the exr image could be misinterpreted.
         if (itversion->type() != oiio::TypeDesc::INT)
         {
             imageSpec.attribute("version", itversion->get_int());
@@ -1235,6 +1236,16 @@ void writeImageNoFloat(const std::string& path,
 
     oiio::ImageSpec imageSpec(image.width(), image.height(), 1, typeDesc);
     imageSpec.extra_attribs = metadata;  // add custom metadata
+
+    auto itversion = metadata.find("version");
+    if (isEXR && itversion != metadata.end())
+    {
+        // The "version" metadata of exr images must be an integer, otherwise the exr image could be misinterpreted.
+        if (itversion->type() != oiio::TypeDesc::INT)
+        {
+            imageSpec.attribute("version", itversion->get_int());
+        }
+    }
 
     imageSpec.attribute("jpeg:subsampling", "4:4:4");             // if possible, always subsampling 4:4:4 for jpeg
     imageSpec.attribute("compression", isEXR ? "zips" : "none");  // if possible, set compression (zips for EXR, none for the other)

--- a/src/aliceVision/image/io.cpp
+++ b/src/aliceVision/image/io.cpp
@@ -1063,6 +1063,15 @@ void writeImage(const std::string& path,
     oiio::ImageSpec imageSpec(image.width(), image.height(), nchannels, typeDesc);
     imageSpec.extra_attribs = metadata;  // add custom metadata
 
+    auto itversion = metadata.find("version");
+    if (isEXR && itversion != metadata.end())
+    {
+        if (itversion->type() != oiio::TypeDesc::INT)
+        {
+            imageSpec.attribute("version", itversion->get_int());
+        }
+    }
+
     imageSpec.attribute("jpeg:subsampling", "4:4:4");  // if possible, always subsampling 4:4:4 for jpeg
 
     std::string compressionMethod = "none";

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -1319,7 +1319,7 @@ int aliceVision_main(int argc, char* argv[])
             const std::string outputfilePath =
               (fs::path(outputPath) / ((pParams.keepImageFilename ? fileName : std::to_string(viewId)) + outputExt)).generic_string();
 
-            ALICEVISION_LOG_INFO(++i << "/" << size << " - Process view '" << viewId << "'.");
+            ALICEVISION_LOG_INFO(++i << "/" << size << " - Process view '" << viewId << (isRAW ? "' (RAW)." : "'."));
 
             auto metadata = view.getImage().getMetadata();
 
@@ -1591,7 +1591,7 @@ int aliceVision_main(int argc, char* argv[])
             const std::string fileExt = path.extension().string();
             const std::string outputExt = extension.empty() ? (isRAW ? ".exr" : fileExt) : (std::string(".") + extension);
 
-            ALICEVISION_LOG_INFO(++i << "/" << size << " - Process image '" << filename << fileExt << "'.");
+            ALICEVISION_LOG_INFO(++i << "/" << size << " - Process image '" << filename << fileExt << (isRAW ? "' (RAW)." : "'."));
 
             const std::string userExt = fs::path(outputPath).extension().string();
             std::string outputFilePath;


### PR DESCRIPTION
This pull request makes minor improvements to logging and metadata handling related to image processing, particularly for RAW images and EXR file metadata.

Logging improvements:

* Enhanced log messages in `main_imageProcessing.cpp` to indicate when a processed image or view is in RAW format, making it easier to identify RAW file handling in logs.

Metadata handling:

* In `image/io.cpp`, added logic to ensure that the `version` metadata attribute is correctly written as an integer for EXR images, improving metadata consistency for EXR outputs.

