### PR TITLE
Adapt cmake to modern CUDA integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -218,12 +218,8 @@ jobs:
           mkdir -p ${{ env.ALICEVISION_ROOT }}
 
       - name: Download zip file with prebuilt binaries
-        uses: suisei-cn/actions-download-file@v1.6.0
-        id: vcpkgDownload
-        with:
-          url: "https://github.com/alicevision/vcpkg/releases/download/2025.09.10/x64-windows-release.zip"
-          target: "${{ env.dependenciesDir }}"
-          filename: installed.zip
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/alicevision/vcpkg/releases/download/2026.03.11/x64-windows-release.zip" -OutFile "${{ env.archivePath }}"
 
       - name: vcpkg - Unzip prebuilt binaries
         run: |
@@ -234,11 +230,11 @@ jobs:
           rm ${{ env.archivePath }}
 
       - name: Get CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.21
+        uses: Jimver/cuda-toolkit@v0.2.30
         id: cuda-toolkit
         with:
           cuda: '12.8.0'
-          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "cusparse", "npp", "npp_dev", "cufft", "cufft_dev"]'
+          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "cusparse", "npp", "npp_dev", "cufft", "cufft_dev", "visual_studio_integration"]'
 
 
       - uses: lukka/get-cmake@latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 project(aliceVision LANGUAGES C CXX)
 
 option(ALICEVISION_BUILD_DEPENDENCIES "Build all AliceVision dependencies" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 message("CMake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}")
 
 # ==============================================================================
@@ -143,9 +143,9 @@ if (WIN32)
         else()
             set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
         endif()
-        add_compile_options(/bigobj)
-        add_compile_options(/MP)
-        add_compile_options(/GR)   # See policy CMP0117: Enable RTTI on MSVC
+        add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/bigobj>)
+        add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/MP>)
+        add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/GR>)   # See policy CMP0117: Enable RTTI on MSVC
     endif()
 endif()
 
@@ -662,45 +662,55 @@ option(ALICEVISION_USE_NVTX_PROFILING "Use CUDA NVTX for profiling." OFF)
 option(ALICEVISION_NVCC_WARNINGS      "Switch on several additional warnings for CUDA nvcc." OFF)
 
 set(ALICEVISION_HAVE_CUDA 0)
+set(ALICEVISION_CUDA_LIBRARIES "")
+set(ALICEVISION_NVTX_LIBRARY "")
 
 if (NOT ALICEVISION_USE_CUDA STREQUAL "OFF")
 
-    if (BUILD_SHARED_LIBS)
-        message(STATUS "BUILD_SHARED_LIBS ON")
-        # Need to declare CUDA_USE_STATIC_CUDA_RUNTIME as an option to ensure that it is not overwritten in FindCUDA.
-        option(CUDA_USE_STATIC_CUDA_RUNTIME "Use the static version of the CUDA runtime library if available" OFF)
-        set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
+    include(CheckLanguage)
+    check_language(CUDA)
+
+    if (NOT CMAKE_CUDA_COMPILER)
+        if (ALICEVISION_USE_CUDA STREQUAL "ON")
+            message(SEND_ERROR "Failed to find a CUDA compiler.")
+        endif()
     else()
-        message(STATUS "BUILD_SHARED_LIBS OFF")
-        option(CUDA_USE_STATIC_CUDA_RUNTIME "Use the static version of the CUDA runtime library if available" ON)
-        set(CUDA_USE_STATIC_CUDA_RUNTIME ON)
-    endif()
+        if (BUILD_SHARED_LIBS)
+            message(STATUS "BUILD_SHARED_LIBS ON")
+            set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
+        else()
+            message(STATUS "BUILD_SHARED_LIBS OFF")
+            set(CMAKE_CUDA_RUNTIME_LIBRARY Static)
+        endif()
 
-    find_package(CUDA 11.0)
+        enable_language(CUDA)
+        find_package(CUDAToolkit 11.0 QUIET)
 
