### PR TITLE
Theta rig calibration

### DIFF
--- a/meshroom/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/aliceVision/LdrToHdrCalibration.py
@@ -1,4 +1,4 @@
-__version__ = "3.1"
+__version__ = "3.2"
 
 import json
 
@@ -145,11 +145,17 @@ class LdrToHdrCalibration(desc.AVCommandLineNode):
     ]
 
     outputs = [
-       desc.File(
+        desc.File(
             name="response",
             label="Response File",
             description="Path to the output response file.",
             value="{nodeCacheFolder}/response_<INTRINSIC_ID>.csv",
+        ),
+        desc.File(
+            name="luminanceStatistics",
+            label="Luminance Statistics",
+            description="File containing the luminance statistics produced by the calibration process",
+            value="{nodeCacheFolder}/luminanceStatistics_<INTRINSIC_ID>.txt",
         ),
     ]
 

--- a/meshroom/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/aliceVision/LdrToHdrMerge.py
@@ -1,4 +1,4 @@
-__version__ = "4.1"
+__version__ = "4.2"
 
 import json
 
@@ -43,6 +43,12 @@ class LdrToHdrMerge(desc.AVCommandLineNode):
             name="response",
             label="Response File",
             description="Response file.",
+            value="",
+        ),
+        desc.File(
+            name="luminanceStatistics",
+            label="Luminance Statistics",
+            description="File containing the luminance statistics produced by the calibration process",
             value="",
         ),
         desc.IntParam(

--- a/meshroom/aliceVision/PanoramaRefining.py
+++ b/meshroom/aliceVision/PanoramaRefining.py
@@ -1,0 +1,69 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class PanoramaRefining(desc.AVCommandLineNode):
+    commandLine = "aliceVision_panoramaRefining {allParams}"
+    size = desc.DynamicNodeSize("input")
+
+    category = "Panorama HDR"
+    documentation = """Refine panorama estimation using bundle adjustment."""
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="Input SfMData file.",
+            value="",
+        ),
+        desc.File(
+            name="pairs",
+            label="Pairs File",
+            description="Information on pairs.",
+            value="",
+        ),
+        desc.File(
+            name="tracksFilename",
+            label="Tracks File",
+            description="Tracks file.",
+            value="",
+        ),      
+        desc.BoolParam(
+            name="intermediateRefineWithFocal",
+            label="Intermediate Refine: Focal",
+            description="Intermediate refine with rotation and focal length only.",
+            value=False,
+            advanced=True,
+        ),
+        desc.BoolParam(
+            name="intermediateRefineWithFocalDist",
+            label="Intermediate Refine: Focal And Distortion",
+            description="Intermediate refine with rotation, focal length and distortion.",
+            value=False,
+            advanced=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfM File",
+            description="Path to the output SfM file.",
+            value="{nodeCacheFolder}/panorama.abc",
+        ),
+        desc.File(
+            name="outputViewsAndPoses",
+            label="Views And Poses",
+            description="Path to the output SfMData file with cameras (views and poses).",
+            value="{nodeCacheFolder}/cameras.sfm",
+        ),
+    ]

--- a/meshroom/aliceVision/PanoramaRigging.py
+++ b/meshroom/aliceVision/PanoramaRigging.py
@@ -1,0 +1,49 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class PanoramaRigging(desc.AVCommandLineNode):
+    commandLine = "aliceVision_panoramaRigging {allParams}"
+    size = desc.DynamicNodeSize("input")
+
+    category = "Panorama HDR"
+    documentation = """Transform a panorama to a panorama with a rig"""
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="Input SfMData file with the estimated panorama.",
+            value="",
+        ),
+        desc.File(
+            name="rigDescription",
+            label="Rig Description",
+            description="Input SfMData file containing the rig structure.",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfM File",
+            description="Path to the output SfM file.",
+            value="{nodeCacheFolder}/panorama.abc",
+        ),
+        desc.File(
+            name="outputViewsAndPoses",
+            label="Views And Poses",
+            description="Path to the output SfMData file with cameras (views and poses).",
+            value="{nodeCacheFolder}/cameras.sfm",
+        ),
+    ]

--- a/meshroom/aliceVision/SfMPoseFlattening.py
+++ b/meshroom/aliceVision/SfMPoseFlattening.py
@@ -1,0 +1,80 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class SfMPoseFlattening(desc.Node):
+
+    size = desc.DynamicNodeSize("input")
+    category = "Utils"
+    documentation = """
+    Takes a sfmData as input.
+    If the sfmData contained a rig, each view will be transformed such that they point to 
+    individual independent poses. The absolute pose of each view is kept numerically.
+    """
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="Input SfMData file.",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        )
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfM File",
+            description="Path to the output SfM file.",
+            value="{nodeCacheFolder}/sfmData.abc",
+        )
+    ]
+
+    def processChunk(self, chunk):
+
+        from pyalicevision import sfmData as avsfmdata
+        from pyalicevision import sfmDataIO as avsfmdataio
+
+        import logging
+        logging.getLogger().setLevel(chunk.node.verboseLevel.value.upper())
+
+        # Open SfMData
+        data = avsfmdata.SfMData()
+        ret = avsfmdataio.load(data, chunk.node.input.value, avsfmdataio.ALL)
+        if not ret:
+            logging.error(f"Can't open sfmData file at {chunk.node.input.value}")
+            raise RuntimeError()
+
+        logging.info(f"Opened sfmData at {chunk.node.input.value}")
+
+        views = data.getViews()
+        poses = {}
+
+        # Backup the absolute pose of each view using the rig
+        for id, v in views.items():
+            if data.isPoseDefined(v):
+                poses[id] = data.getPose(v)
+            
+            # Remove all "rig" references
+            v.setPoseId(id)
+            v.setRigAndSubPoseId(avsfmdata.UndefinedIndexT, avsfmdata.UndefinedIndexT)
+
+        data.getPoses().clear()
+        data.getRigs().clear()
+
+        # ReApply poses as independent poses
+        for id, pose in poses.items():
+            data.getPoses()[id] = pose
+            
+        # Save SfmData
+        avsfmdataio.save(data, chunk.node.output.value, avsfmdataio.ALL)
+        

--- a/meshroom/aliceVision/SfMRigApplying.py
+++ b/meshroom/aliceVision/SfMRigApplying.py
@@ -1,0 +1,120 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class SfMRigApplying(desc.Node):
+
+    size = desc.DynamicNodeSize("input")
+    category = "Utils"
+    documentation = """
+    Assume the input file is a non calibrated rig with only one pose but N views
+    Assume the rig calibration file is a calibrated rig with one or more pose but N sub-poses
+    Assume the number of intrinsics is the same and the intrinsics ids are equals.
+    Copy information for the rig calibration file to the input file such that the poses of the 
+    input file are set to the sub-pose of the calibrated rig.
+    """
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input SfMData",
+            description="Input SfMData file.",
+            value="",
+        ),
+        desc.File(
+            name="rig",
+            label="Rig SfMData",
+            description="Calibrated Rig SfMData file.",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        )
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfM File",
+            description="Path to the output SfM file.",
+            value="{nodeCacheFolder}/sfmData.sfm",
+        )
+    ]
+
+    def processChunk(self, chunk):
+
+        from pyalicevision import sfmData as avsfmdata
+        from pyalicevision import sfmDataIO as avsfmdataio
+        import logging
+        import numpy as np
+
+        logging.getLogger().setLevel(chunk.node.verboseLevel.value.upper())
+
+        # Load the input SfmData
+        dataInput = avsfmdata.SfMData()
+        ret = avsfmdataio.load(dataInput, chunk.node.input.value, avsfmdataio.ALL)
+        if not ret:
+            logging.error(f"Can't open sfmData file at {chunk.node.input.value}")
+            raise RuntimeError()
+
+        logging.info(f"Opened sfmData at {chunk.node.input.value}")
+
+        # Load the sfmData containing the calibrated rig
+        dataRig = avsfmdata.SfMData()
+        ret = avsfmdataio.load(dataRig, chunk.node.rig.evalValue, avsfmdataio.ALL)
+        if not ret:
+            logging.error(f"Can't open sfmData file at {chunk.node.rig.evalValue}")
+            raise RuntimeError()
+
+        logging.info(f"Opened sfmData at {chunk.node.rig.evalValue}")
+
+
+        intrinsicsInput = dataInput.getIntrinsics()
+        intrinsicsRig = dataRig.getIntrinsics()
+        if len(intrinsicsInput) != len(intrinsicsRig):
+            logging.error("Incompatible number of intrinsics")
+            raise RuntimeError()
+
+        # Copy intrinsics from calibrated rig
+        intrinsicsInput.clear()
+        for id, item in intrinsicsRig.items():
+            intrinsicsInput[id] = item
+
+
+        rigs = dataRig.getRigs()
+        if len(rigs) != 1:
+            logging.error("Invalid number of rigs")
+            raise RuntimeError()
+
+        # Get first rig
+        rig = next(iter(rigs.values()))
+        if rig.getNbSubPoses() != len(dataInput.getViews()):
+            logging.error("Invalid number of views")
+            raise RuntimeError()
+
+        if not rig.isFullyCalibrated():
+            logging.error("Rig is not calibrated")
+            raise RuntimeError()
+
+
+        # Copy the relative pose contained in the rig
+        # As the pose of the view
+        posesInput = dataInput.getPoses()
+        for id, v in dataInput.getViews().items():
+            subPose = rig.getSubPose(v.getSubPoseId())
+            pose = avsfmdata.CameraPose(subPose.pose)
+
+            posesInput[id] = pose
+
+            v.setPoseId(id)
+            v.setRigAndSubPoseId(avsfmdata.UndefinedIndexT, avsfmdata.UndefinedIndexT)
+
+        # Save the sfmData
+        avsfmdataio.save(dataInput, chunk.node.output.value, avsfmdataio.ALL)
+        

