### PR TITLE
Replace group by commandLineGroup in nodes

### DIFF
--- a/meshroom/aliceVision/CameraInit.py
+++ b/meshroom/aliceVision/CameraInit.py
@@ -360,7 +360,7 @@ The needed metadata are:
             ),
             label="Viewpoints",
             description="Input viewpoints.",
-            group="",
+            commandLineGroup="",
         ),
         desc.ListAttribute(
             name="intrinsics",
@@ -372,7 +372,7 @@ The needed metadata are:
             ),
             label="Intrinsics",
             description="Camera intrinsics.",
-            group="",
+            commandLineGroup="",
         ),
         desc.File(
             name="sensorDatabase",

--- a/meshroom/aliceVision/CheckerboardDetection.py
+++ b/meshroom/aliceVision/CheckerboardDetection.py
@@ -87,6 +87,6 @@ The detection method also supports nested calibration grids.
             description="Debug images.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>.png",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
     ]

--- a/meshroom/aliceVision/ColorCheckerCorrection.py
+++ b/meshroom/aliceVision/ColorCheckerCorrection.py
@@ -118,7 +118,7 @@ If multiple color charts are submitted, only the first one will be taken in acco
             label="SfMData",
             description="Output SfMData.",
             value=lambda attr: ("{nodeCacheFolder}/" + os.path.basename(attr.node.input.value)) if (os.path.splitext(attr.node.input.value)[1] in [".abc", ".sfm"]) else "",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="output",
@@ -132,6 +132,6 @@ If multiple color charts are submitted, only the first one will be taken in acco
             description="Output images.",
             semantic="image",
             value=outputImagesValueFunct,
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
     ]

--- a/meshroom/aliceVision/ConvertMesh.py
+++ b/meshroom/aliceVision/ConvertMesh.py
@@ -22,7 +22,7 @@ class ConvertMesh(desc.AVCommandLineNode):
             description="Output mesh format (*.obj, *.fbx, *.gltf, *.glb, *.stl, *.ply).",
             value="obj",
             values=["obj", "fbx", "gltf", "glb", "stl", "ply"],
-            group="",
+            commandLineGroup="",
         ),
         desc.BoolParam(
             name="flipNormals",

--- a/meshroom/aliceVision/ConvertSfMFormat.py
+++ b/meshroom/aliceVision/ConvertSfMFormat.py
@@ -27,7 +27,7 @@ It can also be used to remove specific parts of from an SfM scene (like filter a
             description="Output SfM file format.",
             value="abc",
             values=["abc", "sfm", "json", "ply", "baf"],
-            group="",  # exclude from command line
+            commandLineGroup="",  # exclude from command line
         ),
         desc.ChoiceParam(
             name="describerTypes",

--- a/meshroom/aliceVision/DepthMap.py
+++ b/meshroom/aliceVision/DepthMap.py
@@ -71,7 +71,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             name="tiling",
             label="Tiling",
             description="Tiles are used to split the computation into fixed buffers to fit the GPU best.",
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.IntParam(
                     name="tileBufferWidth",
@@ -125,7 +125,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                         "low-resolution depth map.\n"
                         "This method is highly robust but has limited depth precision (banding artifacts due to a "
                         "limited list of depth planes).",
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.IntParam(
                     name="sgmScale",
@@ -268,7 +268,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="The refine step computes a similarity volume in higher resolution but with a small depth "
                         "range around the SGM depth map.\n"
                         "This allows to compute a depth map with sub-pixel accuracy.",
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="refineEnabled",
@@ -379,7 +379,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             name="colorOptimization",
             label="Color Optimization",
             description="Color optimization post-process parameters.",
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="colorOptimizationEnabled",
@@ -403,7 +403,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             label="Custom Patch Pattern",
             description="User custom patch pattern for similarity comparison.",
             advanced=True,
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="sgmUseCustomPatchPattern",
@@ -431,7 +431,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                         label="Patch Pattern Subpart",
                         description="Custom patch pattern subpart configuration for similarity volume computation.",
                         joinChar=":",
-                        group=None,
+                        commandLineGroup=None,
                         items=[
                             desc.ChoiceParam(
                                 name="customPatchPatternSubpartType",
@@ -488,7 +488,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Intermediate results parameters for debug purposes.\n"
                         "Warning: Dramatically affect performances and use large amount of storage.",
             advanced=True,
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="exportIntermediateDepthSimMaps",
@@ -576,7 +576,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Generated depth maps.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_depthMap.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="sim",
@@ -584,14 +584,14 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Generated sim maps.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_simMap.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="tilePattern",
             label="Tile Pattern",
             description="Debug: Tile pattern.",
             value="{nodeCacheFolder}/<VIEW_ID>_tilePattern.obj",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.intermediateResults.exportTilePattern.value,
         ),
         desc.File(
@@ -600,7 +600,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Debug: Depth maps SGM",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_depthMap_sgm.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
         ),
         desc.File(
@@ -609,7 +609,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Debug: Depth maps SGM upscaled.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_depthMap_sgmUpscaled.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
         ),
         desc.File(
@@ -618,7 +618,7 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
             description="Debug: Depth maps after refinement",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_depthMap_refinedFused.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.intermediateResults.exportIntermediateDepthSimMaps.value,
         ),
     ]

--- a/meshroom/aliceVision/DepthMapFilter.py
+++ b/meshroom/aliceVision/DepthMapFilter.py
@@ -124,7 +124,7 @@ This allows to filter unstable points before starting the fusion of all depth ma
             description="Filtered depth maps.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_depthMap.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="sim",
@@ -132,7 +132,7 @@ This allows to filter unstable points before starting the fusion of all depth ma
             description="Filtered sim maps.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_simMap.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="normal",
@@ -141,6 +141,6 @@ This allows to filter unstable points before starting the fusion of all depth ma
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_normalMap.exr",
             enabled=lambda node: node.computeNormalMaps.value,
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
     ]

--- a/meshroom/aliceVision/DepthMapRendering.py
+++ b/meshroom/aliceVision/DepthMapRendering.py
@@ -45,7 +45,7 @@ class DepthMapRendering(desc.AVCommandLineNode):
             description="Rendered depth maps.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_depthMap.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="mask",
@@ -53,6 +53,6 @@ class DepthMapRendering(desc.AVCommandLineNode):
             description="Masks.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_mask.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
     ]

--- a/meshroom/aliceVision/ExportAnimatedCamera.py
+++ b/meshroom/aliceVision/ExportAnimatedCamera.py
@@ -97,14 +97,14 @@ Based on the input image filenames, it will recognize the input video sequence t
             label="Camera",
             description="Output filename for the animated camera in Alembic format.",
             value="{nodeCacheFolder}/camera.abc",
-            group="",  # exclude from command line
+            commandLineGroup="",  # exclude from command line
         ),
         desc.File(
             name="outputUndistorted",
             label="Undistorted Folder",
             description="Output undistorted folder.",
             value="{nodeCacheFolder}/undistort/",
-            group="",  # exclude from command line
+            commandLineGroup="",  # exclude from command line
         ),
         desc.File(
             name="outputImages",
@@ -112,7 +112,7 @@ Based on the input image filenames, it will recognize the input video sequence t
             description="Output undistorted images.",
             value="{nodeCacheFolder}/undistort/<INTRINSIC_ID>_<FILESTEM>.{undistortedImageTypeValue}",
             semantic="image",
-            group="",  # exclude from command line
+            commandLineGroup="",  # exclude from command line
             enabled=lambda node: node.exportUndistortedImages.value,
         ),
     ]