-    if (CUDA_FOUND)
-        set(ALICEVISION_HAVE_CUDA 1)
-        message(STATUS "CUDA found.")
-    elseif (ALICEVISION_USE_CUDA STREQUAL "ON")
-        message(SEND_ERROR "Failed to find CUDA (>= 11.0).")
+        if (CUDAToolkit_FOUND)
+            set(ALICEVISION_HAVE_CUDA 1)
+            list(APPEND ALICEVISION_CUDA_LIBRARIES CUDA::cudart)
+            if (TARGET CUDA::cudadevrt)
+                list(APPEND ALICEVISION_CUDA_LIBRARIES CUDA::cudadevrt)
+            endif()
+            message(STATUS "CUDA found: ${CUDAToolkit_VERSION}")
+        elseif (ALICEVISION_USE_CUDA STREQUAL "ON")
+            message(SEND_ERROR "Failed to find CUDA Toolkit (>= 11.0).")
+        endif()
     endif()
 endif()
 
 if (ALICEVISION_HAVE_CUDA)
-    set(CUDA_SEPARABLE_COMPILATION ON)
     message("Build Mode: ${CMAKE_BUILD_TYPE}")
 
-    set(CUDA_NVCC_FLAGS_DEBUG   "${CUDA_NVCC_FLAGS_DEBUG};-G;-g")
-    # set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-O3")
-    if (CUDA_VERSION_MAJOR VERSION_GREATER_EQUAL 12)
+    if (CUDAToolkit_VERSION_MAJOR VERSION_GREATER_EQUAL 12)
         set(ALICEVISION_CUDA_CC_LIST_BASIC 50 52 60 61 62 70 72 75 80 86 87 89 90)
-    elseif (CUDA_VERSION VERSION_GREATER_EQUAL 11.8)
+    elseif (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.8)
         set(ALICEVISION_CUDA_CC_LIST_BASIC 35 50 52 60 61 62 70 72 75 80 86 87 89 90)
-    elseif (CUDA_VERSION VERSION_GREATER_EQUAL 11.5)
+    elseif (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.5)
         set(ALICEVISION_CUDA_CC_LIST_BASIC 35 50 52 60 61 62 70 72 75 80 86 87)
-    elseif (CUDA_VERSION VERSION_GREATER_EQUAL 11.1)
+    elseif (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.1)
         set(ALICEVISION_CUDA_CC_LIST_BASIC 35 50 52 60 61 62 70 72 75 80 86)
-    elseif (CUDA_VERSION_MAJOR GREATER_EQUAL 11)
+    elseif (CUDAToolkit_VERSION_MAJOR GREATER_EQUAL 11)
         set(ALICEVISION_CUDA_CC_LIST_BASIC 35 50 52 60 61 62 70 72 75 80)
     else()
         message(SEND_ERROR "Requires CUDA >= 11.0.")
@@ -708,47 +718,53 @@ if (ALICEVISION_HAVE_CUDA)
     set(ALICEVISION_CUDA_CC_LIST ${ALICEVISION_CUDA_CC_LIST_BASIC}
         CACHE STRING "CUDA CC versions to compile")
 
-    # Add all requested CUDA CCs to the command line for offline compilation
+    # Add all requested CUDA CCs to the CMake CUDA architecture list.
     list(SORT ALICEVISION_CUDA_CC_LIST)
-    foreach (ALICEVISION_CC_VERSION ${ALICEVISION_CUDA_CC_LIST})
-        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-gencode;arch=compute_${ALICEVISION_CC_VERSION},code=sm_${ALICEVISION_CC_VERSION}")
-    endforeach()
 
