### PR TITLE
Enable `rangeComputation` in Swig

### DIFF
--- a/src/aliceVision/system/Parallelization.i
+++ b/src/aliceVision/system/Parallelization.i
@@ -1,0 +1,18 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+%include "typemaps.i"
+
+%apply int& OUTPUT { int& rangeStart };
+%apply int& OUTPUT { int& rangeEnd };
+
+%{
+#include <aliceVision/system/Parallelization.hpp>
+
+using namespace aliceVision;
+%}
+
+%include <aliceVision/system/Parallelization.hpp>

--- a/src/aliceVision/system/System.i
+++ b/src/aliceVision/system/System.i
@@ -8,7 +8,7 @@
 
 %include <aliceVision/global.i>
 %include <aliceVision/system/ProgressDisplay.i>
-
+%include <aliceVision/system/Parallelization.i>
 
 %{
 #include <aliceVision/system/Logger.hpp>
@@ -20,4 +20,4 @@ void initialize_alicevision_logger(const std::string & verboseLevel)
 }
 %}
 
-void initialize_alicevision_logger(const std::string & verboseLevel);
+void initialize_alicevision_logger(const std::string & verboseLevel);  


### PR DESCRIPTION
Enable aliceVision::rangeComputation in swig 

```python

from pyalicevision import system as avsys
(valid, rangeStart, rangeEnd) = avsys.rangeComputation(rangeIteration, rangeBlocksCount, len(plist))
    if not valid:
        logging.error("Error computing range.")
```