--- a/meshroom/aliceVision/ExportDistortion.py
+++ b/meshroom/aliceVision/ExportDistortion.py
@@ -66,7 +66,7 @@ It also allows to export an undistorted image of the lens grids for validation.
             label="Distortion Nuke Node",
             description="Calibrated distortion ST map.",
             value="{nodeCacheFolder}/nukeLensDistortion_<INTRINSIC_ID>.nk",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.exportNukeNode.value,
         ),
         desc.File(
@@ -75,7 +75,7 @@ It also allows to export an undistorted image of the lens grids for validation.
             description="Undistorted lens grids for validation",
             semantic="image",
             value="{nodeCacheFolder}/lensgrid_<VIEW_ID>_undistort.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.exportLensGridsUndistorted.value,
         ),
         desc.File(
@@ -84,7 +84,7 @@ It also allows to export an undistorted image of the lens grids for validation.
             description="Calibrated distortion ST map.",
             semantic="image",
             value="{nodeCacheFolder}/stmap_<INTRINSIC_ID>_distort.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.exportSTMaps.value,
         ),
         desc.File(
@@ -93,7 +93,7 @@ It also allows to export an undistorted image of the lens grids for validation.
             description="Calibrated undistortion ST map.",
             semantic="image",
             value="{nodeCacheFolder}/stmap_<INTRINSIC_ID>_undistort.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.exportSTMaps.value,
         ),
     ]

--- a/meshroom/aliceVision/ExportImages.py
+++ b/meshroom/aliceVision/ExportImages.py
@@ -115,7 +115,7 @@ For example, the target intrinsics may be the same without the distortion.
             description="List of undistorted images.",
             semantic="image",
             value=lambda attr: getUndistortedPath(attr.node.namingMode.value),