-    # Use the highest request CUDA CC for CUDA JIT compilation
+    # Use the highest requested CUDA CC for PTX JIT compatibility.
     list(LENGTH ALICEVISION_CUDA_CC_LIST ALICEVISION_CC_LIST_LEN)
     MATH(EXPR ALICEVISION_CC_LIST_LEN "${ALICEVISION_CC_LIST_LEN}-1")
     list(GET ALICEVISION_CUDA_CC_LIST ${ALICEVISION_CC_LIST_LEN} ALICEVISION_CUDA_CC_LIST_LAST)
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-gencode;arch=compute_${ALICEVISION_CUDA_CC_LIST_LAST},code=compute_${ALICEVISION_CUDA_CC_LIST_LAST}")
-
-    set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-std=c++20")
+    set(CMAKE_CUDA_ARCHITECTURES
+        "${ALICEVISION_CUDA_CC_LIST};${ALICEVISION_CUDA_CC_LIST_LAST}-virtual"
+        CACHE STRING "CUDA architectures used to build AliceVision" FORCE
+    )
 
     # default stream legacy implies that the 0 stream synchronizes all streams
-    set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;legacy")
+    add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:--default-stream=legacy>)
     # default stream per-thread implies that each host thread has one non-synchronizing 0-stream
-    # set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;per-thread")
+    # add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:--default-stream=per-thread>)
     # print local memory usage per kernel: -Xptxas;-v
     #   -Xptxas;--warn-on-local-memory-usage;-Xptxas;--warn-on-spills
-    message(STATUS "CUDA Version is ${CUDA_VERSION}")
+    message(STATUS "CUDA Version is ${CUDAToolkit_VERSION}")
+    add_compile_options(
+        $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-G>
+        $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-g>
+    )
     if (UNIX)
-        set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-D_FORCE_INLINES")
+        add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-D_FORCE_INLINES>)
     endif()
     if (ALICEVISION_NVCC_WARNINGS)
-        set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;-warn-lmem-usage")
-        set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;-warn-spills")
-        set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;--warn-on-local-memory-usage")
-        set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-Xptxas;--warn-on-spills")
+        add_compile_options(
+            $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:-Xptxas=-warn-lmem-usage>
+            $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:-Xptxas=-warn-spills>
+            $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:-Xptxas=--warn-on-local-memory-usage>
+            $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:-Xptxas=--warn-on-spills>
+        )
     endif()
-
-    # library required for CUDA dynamic parallelism, forgotten by CMake 3.4
-    cuda_find_library_local_first(CUDA_CUDADEVRT_LIBRARY cudadevrt "\"cudadevrt\" library")
 
     # If user activates NVTX profiling, add library and flags
     if (ALICEVISION_USE_NVTX_PROFILING)
         message(STATUS "PROFILING CPU/GPU CODE: NVTX is in use")
-        cuda_find_library_local_first(CUDA_NVTX_LIBRARY nvToolsExt "NVTX library")
-        add_definitions(-DALICEVISION_USE_NVTX)
-        include_directories(${CUDA_INCLUDE_DIRS})
-        set(ALICEVISION_NVTX_LIBRARY ${CUDA_NVTX_LIBRARY})
+        if (TARGET CUDA::nvToolsExt)
+            add_definitions(-DALICEVISION_USE_NVTX)
+            set(ALICEVISION_NVTX_LIBRARY CUDA::nvToolsExt)
+        elseif (TARGET CUDA::nvtx3)
+            add_definitions(-DALICEVISION_USE_NVTX)
+            set(ALICEVISION_NVTX_LIBRARY CUDA::nvtx3)
+        else()
+            message(WARNING "NVTX profiling requested but no NVTX CMake target was found in CUDAToolkit.")
+        endif()
     endif()
 endif()
 

