### PR TITLE
Upgrade docker containers with modern cmake

### DIFF
--- a/docker/Dockerfile_rocky_deps
+++ b/docker/Dockerfile_rocky_deps
@@ -28,7 +28,7 @@ RUN update-alternatives --install /usr/bin/g++ g++ /opt/rh/gcc-toolset-12/root/u
 RUN update-alternatives --install /usr/bin/cpp cpp /opt/rh/gcc-toolset-12/root/usr/bin/cpp 60
 RUN dnf install -y ca-certificates wget cmake git unzip pcre2-devel xerces-c-devel
 RUN dnf install -y python3.11-devel python3.11-pip python3.11-pybind11-devel bison diffutils which file yasm
-RUN dnf install -y gcc-toolset-12-gcc-gfortran libasan libubsan yaml-cpp
+RUN dnf install -y gcc-toolset-12-gcc-gfortran libasan libubsan yaml-cpp openssl-devel texinfo libtool automake
 RUN dnf update -y
 
 # RUN scl enable gcc-toolset-12 bash
@@ -45,10 +45,17 @@ RUN gfortran --version
 
 RUN python3.11 -m pip install numpy==1.*
 
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6.tar.gz 
+RUN tar -xzf cmake-3.31.6.tar.gz && \
+    cd cmake-3.31.6 && \
+    ./bootstrap --prefix=/usr/local && \
+    make -j 16 && \
+    make install
+
 ENV AV_DEV=/opt/AliceVision_git \
     AV_BUILD=/tmp/AliceVision_build \
     AV_INSTALL=/opt/AliceVision_install \
-    PATH="${PATH}:${AV_BUNDLE}"
+    PATH="/usr/local/bin:${PATH}"
 
 COPY dl/vlfeat_K80L3.SIFT.tree ${AV_INSTALL}/share/aliceVision/
 RUN echo "export ALICEVISION_VOCTREE=${AV_INSTALL}/share/aliceVision/vlfeat_K80L3.SIFT.tree" >> /etc/profile.d/alicevision.sh
@@ -115,5 +122,5 @@ RUN test -e /usr/local/cuda/lib64/libcublas.so || ln -s /usr/lib/x86_64-linux-gn
 
 
 RUN cmake --build . -j ${CPU_CORES} && \
-   mv "${AV_INSTALL}/bin" "${AV_INSTALL}/bin-deps" && \
-   rm -rf "${AV_BUILD}"
+mv "${AV_INSTALL}/bin" "${AV_INSTALL}/bin-deps" && \
+rm -rf "${AV_BUILD}"

--- a/docker/Dockerfile_ubuntu_deps
+++ b/docker/Dockerfile_ubuntu_deps
@@ -37,7 +37,6 @@ RUN . ./etc/os-release && \
         libssl-dev \
         nasm \
         automake \
-        cmake \
         clang-format \
         libxerces-c-dev \
         gcc-12 \
@@ -45,8 +44,18 @@ RUN . ./etc/os-release && \
         cpp-12 \
         gfortran-12 \
         libpcre2-dev \
+        texinfo \
+        automake \
+        libtool \
         bison && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12  --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-12
+
+# The Kitware repo provides a recent cmake
+RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y cmake=3.31.11-0kitware1ubuntu22.04.1 cmake-data=3.31.11-0kitware1ubuntu22.04.1
+
 
 RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-distutils curl && \

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -1254,7 +1254,7 @@ if(AV_BUILD_SUITESPARSE)
         BUILD_ALWAYS 0
         UPDATE_COMMAND ""
         INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-        CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --with-gmp=<INSTALL_DIR>
+        CONFIGURE_COMMAND autoreconf -f -i <SOURCE_DIR> && <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --with-gmp=<INSTALL_DIR>
         BUILD_COMMAND $(MAKE) -j${AV_BUILD_DEPENDENCIES_PARALLEL}
         DEPENDS gmp
     )


### PR DESCRIPTION
Upgrading both Docker recipes:
- Rocky is updated with CMake 3.31.6
- Ubuntu is updated with CMake 3.31.11

see https://github.com/alicevision/AliceVision/pull/2058