-            group="",
+            commandLineGroup="",
             advanced=True,
         ),
          desc.File(

--- a/meshroom/aliceVision/FeatureExtraction.py
+++ b/meshroom/aliceVision/FeatureExtraction.py
@@ -74,7 +74,7 @@ It is robust to motion-blur, depth-of-field, occlusion. Be careful to have enoug
                         "Warning: Use ULTRA only on small datasets.",
             value="normal",
             values=["low", "medium", "normal", "high", "ultra", "custom"],
-            group=lambda node: 'allParams' if node.describerPreset.value != 'custom' else None,
+            commandLineGroup=lambda node: 'allParams' if node.describerPreset.value != 'custom' else None,
         ),
         desc.IntParam(
             name="maxNbFeatures",

--- a/meshroom/aliceVision/FeatureRepeatability.py
+++ b/meshroom/aliceVision/FeatureRepeatability.py
@@ -91,14 +91,14 @@ Compare feature/descriptor matching repeatability on some dataset with known hom
             description="Invalidate.",
             value=0,
             range=(0, 10000, 1),
-            group="",
+            commandLineGroup="",
         ),
         desc.StringParam(
             name="comments",
             label="Comments",
             description="Comments.",
             value="",
-            group="",
+            commandLineGroup="",
             invalidate=False,
         ),
         desc.ChoiceParam(

--- a/meshroom/aliceVision/ImageMasking.py
+++ b/meshroom/aliceVision/ImageMasking.py
@@ -33,7 +33,7 @@ class ImageMasking(desc.AVCommandLineNode):
                         " - Green: default values\n"
                         " - White: Tolerance = 1, minSaturation = 0, maxSaturation = 0.1, minValue = 0.8, maxValue = 1\n"
                         " - Black: Tolerance = 1, minSaturation = 0, maxSaturation = 0.1, minValue = 0, maxValue = 0.2",
-            group=None,
+            commandLineGroup=None,
             enabled=lambda node: node.algorithm.value == "HSV",
             items=[
                 desc.FloatParam(

--- a/meshroom/aliceVision/ImageProcessing.py
+++ b/meshroom/aliceVision/ImageProcessing.py
@@ -607,7 +607,7 @@ class ImageProcessing(desc.AVCommandLineNode):
             label="SfMData",
             description="Output SfMData file.",
             value=lambda attr: ("{nodeCacheFolder}/" + os.path.basename(attr.node.input.value)) if (os.path.splitext(attr.node.input.value)[1] in [".abc", ".sfm"]) else "",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="output",
@@ -621,6 +621,6 @@ class ImageProcessing(desc.AVCommandLineNode):
             description="Output images.",
             semantic="image",
             value=outputImagesValueFunct,
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
     ]

--- a/meshroom/aliceVision/ImageSegmentation.py
+++ b/meshroom/aliceVision/ImageSegmentation.py
@@ -87,6 +87,6 @@ class ImageSegmentation(desc.AVCommandLineNode):
             description="Generated segmentation masks.",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/<VIEW_ID>.exr" if not attr.node.keepFilename.value else "{nodeCacheFolder}/<FILESTEM>.exr",
-            group="",
+            commandLineGroup="",
         ),
     ]

--- a/meshroom/aliceVision/KeyframeSelection.py
+++ b/meshroom/aliceVision/KeyframeSelection.py
@@ -141,7 +141,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                         "sequence with respect to the set parameters.\n"
                         "- With the smart method, keyframes are selected based on their sharpness "
                         "and optical flow scores.",