--- a/src/aliceVision/depthMap/CMakeLists.txt
+++ b/src/aliceVision/depthMap/CMakeLists.txt
@@ -129,12 +129,11 @@ alicevision_add_library(aliceVision_depthMap
         aliceVision_mvsUtils
         aliceVision_system
         assimp::assimp
+        CUDA::cudart
     PRIVATE_LINKS
         aliceVision_gpu
         aliceVision_sfmData
         aliceVision_sfmDataIO
-    PUBLIC_INCLUDE_DIRS
-        ${CUDA_INCLUDE_DIRS}
 )
 
 # target_compile_definitions(aliceVision_depthMap PUBLIC TSIM_USE_FLOAT)

--- a/src/aliceVision/gpu/CMakeLists.txt
+++ b/src/aliceVision/gpu/CMakeLists.txt
@@ -9,17 +9,13 @@ set(gpu_files_sources
 )
 
 set(GPU_PRIVATE_LINKS aliceVision_system)
-set(GPU_PRIVATE_INCLUDE_DIRS "")
 
 if (ALICEVISION_HAVE_CUDA)
-    set(GPU_PRIVATE_LINKS ${GPU_PRIVATE_LINKS} ${CUDA_LIBRARIES})
-    set(GPU_PRIVATE_INCLUDE_DIRS ${GPU_PRIVATE_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS})
+    set(GPU_PRIVATE_LINKS ${GPU_PRIVATE_LINKS} ${ALICEVISION_CUDA_LIBRARIES})
 endif()
 
 alicevision_add_library(aliceVision_gpu
     SOURCES ${gpu_files_headers} ${gpu_files_sources}
     PRIVATE_LINKS
         ${GPU_PRIVATE_LINKS}
-    PRIVATE_INCLUDE_DIRS
-        ${GPU_PRIVATE_INCLUDE_DIRS}
 )

--- a/src/aliceVision/segmentation/CMakeLists.txt
+++ b/src/aliceVision/segmentation/CMakeLists.txt
@@ -9,10 +9,8 @@ set(segmentation_files_sources
 )
 
 set(SEGMENTATION_PRIVATE_LINKS "")
-set(SEGMENTATION_PRIVATE_INCLUDE_DIRS "")
 if (ALICEVISION_HAVE_CUDA)
