### PR TITLE
[FIX] Remove potentially dangling reference from LineKernel.hpp

### DIFF
--- a/src/aliceVision/robustEstimation/LineKernel.hpp
+++ b/src/aliceVision/robustEstimation/LineKernel.hpp
@@ -213,7 +213,7 @@ class LineKernel : public IRansacKernel<robustEstimation::MatrixModel<Vec2>>
     inline double unormalizeError(double val) const override { return std::sqrt(val); }
 
   private:
-    const Mat2X& _xs;
+    const Mat2X _xs;
     double _logalpha0;
 };
 


### PR DESCRIPTION
This fixes a crash in the `RansacLineFitter_TooFewPoints` unit test, which is caused by a dangling reference: The constructor of the `LineKernel` class creates a temporary Eigen matrix instance (if the passed reference does not exactly match the defined Eigen template it expects) and stores a reference to it. Once the constructor returns, the reference in the `LineKernel` instance potentially becomes dangling. Storing an owned Eigen matrix (performing an implicit copy) removes the issue.

Caught by LLVM ASAN: https://gist.github.com/philippremy/180bcc7d042755206f4261b57af41e11