-            group=None,  # skip group from command line
+            commandLineGroup=None,  # skip group from command line
             items=[
                 desc.BoolParam(
                     name="useSmartSelection",
@@ -155,7 +155,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     description="Parameters for the regular keyframe selection.\n"
                                 "Keyframes are selected regularly over the sequence with respect "
                                 "to the set parameters.",
-                    group=None,  # skip group from command line
+                    commandLineGroup=None,  # skip group from command line
                     enabled=lambda node: node.selectionMethod.useSmartSelection.value is False,
                     items=[
                         desc.IntParam(
@@ -195,7 +195,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     description="Parameters for the smart keyframe selection.\n"
                                 "Keyframes are selected based on their sharpness and optical "
                                 "flow scores.",
-                    group=None,  # skip group from command line
+                    commandLineGroup=None,  # skip group from command line
                     enabled=lambda node: node.selectionMethod.useSmartSelection.value,
                     items=[
                         desc.FloatParam(
@@ -334,7 +334,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
             name="debugOptions",
             label="Debug Options",
             description="Debug options for the Smart keyframe selection method.",
-            group=None,  # skip group from command line
+            commandLineGroup=None,  # skip group from command line
             enabled=lambda node: node.selectionMethod.useSmartSelection.value,
             advanced=True,
             items=[
@@ -342,7 +342,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     name="debugScores",
                     label="Export Scores",
                     description="Export the computed sharpness and optical flow scores to a file.",
-                    group=None,  # skip group from command line
+                    commandLineGroup=None,  # skip group from command line
                     enabled=lambda node: node.debugOptions.enabled,
                     items=[
                         desc.BoolParam(
@@ -374,7 +374,7 @@ You can extract frames at regular interval by configuring only the min/maxFrameS
                     name="opticalFlowVisualisation",
                     label="Optical Flow Visualisation",
                     description="Visualise the motion vectors for each input frame in HSV.",
-                    group=None,  # skip group from command line
+                    commandLineGroup=None,  # skip group from command line
                     enabled=lambda node: node.debugOptions.enabled,
                     items=[
                         desc.BoolParam(

--- a/meshroom/aliceVision/LdrToHdrCalibration.py
+++ b/meshroom/aliceVision/LdrToHdrCalibration.py
@@ -53,7 +53,7 @@ class LdrToHdrCalibration(desc.AVCommandLineNode):
             value=0,
             range=(0, 15, 1),
             invalidate=False,
-            group="user",  # not used directly on the command line
+            commandLineGroup="user",  # not used directly on the command line
             errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
                          "Errors will occur during the computation.",
             exposed=True,
@@ -66,7 +66,7 @@ class LdrToHdrCalibration(desc.AVCommandLineNode):
                         "else it is equal to 'userNbBrackets'.",
             value=0,
             range=(0, 15, 1),
-            group="bracketsParams",
+            commandLineGroup="bracketsParams",
         ),
         desc.BoolParam(
             name="byPass",
@@ -120,7 +120,7 @@ class LdrToHdrCalibration(desc.AVCommandLineNode):
             values=COLORSPACES,
             value="AUTO",
             invalidate=False,
-            group="user",  # not used directly on the command line
+            commandLineGroup="user",  # not used directly on the command line
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
             exposed=True,
         ),

--- a/meshroom/aliceVision/LdrToHdrMerge.py
+++ b/meshroom/aliceVision/LdrToHdrMerge.py
@@ -59,7 +59,7 @@ class LdrToHdrMerge(desc.AVCommandLineNode):
             value=0,
             range=(0, 15, 1),
             invalidate=False,
-            group="user",  # not used directly on the command line
+            commandLineGroup="user",  # not used directly on the command line
             errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
                          "Errors will occur during the computation.",
             exposed=True,
@@ -72,14 +72,14 @@ class LdrToHdrMerge(desc.AVCommandLineNode):
                         "is 0, else it is equal to 'userNbBrackets'.",
             value=0,
             range=(0, 15, 1),
-            group="bracketsParams",
+            commandLineGroup="bracketsParams",
         ),
         desc.BoolParam(
             name="offsetRefBracketIndexEnabled",
             label="Manually Specify Ref Bracket",
             description="Manually specify the reference bracket index to control the exposure of the HDR image.",
             value=False,
-            group="user",  # not used directly on the command line
+            commandLineGroup="user",  # not used directly on the command line
         ),
         desc.IntParam(
             name="offsetRefBracketIndex",
@@ -171,7 +171,7 @@ class LdrToHdrMerge(desc.AVCommandLineNode):
             label="Enable Highlight",
             description="Enable highlights correction.",
             value=False,
-            group="user",  # not used directly on the command line
+            commandLineGroup="user",  # not used directly on the command line
             enabled=lambda node: node.byPass.enabled and not node.byPass.value,
         ),
         desc.FloatParam(
@@ -234,7 +234,7 @@ class LdrToHdrMerge(desc.AVCommandLineNode):
             label="Folder",
             description="Path to the folder containing the merged HDR images.",
             value="{nodeCacheFolder}",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="outSfMData",

--- a/meshroom/aliceVision/LdrToHdrSampling.py
+++ b/meshroom/aliceVision/LdrToHdrSampling.py
@@ -50,7 +50,7 @@ class LdrToHdrSampling(desc.AVCommandLineNode):
             value=0,
             range=(0, 15, 1),
             invalidate=False,
-            group="user",  # not used directly on the command line
+            commandLineGroup="user",  # not used directly on the command line
             errorMessage="The set number of brackets is not a multiple of the number of input images.\n"
                          "Errors will occur during the computation.",
             exposed=True,
@@ -63,7 +63,7 @@ class LdrToHdrSampling(desc.AVCommandLineNode):
                         "is 0, else it is equal to 'userNbBrackets'.",
             value=0,
             range=(0, 15, 1),
-            group="bracketsParams",
+            commandLineGroup="bracketsParams",
         ),
         desc.BoolParam(
             name="byPass",

--- a/meshroom/aliceVision/LidarMeshing.py
+++ b/meshroom/aliceVision/LidarMeshing.py
@@ -30,7 +30,7 @@ class LidarMeshing(desc.AVCommandLineNode):
                         "If enabled, it takes priority over the 'Estimate Space From SfM' option.\n"
                         "Parameters can be adjusted in advanced settings.",
             value=False,
-            group="",
+            commandLineGroup="",
         ),
         desc.GroupAttribute(
             name="boundingBox",

--- a/meshroom/aliceVision/LightingCalibration.py
+++ b/meshroom/aliceVision/LightingCalibration.py
@@ -68,6 +68,6 @@ Can also be used to calibrate a lighting dome (RTI type).
             description="Estimated Lighting Visualization.",
             semantic="image",
             value="{nodeCacheFolder}/<FILESTEM>_{methodValue}.png",
-            group=None,
+            commandLineGroup=None,
         ),
     ]

--- a/meshroom/aliceVision/MaskEroding.py
+++ b/meshroom/aliceVision/MaskEroding.py
@@ -52,6 +52,6 @@ class MaskEroding(desc.AVCommandLineNode):
             description="Processed masks.",
             semantic="imageList",
             value= "{nodeCacheFolder}/*.exr",
-            group="",
+            commandLineGroup="",
         ),
     ]

--- a/meshroom/aliceVision/MaskProcessing.py
+++ b/meshroom/aliceVision/MaskProcessing.py
@@ -78,6 +78,6 @@ class MaskProcessing(desc.AVCommandLineNode):
             description="Processed segmentation masks.",
             semantic="imageList",
             value= "{nodeCacheFolder}/*.exr",
-            group="",
+            commandLineGroup="",
         ),
     ]

--- a/meshroom/aliceVision/MeshFiltering.py
+++ b/meshroom/aliceVision/MeshFiltering.py
@@ -25,7 +25,7 @@ This node applies a Laplacian filtering to remove local defects from the raw Mes
             description="File type for the output mesh.",
             value="obj",
             values=["gltf", "obj", "fbx", "stl"],
-            group="",
+            commandLineGroup="",
         ),
         desc.BoolParam(
             name="keepLargestMeshOnly",

--- a/meshroom/aliceVision/MeshMasking.py
+++ b/meshroom/aliceVision/MeshMasking.py
@@ -28,7 +28,7 @@ class MeshMasking(desc.AVCommandLineNode):
             description="File type of the output mesh.",
             value="obj",
             values=["obj", "gltf", "fbx", "stl"],
-            group="",
+            commandLineGroup="",
         ),
         desc.ListAttribute(
             elementDesc=desc.File(

--- a/meshroom/aliceVision/MeshRemoveUnseenFaces.py
+++ b/meshroom/aliceVision/MeshRemoveUnseenFaces.py
@@ -32,7 +32,7 @@ class MeshRemoveUnseenFaces(desc.AVCommandLineNode):
             description="File type for the output mesh.",
             value="obj",
             values=["gltf", "obj", "fbx", "stl"],
-            group="",
+            commandLineGroup="",
         ),
         desc.IntParam(
             name="minObservations",

--- a/meshroom/aliceVision/Meshing.py
+++ b/meshroom/aliceVision/Meshing.py
@@ -41,7 +41,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             description="File type for the output mesh.",
             value="obj",
             values=["gltf", "obj", "fbx", "stl"],
-            group="",
+            commandLineGroup="",
         ),
         desc.BoolParam(
             name="useBoundingBox",
@@ -50,7 +50,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
                         "If enabled, it takes priority over the 'Estimate Space From SfM' option.\n"
                         "Parameters can be adjusted in advanced settings.",
             value=False,
-            group="",
+            commandLineGroup="",
         ),
         desc.GroupAttribute(
             name="boundingBox",
@@ -304,7 +304,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             value=False,
             invalidate=False,
             advanced=True,
-            group="",
+            commandLineGroup="",
         ),
         desc.IntParam(
             name="densifyNbFront",
@@ -402,7 +402,7 @@ A Graph Cut Max-Flow is applied to optimally cut the volume. This cut represents
             value=False,
             invalidate=False,
             advanced=True,
-            group="",
+            commandLineGroup="",
         ),
         desc.FloatParam(
             name="maskHelperPointsWeight",

--- a/meshroom/aliceVision/NormalIntegration.py
+++ b/meshroom/aliceVision/NormalIntegration.py
@@ -45,6 +45,6 @@ class NormalIntegration(desc.CommandLineNode):
             description="Generated depth in the camera coordinate system.",
             semantic="image",
             value="{nodeCacheFolder}/<POSE_ID>_depthMap.exr",
-            group="", # do not export on the command line
+            commandLineGroup="", # do not export on the command line
         )
     ]

--- a/meshroom/aliceVision/NormalMapRendering.py
+++ b/meshroom/aliceVision/NormalMapRendering.py
@@ -45,6 +45,6 @@ class NormalMapRendering(desc.AVCommandLineNode):
             description="Rendered normal maps.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>_normalMap.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
     ]

--- a/meshroom/aliceVision/PanoramaInit.py
+++ b/meshroom/aliceVision/PanoramaInit.py
@@ -105,7 +105,7 @@ This node allows to setup the Panorama:
                     range=(-1000.0, 10000.0, 1.0),
                 ),
             ],
