### PR TITLE
ExportImages use modern parallelization

### DIFF
--- a/meshroom/aliceVision/ExportImages.py
+++ b/meshroom/aliceVision/ExportImages.py
@@ -2,11 +2,12 @@ __version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import COLORSPACES, EXR_STORAGE_DATA_TYPE, VERBOSE_LEVEL
-
+from pyalicevision import parallelization as avpar
 
 class ExportImages(desc.AVCommandLineNode):
     commandLine = "aliceVision_exportImages {allParams}"
-    size = desc.DynamicNodeSize("input")
+    size = avpar.DynamicViewsSize("input")
+    
     parallelization = desc.Parallelization(blockSize=40)
     commandLineRange = "--rangeStart {rangeStart} --rangeSize {rangeBlockSize}"
 

--- a/src/software/utils/main_exportImages.cpp
+++ b/src/software/utils/main_exportImages.cpp
@@ -485,8 +485,11 @@ int aliceVision_main(int argc, char* argv[])
                 sfmDataIO::ESfMData::INTRINSICS | 
                 sfmDataIO::ESfMData::EXTRINSICS
     );
-    if (rangeStart == 0)
+
+    if (rangeStart <= 0)
+    {
         flagsPart = sfmDataIO::ESfMData::ALL;
+    }
 
     // Read the input SfM scene
     sfmData::SfMData inputSfmData;


### PR DESCRIPTION
This pull request updates the image export functionality to improve parallelization handling and corrects a minor logic issue in the export range selection. The changes ensure more robust and flexible processing of image export tasks.

**Parallelization improvements:**

* Switched from using `desc.DynamicNodeSize` to `avpar.DynamicViewsSize` for determining node size in `ExportImages.py`, which aligns the node sizing logic with the parallelization strategy used elsewhere.

**Logic correction:**

* Updated the range start condition in `main_exportImages.cpp` to use `rangeStart <= 0` instead of `rangeStart == 0`. Point cloud will be exported for small datasets too (When there is no parallelization).