--- a/meshroom/hdrFusion.mg
+++ b/meshroom/hdrFusion.mg
@@ -1,12 +1,12 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "LdrToHdrCalibration": "3.1",
-            "LdrToHdrMerge": "4.1",
+            "LdrToHdrCalibration": "3.2",
+            "LdrToHdrMerge": "4.2",
             "LdrToHdrSampling": "4.0"
         },
         "template": true
@@ -19,6 +19,18 @@
                 0
             ],
             "inputs": {}
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                800,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{LdrToHdrMerge_1.outputFolder}"
+                ]
+            }
         },
         "LdrToHdrCalibration_1": {
             "nodeType": "LdrToHdrCalibration",
@@ -45,6 +57,7 @@
             "inputs": {
                 "input": "{LdrToHdrCalibration_1.input}",
                 "response": "{LdrToHdrCalibration_1.response}",
+                "luminanceStatistics": "{LdrToHdrCalibration_1.luminanceStatistics}",
                 "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}",
                 "byPass": "{LdrToHdrCalibration_1.byPass}",
                 "channelQuantizationPower": "{LdrToHdrCalibration_1.channelQuantizationPower}",
@@ -59,18 +72,6 @@
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}"
-            }
-        },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                800,
-                0
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{LdrToHdrMerge_1.outputFolder}"
-                ]
             }
         }
     }

--- a/meshroom/panoramaFisheyeHdr.mg
+++ b/meshroom/panoramaFisheyeHdr.mg
@@ -1,6 +1,6 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
@@ -8,8 +8,8 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "LdrToHdrCalibration": "3.1",
-            "LdrToHdrMerge": "4.1",
+            "LdrToHdrCalibration": "3.2",
+            "LdrToHdrMerge": "4.2",
             "LdrToHdrSampling": "4.0",
             "PanoramaCompositing": "2.0",
             "PanoramaEstimation": "1.0",
@@ -19,7 +19,7 @@
             "PanoramaPrepareImages": "1.1",
             "PanoramaSeams": "2.0",
             "PanoramaWarping": "1.1",
-            "SfMTransform": "3.1"
+            "SfMTransform": "3.2"
         },
         "template": true
     },
@@ -31,6 +31,20 @@
                 0
             ],
             "inputs": {}
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                3200,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{PanoramaPostProcessing_1.outputPanorama}",
+                    "{PanoramaPostProcessing_1.outputPanoramaPreview}",
+                    "{PanoramaPostProcessing_1.downscaledPanoramaLevels}"
+                ]
+            }
         },
         "FeatureExtraction_1": {
             "nodeType": "FeatureExtraction",
@@ -100,6 +114,7 @@
             "inputs": {
                 "input": "{LdrToHdrCalibration_1.input}",
                 "response": "{LdrToHdrCalibration_1.response}",
+                "luminanceStatistics": "{LdrToHdrCalibration_1.luminanceStatistics}",
                 "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}",
                 "byPass": "{LdrToHdrCalibration_1.byPass}",
                 "channelQuantizationPower": "{LdrToHdrCalibration_1.channelQuantizationPower}",
@@ -207,20 +222,6 @@
             ],
             "inputs": {
                 "input": "{SfMTransform_1.output}"
-            }
-        },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                3200,
-                0
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{PanoramaPostProcessing_1.outputPanorama}",
-                    "{PanoramaPostProcessing_1.outputPanoramaPreview}",
-                    "{PanoramaPostProcessing_1.downscaledPanoramaLevels}"
-                ]
             }
         },
         "SfMTransform_1": {

--- a/meshroom/panoramaHdr.mg
+++ b/meshroom/panoramaHdr.mg
@@ -1,6 +1,6 @@
 {
     "header": {
-        "releaseVersion": "2025.1.0",
+        "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
@@ -8,8 +8,8 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "LdrToHdrCalibration": "3.1",
-            "LdrToHdrMerge": "4.1",
+            "LdrToHdrCalibration": "3.2",
+            "LdrToHdrMerge": "4.2",
             "LdrToHdrSampling": "4.0",
             "PanoramaCompositing": "2.0",
             "PanoramaEstimation": "1.0",
@@ -19,7 +19,7 @@
             "PanoramaPrepareImages": "1.1",
             "PanoramaSeams": "2.0",
             "PanoramaWarping": "1.1",
-            "SfMTransform": "3.1"
+            "SfMTransform": "3.2"
         },
         "template": true
     },
@@ -31,6 +31,20 @@
                 0
             ],
             "inputs": {}
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                3000,
+                0
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{PanoramaPostProcessing_1.outputPanorama}",
+                    "{PanoramaPostProcessing_1.outputPanoramaPreview}",
+                    "{PanoramaPostProcessing_1.downscaledPanoramaLevels}"
+                ]
+            }
         },
         "FeatureExtraction_1": {
             "nodeType": "FeatureExtraction",
@@ -96,6 +110,7 @@
             "inputs": {
                 "input": "{LdrToHdrCalibration_1.input}",
                 "response": "{LdrToHdrCalibration_1.response}",
+                "luminanceStatistics": "{LdrToHdrCalibration_1.luminanceStatistics}",
                 "userNbBrackets": "{LdrToHdrCalibration_1.userNbBrackets}",
                 "byPass": "{LdrToHdrCalibration_1.byPass}",
                 "channelQuantizationPower": "{LdrToHdrCalibration_1.channelQuantizationPower}",
@@ -202,20 +217,6 @@
             ],
             "inputs": {
                 "input": "{SfMTransform_1.output}"
-            }
-        },
-        "CopyFiles_1": {
-            "nodeType": "CopyFiles",
-            "position": [
-                3000,
-                0
-            ],
-            "inputs": {
-                "inputFiles": [
-                    "{PanoramaPostProcessing_1.outputPanorama}",
-                    "{PanoramaPostProcessing_1.outputPanoramaPreview}",
-                    "{PanoramaPostProcessing_1.downscaledPanoramaLevels}"
-                ]
             }
         },
         "SfMTransform_1": {

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -801,8 +801,6 @@ void BundleAdjustmentCeres::addConstraints2DToProblem(const sfmData::SfMData& sf
         const std::shared_ptr<IntrinsicBase> intrinsicObject1 = _intrinsicObjects[intrinsicId_1];
         const std::shared_ptr<IntrinsicBase> intrinsicObject2 = _intrinsicObjects[intrinsicId_2];
 
-        // For the moment assume a unique camera
-        assert(intrinsicBlockPtr_1 == intrinsicBlockPtr_2);
 
         double * distortionBlockPtr_1 = fakeDistortionBlockPtr;
         if (_distortionsBlocks.find(intrinsicId_1) != _distortionsBlocks.end())
@@ -810,11 +808,67 @@ void BundleAdjustmentCeres::addConstraints2DToProblem(const sfmData::SfMData& sf
             distortionBlockPtr_1 = _distortionsBlocks.at(intrinsicId_1).data();
         }
 
-        ceres::CostFunction* costFunction = Constraint2dErrorFunctor::createCostFunction(intrinsicObject1,
-                                                                                        constraint.ObservationFirst,
-                                                                                        constraint.ObservationSecond);
+        double * distortionBlockPtr_2 = fakeDistortionBlockPtr;
+        if (_distortionsBlocks.find(intrinsicId_2) != _distortionsBlocks.end())
+        {
+            distortionBlockPtr_2 = _distortionsBlocks.at(intrinsicId_2).data();
+        }
 
-        problem.AddResidualBlock(costFunction, lossFunction, intrinsicBlockPtr_1, distortionBlockPtr_1, poseBlockPtr_1, poseBlockPtr_2);
+        bool view_1_rig = false;
+        double * rigBlockPtr_1 = nullptr;
+        if (view_1.getRigId() != UndefinedIndexT)
+        {
+            view_1_rig = true;
+            IndexT rigId = view_1.getRigId();
+            IndexT subPoseId = view_1.getSubPoseId();
+            rigBlockPtr_1 = _rigBlocks[rigId][subPoseId].data();
+        }
+
+        bool view_2_rig = false;
+        double * rigBlockPtr_2 = nullptr;
+        if (view_2.getRigId() != UndefinedIndexT)
+        {
+            view_2_rig = true;
+            IndexT rigId = view_2.getRigId();
+            IndexT subPoseId = view_2.getSubPoseId();
+            rigBlockPtr_2 = _rigBlocks[rigId][subPoseId].data();
+        }
+
+        ceres::CostFunction* costFunction = Constraint2dErrorFunctor::createCostFunction(intrinsicObject1,
+                                                                                        intrinsicObject2,
+                                                                                        constraint.ObservationFirst,
+                                                                                        constraint.ObservationSecond,
+                                                                                        view_1_rig,
+                                                                                        view_2_rig,
+                                                                                        (poseBlockPtr_1 == poseBlockPtr_2),
+                                                                                        (rigBlockPtr_1 == rigBlockPtr_2));
+        std::vector<double*> params;
+        params.push_back(intrinsicBlockPtr_1);        
+        params.push_back(distortionBlockPtr_1);
+
+        if (intrinsicBlockPtr_1 != intrinsicBlockPtr_2)
+        {
+            params.push_back(intrinsicBlockPtr_2);
+            params.push_back(distortionBlockPtr_2);
+        }
+
+        params.push_back(poseBlockPtr_1);
+        if (poseBlockPtr_2 != poseBlockPtr_1)
+        {
+            params.push_back(poseBlockPtr_2);
+        }
+
+        if (view_1_rig)
+        {
+            params.push_back(rigBlockPtr_1);
+        }
+
+        if (view_2_rig && rigBlockPtr_1 != rigBlockPtr_2)
+        {
+            params.push_back(rigBlockPtr_2);
+        }
+
+        problem.AddResidualBlock(costFunction, lossFunction, params);
     }
 }
 