-    set(SEGMENTATION_PRIVATE_LINKS ${CUDA_LIBRARIES})
-    set(SEGMENTATION_PRIVATE_INCLUDE_DIRS ${CUDA_INCLUDE_DIRS})
+    set(SEGMENTATION_PRIVATE_LINKS ${ALICEVISION_CUDA_LIBRARIES})
 endif()
 
 alicevision_add_library(aliceVision_segmentation
@@ -24,6 +22,4 @@ alicevision_add_library(aliceVision_segmentation
         ONNXRuntime::ONNXRuntime
     PRIVATE_LINKS
         ${SEGMENTATION_PRIVATE_LINKS}
-    PRIVATE_INCLUDE_DIRS
-        ${SEGMENTATION_PRIVATE_INCLUDE_DIRS}
 )

--- a/src/aliceVision/system/nvtx.cpp
+++ b/src/aliceVision/system/nvtx.cpp
@@ -1,8 +1,17 @@
 #ifdef ALICEVISION_USE_NVTX
 
     #include <sstream>
-    #include <nvToolsExtCuda.h>
     #include <filesystem>
+
+    #if __has_include(<nvtx3/nvToolsExt.h>)
+        #include <nvtx3/nvToolsExt.h>
+    #elif __has_include(<nvToolsExtCuda.h>)
+        #include <nvToolsExtCuda.h>
+    #elif __has_include(<nvToolsExt.h>)
+        #include <nvToolsExt.h>
+    #else
+        #error "ALICEVISION_USE_NVTX is enabled but no NVTX headers were found."
+    #endif
 
     #include "aliceVision/system/nvtx.hpp"
 

--- a/src/cmake/FindONNXRuntime.cmake
+++ b/src/cmake/FindONNXRuntime.cmake
@@ -18,24 +18,19 @@ find_path(ONNXRuntime_INCLUDE_DIR
 )
 
 # Check that we found everything we need
-if (NOT ONNXRuntime_LIBRARY)
-  message(FATAL_ERROR "Failed to find ONNX Runtime library")
+if (ONNXRuntime_LIBRARY AND ONNXRuntime_INCLUDE_DIR)
+
+  # Export the target for downstream use
+  add_library(ONNXRuntime::ONNXRuntime INTERFACE IMPORTED)
+  set_target_properties(ONNXRuntime::ONNXRuntime PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${ONNXRuntime_LIBRARY}"
+  )
+
+  # Export variables for use in downstream projects
+  set(ONNXRuntime_FOUND TRUE)
+  set(ONNXRuntime_INCLUDE_DIRS "${ONNXRuntime_INCLUDE_DIR}")
+  set(ONNXRuntime_LIBRARIES "${ONNXRuntime_LIBRARY}")
+  mark_as_advanced(ONNXRuntime_INCLUDE_DIRS ONNXRuntime_LIBRARIES)
+
 endif()
-
-if (NOT ONNXRuntime_INCLUDE_DIR)
-  message(FATAL_ERROR "Failed to find ONNX Runtime headers")
-endif()
-
-# Export the target for downstream use
-add_library(ONNXRuntime::ONNXRuntime INTERFACE IMPORTED)
-set_target_properties(ONNXRuntime::ONNXRuntime PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRuntime_INCLUDE_DIR}"
-  INTERFACE_LINK_LIBRARIES "${ONNXRuntime_LIBRARY}"
-)
-
-# Export variables for use in downstream projects
-set(ONNXRuntime_FOUND TRUE)
-set(ONNXRuntime_INCLUDE_DIRS "${ONNXRuntime_INCLUDE_DIR}")
-set(ONNXRuntime_LIBRARIES "${ONNXRuntime_LIBRARY}")
-mark_as_advanced(ONNXRuntime_INCLUDE_DIRS ONNXRuntime_LIBRARIES)
-

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -32,35 +32,19 @@ function(alicevision_add_library library_name)
         list(APPEND LIBRARY_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/${library_name}_version.rc")
     endif()
 
-    if (NOT LIBRARY_USE_CUDA)
-        add_library(${library_name} ${LIBRARY_SOURCES})
-    
-        if (ALICEVISION_BUILD_COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
-            append_coverage_compiler_flags_to_target(${library_name})
-        endif()
+    add_library(${library_name} ${LIBRARY_SOURCES})
 
-    elseif (BUILD_SHARED_LIBS)
-        if(MSVC)
-            if(CMAKE_BUILD_TYPE MATCHES "Debug")
-                set(CUDA_LIB_OPTIONS --compiler-options "/MDd")
-            else()
-                set(CUDA_LIB_OPTIONS --compiler-options "/MD")
-            endif()
-        else()
-            set(CUDA_LIB_OPTIONS --compiler-options "-fPIC")
-        endif()
-        cuda_add_library(${library_name} SHARED ${LIBRARY_SOURCES} OPTIONS ${CUDA_LIB_OPTIONS})
-    else()
-        if(MSVC)
-            if(CMAKE_BUILD_TYPE MATCHES "Debug")
-                set(CUDA_LIB_OPTIONS --compiler-options "/MTd")
-            else()
-                set(CUDA_LIB_OPTIONS --compiler-options "/MT")
-            endif()
-        else()
-            set(CUDA_LIB_OPTIONS --compiler-options "-fPIC")
-        endif()
-        cuda_add_library(${library_name} ${LIBRARY_SOURCES} OPTIONS ${CUDA_LIB_OPTIONS})
+    if (ALICEVISION_BUILD_COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
+        append_coverage_compiler_flags_to_target(${library_name})
+    endif()
+
+    if (LIBRARY_USE_CUDA)
+        set_target_properties(${library_name}
+            PROPERTIES
+                CUDA_SEPARABLE_COMPILATION ON
+                CUDA_RESOLVE_DEVICE_SYMBOLS ON
+                POSITION_INDEPENDENT_CODE ON
+        )
     endif()
 
     if (ALICEVISION_REMOVE_ABSOLUTE)
@@ -72,18 +56,16 @@ function(alicevision_add_library library_name)
         set(TRANSFORMED_LIBRARY_PUBLIC_LINKS ${LIBRARY_PUBLIC_LINKS})
     endif()
 
-    # FindCUDA.cmake implicit	target_link_libraries() can not be mixed with new signature (CMake < 3.9.0)
-    if (NOT LIBRARY_USE_CUDA)
-        target_link_libraries(${library_name}
-            PUBLIC ${TRANSFORMED_LIBRARY_PUBLIC_LINKS}
-            PRIVATE ${LIBRARY_PRIVATE_LINKS}
-        )
-    else()
-        target_link_libraries(${library_name}
-            ${TRANSFORMED_LIBRARY_PUBLIC_LINKS}
-            ${LIBRARY_PRIVATE_LINKS}
-        )
+    set(ALICEVISION_LIBRARY_PRIVATE_LINKS ${LIBRARY_PRIVATE_LINKS})
+    if (LIBRARY_USE_CUDA)
+        list(APPEND ALICEVISION_LIBRARY_PRIVATE_LINKS ${ALICEVISION_CUDA_LIBRARIES})
     endif()
+
+    target_link_libraries(${library_name}
+        PUBLIC ${TRANSFORMED_LIBRARY_PUBLIC_LINKS}
+        PRIVATE ${ALICEVISION_LIBRARY_PRIVATE_LINKS}
+    )
+    unset(ALICEVISION_LIBRARY_PRIVATE_LINKS)
 
     target_include_directories(${library_name}
         PUBLIC $<BUILD_INTERFACE:${ALICEVISION_INCLUDE_DIR}>
@@ -108,7 +90,7 @@ function(alicevision_add_library library_name)
     )
 
     if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1914))
-        target_compile_options(${library_name} PUBLIC "/Zc:__cplusplus")
+        target_compile_options(${library_name} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>)
     endif()
 
     install(TARGETS ${library_name}
@@ -222,7 +204,7 @@ function(alicevision_add_software software_name)
     )
 
     if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1914))