-            group=None,  # skip group from command line
+            commandLineGroup=None,  # skip group from command line
             enabled=lambda node: node.useFisheye.value and not node.estimateFisheyeCircle.value,
         ),
         desc.FloatParam(
@@ -147,7 +147,7 @@ This node allows to setup the Panorama:
             semantic="image",
             description="Contact sheet path.",
             value="{nodeCacheFolder}/contactSheetImage.jpg",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
             enabled=lambda node: node.buildContactSheet.enabled
         ),
         desc.File(

--- a/meshroom/aliceVision/PanoramaMerging.py
+++ b/meshroom/aliceVision/PanoramaMerging.py
@@ -35,7 +35,7 @@ class PanoramaMerging(desc.AVCommandLineNode):
             description="Output file type for the merged panorama.",
             value="exr",
             values=["jpg", "png", "tif", "exr"],
-            group="",  # not part of allParams, as this is not a parameter for the command line
+            commandLineGroup="",  # not part of allParams, as this is not a parameter for the command line
         ),
         desc.BoolParam(
             name="useTiling",

--- a/meshroom/aliceVision/PanoramaPostProcessing.py
+++ b/meshroom/aliceVision/PanoramaPostProcessing.py
@@ -78,7 +78,7 @@ class PanoramaPostProcessing(desc.CommandLineNode):
             description="Name of the output panorama.",
             value="panorama.exr",
             invalidate=False,
-            group=None,
+            commandLineGroup=None,
             advanced=True,
         ),
         desc.StringParam(
@@ -87,7 +87,7 @@ class PanoramaPostProcessing(desc.CommandLineNode):
             description="Name of the preview of the output panorama.",
             value="panoramaPreview.jpg",
             invalidate=False,
-            group=None,
+            commandLineGroup=None,
             advanced=True,
         ),
         desc.ChoiceParam(
@@ -119,6 +119,6 @@ class PanoramaPostProcessing(desc.CommandLineNode):
             label="Downscaled Panorama Levels",
             description="Downscaled versions of the generated panorama.",
             value=lambda attr: "{nodeCacheFolder}/" + os.path.splitext(attr.node.panoramaName.value)[0] + "_level_*.exr",
-            group="",
+            commandLineGroup="",
         ),
     ]