--- a/src/aliceVision/sfm/bundle/costfunctions/constraint2d.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/constraint2d.hpp
@@ -20,73 +20,166 @@ namespace sfm {
 struct Constraint2dErrorFunctor
 {
     explicit Constraint2dErrorFunctor(const sfmData::Observation& obs1, 
-                                            const sfmData::Observation& obs2, 
-                                            const std::shared_ptr<camera::IntrinsicBase>& intrinsics)        
-    : _intrinsicLiftFunctor(new CostIntrinsicsLift(obs1.getCoordinates(), intrinsics)),
-    _intrinsicProjectFunctor(new CostIntrinsicsProject(obs2, intrinsics))
+                                    const sfmData::Observation& obs2, 
+                                    const std::shared_ptr<camera::IntrinsicBase>& intrinsic_1,
+                                    const std::shared_ptr<camera::IntrinsicBase>& intrinsic_2,
+                                    bool hasRig1,
+                                    bool hasRig2,
+                                    bool sharedPose,
+                                    bool sharedSubPose)        
+    : _sharedIntrinsic(intrinsic_1==intrinsic_2),
+    _sharedSubPose(sharedSubPose),
+    _sharedPose(sharedPose),
+    _hasRig1(hasRig1),
+    _hasRig2(hasRig2),
+    _intrinsicLiftFunctor(new CostIntrinsicsLift(obs1.getCoordinates(), intrinsic_1)),
+    _intrinsicProjectFunctor(new CostIntrinsicsProject(obs2, intrinsic_2))
     {        
     }
 
     template<typename T>
     bool operator()(T const* const* parameters, T* residuals) const
     {       
-        const T* parameter_intrinsics = parameters[0];
-        const T* parameter_distortion = parameters[1];
-        const T* parameter_pose1 = parameters[2];
-        const T* parameter_pose2 = parameters[3];
+        int lastParam = 0;
 
+        const T * parameter_intrinsics_lift = parameters[lastParam++];
+        const T * parameter_distortion_lift = parameters[lastParam++];
+        const T * parameter_intrinsics_project = _sharedIntrinsic ? parameter_intrinsics_lift : parameters[lastParam++];
+        const T * parameter_distortion_project = _sharedIntrinsic ? parameter_distortion_lift : parameters[lastParam++];
+        const T * parameter_pose1 = parameters[lastParam++];
+        const T * parameter_pose2 = (_sharedPose) ? parameter_pose1 : parameters[lastParam++];
+        const T * parameter_rig1 = (_hasRig1) ? parameters[lastParam++] : nullptr;
+        const T * parameter_rig2 = (_hasRig2) ? (_sharedSubPose ? parameter_rig1 : parameters[lastParam++]) : nullptr;
         
-        Eigen::Matrix<T, 3, 3> oneRo, twoRo, twoRone;
-        ceres::AngleAxisToRotationMatrix(parameter_pose1, oneRo.data());
-        ceres::AngleAxisToRotationMatrix(parameter_pose2, twoRo.data());
-        twoRone = twoRo * oneRo.transpose();
+
+        Eigen::Matrix<T, 3, 3> oneRo;
+        if (parameter_rig1)
+        {
+            Eigen::Matrix<T, 3, 3> oneRrig;
+            Eigen::Matrix<T, 3, 3> rigRo;
+            ceres::AngleAxisToRotationMatrix(parameter_pose1, rigRo.data());
+            ceres::AngleAxisToRotationMatrix(parameter_rig1, oneRrig.data());
+            oneRo = oneRrig * rigRo;
+        }   
+        else
+        {
+            ceres::AngleAxisToRotationMatrix(parameter_pose1, oneRo.data());
+        }
+
+        Eigen::Matrix<T, 3, 3> twoRo;
+        if (parameter_rig2)
+        {
+            Eigen::Matrix<T, 3, 3> twoRrig;
+            Eigen::Matrix<T, 3, 3> rigRo;
+            ceres::AngleAxisToRotationMatrix(parameter_pose2, rigRo.data());
+            ceres::AngleAxisToRotationMatrix(parameter_rig2, twoRrig.data());
+            twoRo = twoRrig * rigRo;
+        }   
+        else
+        {
+            ceres::AngleAxisToRotationMatrix(parameter_pose2, twoRo.data());
+        }
+
+        Eigen::Matrix<T, 3, 3> twoRone = twoRo * oneRo.transpose();
 
         Eigen::Vector<T, 3> lifted;
         const T * liftParameters[2];
-        liftParameters[0] = parameter_intrinsics;
-        liftParameters[1] = parameter_distortion;
+        liftParameters[0] = parameter_intrinsics_lift;
+        liftParameters[1] = parameter_distortion_lift;
         _intrinsicLiftFunctor(liftParameters, lifted.data());
         Eigen::Vector<T, 3> transformed = twoRone * lifted;
 
         const T * projectParameters[3];
-        projectParameters[0] = parameter_intrinsics;
-        projectParameters[1] = parameter_distortion;
+        projectParameters[0] = parameter_intrinsics_project;
+        projectParameters[1] = parameter_distortion_project;
         projectParameters[2] = transformed.data();
+
         return _intrinsicProjectFunctor(projectParameters, residuals);
     }
 
     /**
-     * @brief Create the appropriate cost functor according the provided input camera intrinsic model
-     * @param[in] intrinsicPtr The intrinsic pointer
-     * @param[in] observation The corresponding observation
+     * @brief Create the appropriate cost functor according to the provided input camera intrinsic model
+     * @param[in] intrinsicLift The intrinsic pointer of the origin camera (lifted)
+     * @param[in] intrinsicProject The intrinsic pointer of the destination camera (projected)
+     * @param[in] observation_first The corresponding observation in the first view
+     * @param[in] observation_second The corresponding observation in the second view
+     * @param[in] rigLift Is the first view part of a rig ?
+     * @param[in] rigProject Is the second view part of a rig ?
+     * @param[in] sharedPose both views are using the same pose
+     * @param[in] sharedSubPose both views are using the same subpose of the rig
      * @return cost functor
      */
-    inline static ceres::CostFunction* createCostFunction(std::shared_ptr<camera::IntrinsicBase> intrinsic,
+    inline static ceres::CostFunction* createCostFunction(std::shared_ptr<camera::IntrinsicBase> intrinsicLift,
+                                            std::shared_ptr<camera::IntrinsicBase> intrinsicProject,
                                             const sfmData::Observation& observation_first,
-                                            const sfmData::Observation& observation_second)
+                                            const sfmData::Observation& observation_second,
+                                            bool rigLift,
+                                            bool rigProject,
+                                            bool sharedPose,
+                                            bool sharedSubPose
+                                        )
     {       
-        auto costFunction = new ceres::DynamicAutoDiffCostFunction<Constraint2dErrorFunctor>(new Constraint2dErrorFunctor(observation_first, observation_second, intrinsic));
+        auto costFunction = new ceres::DynamicAutoDiffCostFunction<Constraint2dErrorFunctor>(new Constraint2dErrorFunctor(observation_first, observation_second, intrinsicLift, intrinsicProject, rigLift, rigProject, sharedPose, sharedSubPose));
 
-        int distortionSize = 1;
-        auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);
+        int distortionLiftSize = 1;
+        auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsicLift);
         if (isod)
         {
             auto distortion = isod->getDistortion();
             if (distortion)
             {
-                distortionSize = distortion->getParameters().size();
+                distortionLiftSize = distortion->getParameters().size();
             }
         }
 
