### PR TITLE
Upgrade CI docker images

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: "alicevision/alicevision-deps:2025.09.12-rocky9-cuda12.1.1"
+      image: "alicevision/alicevision-deps:2026.02.17-rocky9-cuda12.1.1"
     env:
       DEPS_INSTALL_DIR: /opt/AliceVision_install
       BUILD_TYPE: Release

--- a/src/cmake/Dependencies.cmake
+++ b/src/cmake/Dependencies.cmake
@@ -112,8 +112,8 @@ if(AV_BUILD_ZLIB)
     set(ZLIB_TARGET zlib)
 
     ExternalProject_Add(${ZLIB_TARGET}
-        URL https://www.zlib.net/zlib-1.3.1.tar.gz
-        URL_HASH SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+        URL https://www.zlib.net/zlib-1.3.2.tar.gz
+        URL_HASH SHA256=bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
         DOWNLOAD_DIR ${BUILD_DIR}/download/zlib
         PREFIX ${BUILD_DIR}
         BUILD_IN_SOURCE 0


### PR DESCRIPTION
This pull request contains two small but important dependency updates: it updates the base container image used in CI builds and bumps the version of the zlib library used in external dependencies.

Dependency updates:

* Updated the CI workflow to use the newer `alicevision/alicevision-deps:2026.02.17-rocky9-cuda12.1.1` container image, ensuring the build environment uses the latest dependencies and patches.
* Updated the zlib dependency from version 1.3.1 to 1.3.2 in `Dependencies.cmake`, including the new download URL and SHA256 hash, to incorporate the latest bug fixes and improvements.