### PR TITLE
Fix array usage and add useAllSeeds option for checkerBoards

### DIFF
--- a/meshroom/aliceVision/CheckerboardDetection.py
+++ b/meshroom/aliceVision/CheckerboardDetection.py
@@ -42,6 +42,12 @@ The detection method also supports nested calibration grids.
             description="Ignore pixel aspect ratio for detection.",
             value=False,
         ),
+        desc.BoolParam(
+            name="useAllSeeds",
+            label="Use all seeds",
+            description="False will ignore seed corner point if it is already part of a detected potential checkerboard.",
+            value=False,
+        ),
         desc.IntParam(
             name="maxLevels",
             label="Maximum scale for pyramid",

--- a/src/aliceVision/calibration/checkerDetector.cpp
+++ b/src/aliceVision/calibration/checkerDetector.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/math/constants/constants.hpp>
 
+#include <atomic>
 #include <limits>
 #include <algorithm>
 
@@ -31,7 +32,7 @@ using RowVector = Matrix<Type, 1, Size>;
 namespace aliceVision {
 namespace calibration {
 
-bool CheckerDetector::process(const image::Image<image::RGBColor>& source, size_t maxLevels, size_t minConsensus, bool useNestedGrids, bool debug)
+bool CheckerDetector::process(const image::Image<image::RGBColor>& source, size_t maxLevels, size_t minConsensus, bool useNestedGrids, bool useAllSeeds, bool debug)
 {
     image::Image<float> grayscale;
     image::ConvertPixelType(source, &grayscale);
@@ -119,7 +120,7 @@ bool CheckerDetector::process(const image::Image<image::RGBColor>& source, size_
 
     ALICEVISION_LOG_INFO("[CheckerDetector] extracting checkerboards with " << _corners.size() << " corners");
 
-    buildCheckerboards(_boards, _corners);
+    buildCheckerboards(_boards, _corners, useAllSeeds);
 
     ALICEVISION_LOG_DEBUG("[CheckerDetector] built " << _boards.size() << " checkerboards");
 
@@ -1028,13 +1029,25 @@ bool CheckerDetector::growIteration(CheckerBoard& board, const std::vector<Check
     return false;
 }
 
-void CheckerDetector::buildCheckerboards(std::vector<CheckerBoard>& boards, const std::vector<CheckerBoardCorner>& refinedCorners) const
+void CheckerDetector::buildCheckerboards(std::vector<CheckerBoard>& boards, const std::vector<CheckerBoardCorner>& refinedCorners, bool useAllSeeds) const
 {
-    std::vector<bool> used(refinedCorners.size(), false);
+    std::vector<std::atomic<unsigned char>> used(refinedCorners.size());
+
+    #pragma omp parallel for schedule(dynamic)
     for (IndexT cid = 0; cid < refinedCorners.size(); ++cid)
     {
-        if (used[cid])
-            continue;
+        // Early skip: if this seed corner is already used, no point trying it.
+        // This is a racy read but only serves as a fast-path optimization;
+        // the authoritative check happens inside the critical section below.
+        if (!useAllSeeds)
+        {
+            unsigned char lused = used[cid].load(std::memory_order_relaxed);
+
+            if (lused)
+            {
+                continue;
+            }
+        }
 
         // Check if corner can be used as seed
         CheckerBoard board;
@@ -1042,22 +1055,6 @@ void CheckerDetector::buildCheckerboards(std::vector<CheckerBoard>& boards, cons
         {
             continue;
         }
-
-        // Check if board contains already used corners
-        bool valid = true;
-        for (int i = 0; i < board.rows(); ++i)
-        {
-            for (int j = 0; j < board.cols(); ++j)
-            {
-                if (used[board(i, j)])
-                {
-                    valid = false;
-                }
-            }
-        }
-
-        if (!valid)
-            continue;
 
         // Extend board as much as possible
         while (growIteration(board, refinedCorners)) {}
@@ -1069,25 +1066,17 @@ void CheckerDetector::buildCheckerboards(std::vector<CheckerBoard>& boards, cons
             for (int j = 0; j < board.cols(); ++j)
             {
                 if (board(i, j) == UndefinedIndexT)
+                {
                     continue;
+                }
+
                 count++;
             }
         }
 
         if (count < 10)
-            continue;
-
-        // Update used corners
-        for (int i = 0; i < board.rows(); ++i)
         {
-            for (int j = 0; j < board.cols(); ++j)
-            {
-                if (board(i, j) == UndefinedIndexT)
-                    continue;
-
-                const IndexT id = board(i, j);
-                used[id] = true;
-            }
+            continue;
         }
 
         // Threshold on energy value
@@ -1096,7 +1085,48 @@ void CheckerDetector::buildCheckerboards(std::vector<CheckerBoard>& boards, cons
             continue;
         }
 
-        boards.push_back(board);
+        // Atomically check for corner conflicts and commit the board.
+        // This critical section ensures no two boards can claim the same
+        // corners: the "check used" and "mark used" steps are indivisible.
+        #pragma omp critical
+        {
+            bool valid = true;
+
+            if (!useAllSeeds)
+            {
+                // Check if board contains already used corners
+                for (int i = 0; i < board.rows() && valid; ++i)
+                {
+                    for (int j = 0; j < board.cols() && valid; ++j)
+                    {
+                        if (board(i, j) != UndefinedIndexT && used[board(i, j)].load(std::memory_order_relaxed))
+                        {
+                            valid = false;
+                        }
+                    }
+                }
+            }
+
+            if (valid)
+            {
+                // Mark corners as used
+                if (!useAllSeeds)
+                {
+                    for (int i = 0; i < board.rows(); ++i)
+                    {
+                        for (int j = 0; j < board.cols(); ++j)
+                        {
+                            if (board(i, j) != UndefinedIndexT)
+                            {
+                                used[board(i, j)].store(1, std::memory_order_relaxed);
+                            }
+                        }
+                    }
+                }
+
+                boards.push_back(board);
+            }
+        }
     }
 }
 

--- a/src/aliceVision/calibration/checkerDetector.cpp
+++ b/src/aliceVision/calibration/checkerDetector.cpp
@@ -1159,8 +1159,10 @@ void CheckerDetector::drawCheckerBoard(image::Image<image::RGBColor>& img, bool 
         drawEdges(board, colors[idx], false);
 
         idx++;
-        if (idx >= _boards.size())
+        if (idx >= colors.size())
+        {
             idx = 0;
+        }
     }
 }
 

--- a/src/aliceVision/calibration/checkerDetector.hpp
+++ b/src/aliceVision/calibration/checkerDetector.hpp
@@ -112,10 +112,11 @@ class CheckerDetector
      * @param[in] maxLevels maximum number of levels used in multiscale point detection
      * @param[in] minConsensus minimum number of shared corners to merge checkerboards
      * @param[in] useNestedGrid Indicate if the image contains nested calibration grids.
+     * @param[in] useAllSeeds Indicate if we want to use all detected corners as seeds or try to quickly ignore those already used in a board
      * @param[in] debug Indicate if debug images should be drawn.
      * @return False if a problem occurred during detection, otherwise true.
      */
-    bool process(const image::Image<image::RGBColor>& source, size_t maxLevels = 3, size_t minConsensus = 5, bool useNestedGrids = false, bool debug = false);
+    bool process(const image::Image<image::RGBColor>& source, size_t maxLevels, size_t minConsensus, bool useNestedGrids, bool useAllSeeds, bool debug);
 
     /// Return a copy of detected checkerboards.
     std::vector<CheckerBoard> getBoards() const { return _boards; }
@@ -249,8 +250,9 @@ class CheckerDetector
      *
      * @param[out] boards Container for the built checkerboards.
      * @param[in] refinedCorners Corners with directions information.
+     * @param[in] useAllSeeds Indicate if we want to use all detected corners as seeds or try to quickly ignore those already used in a board
      */
-    void buildCheckerboards(std::vector<CheckerBoard>& boards, const std::vector<CheckerBoardCorner>& refinedCorners) const;
+    void buildCheckerboards(std::vector<CheckerBoard>& boards, const std::vector<CheckerBoardCorner>& refinedCorners, bool useAllSeeds) const;
 
     /**
      * @brief Find corner closest to a given position in an area constrained to a small cone around a given direction.

--- a/src/software/pipeline/main_checkerboardDetection.cpp
+++ b/src/software/pipeline/main_checkerboardDetection.cpp
@@ -40,6 +40,7 @@ int aliceVision_main(int argc, char* argv[])
     bool doubleSize = false;
     bool useNestedGrids = false;
     bool ignorePixelAspectRatio = false;
+    bool useAllSeeds = false;
     size_t minConsensus = 5;
     size_t maxLevels = 2;
 
@@ -65,6 +66,8 @@ int aliceVision_main(int argc, char* argv[])
          "Double image size prior to processing.")
         ("ignorePixelAspectRatio", po::value<bool>(&ignorePixelAspectRatio)->default_value(ignorePixelAspectRatio), 
          "Ignore pixel aspect ratio.")
+        ("useAllSeeds", po::value<bool>(&useAllSeeds)->default_value(useAllSeeds), 
+         "Use all possible seeds instead of pruning decision tree.")
         ("minConsensus", po::value<size_t>(&minConsensus)->default_value(minConsensus), 
          "Minimum number of shared corners to merge checkerboards.")
         ("maxLevels", po::value<size_t>(&maxLevels)->default_value(maxLevels), 
@@ -161,7 +164,7 @@ int aliceVision_main(int argc, char* argv[])
         // Lookup checkerboard
         calibration::CheckerDetector detect;
         ALICEVISION_LOG_INFO("Launching checkerboard detection");
-        if (!detect.process(source, maxLevels, minConsensus, useNestedGrids, exportDebugImages))
+        if (!detect.process(source, maxLevels, minConsensus, useNestedGrids, useAllSeeds, exportDebugImages))
         {
             ALICEVISION_LOG_ERROR("Detection failed");
             continue;


### PR DESCRIPTION
This pull request adds a new option to the checkerboard detection pipeline to control whether all detected corners should be used as seeds when finding checkerboards, or whether to prune seeds that have already been used. This introduces a new `useAllSeeds` parameter throughout the detection API and improves parallelism and atomicity in the checkerboard-building process.

**Parameterization and API changes:**

* Added a new `useAllSeeds` boolean parameter to the `CheckerDetector::process` and `buildCheckerboards` methods, and updated their declarations and documentation in `checkerDetector.hpp` and `checkerDetector.cpp`. This allows users to control whether all corners are considered as seeds or if the algorithm should skip corners already part of a detected checkerboard. [[1]](diffhunk://#diff-e321151d4dcf181cb373ff9a8bd275b91fc4eedd9eb1a2e455e7f981f0885fb2R115-R119) [[2]](diffhunk://#diff-e321151d4dcf181cb373ff9a8bd275b91fc4eedd9eb1a2e455e7f981f0885fb2R253-R255) [[3]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8L34-R34) [[4]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8L122-R122)

* Exposed the `useAllSeeds` option in the command-line interface (`main_checkerboardDetection.cpp`) and the Python node parameters (`CheckerboardDetection.py`), enabling users to set this behavior via configuration. [[1]](diffhunk://#diff-55d13fec1a557e57cfea89a8db6172811e915730aa0f08525f36de6aa567f578R43) [[2]](diffhunk://#diff-55d13fec1a557e57cfea89a8db6172811e915730aa0f08525f36de6aa567f578R69-R70) [[3]](diffhunk://#diff-55d13fec1a557e57cfea89a8db6172811e915730aa0f08525f36de6aa567f578L164-R167) [[4]](diffhunk://#diff-8618928eea66e8a4a0c0ce177d59a1e7c00d28f7f80f0f0d5e23b2eb6716aa0bR45-R50)

**Algorithm and performance improvements:**

* Refactored `buildCheckerboards` to use an `unsigned char` vector for the `used` flags (instead of `bool`) to ensure atomic operations with OpenMP, and added atomic read/write for thread safety. The function now respects the `useAllSeeds` parameter to determine whether to skip already-used corners. [[1]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8L1031-R1046) [[2]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8L1052-R1074) [[3]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8R1086-R1130)

* Added OpenMP parallelization and critical sections in `buildCheckerboards` to safely handle concurrent updates to checkerboard lists and corner usage, improving performance on multi-core systems. [[1]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8L1031-R1046) [[2]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8R1086-R1130)

**Minor fixes:**

* Fixed a bug in the checkerboard drawing function to prevent out-of-bounds access to the color array.