-        costFunction->AddParameterBlock(intrinsic->getParameters().size()); 
-        costFunction->AddParameterBlock(distortionSize);
+        costFunction->AddParameterBlock(intrinsicLift->getParameters().size()); 
+        costFunction->AddParameterBlock(distortionLiftSize);
+
+        // Add intrinsic parameters for the second camera if this
+        // camera is different from the first
+        if (intrinsicLift != intrinsicProject)
+        {
+            int distortionProjectSize = 1;
+            auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsicProject);
+            if (isod)
+            {
+                auto distortion = isod->getDistortion();
+                if (distortion)
+                {
+                    distortionProjectSize = distortion->getParameters().size();
+                }
+            }
+
+            costFunction->AddParameterBlock(intrinsicProject->getParameters().size()); 
+            costFunction->AddParameterBlock(distortionProjectSize);
+        }
+
         costFunction->AddParameterBlock(6);
-        costFunction->AddParameterBlock(6);
+        if (!sharedPose)
+        {
+            costFunction->AddParameterBlock(6);
+        }
+
+        if (rigLift)
+        {
+            costFunction->AddParameterBlock(6);
+        }
+
+        if (rigProject && !sharedSubPose)
+        {
+            costFunction->AddParameterBlock(6);
+        }
+
         costFunction->SetNumResiduals(2);
 
         return costFunction;
     }
 
+    bool _sharedIntrinsic;
+    bool _sharedSubPose;
+    bool _sharedPose;
+    bool _hasRig1;
+    bool _hasRig2;
     ceres::DynamicCostFunctionToFunctorTmp _intrinsicLiftFunctor;
     ceres::DynamicCostFunctionToFunctorTmp _intrinsicProjectFunctor;
 };

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -302,7 +302,7 @@ class SfMData
     }
 
     /**
-     * @brief Check if the given view have defined intrinsic and pose
+     * @brief Check if the given view has defined intrinsic and pose
      * @param[in] view The given view
      * @return true if intrinsic  defined
      */
@@ -313,7 +313,7 @@ class SfMData
     }
 
     /**
-     * @brief Check if the given view have defined intrinsic and pose
+     * @brief Check if the given view has defined intrinsic and pose
      * @param[in] viewID The given viewID
      * @return true if intrinsic and pose defined
      */
@@ -323,7 +323,45 @@ class SfMData
     }
 
     /**
-     * @brief Check if the given view have defined intrinsi
+     * @brief Check if the given view has a valid pose
+     * @param[in] view The given view
+     * @return true if pose defined
+     */
+    bool isPoseDefined(const View & view) const
+    {        
+        const IndexT poseId = view.getPoseId();
+        if (poseId == UndefinedIndexT)
+        {
+            return false;
+        }
+        
+        auto it = _poses.find(poseId);
+        if (it == _poses.end())
+        {
+            return false;
+        }
+
+        bool rigValid = ((!view.isPartOfRig() || view.isPoseIndependant() || getRigSubPose(view).status != ERigSubPoseStatus::UNINITIALIZED));
+        if (!rigValid)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Check if the given view has a defined pose
+     * @param[in] viewID The given viewID
+     * @return true if pose defined
+     */
+    bool isPoseDefined(IndexT viewId) const 
+    { 
+        return isPoseDefined(*_views.at(viewId)); 
+    }
+
+    /**
+     * @brief Check if the given view has defined intrinsic
      * @param[in] view The given view
      * @return true if intrinsic and pose defined
      */
@@ -362,7 +400,7 @@ class SfMData
     }
 
     /**
-     * @brief Check if the given view have defined intrinsi
+     * @brief Check if the given view has defined intrinsic
      * @param[in] view The given view
      * @return true if intrinsic and pose defined
      */
@@ -377,7 +415,7 @@ class SfMData
     }
 
     /**
-     * @brief Check if the given view have defined intrinsic and pose
+     * @brief Check if the given view has defined intrinsic and pose
      * @param[in] viewID The given view ID
      * @return true if intrinsic and pose defined
      */

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -388,6 +388,20 @@ if (ALICEVISION_BUILD_PANORAMA)
               ${Boost_LIBRARIES}
     )
 
+    alicevision_add_software(aliceVision_panoramaRefining
+        SOURCE main_panoramaRefining.cpp
+        FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_image
+              aliceVision_feature
+              aliceVision_sfm
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              aliceVision_track
+              ${Boost_LIBRARIES}
+    )
+
     alicevision_add_software(aliceVision_panoramaRigging
         SOURCE main_panoramaRigging.cpp
         FOLDER ${FOLDER_SOFTWARE_PIPELINE}

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -387,6 +387,20 @@ if (ALICEVISION_BUILD_PANORAMA)
               aliceVision_sfmDataIO
               ${Boost_LIBRARIES}
     )
