### PR TITLE
New heuristic for sfm Expansion

### DIFF
--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.cpp
@@ -13,7 +13,7 @@ namespace aliceVision {
 namespace sfm {
 
 
-bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler, const std::set<IndexT> & viewsChunk)
+bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler, const std::set<IndexT> & viewsChunk, EExpansionMode expansionMode)
 {   
     _ignoredViews.clear();
     ALICEVISION_LOG_INFO("ExpansionChunk::process start");
@@ -154,8 +154,20 @@ bool ExpansionChunk::process(sfmData::SfMData & sfmData, const track::TracksHand
     {
         return false;
     }
+
+    // When not in try hard mode, increase the default min points per pose
+    size_t minPoints = _bundleHandler->getMinPointsPerPose();
+    if (expansionMode == EExpansionMode::EXPANSION_STRICT)
+    { 
+        _bundleHandler->setMinPointsPerPose(minPoints * 2);
+    }
     
-    if (!_bundleHandler->process(sfmData, tracksHandler, validViewIds))
+    bool sfmCheck = _bundleHandler->process(sfmData, tracksHandler, validViewIds);
+    
+    //Roll back the bundle parameters
+    _bundleHandler->setMinPointsPerPose(minPoints);
+
+    if (!sfmCheck)
     {
         return false;
     }

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionChunk.hpp
@@ -13,6 +13,7 @@
 #include <aliceVision/sfm/pipeline/expanding/SfmBundle.hpp>
 #include <aliceVision/sfm/pipeline/expanding/SfmResection.hpp>
 #include <aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp>
+#include <aliceVision/sfm/pipeline/expanding/ExpansionConfig.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -30,10 +31,12 @@ public:
      * @param sfmData the sfmData which describes the current sfm state
      * @param tracksHandler the scene tracks handler
      * @param viewsChunks a list of view ids to process in this chunk
+     * @param expansionMode select a configuration set among an enum
     */
     bool process(sfmData::SfMData & sfmData, 
                 const track::TracksHandler & tracksHandler, 
-                const std::set<IndexT> & viewsChunk);
+                const std::set<IndexT> & viewsChunk,
+                EExpansionMode expansionMode);
 
     /**
      * @brief setup the bundle handler

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionConfig.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionConfig.hpp
@@ -1,0 +1,18 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+namespace aliceVision {
+namespace sfm {
+
+enum class EExpansionMode
+{
+    EXPANSION_STRICT,    // High thresholds — only stable, well-conditioned cameras
+    EXPANSION_PERMISSIVE // Lower thresholds — accepts weaker cameras
+};
+
+
+}
+}

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionIteration.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionIteration.cpp
@@ -13,7 +13,7 @@ namespace aliceVision {
 namespace sfm {
 
 
-bool ExpansionIteration::process(sfmData::SfMData & sfmData, track::TracksHandler & tracksHandler)
+bool ExpansionIteration::process(sfmData::SfMData & sfmData, track::TracksHandler & tracksHandler, EExpansionMode expansionMode)
 {
     ALICEVISION_LOG_INFO("ExpansionIteration::process start");
 
@@ -44,7 +44,7 @@ bool ExpansionIteration::process(sfmData::SfMData & sfmData, track::TracksHandle
             break;
         }
    
-        if (!_chunkHandler->process(sfmData, tracksHandler, _policy->getNextViews()))
+        if (!_chunkHandler->process(sfmData, tracksHandler, _policy->getNextViews(), expansionMode))
         {
             continue;
         }

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionIteration.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionIteration.hpp
@@ -29,9 +29,10 @@ public:
      * Multiple iteration may be necessary to complete.
      * @param sfmData the scene to process
      * @param tracksHandler the tracks for this scene
+     * @param expansionMode select a configuration set among an enum
      * @return true if the iteration succeeded
     */
-    bool process(sfmData::SfMData & sfmData,  track::TracksHandler & tracksHandler);
+    bool process(sfmData::SfMData & sfmData,  track::TracksHandler & tracksHandler, EExpansionMode expansionMode);
 
     /**
      * @return a pointer to the chunk handler

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionProcess.cpp
@@ -31,14 +31,21 @@ bool ExpansionProcess::process(sfmData::SfMData & sfmData, track::TracksHandler 
     }
 
     //Prepare existing data
-    prepareExisting(sfmData, tracksHandler);
+    if (!prepareExisting(sfmData, tracksHandler))
+    {
+        ALICEVISION_LOG_ERROR("Failed to prepare process");
+        return false;
+    }
+
+    EExpansionMode expansionMode = EExpansionMode::EXPANSION_STRICT;
 
     int nbPoses = 0;
-    do
+    
+    while (true)
     {
         nbPoses = sfmData.getPoses().size();
 
-        if (!_iterationHandler->process(sfmData, tracksHandler))
+        if (!_iterationHandler->process(sfmData, tracksHandler, expansionMode))
         {
             return false;
         }
@@ -46,16 +53,14 @@ bool ExpansionProcess::process(sfmData::SfMData & sfmData, track::TracksHandler 
         if (_postProcessHandler)
         {
             if (_postProcessHandler->process(sfmData, tracksHandler))
-            {
-                return true;
-                
+            {                
                 if (_iterationHandler->getChunkHandler() == nullptr)
                 {
                     return false;
                 }
 
                 // Perform a new estimation step on modified views
-                if (!_iterationHandler->getChunkHandler()->process(sfmData, tracksHandler, _postProcessHandler->getUpdatedViews()))
+                if (!_iterationHandler->getChunkHandler()->process(sfmData, tracksHandler, _postProcessHandler->getUpdatedViews(), expansionMode))
                 {
                     return false;
                 }
@@ -63,8 +68,26 @@ bool ExpansionProcess::process(sfmData::SfMData & sfmData, track::TracksHandler 
         }
 
         ALICEVISION_LOG_INFO("ExpansionProcess poses count : " << sfmData.getPoses().size());
+        
+        // Everything is already computed, exit
+        if (sfmData.isFullyReconstructed())
+        {
+            break;
+        }
+
+        // Nothing changed in the last iteration
+        if (sfmData.getPoses().size() == nbPoses)
+        {
+            //Before exiting, try again with less constraints
+            if (expansionMode == EExpansionMode::EXPANSION_PERMISSIVE)
+            {
+                break;
+            }
+
+            expansionMode = EExpansionMode::EXPANSION_PERMISSIVE;
+        }
     }
-    while (sfmData.getPoses().size() != nbPoses);
+    
 
     ALICEVISION_LOG_INFO("ExpansionProcess end");
 
@@ -104,7 +127,7 @@ bool ExpansionProcess::prepareExisting(sfmData::SfMData & sfmData, const track::
         }
 
         // Process everything in existing sfmData
-        if (!_iterationHandler->getChunkHandler()->process(sfmData, tracksHandler, sfmData.getValidViews()))
+        if (!_iterationHandler->getChunkHandler()->process(sfmData, tracksHandler, sfmData.getValidViews(), EExpansionMode::EXPANSION_STRICT))
         {
             return false;
         }

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
@@ -87,6 +87,24 @@ public:
         _isStructureRefinementEnabled = flag;
     }
 
+    /**
+     * @brief Get the number of valid points per pose required
+     * @return the threshold used to discriminate a valid pose
+    */
+    size_t getMinPointsPerPose() const
+    {
+        return _minPointsPerPose;
+    }
+
+    /**
+     * @brief Set the number of valid points per pose required
+     * @param minPointsPerPose the threshold used to discriminate a valid pose
+    */
+    void setMinPointsPerPose(size_t minPointsPerPose)
+    {
+        _minPointsPerPose = minPointsPerPose;
+    }
+
 private:
     /**
      * Initialize bundle properties

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -48,7 +48,8 @@ alicevision_add_library(aliceVision_sfmData
 alicevision_add_test(sfmData_test.cpp
     NAME "sfmData"
     LINKS aliceVision_sfmData
-          aliceVision_system
+        aliceVision_camera
+        aliceVision_system
 )
 alicevision_add_test(view_test.cpp
     NAME "view"

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -477,6 +477,19 @@ void SfMData::repair()
     removeUnusedLandmarks();
 }
 
+bool SfMData::isFullyReconstructed() const
+{
+    for (const auto & [_, view] : getViews().valueRange())
+    {
+        if (!isPoseAndIntrinsicDefined(view))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 LandmarksPerView getLandmarksPerViews(const SfMData& sfmData)
 {
     LandmarksPerView landmarksPerView;

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -758,6 +758,12 @@ class SfMData
     */
     void getBoundingBox(Eigen::Vector3d & bbMin, Eigen::Vector3d & bbMax);
 
+    /**
+     * Are all views fully estimated ?
+     * @return true if no views have invalid pose or intrinsic
+     */
+    bool isFullyReconstructed() const;
+
   private:
     /// Structure (3D points with their 2D observations)
     Landmarks _landmarks;

--- a/src/aliceVision/sfmData/sfmData_test.cpp
+++ b/src/aliceVision/sfmData/sfmData_test.cpp
@@ -1,4 +1,5 @@
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/camera/Pinhole.hpp>
 
 #define BOOST_TEST_MODULE sfmData
 
@@ -49,4 +50,32 @@ BOOST_AUTO_TEST_CASE(SfMData_InternalFolders)
     BOOST_CHECK(fs::equivalent(matchesFolders[0], refFolder));
     BOOST_CHECK_EQUAL(sfmData.getRelativeFeaturesFolders()[0], fs::relative(refFolder, otherFolder));
     BOOST_CHECK_EQUAL(sfmData.getRelativeMatchesFolders()[0], fs::relative(refFolder, otherFolder));
+}
+
+BOOST_AUTO_TEST_CASE(SfMData_IsFullyReconstructed)
+{
+    sfmData::SfMData sfmData;
+
+    // Add a view with undefined pose/intrinsic: should not be fully reconstructed
+    auto view1 = std::make_shared<sfmData::View>("image1.jpg", 0, aliceVision::UndefinedIndexT, aliceVision::UndefinedIndexT, 100, 100);
+    sfmData.getViews().emplace(0, view1);
+    BOOST_CHECK(!sfmData.isFullyReconstructed());
+
+    // Add valid intrinsic and pose
+    aliceVision::camera::IntrinsicBase::sptr intrinsic = std::make_shared<aliceVision::camera::Pinhole>();
+    sfmData.getViews().at(0)->setIntrinsicId(1);
+    sfmData.getViews().at(0)->setPoseId(2);
+    sfmData.getIntrinsics().emplace(1, intrinsic);
+    sfmData.getPoses().emplace(2, std::make_shared<sfmData::CameraPose>());
+    BOOST_CHECK(sfmData.isFullyReconstructed());
+
+    // Add another view with missing intrinsic
+    auto view2 = std::make_shared<sfmData::View>("image2.jpg", 1, aliceVision::UndefinedIndexT, 3, 100, 100);
+    sfmData.getViews().emplace(1, view2);
+    sfmData.getPoses().emplace(3, std::make_shared<sfmData::CameraPose>());
+    BOOST_CHECK(!sfmData.isFullyReconstructed());
+
+    // Fix intrinsic for view2
+    view2->setIntrinsicId(1);
+    BOOST_CHECK(sfmData.isFullyReconstructed());
 }

--- a/src/software/pipeline/main_sfmBootstrapping.cpp
+++ b/src/software/pipeline/main_sfmBootstrapping.cpp
@@ -577,6 +577,17 @@ int aliceVision_main(int argc, char** argv)
     {
         return EXIT_FAILURE;
     }
+
+    // Set resection ID to 0 for all reconstructed views
+    for (auto & [viewId, view] : sfmData.getViews().valueRange())
+    {
+        if (!sfmData.isPoseAndIntrinsicDefined(view))
+        {
+            continue;
+        }
+
+        view.setResectionId(0);
+    }
     
     showStatsAngles(sfmData);
     


### PR DESCRIPTION
- New heuristic : ExpansionProcess first iterate in a normal mode. When the last iteration produces no change, and the sfmData is not fully reconstructed, then we continue to iterate but in a tryHard mode.
- In normal mode, the sfm filter will remove the views with a number of observed landmarks twice larger than in tryHardMode mode. We may add other changes later.

- Added a resection Id to views built in the bootstrapping phase.

- Added a isFullyReconstructed() to the sfmData class.