### PR TITLE
Add Google Pixel 9 Pro sensor data

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -2213,6 +2213,7 @@ Google;Pixel 8;9.8;dpreview
 Google;Pixel 8 Pro;9.8;dpreview
 Google;Pixel 9a;6.4;dpreview
 Google;Pixel 9 Pro;9.8;usercontribution
+Google;Pixel 9 Pro XL;9.8;usercontribution
 GoPro;GoPro Fusion;6.17;dpreview
 GoPro;GoPro Hero 2018;6.17;dpreview
 GoPro;GoPro Hero3-Silver Edition;5.37;usercontribution

--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -2212,6 +2212,7 @@ Google;Pixel 7 Pro;9.79;usercontribution
 Google;Pixel 8;9.8;dpreview
 Google;Pixel 8 Pro;9.8;dpreview
 Google;Pixel 9a;6.4;dpreview
+Google;Pixel 9 Pro;9.8;usercontribution
 GoPro;GoPro Fusion;6.17;dpreview
 GoPro;GoPro Hero 2018;6.17;dpreview
 GoPro;GoPro Hero3-Silver Edition;5.37;usercontribution


### PR DESCRIPTION
Added the main rear camera sensor size of the Pixel 9 Pro into the sensor database.

<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).

-->
## Description



## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