+
+    alicevision_add_software(aliceVision_panoramaRigging
+        SOURCE main_panoramaRigging.cpp
+        FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_image
+              aliceVision_feature
+              aliceVision_sfm
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              ${Boost_LIBRARIES}
+    )
+
     alicevision_add_software(aliceVision_panoramaWarping
         SOURCE main_panoramaWarping.cpp
         FOLDER ${FOLDER_SOFTWARE_PIPELINE}

--- a/src/software/pipeline/main_LdrToHdrCalibration.cpp
+++ b/src/software/pipeline/main_LdrToHdrCalibration.cpp
@@ -38,8 +38,8 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 0
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 3
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 2
 
 using namespace aliceVision;
 using namespace aliceVision::hdr;
@@ -144,6 +144,7 @@ int aliceVision_main(int argc, char** argv)
     std::string sfmInputDataFilename;
     std::string samplesFolder;
     std::string outputResponsePath;
+    std::string outputLuminanceStatisticsPath;
     ECalibrationMethod calibrationMethod = ECalibrationMethod::AUTO;
     std::string calibrationWeightFunction = "default";
     int nbBrackets = 0;
@@ -158,11 +159,13 @@ int aliceVision_main(int argc, char** argv)
     requiredParams.add_options()
         ("input,i", po::value<std::string>(&sfmInputDataFilename)->required(),
          "SfMData file input.")
-        ("response,o", po::value<std::string>(&outputResponsePath)->required(),
-         "Output path for the response file.");
+        ("luminanceStatistics", po::value<std::string>(&outputLuminanceStatisticsPath)->required(),
+         "File containing the luminance statistics produced by the calibration process.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
+        ("response,o", po::value<std::string>(&outputResponsePath)->required(),
+         "Output path for the response file.")
         ("samplesFolders,f", po::value<std::string>(&samplesFolder)->default_value(samplesFolder),
          "Path to folder containing the extracted samples (required if the calibration is not linear).")
         ("calibrationMethod,m", po::value<ECalibrationMethod>(&calibrationMethod)->default_value(calibrationMethod),
@@ -499,9 +502,19 @@ int aliceVision_main(int argc, char** argv)
             response.writeHtml(htmlName, "response");
         }
 
-        const std::string lumastatBasename = "luminanceStatistics";
-        const std::string lumastatFilename =
-          (fs::path(outputResponsePath).parent_path() / (lumastatBasename + "_" + std::to_string(intrinsicId) + ".txt")).string();
+        
+        // Setup luminance statistics file path
+        std::string lumastatFilename = outputLuminanceStatisticsPath;
+        const std::string token = "<INTRINSIC_ID>";
+        const std::size_t tokenPos = lumastatFilename.find(token);
+        if (tokenPos == std::string::npos)
+        {
+            ALICEVISION_LOG_ERROR("Invalid luminance statistics path '" << outputLuminanceStatisticsPath << "': missing required token '" << token << "'.");
+            return EXIT_FAILURE;
+        }
+        lumastatFilename.replace(tokenPos, token.length(), std::to_string(intrinsicId));
+
+
         std::ofstream file(lumastatFilename);
         if (!file)
         {

--- a/src/software/pipeline/main_LdrToHdrMerge.cpp
+++ b/src/software/pipeline/main_LdrToHdrMerge.cpp
@@ -30,8 +30,8 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 0
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 4
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 2
 
 using namespace aliceVision;
 
@@ -75,6 +75,8 @@ int aliceVision_main(int argc, char** argv)
     std::string sfmInputDataFilename;
     std::string inputResponsePath;
     std::string sfmOutputDataFilepath;
+    std::string luminanceStatisticsPath;
+
     int nbBrackets = 0;
     bool byPass = false;
     bool keepSourceImageName = false;
@@ -101,6 +103,8 @@ int aliceVision_main(int argc, char** argv)
     requiredParams.add_options()
         ("input,i", po::value<std::string>(&sfmInputDataFilename)->required(),
          "SfMData file input.")
+        ("luminanceStatistics", po::value<std::string>(&luminanceStatisticsPath)->required(),
+         "Path to the luminance statistics file.")
         ("response,o", po::value<std::string>(&inputResponsePath)->required(),
          "Input path for the response file.")
         ("outSfMData,o", po::value<std::string>(&sfmOutputDataFilepath)->required(),
@@ -294,7 +298,7 @@ int aliceVision_main(int argc, char** argv)
             const int targetIndex = middleIndex + offsetRefBracketIndex;
             const bool isOffsetRefBracketIndexValid = (targetIndex >= 0) && (targetIndex < usedNbBrackets);
 
-            const fs::path lumaStatFilepath(fs::path(inputResponsePath).parent_path() /
+            const fs::path lumaStatFilepath(fs::path(luminanceStatisticsPath).parent_path() /
                                             (std::string("luminanceStatistics") + "_" + std::to_string(intrinsicId) + ".txt"));
 
             if (!fs::is_regular_file(lumaStatFilepath) && !isOffsetRefBracketIndexValid)
@@ -353,6 +357,7 @@ int aliceVision_main(int argc, char** argv)
         int pos = 0;
         sfmData::SfMData outputSfm;
         outputSfm.getIntrinsics() = sfmData.getIntrinsics();
+        outputSfm.getRigs() = sfmData.getRigs();
 
         // If we are on the first chunk, or we are computing all the dataset
         // Export a new sfmData with HDR images as new Views and LDR images as ancestors

--- a/src/software/pipeline/main_panoramaEstimation.cpp
+++ b/src/software/pipeline/main_panoramaEstimation.cpp
@@ -143,12 +143,6 @@ int aliceVision_main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    if (!inputSfmData.getRigs().empty())
-    {
-        ALICEVISION_LOG_ERROR("Rigs are not currently supported in PanoramaEstimation.");
-        return EXIT_FAILURE;
-    }
-
     /* Store the pose c1_R_o of the prior */
     sfmData::Poses& initial_poses = inputSfmData.getPoses();
     Eigen::Matrix3d c1_R_oprior = Eigen::Matrix3d::Identity();

--- a/src/software/pipeline/main_panoramaInit.cpp
+++ b/src/software/pipeline/main_panoramaInit.cpp
@@ -1294,37 +1294,47 @@ int main(int argc, char* argv[])
         }
     }
 
+    if (useFisheye)
     {
         int equidistantCount = 0;
 
-        if (useFisheye && estimateFisheyeCircle)
+        if (estimateFisheyeCircle)
         {
-            if (sfmData.getIntrinsics().size() != 1)
+            // Build a map of views indexed by their intrinsicId, ignoring all but equidistant cameras
+            std::map<IndexT, std::vector<sfmData::View::sptr>> viewsPerIntrinsic;
+            for (const auto [idView, view] : sfmData.getViews())
             {
-                ALICEVISION_LOG_ERROR("Only one intrinsic allowed (" << sfmData.getIntrinsics().size() << " found)");
-                return EXIT_FAILURE;
+                IndexT intrinsicId = view->getIntrinsicId();
+                if (intrinsicId == UndefinedIndexT)
+                {
+                    continue;
+                }
+
+                const camera::IntrinsicBase & cam = sfmData.getIntrinsic(intrinsicId);
+                if (!camera::isEquidistant(cam.getType()))
+                {
+                    continue;
+                }
+
+                viewsPerIntrinsic[intrinsicId].push_back(view);
             }
 
-            std::shared_ptr<camera::IntrinsicBase> intrinsic = sfmData.getIntrinsics().begin()->second;
-            if (!intrinsic)
+            for (const auto & [intrinsicId, vViews]: viewsPerIntrinsic)
             {
-                ALICEVISION_LOG_ERROR("No valid intrinsic");
-                return EXIT_FAILURE;
-            }
+                camera::Equidistant & cam = dynamic_cast<camera::Equidistant&>(sfmData.getIntrinsic(intrinsicId));
 
-            if (camera::isEquidistant(intrinsic->getType()))
-            {
-                CircleDetector detector(intrinsic->w(), intrinsic->h(), 256);
+                CircleDetector detector(cam.w(), cam.h(), 256);
                 if (debugFisheyeCircleEstimation)
                 {
                     fs::path path(sfmOutputDataFilepath);
                     detector.setDebugDirectory(path.parent_path().string());
                 }
-                for (const auto& v : sfmData.getViews())
+
+                for (const auto& v : vViews)
                 {
                     // Read original image
                     image::Image<float> grayscale;
-                    image::readImage(v.second->getImage().getImagePath(), grayscale, image::EImageColorSpace::SRGB);
+                    image::readImage(v->getImage().getImagePath(), grayscale, image::EImageColorSpace::SRGB);
 
                     const bool res = detector.appendImage(grayscale);
                     if (!res)
@@ -1343,35 +1353,37 @@ int main(int argc, char* argv[])
                 const double cx = detector.getCircleCenterX();
                 const double cy = detector.getCircleCenterY();
                 const double r = detector.getCircleRadius();
+                
+                cam.setCircleCenterX(cx);
+                cam.setCircleCenterY(cy);
+                cam.setCircleRadius(0.98 * r);
 
-                // Update parameters with estimated values
-                fisheyeCenterOffset(0) = cx - 0.5 * double(intrinsic->w());
-                fisheyeCenterOffset(1) = cy - 0.5 * double(intrinsic->h());
-                fisheyeRadius = 98.0 * r / (0.5 * std::min(double(intrinsic->w()), double(intrinsic->h())));
-
-                ALICEVISION_LOG_INFO("Computing automatic fisheye circle");
-                ALICEVISION_LOG_INFO(" * Center Offset: " << fisheyeCenterOffset);
-                ALICEVISION_LOG_INFO(" * Radius: " << fisheyeRadius);
+                ALICEVISION_LOG_INFO("Computing automatic fisheye circle for intrinsic " << intrinsicId);
+                ALICEVISION_LOG_INFO(" * Circle center (cx, cy): " << cx << " " << cy);
+                ALICEVISION_LOG_INFO(" * Detected radius: " << r << ", applied radius: " << 0.98 * r);
             }
+
+            equidistantCount = viewsPerIntrinsic.size();
         }
-
-        sfmData::Intrinsics& intrinsics = sfmData.getIntrinsics();
-        for (const auto& intrinsic_pair : intrinsics)
+        else 
         {
-            std::shared_ptr<camera::IntrinsicBase> intrinsic = intrinsic_pair.second;
-            std::shared_ptr<camera::Equidistant> equidistant = std::dynamic_pointer_cast<camera::Equidistant>(intrinsic);
-            if (!equidistant)
+            sfmData::Intrinsics& intrinsics = sfmData.getIntrinsics();
+            for (const auto& intrinsic_pair : intrinsics)
             {
-                // skip non equidistant cameras
-                continue;
+                std::shared_ptr<camera::IntrinsicBase> intrinsic = intrinsic_pair.second;
+                std::shared_ptr<camera::Equidistant> equidistant = std::dynamic_pointer_cast<camera::Equidistant>(intrinsic);
+                if (!equidistant)
+                {
+                    // skip non equidistant cameras
+                    continue;
+                }
+                ALICEVISION_LOG_INFO("Update Equidistant camera intrinsic " << intrinsic_pair.first << " with center and offset.");
+
+                equidistant->setCircleCenterX(double(equidistant->w()) / 2.0 + fisheyeCenterOffset(0));
+                equidistant->setCircleCenterY(double(equidistant->h()) / 2.0 + fisheyeCenterOffset(1));
+                equidistant->setCircleRadius(fisheyeRadius / 100.0 * 0.5 * std::min(double(equidistant->w()), double(equidistant->h())));
+                ++equidistantCount;
             }
-            ALICEVISION_LOG_INFO("Update Equidistant camera intrinsic " << intrinsic_pair.first << " with center and offset.");
-
-            equidistant->setCircleCenterX(double(equidistant->w()) / 2.0 + fisheyeCenterOffset(0));
-            equidistant->setCircleCenterY(double(equidistant->h()) / 2.0 + fisheyeCenterOffset(1));
-
-            equidistant->setCircleRadius(fisheyeRadius / 100.0 * 0.5 * std::min(double(equidistant->w()), double(equidistant->h())));
-            ++equidistantCount;
         }
 
         ALICEVISION_LOG_INFO(equidistantCount << " equidistant camera intrinsics have been updated");

--- a/src/software/pipeline/main_panoramaRefining.cpp
+++ b/src/software/pipeline/main_panoramaRefining.cpp
@@ -1,0 +1,252 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/system/Timer.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/track/TracksHandler.hpp>
+#include <aliceVision/dataio/json.hpp>
+#include <aliceVision/sfm/pipeline/relativePoses.hpp>
+#include <aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp>
+#include <aliceVision/numeric/numeric.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <random>
+#include <regex>
+#include <fstream>
+#include <algorithm>
+#include <iterator>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string outputSfMDataFilepath;
+    std::string outputViewsAndPosesFilepath;
+    std::string tracksFilename;
+    std::string pairsDirectory;
+    bool intermediateRefineWithFocal = true;
+    bool intermediateRefineWithFocalDist = true;
+
+    // user optional parameters
+    int randomSeed = std::mt19937::default_seed;
+    
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
+        ("output,o", po::value<std::string>(&outputSfMDataFilepath)->required(), "Path of the output SfMData file.")
+        ("tracksFilename,t", po::value<std::string>(&tracksFilename)->required(), "Tracks file.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("pairs,p", po::value<std::string>(&pairsDirectory)->required(), "Path to the pairs directory.")
+        ("outputViewsAndPoses", po::value<std::string>(&outputViewsAndPosesFilepath),
+         "Path of the output SfMData file with cameras (views and poses).")
+        ("intermediateRefineWithFocal", po::value<bool>(&intermediateRefineWithFocal)->default_value(intermediateRefineWithFocal),
+         "Add an intermediate refine with rotation+focal in the different BA steps.")
+        ("intermediateRefineWithFocalDist", po::value<bool>(&intermediateRefineWithFocalDist)->default_value(intermediateRefineWithFocalDist),
+         "Add an intermediate refine with rotation+focal+distortion in the different BA steps.")
+        ("randomSeed", po::value<int>(&randomSeed)->default_value(randomSeed),
+         "This seed value will generate a sequence using a linear random generator. Set -1 to use a random seed.");
+    // clang-format on
+
+    CmdLine cmdline("Estimates the orientation of a camera around a nodal point for the creation of a 360° panorama.\n"
+                    "AliceVision panoramaEstimation");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // load input SfMData scene
+    sfmData::SfMData sfmData;
+    if (!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::INTRINSICS | sfmDataIO::EXTRINSICS)))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    // Load tracks
+    ALICEVISION_LOG_INFO("Load tracks");
+    track::TracksHandler tracksHandler;
+    if (!tracksHandler.load(tracksFilename, sfmData.getViewsKeys()))
+    {
+        ALICEVISION_LOG_ERROR("The input tracks file '" + tracksFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }    
+
+    // Result of pair estimations are stored in multiple files
+    std::vector<sfm::ReconstructedPair> reconstructedPairs;
+    const std::regex regex("pairs\\_[0-9]+\\.json");
+    for(const fs::directory_entry & file : boost::make_iterator_range(fs::directory_iterator(pairsDirectory), {}))
+    {
+        if (!std::regex_search(file.path().string(), regex))
+        {
+            continue;
+        }
+
+        std::ifstream inputfile(file.path().string());
+
+        boost::system::error_code ec;
+        std::vector<boost::json::value> values = readJsons(inputfile, ec);
+        for (const boost::json::value& value : values)
+        {
+            std::vector<sfm::ReconstructedPair> localVector = boost::json::value_to<std::vector<sfm::ReconstructedPair>>(value);
+            reconstructedPairs.insert(reconstructedPairs.end(), localVector.begin(), localVector.end());
+        }
+    }
+
+    
+    const auto & tracksPerView = tracksHandler.getTracksPerView();
+    const auto & tracksMap = tracksHandler.getAllTracks();
+
+    sfmData::Constraints2D& constraints2d = sfmData.getConstraints2D();
+    constraints2d.clear();
+
+    // Build relative constraints
+    for (const auto & pair: reconstructedPairs)
+    {
+        const track::TrackIdSet& refTracksIds = tracksPerView.at(pair.reference);
+        const track::TrackIdSet& nextTracksIds = tracksPerView.at(pair.next);
+        
+        track::TrackIdSet coobservedTracksIds;
+        std::set_intersection(refTracksIds.begin(), refTracksIds.end(), nextTracksIds.begin(), nextTracksIds.end(), std::back_inserter(coobservedTracksIds));
+        if (coobservedTracksIds.empty())
+        {
+            continue;
+        }
+
+        const auto & viewRef = sfmData.getView(pair.reference);
+        const auto & viewNext = sfmData.getView(pair.next);
+
+        const auto & intrinsicRef = sfmData.getIntrinsic(viewRef.getIntrinsicId());
+        const auto & intrinsicNext = sfmData.getIntrinsic(viewNext.getIntrinsicId());
+
+
+        for (const auto & trackId : coobservedTracksIds)
+        {
+            const auto & track = tracksMap.at(trackId);
+            const auto & featRef = track.featPerView.at(pair.reference);
+            const auto & featNext = track.featPerView.at(pair.next);
+
+            Vec3 wpt = intrinsicRef.backProjectUnit(featRef.coords);
+            Vec3 npt = intrinsicNext.backProjectUnit(featNext.coords);
+
+            // Remove outliers
+            // Use the same check that the rotation RANSAC used in relativePoseEstimating
+            const Vec3 nest = pair.pose.rotation() * wpt;
+            const double dot = clamp<double>(npt.dot(nest), -1.0, 1.0);
+            const double error = std::acos(dot);
+            if (error > pair.errorMax)
+            {
+                continue;
+            } 
+            
+            // Add a constraint to sfmData
+            const sfmData::Constraint2D constraint(pair.reference,
+                                            sfmData::Observation(featRef.coords, featRef.featureId, featRef.scale),
+                                            pair.next,
+                                            sfmData::Observation(featNext.coords, featNext.featureId, featNext.scale),
+                                            track.descType);
+
+            constraints2d.push_back(constraint);
+        }
+    }
+
+    sfm::BundleAdjustmentCeres::CeresOptions options;
+    options.summary = true;
+    options.maxNumIterations = 300;
+    options.useFocalPrior = false;
+    options.useParametersOrdering = false;
+
+    // Start bundle with rotation only
+    sfm::BundleAdjustmentCeres bundleAdjustment(options);
+    bool success = bundleAdjustment.adjust(sfmData, sfm::BundleAdjustmentCeres::REFINE_ROTATION);
+    if (success)
+    {
+        ALICEVISION_LOG_INFO("Rotations successfully refined.");
+    }
+    else
+    {
+        ALICEVISION_LOG_WARNING("Failed to refine the rotations only.");
+        return EXIT_FAILURE;
+    }
+
+    if (intermediateRefineWithFocal)
+    {
+        success = bundleAdjustment.adjust(sfmData, sfm::BundleAdjustmentCeres::REFINE_ROTATION | sfm::BundleAdjustmentCeres::REFINE_INTRINSICS_FOCAL);
+        if (success)
+        {
+            ALICEVISION_LOG_INFO("Bundle successfully refined: Rotation + Focal");
+        }
+        else
+        {
+            ALICEVISION_LOG_WARNING("Failed to refine: Rotation + Focal");
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (intermediateRefineWithFocalDist)
+    {
+        success = bundleAdjustment.adjust(sfmData,
+                            sfm::BundleAdjustmentCeres::REFINE_ROTATION | sfm::BundleAdjustmentCeres::REFINE_INTRINSICS_FOCAL |
+                            sfm::BundleAdjustmentCeres::REFINE_INTRINSICS_DISTORTION);
+        if (success)
+        {
+            ALICEVISION_LOG_INFO("Bundle successfully refined: Rotation + Focal + Distortion");
+        }
+        else
+        {
+            ALICEVISION_LOG_WARNING("Failed to refine: Rotation + Focal + Distortion");
+            return EXIT_FAILURE;
+        }
+    }
+
+    // Minimize All
+    success = bundleAdjustment.adjust(sfmData,
+                        sfm::BundleAdjustmentCeres::REFINE_ROTATION | sfm::BundleAdjustmentCeres::REFINE_INTRINSICS_FOCAL |
+                        sfm::BundleAdjustmentCeres::REFINE_INTRINSICS_DISTORTION |
+                        sfm::BundleAdjustmentCeres::REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS);
+    if (success)
+    {
+        ALICEVISION_LOG_INFO("Bundle successfully refined: Rotation + Focal + Optical Center + Distortion");
+    }
+    else
+    {
+        ALICEVISION_LOG_WARNING("Failed to refine: Rotation + Focal + Distortion + Optical Center");
+        return EXIT_FAILURE;
+    }
+
+    // Export to disk computed scene (data & visualizable results)
+    ALICEVISION_LOG_INFO("Export SfMData to disk");
+    sfmDataIO::save(sfmData, outputSfMDataFilepath, sfmDataIO::ESfMData::ALL);
+
+    if (!outputViewsAndPosesFilepath.empty())
+    {
+        sfmDataIO::save(sfmData, outputViewsAndPosesFilepath, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::EXTRINSICS | sfmDataIO::INTRINSICS));
+    }
+
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/pipeline/main_panoramaRigging.cpp
+++ b/src/software/pipeline/main_panoramaRigging.cpp
@@ -1,0 +1,232 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmData/Rig.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/cmdline/cmdline.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <map>
+#include <set>
+#include <vector>
+#include <algorithm>
+#include <iterator>
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+int aliceVision_main(int argc, char** argv)
+{
+    // command-line parameters
+    std::string sfmDataFilename;
+    std::string rigDescriptionFilename;
+    std::string outputSfMDataFilepath;
+    std::string outputViewsAndPosesFilepath;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(),
+         "SfMData file.")
+        ("rigDescription", po::value<std::string>(&rigDescriptionFilename)->required(),
+         "Rig description file.")
+        ("output,o", po::value<std::string>(&outputSfMDataFilepath)->required(),
+         "Path of the output SfMData file.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("outputViewsAndPoses", po::value<std::string>(&outputViewsAndPosesFilepath),
+         "Path of the output SfMData file.");
+    // clang-format on
+
+    CmdLine cmdline("Apply rig structure ('rigDescription') to a fully solved panorama ('Input')");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+   
+    // load panorama SfMData scene
+    sfmData::SfMData inputSfmData;
+    if (!sfmDataIO::load(inputSfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" << sfmDataFilename << "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    // load rig SfMData scene
+    sfmData::SfMData rigSfmData;
+    if (!sfmDataIO::load(rigSfmData, rigDescriptionFilename, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::INTRINSICS | sfmDataIO::EXTRINSICS)))
+    {
+        ALICEVISION_LOG_ERROR("The rigDescription SfMData file '" << rigDescriptionFilename << "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+    
+    if (rigSfmData.getRigs().size() != 1)
+    {
+        ALICEVISION_LOG_ERROR("One and only one rig is required.");
+        return EXIT_FAILURE;
+    }
+
+    // Will we ever have panorama rigs with more than 2 views ?
+    if (rigSfmData.getRigs().begin()->second.getNbSubPoses() != 2)
+    {
+        ALICEVISION_LOG_ERROR("At the moment, only 2 subposes supported.");
+        return EXIT_FAILURE;
+    }
+
+    // Build set of landmarks per view
+    std::map<IndexT, std::set<IndexT>> landmarkPerView;
+    for (const auto [id, landmark] : inputSfmData.getLandmarks())
+    {
+        for (const auto [viewId, obs]: landmark.getObservations())
+        {
+            landmarkPerView[viewId].insert(id);
+        }
+    }
+    
+    std::vector<std::pair<Pair, size_t>> scores;
+    for (const auto & [idViewRef, _] : inputSfmData.getViews())
+    {
+        const auto & setRef = landmarkPerView[idViewRef];
+
+        for (const auto & [idViewOther, _] : inputSfmData.getViews())
+        {
+            if (idViewOther <= idViewRef)
+            {
+                continue;
+            }
+
+            const auto & setOther = landmarkPerView[idViewOther];
+
+            std::vector<IndexT> commonSet;
+            std::set_intersection(setRef.begin(), setRef.end(), setOther.begin(), setOther.end(), std::back_inserter(commonSet));
+
+            Pair p;
+            p.first = idViewRef;
+            p.second = idViewOther;
+
+            scores.push_back(std::make_pair(p, commonSet.size()));
+        }
+    }
+
+    // Sort pairs per overlap
+    std::sort(scores.begin(), scores.end(), [](const auto & item1, const auto & item2)
+    {
+        return item1.second > item2.second;
+    });
+    
+
+    // loop over pairs which are sorted by scores
+    bool found = false;
+    geometry::Pose3 relativeRotation;
+    const sfmData::Views & rigViews = rigSfmData.getViews();
+    for (const auto & [pair, score] : scores)
+    {
+        if (rigViews.find(pair.first) == rigViews.end())
+        {
+            continue;
+        }
+
+        if (rigViews.find(pair.second) == rigViews.end())
+        {
+            continue;
+        }
+
+        const auto & rigvref = rigSfmData.getView(pair.first);
+        const auto & rigvother = rigSfmData.getView(pair.second);
+        const auto & invref = inputSfmData.getView(pair.first);
+        const auto & invother = inputSfmData.getView(pair.second);
+
+        // Looking for a pair with different subposeId
+        if (rigvref.getSubPoseId() == rigvother.getSubPoseId())
+        {
+            continue;
+        }
+
+        // Looking for a pair with same poseId
+        // Those are obviously not the most constrained pairs
+        // But this make the computation easy and should be ok if the panorama is well constrained.
+        if (rigvref.getPoseId() != rigvother.getPoseId())
+        {
+            continue;
+        }
+
+        
+
+        const sfmData::CameraPose & cpref = inputSfmData.getPose(invref);
+        const sfmData::CameraPose & cpother = inputSfmData.getPose(invother);
+
+        Eigen::Matrix3d R = cpother.getTransform().rotation() * cpref.getTransform().rotation().transpose();
+
+        // The relative rotation may be the inverse of the rig relative rotation (Pair order)
+        if (rigvref.getSubPoseId() == 0)
+        {
+            relativeRotation.setRotation(R);
+        }
+        else 
+        {
+            relativeRotation.setRotation(R.transpose());
+        }
+
+        found = true;
+
+        break;
+    }
+
+    if (!found)
+    {
+        ALICEVISION_LOG_ERROR("Can't find a suitable pair of poses.");
+        return EXIT_FAILURE;
+    }
+
+    sfmData::SfMData outSfmData = rigSfmData;
+
+    sfmData::Rig & rig = outSfmData.getRigs().begin()->second;
+    rig.setSubPose(0, sfmData::RigSubPose(geometry::Pose3(), sfmData::ERigSubPoseStatus::ESTIMATED));
+    rig.setSubPose(1, sfmData::RigSubPose(relativeRotation, sfmData::ERigSubPoseStatus::ESTIMATED));
+
+
+    // Loop on all views which are from the first element of the rig
+    for (const auto & [idView, view] : rigSfmData.getViews().valueRange())
+    {
+        if (view.getSubPoseId() != 0)
+        {
+            continue;
+        }
+
+        //Read pose from input
+        const sfmData::View & iview = inputSfmData.getView(idView);
+        const sfmData::CameraPose & cp = inputSfmData.getPose(iview);
+
+        //Set absolute pose for rig
+        IndexT destPoseId = view.getPoseId();
+        outSfmData.getPoses().assign(destPoseId, cp);
+    }
+
+    // Export to disk computed scene (data & visualizable results)
+    ALICEVISION_LOG_INFO("Export SfMData to disk");
+    sfmDataIO::save(outSfmData, outputSfMDataFilepath, sfmDataIO::ESfMData::ALL);
+
+    if (!outputViewsAndPosesFilepath.empty())
+    {
+        sfmDataIO::save(outSfmData, outputViewsAndPosesFilepath, sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::EXTRINSICS | sfmDataIO::INTRINSICS));
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_split360Images.cpp
+++ b/src/software/utils/main_split360Images.cpp
@@ -90,7 +90,8 @@ bool splitDualFisheye(sfmData::SfMData& outSfmData,
                       const std::string& outputFolder,
                       const std::string& extension,
                       const std::string& offsetPresetX,
-                      const std::string& offsetPresetY)
+                      const std::string& offsetPresetY,
+                      IndexT poseId)
 {
     // Load source image from disk
     image::Image<image::RGBfColor> imageSource;
@@ -153,8 +154,8 @@ bool splitDualFisheye(sfmData::SfMData& outSfmData,
             auto view = std::make_shared<sfmData::View>(
               /* image path */ subFolder + std::string("/") + filename,
               /* viewId */ viewId,
-              /* intrinsicId */ 0,
-              /* poseId */ UndefinedIndexT,
+              /* intrinsicId */ i,
+              /* poseId */ poseId,
               /* width */ outSide,
               /* height */ outSide,
               /* rigId */ 0,
@@ -540,7 +541,7 @@ int aliceVision_main(int argc, char** argv)
         }
         else if (splitMode == "dualfisheye")
         {
-            hasCorrectPath = splitDualFisheye(outSfmData, imagePath, outputFolder, extension, dualFisheyeOffsetPresetX, dualFisheyeOffsetPresetY);
+            hasCorrectPath = splitDualFisheye(outSfmData, imagePath, outputFolder, extension, dualFisheyeOffsetPresetX, dualFisheyeOffsetPresetY, i);
         }
 
         if (!hasCorrectPath)
@@ -596,22 +597,26 @@ int aliceVision_main(int argc, char** argv)
             width = view->getImage().getWidth();
             height = view->getImage().getHeight();
             focal_px = view->getImage().getMetadataFocalLength() * (width / 36.0);
-            if (focal_px < 0)
-            {
-                // If there is no focal metadata, use a default field of view of 170 degrees
-                focal_px = (width / 2.0) / tan(degreeToRadian(170.0) / 2.0);
-            }
 
             // Use either a pinhole fisheye model or an equidistant model depending on user choice
             if (dualFisheyeCameraModel == "fisheye4")
             {
                 cameraModel = camera::EINTRINSIC::PINHOLE_CAMERA;
                 distortionModel = camera::EDISTORTION::DISTORTION_FISHEYE;
+
+                if (focal_px < 0)
+                {
+                    // If there is no focal metadata, use a default field of view of 170 degrees
+                    focal_px = (width / 2.0) / tan(degreeToRadian(170.0) / 2.0);
+                }
             }
             else 
             {
                 cameraModel = camera::EINTRINSIC::EQUIDISTANT_CAMERA;
                 distortionModel = camera::EDISTORTION::DISTORTION_RADIALK3PT;
+                // For equidistant, always replace focal
+                // As the existing focal make no real sense
+                focal_px = width / M_PI;
             }
         }
 
@@ -625,6 +630,11 @@ int aliceVision_main(int argc, char** argv)
         // Note: intrinsic ID is 0, this convention is used in several places in this file
         auto& intrinsics = outSfmData.getIntrinsics();
         intrinsics.emplace(0, intrinsic);
+        if (splitMode == "dualfisheye")
+        {
+            // In dual-fisheye mode, also register the same intrinsic under ID 1 for the second view.
+            intrinsics.emplace(1, intrinsic);
+        }
     }
 
     // Save sfmData with modified path to images


### PR DESCRIPTION
This pull request introduces several new panorama and SfM utility nodes, updates existing node versions, and enhances the HDR calibration/merge workflow by adding support for luminance statistics output. It also updates the workflow files to use the new node versions and integrates the new luminance statistics parameter. The sum of all these modifications is meant to support dual fisheye based panoramas.

**New Panorama and SfM Utility Nodes:**

* Added new nodes: `PanoramaRefining`, `PanoramaRigging`, `SfMPoseFlattening`, and `SfMRigApplying`, providing advanced panorama HDR refinement, rigging, and SfM data manipulation capabilities. [[1]](diffhunk://#diff-b024fcc491c5d08e62169ed499cab90885a217ad9ede0c594313640c978c7299R1-R72) [[2]](diffhunk://#diff-4c2b49b85ed1a62fa9922f393073eeff43f5119891a6779678cedf4f03479aa7R1-R52) [[3]](diffhunk://#diff-5d8bcefdf095894c53aa6ef6c0960b9ddfad7c861e80cc9577c7f3c09001def5R1-R80) [[4]](diffhunk://#diff-99494a9bc8b855c2f04eeaf044c60ae69bf00656ef8a0d300390d60c8d76c87cR1-R119)

**HDR Calibration and Merge Enhancements:**

* Added a new `luminanceStatistics` output parameter to both `LdrToHdrCalibration` and `LdrToHdrMerge` nodes, allowing workflows to capture and use luminance statistics generated during calibration. [[1]](diffhunk://#diff-8f1e52e219b557dab4a9ac60c134a75a44e7271a09828267d52daef4fb7fca0cR154-R159) [[2]](diffhunk://#diff-f183d1fb35300607a5a9330120ed7f7e48f82508b7add3d23d33907afcbebd21R48-R53)

**Workflow and Version Updates:**

* Updated workflow files (`hdrFusion.mg`, `panoramaHdr.mg`, `panoramaFisheyeHdr.mg`) to reference the new node versions (`LdrToHdrCalibration` 3.2, `LdrToHdrMerge` 4.2, `SfMTransform` 3.2) and to include the new `luminanceStatistics` parameter in node inputs. [[1]](diffhunk://#diff-f1cfdd8a1aa79c1a4341a87e56625a8b224d0cec4ffe53a3994e9435b731aa4bL3-R9) [[2]](diffhunk://#diff-f1cfdd8a1aa79c1a4341a87e56625a8b224d0cec4ffe53a3994e9435b731aa4bR60) [[3]](diffhunk://#diff-655d9081a9bcbe86e60cadbfc668c224a1448030e29e44d9556e5811cad330a6L3-R12) [[4]](diffhunk://#diff-655d9081a9bcbe86e60cadbfc668c224a1448030e29e44d9556e5811cad330a6R117) [[5]](diffhunk://#diff-ffca8002231f0f6f652cc6bcc0583c4cd02a39f49b7234e0321c630a8ae32a81L3-R12) [[6]](diffhunk://#diff-ffca8002231f0f6f652cc6bcc0583c4cd02a39f49b7234e0321c630a8ae32a81R113) [[7]](diffhunk://#diff-655d9081a9bcbe86e60cadbfc668c224a1448030e29e44d9556e5811cad330a6L22-R22) [[8]](diffhunk://#diff-ffca8002231f0f6f652cc6bcc0583c4cd02a39f49b7234e0321c630a8ae32a81L22-R22)

**Workflow Structure Improvements:**

* Reorganized workflow files to ensure correct node ordering and input/output connections, including the addition and repositioning of `CopyFiles_1` nodes. [[1]](diffhunk://#diff-f1cfdd8a1aa79c1a4341a87e56625a8b224d0cec4ffe53a3994e9435b731aa4bR23-R34) [[2]](diffhunk://#diff-f1cfdd8a1aa79c1a4341a87e56625a8b224d0cec4ffe53a3994e9435b731aa4bL63-L74) [[3]](diffhunk://#diff-655d9081a9bcbe86e60cadbfc668c224a1448030e29e44d9556e5811cad330a6R35-R48) [[4]](diffhunk://#diff-655d9081a9bcbe86e60cadbfc668c224a1448030e29e44d9556e5811cad330a6L212-L225) [[5]](diffhunk://#diff-ffca8002231f0f6f652cc6bcc0583c4cd02a39f49b7234e0321c630a8ae32a81R35-R48) [[6]](diffhunk://#diff-ffca8002231f0f6f652cc6bcc0583c4cd02a39f49b7234e0321c630a8ae32a81L207-L220)

**Version Bumps:**

* Updated release versions in workflow headers to `2026.1.0+develop` to reflect new development changes. [[1]](diffhunk://#diff-f1cfdd8a1aa79c1a4341a87e56625a8b224d0cec4ffe53a3994e9435b731aa4bL3-R9) [[2]](diffhunk://#diff-655d9081a9bcbe86e60cadbfc668c224a1448030e29e44d9556e5811cad330a6L3-R12) [[3]](diffhunk://#diff-ffca8002231f0f6f652cc6bcc0583c4cd02a39f49b7234e0321c630a8ae32a81L3-R12)