### PR TITLE
[meshroom] Rename `groupDesc` to `items` in node descriptions

### DIFF
--- a/meshroom/aliceVision/CameraInit.py
+++ b/meshroom/aliceVision/CameraInit.py
@@ -188,7 +188,7 @@ Intrinsic = [
         name="principalPoint",
         label="Principal Point",
         description="Position of the optical center in the image (i.e. the sensor surface).",
-        groupDesc=[
+        items=[
             desc.FloatParam(
                 name="x",
                 label="x",
@@ -243,7 +243,7 @@ Intrinsic = [
         name="undistortionOffset",
         label="Undistortion Offset",
         description="Undistortion offset.",
-        groupDesc=[
+        items=[
             desc.FloatParam(
                 name="x",
                 label="x",
@@ -356,7 +356,7 @@ The needed metadata are:
                 name="viewpoint",
                 label="Viewpoint",
                 description="Viewpoint.",
-                groupDesc=Viewpoint,
+                items=Viewpoint,
             ),
             label="Viewpoints",
             description="Input viewpoints.",
@@ -368,7 +368,7 @@ The needed metadata are:
                 name="intrinsic",
                 label="Intrinsic",
                 description="Intrinsic.",
-                groupDesc=Intrinsic,
+                items=Intrinsic,
             ),
             label="Intrinsics",
             description="Camera intrinsics.",

--- a/meshroom/aliceVision/DepthMap.py
+++ b/meshroom/aliceVision/DepthMap.py
@@ -72,7 +72,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             label="Tiling",
             description="Tiles are used to split the computation into fixed buffers to fit the GPU best.",
             group=None,
-            groupDesc=[
+            items=[
                 desc.IntParam(
                     name="tileBufferWidth",
                     label="Buffer Width",
@@ -126,7 +126,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                         "This method is highly robust but has limited depth precision (banding artifacts due to a "
                         "limited list of depth planes).",
             group=None,
-            groupDesc=[
+            items=[
                 desc.IntParam(
                     name="sgmScale",
                     label="Downscale Factor",
@@ -269,7 +269,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                         "range around the SGM depth map.\n"
                         "This allows to compute a depth map with sub-pixel accuracy.",
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="refineEnabled",
                     label="Enable",
@@ -380,7 +380,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             label="Color Optimization",
             description="Color optimization post-process parameters.",
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="colorOptimizationEnabled",
                     label="Enable",
@@ -404,7 +404,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="User custom patch pattern for similarity comparison.",
             advanced=True,
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="sgmUseCustomPatchPattern",
                     label="Enable For SGM",
@@ -432,7 +432,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                         description="Custom patch pattern subpart configuration for similarity volume computation.",
                         joinChar=":",
                         group=None,
-                        groupDesc=[
+                        items=[
                             desc.ChoiceParam(
                                 name="customPatchPatternSubpartType",
                                 label="Type",
@@ -489,7 +489,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                         "Warning: Dramatically affect performances and use large amount of storage.",
             advanced=True,
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="exportIntermediateDepthSimMaps",
                     label="Export Depth Maps",

--- a/meshroom/aliceVision/ImageMasking.py
+++ b/meshroom/aliceVision/ImageMasking.py
@@ -35,7 +35,7 @@ class ImageMasking(desc.AVCommandLineNode):
                         " - Black: Tolerance = 1, minSaturation = 0, maxSaturation = 0.1, minValue = 0, maxValue = 0.2",
             group=None,
             enabled=lambda node: node.algorithm.value == "HSV",
-            groupDesc=[
+            items=[
                 desc.FloatParam(
                     name="hsvHue",
                     label="Hue",

--- a/meshroom/aliceVision/ImageProcessing.py
+++ b/meshroom/aliceVision/ImageProcessing.py
@@ -130,7 +130,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             label="Lens Correction",
             description="Automatic lens correction settings.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="lensCorrectionEnabled",
                     label="Enable",
@@ -207,7 +207,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             label="Sharpen Filter",
             description="Sharpen filter parameters.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="sharpenFilterEnabled",
                     label="Enable",
@@ -245,7 +245,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             label="Bilateral Filter",
             description="Bilateral filter parameters.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="bilateralFilterEnabled",
                     label="Enable",
@@ -284,7 +284,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             label="Clahe Filter",
             description="Clahe filter parameters.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="claheEnabled",
                     label="Enable",
@@ -315,7 +315,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             label="Noise Filter",
             description="Noise filter parameters.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="noiseEnabled",
                     label="Enable",
@@ -371,7 +371,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             description="NL Means Denoising Parameters.\n"
                         "This implementation only works on 8-bit images, so the colors can be reduced and clamped.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="nlmFilterEnabled",
                     label="Enable",
@@ -422,7 +422,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             label="Pixel Aspect Ratio",
             description="Pixel Aspect Ratio parameters.",
             joinChar=":",
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="parEnabled",
                     label="Enable",

--- a/meshroom/aliceVision/KeyframeSelection.py
+++ b/meshroom/aliceVision/KeyframeSelection.py
@@ -142,7 +142,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         "- With the smart method, keyframes are selected based on their sharpness "
                         "and optical flow scores.",
             group=None,  # skip group from command line
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="useSmartSelection",
                     label="Use Smart Keyframe Selection",
@@ -157,7 +157,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                                 "to the set parameters.",
                     group=None,  # skip group from command line
                     enabled=lambda node: node.selectionMethod.useSmartSelection.value is False,
-                    groupDesc=[
+                    items=[
                         desc.IntParam(
                             name="minFrameStep",
                             label="Min Frame Step",
@@ -197,7 +197,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                                 "flow scores.",
                     group=None,  # skip group from command line
                     enabled=lambda node: node.selectionMethod.useSmartSelection.value,
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="pxDisplacement",
                             label="Pixel Displacement",
@@ -337,14 +337,14 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             group=None,  # skip group from command line
             enabled=lambda node: node.selectionMethod.useSmartSelection.value,
             advanced=True,
-            groupDesc=[
+            items=[
                 desc.GroupAttribute(
                     name="debugScores",
                     label="Export Scores",
                     description="Export the computed sharpness and optical flow scores to a file.",
                     group=None,  # skip group from command line
                     enabled=lambda node: node.debugOptions.enabled,
-                    groupDesc=[
+                    items=[
                         desc.BoolParam(
                             name="exportScores",
                             label="Export Scores To CSV",
@@ -376,7 +376,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     description="Visualise the motion vectors for each input frame in HSV.",
                     group=None,  # skip group from command line
                     enabled=lambda node: node.debugOptions.enabled,
-                    groupDesc=[
+                    items=[
                         desc.BoolParam(
                             name="exportFlowVisualisation",
                             label="Visualise Optical Flow",

--- a/meshroom/aliceVision/LidarMeshing.py
+++ b/meshroom/aliceVision/LidarMeshing.py
@@ -36,12 +36,12 @@ class LidarMeshing(desc.AVCommandLineNode):
             name="boundingBox",
             label="Bounding Box Settings",
             description="Translation, rotation and scale of the bounding box.",
-            groupDesc=[
+            items=[
                 desc.GroupAttribute(
                     name="bboxTranslation",
                     label="Translation",
                     description="Position in space.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x", label="x", description="X offset.",
                             value=0.0,
@@ -64,7 +64,7 @@ class LidarMeshing(desc.AVCommandLineNode):
                     name="bboxRotation",
                     label="Euler Rotation",
                     description="Rotation in Euler degrees.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x", label="x", description="Euler X rotation.",
                             value=0.0,
@@ -87,7 +87,7 @@ class LidarMeshing(desc.AVCommandLineNode):
                     name="bboxScale",
                     label="Scale",
                     description="Scale of the bounding box.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x", label="x", description="X scale.",
                             value=1.0,

--- a/meshroom/aliceVision/Meshing.py
+++ b/meshroom/aliceVision/Meshing.py
@@ -56,12 +56,12 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             name="boundingBox",
             label="Bounding Box Settings",
             description="Translation, rotation and scale of the bounding box.",
-            groupDesc=[
+            items=[
                 desc.GroupAttribute(
                     name="bboxTranslation",
                     label="Translation",
                     description="Position in space.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x", label="x", description="X offset.",
                             value=0.0,
@@ -84,7 +84,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                     name="bboxRotation",
                     label="Euler Rotation",
                     description="Rotation in Euler degrees.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x", label="x", description="Euler X rotation.",
                             value=0.0,
@@ -107,7 +107,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                     name="bboxScale",
                     label="Scale",
                     description="Scale of the bounding box.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x", label="x", description="X scale.",
                             value=1.0,

--- a/meshroom/aliceVision/PanoramaInit.py
+++ b/meshroom/aliceVision/PanoramaInit.py
@@ -89,7 +89,7 @@ This node allows to setup the Panorama:
             name="fisheyeCenterOffset",
             label="Fisheye Center",
             description="Center of the fisheye circle (XY offset to the center in pixels).",
-            groupDesc=[
+            items=[
                 desc.FloatParam(
                     name="fisheyeCenterOffset_x",
                     label="x",

--- a/meshroom/aliceVision/SfMTransform.py
+++ b/meshroom/aliceVision/SfMTransform.py
@@ -87,12 +87,12 @@ The transformation can be based on:
             name="manualTransform",
             label="Manual Transform (Gizmo)",
             description="Translation, rotation (Euler ZXY) and uniform scale.",
-            groupDesc=[
+            items=[
                 desc.GroupAttribute(
                     name="manualTranslation",
                     label="Translation",
                     description="Translation in space.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x",
                             label="x",
@@ -121,7 +121,7 @@ The transformation can be based on:
                     name="manualRotation",
                     label="Euler Rotation",
                     description="Rotation in Euler angles.",
-                    groupDesc=[
+                    items=[
                         desc.FloatParam(
                             name="x",
                             label="x",
@@ -180,7 +180,7 @@ The transformation can be based on:
                 label="Marker Align",
                 description="",
                 joinChar=":",
-                groupDesc=[
+                items=[
                     desc.IntParam(
                         name="markerId",
                         label="Marker",
@@ -193,7 +193,7 @@ The transformation can be based on:
                         label="Coord",
                         description="Marker coordinates.",
                         joinChar=",",
-                        groupDesc=[
+                        items=[
                             desc.FloatParam(
                                 name="x",
                                 label="x",

--- a/meshroom/aliceVision/SphereDetection.py
+++ b/meshroom/aliceVision/SphereDetection.py
@@ -43,7 +43,7 @@ Spheres can be automatically detected or manually defined in the interface.
             name="sphereCenter",
             label="Sphere Center",
             description="Center of the circle (XY offset to the center of the image in pixels).",
-            groupDesc=[
+            items=[
                 desc.FloatParam(
                     name="x",
                     label="x",

--- a/meshroom/aliceVision/Split360Images.py
+++ b/meshroom/aliceVision/Split360Images.py
@@ -47,7 +47,7 @@ class Split360Images(desc.AVCommandLineNode):
             description="Dual Fisheye.",
             group=None,
             enabled=lambda node: node.splitMode.value == "dualfisheye",
-            groupDesc=[
+            items=[
                 desc.ChoiceParam(
                     name="dualFisheyeOffsetPresetX",
                     label="X Offset Preset",
@@ -77,7 +77,7 @@ class Split360Images(desc.AVCommandLineNode):
             description="Equirectangular",
             group=None,
             enabled=lambda node: node.splitMode.value == "equirectangular",
-            groupDesc=[
+            items=[
                 desc.IntParam(
                     name="equirectangularNbSplits",
                     label="Nb Splits",

--- a/meshroom/aliceVision/Texturing.py
+++ b/meshroom/aliceVision/Texturing.py
@@ -85,7 +85,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Color map parameters.",
             enabled=lambda node: (node.imagesFolder.value != ''),
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="enable",
                     label="Enable",
@@ -110,7 +110,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Bump mapping parameters.",
             enabled=lambda node: (node.inputRefMesh.value != ''),
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="enable",
                     label="Enable",
@@ -151,7 +151,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             description="Displacement mapping parameters.",
             enabled=lambda node: (node.inputRefMesh.value != ""),
             group=None,
-            groupDesc=[
+            items=[
                 desc.BoolParam(
                     name="enable",
                     label="Enable",
@@ -211,7 +211,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
         desc.GroupAttribute(
             name="multiBandNbContrib",
             label="Multi-Band Contributions",
-            groupDesc=[
+            items=[
                 desc.IntParam(
                     name="high",
                     label="High Freq",


### PR DESCRIPTION
## Description

Following https://github.com/alicevision/Meshroom/pull/3002, this PR renames all the `groupDesc` arguments used in `GroupAttributes` to `items` in all the node descriptions. 