-        target_compile_options(${software_name}_exe PUBLIC "/Zc:__cplusplus")
+        target_compile_options(${software_name}_exe PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>)
     endif()
 
     set_property(TARGET ${software_name}_exe
@@ -281,7 +263,7 @@ function(alicevision_add_test test_file)
     )
 
     if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1914))
-        target_compile_options(${TEST_EXECUTABLE_NAME} PUBLIC "/Zc:__cplusplus")
+        target_compile_options(${TEST_EXECUTABLE_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>)
     endif()
 
     add_test(NAME test_${TEST_EXECUTABLE_NAME}

--- a/src/dependencies/MeshSDFilter/CMakeLists.txt
+++ b/src/dependencies/MeshSDFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 
 project(SDFilter)
 

--- a/src/dependencies/vectorGraphics/CMakeLists.txt
+++ b/src/dependencies/vectorGraphics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 
 add_executable(main_svgSample main.cpp)
 

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -19,23 +19,21 @@ endif()
 if (ALICEVISION_BUILD_SFM)
     # Uncertainty
     if (ALICEVISION_HAVE_UNCERTAINTYTE)
-        alicevision_add_software(aliceVision_computeUncertainty
-            SOURCE main_computeUncertainty.cpp
-            FOLDER ${FOLDER_SOFTWARE_UTILS}
-            LINKS aliceVision_sfm
-                  aliceVision_system
-                  aliceVision_cmdline
-                  ${CUDA_LIBRARIES}
-                  ${CUDA_CUBLAS_LIBRARIES}
-                  ${CUDA_cusparse_LIBRARY}
-                  ${UNCERTAINTYTE_LIBRARY}
-                  Boost::program_options
-            INCLUDE_DIRS ${UNCERTAINTYTE_INCLUDE_DIR}
-        )
-        # message(warning "UNCERTAINTYTE_LIBRARY: ${UNCERTAINTYTE_LIBRARY}")
-        # message(warning "CUDA_LIBRARIES: ${CUDA_LIBRARIES}")
-        # message(warning "CUDA_CUBLAS_LIBRARIES: ${CUDA_CUBLAS_LIBRARIES}")
-        # message(warning "CUDA_cusparse_LIBRARY: ${CUDA_cusparse_LIBRARY}")
+        if (ALICEVISION_HAVE_CUDA)
+            alicevision_add_software(aliceVision_computeUncertainty
+                SOURCE main_computeUncertainty.cpp
+                FOLDER ${FOLDER_SOFTWARE_UTILS}
+                LINKS aliceVision_sfm
+                    aliceVision_system
+                    aliceVision_cmdline
+                    CUDA::cudart
+                    CUDA::cublas
+                    CUDA::cusparse
+                    ${UNCERTAINTYTE_LIBRARY}
+                    Boost::program_options
+                INCLUDE_DIRS ${UNCERTAINTYTE_INCLUDE_DIR}
+            )
+        endif()
     endif()
 
     alicevision_add_software(aliceVision_imageProcessing 

--- a/src/software/utils/aliceVisionAs3rdParty/CMakeLists.txt
+++ b/src/software/utils/aliceVisionAs3rdParty/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 
 project(AliceVisionAs3rdParty)
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "d5182f703b51d7b258f83f94d936ac03488dcdbe",
+    "baseline": "f6735d5aa1537081e8d425372ea7e585b0ad65e8",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,7 +27,6 @@
     "geogram",
     "cctag",
     "popsift",
-    "eigen3",
     "expat",
     "flann",
     "nanoflann",
@@ -103,6 +102,11 @@
     {
       "name": "cctag",
       "version": "1.0.4"
+    },
+    {
+      "name": "eigen3",
+      "version": "3.4.1#1"
+    },
     {
       "name": "python3",
       "version": "3.11.10#0"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -46,7 +46,7 @@
     },
     {
       "name":"openimageio",
-      "features": ["opencolorio","libraw","gif","openjpeg"],
+      "features": ["opencolorio","libraw","gif","openjpeg", "pybind11"],
       "default-features": false
     },
     {
@@ -103,6 +103,9 @@
     {
       "name": "cctag",
       "version": "1.0.4"
+    {
+      "name": "python3",
+      "version": "3.11.10#0"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -30,7 +30,7 @@
     "expat",
     "flann",
     "nanoflann",
-    "onnxruntime-gpu",
+    "onnxruntime",
     "openmesh",
     "tbb",
     "cuda",


### PR DESCRIPTION
This pull request modernizes and simplifies the project's CUDA integration, updates dependency versions, and improves CMake usage. The main changes are a migration from legacy CUDA handling (FindCUDA) to the modern CMake CUDAToolkit approach, updates to minimum CMake requirements, and improvements to build scripts to ensure compatibility and maintainability.

**CUDA Integration Modernization:**
- Replaced legacy `FindCUDA` usage with modern CMake `CUDAToolkit` handling, including `enable_language(CUDA)`, updated detection, and target-based linking (`CUDA::cudart`, etc.), and refactored CMake logic to use proper CUDA targets and architecture specification. This includes updating how NVTX profiling is detected and linked. [[1]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R665-R767) [[2]](diffhunk://#diff-1ea0433dfa41fa113ff35708dbae9af805c1b88691c03797dd0536a89529e183R132-L137) [[3]](diffhunk://#diff-3145e2bb6cf438f4d52577197a5046a9551dc3f5479925ba73f8f4dc516b5a8cL12-L24) [[4]](diffhunk://#diff-710de7166a01952ba8adaaa13084e1fafbccff1bee88bea57c5a63ecb1a81714L12-R13) [[5]](diffhunk://#diff-710de7166a01952ba8adaaa13084e1fafbccff1bee88bea57c5a63ecb1a81714L27-L28) [[6]](diffhunk://#diff-a7b5f932971072621b86ead9cc8db6e758b9d8c2f448e4733804c5c5a2578eadL4-R15) [[7]](diffhunk://#diff-055ed3c174afdfc8a699fce6bc2bce76828b4d65b73d435e81336a687d49382aR22-R36) [[8]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L35-R47) [[9]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L75-R68)
- Updated CUDA Toolkit setup in CI to use a newer version and include Visual Studio integration.

**Build System and CMake Improvements:**
- Raised minimum required CMake version from 3.25 to 3.30 across all CMakeLists files, enabling use of newer CMake features. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1-R1) [[2]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L1-R1) [[3]](diffhunk://#diff-d8038dd55c6f25e33f3c6d6b99106bead9aaab9d62c173581d4e16303cc6e1a2L1-R1) [[4]](diffhunk://#diff-7d6faf7cbeb43785ff1209522fc18cded160eeda90e82708034eb54bcb2fefbeL1-R1) [[5]](diffhunk://#diff-c2459f9ce2685d90b6e0cbc88a69d3bdfd7924326433e58644951526c2324526L1-R1)
- Refactored `alicevision_add_library` and related CMake helper functions to use generator expressions for compile options, ensure proper CUDA property settings, and clean up legacy/duplicated logic. [[1]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L35-R47) [[2]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L75-R68) [[3]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L111-R93) [[4]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L225-R207) [[5]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L284-R266)
- Improved handling of compile options for MSVC and CUDA, using generator expressions to apply them only to relevant languages. [[1]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L146-R148) [[2]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L111-R93) [[3]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L225-R207) [[4]](diffhunk://#diff-43bf312f722f7f3c705a6b98e5aebe00e3428fbec2ce4142fd37c6e28d0fa673L284-R266)

**Dependency and CI Updates:**
- Updated vcpkg baseline in `vcpkg-configuration.json` and switched to newer prebuilt binaries in CI. [[1]](diffhunk://#diff-d1eeedcb0ab2a1a0981b8ae24009855b0ae605a667172d453f19b9713b99b896L4-R4) [[2]](diffhunk://#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434L221-R222)
- Improved ONNXRuntime CMake find module to only export the imported target if both library and headers are found, avoiding fatal errors on partial presence. [[1]](diffhunk://#diff-c5ae9aaeff383e561a4e25de6aa47047739d2133d509a9dce24062b6b3a1d65fL21-R21) [[2]](diffhunk://#diff-c5ae9aaeff383e561a4e25de6aa47047739d2133d509a9dce24062b6b3a1d65fR36)

**General Codebase Cleanup:**
- Removed unnecessary include directories and legacy variables from target definitions, relying on target-based linking and modern CMake practices. [[1]](diffhunk://#diff-1ea0433dfa41fa113ff35708dbae9af805c1b88691c03797dd0536a89529e183R132-L137) [[2]](diffhunk://#diff-3145e2bb6cf438f4d52577197a5046a9551dc3f5479925ba73f8f4dc516b5a8cL12-L24) [[3]](diffhunk://#diff-710de7166a01952ba8adaaa13084e1fafbccff1bee88bea57c5a63ecb1a81714L12-R13) [[4]](diffhunk://#diff-710de7166a01952ba8adaaa13084e1fafbccff1bee88bea57c5a63ecb1a81714L27-L28)

**NVTX Profiling Support:**
- Enhanced NVTX header detection to support multiple possible header locations and ensure proper error reporting if none are found.

These changes collectively make the build system more robust, future-proof, and easier to maintain.