--- a/meshroom/aliceVision/PanoramaWarping.py
+++ b/meshroom/aliceVision/PanoramaWarping.py
@@ -25,7 +25,7 @@ class PanoramaWarping(desc.AVCommandLineNode):
             label="Estimate Resolution",
             description="Estimate output panorama resolution automatically based on the resolution of input images.",
             value=True,
-            group=None, # skip group from command line
+            commandLineGroup=None, # skip group from command line
         ),
         desc.IntParam(
             name="panoramaWidth",

--- a/meshroom/aliceVision/PhotometricStereo.py
+++ b/meshroom/aliceVision/PhotometricStereo.py
@@ -87,21 +87,21 @@ The lighting conditions are assumed to be known.
             label="SfMData Albedo",
             description="Output SfMData file containing the albedo information.",
             value="{nodeCacheFolder}/albedoMaps.sfm",
-            group="",  # remove from command line
+            commandLineGroup="",  # remove from command line
         ),
         desc.File(
             name="outputSfmDataNormal",
             label="SfMData Normal",
             description="Output SfMData file containing the normal maps information.",
             value="{nodeCacheFolder}/normalMaps.sfm",
-            group="",  # remove from command line
+            commandLineGroup="",  # remove from command line
         ),
         desc.File(
             name="outputSfmDataNormalPNG",
             label="SfMData Normal PNG",
             description="Output SfMData file containing the normal maps information.",
             value="{nodeCacheFolder}/normalMapsPNG.sfm",
-            group="", # remove from command line
+            commandLineGroup="", # remove from command line
         ),
         # these attributes are only here to describe more accurately the output of the node
         # by specifying that it generates 2 sequences of images
@@ -112,7 +112,7 @@ The lighting conditions are assumed to be known.
             description="Generated normal maps in the camera coordinate system.",
             semantic="image",
             value="{nodeCacheFolder}/<POSE_ID>_normals.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
         desc.File(
             name="normalsPNG",
@@ -120,7 +120,7 @@ The lighting conditions are assumed to be known.
             description="Generated normal maps in the camera coordinate system (in false colors).",
             semantic="image",
             value="{nodeCacheFolder}/<POSE_ID>_normals.png",
-            group="", # do not export on the command line
+            commandLineGroup="", # do not export on the command line
         ),
         desc.File(
             name="normalsWorld",
@@ -128,7 +128,7 @@ The lighting conditions are assumed to be known.
             description="Generated normal maps in the world coordinate system.",
             semantic="image",
             value="{nodeCacheFolder}/<POSE_ID>_normals_w.exr",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
 
         desc.File(
@@ -137,6 +137,6 @@ The lighting conditions are assumed to be known.
             description="Generated albedo maps.",
             semantic="image",
             value="{nodeCacheFolder}/<POSE_ID>_albedo.png",
-            group="",  # do not export on the command line
+            commandLineGroup="",  # do not export on the command line
         ),
     ]

--- a/meshroom/aliceVision/PrepareDenseScene.py
+++ b/meshroom/aliceVision/PrepareDenseScene.py
@@ -104,7 +104,7 @@ This node export undistorted images so the depth map and texturing can be comput
             description="List of undistorted images.",
             semantic="image",
             value="{nodeCacheFolder}/<VIEW_ID>.{outputFileTypeValue}",
-            group="",
+            commandLineGroup="",
             advanced=True,
         ),
     ]

--- a/meshroom/aliceVision/SfMMerge.py
+++ b/meshroom/aliceVision/SfMMerge.py
@@ -80,7 +80,7 @@ class SfMMerge(desc.AVCommandLineNode):
             description="Output SfM file format.",
             value="abc",
             values=["abc", "sfm", "json"],
-            group="",  # exclude from command line
+            commandLineGroup="",  # exclude from command line
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/aliceVision/SketchfabUpload.py
+++ b/meshroom/aliceVision/SketchfabUpload.py
@@ -67,7 +67,7 @@ class SketchfabUpload(desc.Node):
             name="inputFiles",
             label="Input Files",
             description="Input Files to export.",
-            group="",
+            commandLineGroup="",
         ),
         desc.StringParam(
             name="apiToken",
@@ -109,7 +109,7 @@ class SketchfabUpload(desc.Node):
             name="tags",
             label="Tags",
             description="Maximum of 42 separate tags.",
-            group="",
+            commandLineGroup="",
         ),
         desc.ChoiceParam(
             name="category",

--- a/meshroom/aliceVision/SphereDetection.py
+++ b/meshroom/aliceVision/SphereDetection.py
@@ -60,7 +60,7 @@ Spheres can be automatically detected or manually defined in the interface.
                 ),
             ],
             enabled=lambda node: not node.autoDetect.value,
-            group=None,  # skip group from command line
+            commandLineGroup=None,  # skip group from command line
         ),
         desc.FloatParam(
             name="sphereRadius",

--- a/meshroom/aliceVision/Split360Images.py
+++ b/meshroom/aliceVision/Split360Images.py
@@ -45,7 +45,7 @@ class Split360Images(desc.AVCommandLineNode):
             name="dualFisheyeGroup",
             label="Dual Fisheye",
             description="Dual Fisheye.",
-            group=None,
+            commandLineGroup=None,
             enabled=lambda node: node.splitMode.value == "dualfisheye",
             items=[
                 desc.ChoiceParam(
@@ -75,7 +75,7 @@ class Split360Images(desc.AVCommandLineNode):
             name="equirectangularGroup",
             label="Equirectangular",
             description="Equirectangular",
-            group=None,
+            commandLineGroup=None,
             enabled=lambda node: node.splitMode.value == "equirectangular",
             items=[
                 desc.IntParam(

--- a/meshroom/aliceVision/Texturing.py
+++ b/meshroom/aliceVision/Texturing.py
@@ -84,7 +84,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             label="Color Mapping",
             description="Color map parameters.",
             enabled=lambda node: (node.imagesFolder.value != ''),
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="enable",
@@ -92,7 +92,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="Generate textures if set to true.",
                     value=True,
                     invalidate=False,
-                    group=None,
+                    commandLineGroup=None,
                 ),
                 desc.ChoiceParam(
                     name="colorMappingFileType",
@@ -109,7 +109,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             label="Bump Mapping",
             description="Bump mapping parameters.",
             enabled=lambda node: (node.inputRefMesh.value != ''),
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="enable",
@@ -117,7 +117,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="Generate normal / bump maps if set to true.",
                     value=True,
                     invalidate=False,
-                    group=None,
+                    commandLineGroup=None,
                 ),
                 desc.ChoiceParam(
                     name="bumpType",
@@ -150,7 +150,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             label="Displacement Mapping",
             description="Displacement mapping parameters.",
             enabled=lambda node: (node.inputRefMesh.value != ""),
-            group=None,
+            commandLineGroup=None,
             items=[
                 desc.BoolParam(
                     name="enable",
@@ -158,7 +158,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
                     description="Generate height maps for displacement.",
                     value=True,
                     invalidate=False,
-                    group=None,
+                    commandLineGroup=None,
                 ),
                 desc.ChoiceParam(
                     name="displacementMappingFileType",
@@ -343,7 +343,7 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             label="Mesh",
             description="Output mesh file.",
             value="{nodeCacheFolder}/texturedMesh.{outputMeshFileTypeValue}",
-            group="",
+            commandLineGroup="",
             ),
         desc.File(
             name="outputMaterial",
@@ -351,14 +351,14 @@ Many cameras are contributing to the low frequencies and only the best ones cont
             label="Material",
             description="Output material file.",
             value="{nodeCacheFolder}/texturedMesh.mtl",
-            group="",
+            commandLineGroup="",
             ),
         desc.File(
             name="outputTextures",
             label="Textures",
             description="Output texture files.",
             value=lambda attr: "{nodeCacheFolder}/texture_*." + attr.node.colorMapping.colorMappingFileType.value if attr.node.colorMapping.enable.value else "",
-            group="",
+            commandLineGroup="",
         ),
     ]
 


### PR DESCRIPTION
This pull request standardizes the use of the `commandLineGroup` keyword argument in descriptor attributes across multiple nodes in the `meshroom/aliceVision` package, replacing the previous `group` argument. This change ensures consistency in how parameters are marked for inclusion or exclusion from command-line generation, improving maintainability and clarity in the codebase.

Key changes by theme:

**Standardization of Descriptor Arguments:**

* Replaced all occurrences of the `group` argument with `commandLineGroup` in descriptor attributes for nodes such as `CameraInit`, `CheckerboardDetection`, `ColorCheckerCorrection`, `ConvertMesh`, `ConvertSfMFormat`, `DepthMap`, `DepthMapFilter`, `DepthMapRendering`, `ExportAnimatedCamera`, `ExportDistortion`, `ExportImages`, `FeatureExtraction`, `FeatureRepeatability`, and `ImageMasking`. This affects both parameters included and excluded from command-line export. [[1]](diffhunk://#diff-34c22838dc355960bed17f17b77be30bca38d40322d862e9ed9bd5a9983f6064L363-R363) [[2]](diffhunk://#diff-34c22838dc355960bed17f17b77be30bca38d40322d862e9ed9bd5a9983f6064L375-R375) [[3]](diffhunk://#diff-8618928eea66e8a4a0c0ce177d59a1e7c00d28f7f80f0f0d5e23b2eb6716aa0bL90-R90) [[4]](diffhunk://#diff-860a1db9d4daa12dc1501d012121a15d7f8502e364b60cca0b0a6551f4b6536cL121-R121) [[5]](diffhunk://#diff-860a1db9d4daa12dc1501d012121a15d7f8502e364b60cca0b0a6551f4b6536cL135-R135) [[6]](diffhunk://#diff-37a9966c23a67db9dd14379c79873249ae7bbec89781ad39f103c9c7dee9c261L25-R25) [[7]](diffhunk://#diff-1ac21ffb960a16da5bb4b80391ad6285c21eb0e0052498d83a89cd813ea5081dL30-R30) [[8]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL74-R74) [[9]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL128-R128) [[10]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL271-R271) [[11]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL382-R382) [[12]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL406-R406) [[13]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL434-R434) [[14]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL491-R491) [[15]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL579-R594) [[16]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL603-R603) [[17]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL612-R612) [[18]](diffhunk://#diff-82cdd6560e250e23d3cabeca2a64a09cd59422e78bcc9cd458a761ca1b43a33aL621-R621) [[19]](diffhunk://#diff-a17042b2e21702d2e8697a0b3cb7910bfc2e6d946ec45d57c385b92167119f45L127-R135) [[20]](diffhunk://#diff-a17042b2e21702d2e8697a0b3cb7910bfc2e6d946ec45d57c385b92167119f45L144-R144) [[21]](diffhunk://#diff-fdd7282688b951ae6ef709f846561d1cb028a9a17698fed84f00253dbe3f1910L48-R56) [[22]](diffhunk://#diff-656d7ba453e57ea051bfd8be888b5b48c0c60ba3d56a72f3003b2fd8f060bac2L100-R115) [[23]](diffhunk://#diff-5e6a5da6dc67e208e5d746d97e1f8d99c62243dcf81d29c13bcd784a469498ddL69-R69) [[24]](diffhunk://#diff-5e6a5da6dc67e208e5d746d97e1f8d99c62243dcf81d29c13bcd784a469498ddL78-R78) [[25]](diffhunk://#diff-5e6a5da6dc67e208e5d746d97e1f8d99c62243dcf81d29c13bcd784a469498ddL87-R87) [[26]](diffhunk://#diff-5e6a5da6dc67e208e5d746d97e1f8d99c62243dcf81d29c13bcd784a469498ddL96-R96) [[27]](diffhunk://#diff-e166e29f8beddde6aefbfe8c0cdd2909eb23f30cc9daab2f33b0904a2f5d6db4L118-R118) [[28]](diffhunk://#diff-bc4fa96570e4e4556cdb3d13f0e98a22b019b4f5313f9ed3e526a839c6b14fa0L77-R77) [[29]](diffhunk://#diff-bdb71c9d878f0c5a95470ba0444e51b404aec6074a74e5980e51f8c96bc371adL94-R101) [[30]](diffhunk://#diff-556269c7d76a023edcebe8ba6c6673be7cac14b5f046f3e410f11b95fc97e946L36-R36)

**No Functional Changes:**

* This update is a refactor for consistency; it does not alter the logic or behavior of the nodes but clarifies the intent regarding command-line parameter inclusion. (all references above)