### PR TITLE
Use LLVM openmp on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,6 +253,9 @@ endif()
 if (ALICEVISION_USE_OPENMP STREQUAL "OFF")
     set(ALICEVISION_HAVE_OPENMP 0)
 else() # ON OR AUTO
+    if (MSVC)
+        set(OpenMP_RUNTIME_MSVC "llvm")
+    endif()
     find_package(OpenMP)
 
     if (OPENMP_FOUND)


### PR DESCRIPTION
This pull request makes a minor update to the OpenMP configuration for MSVC in the `src/CMakeLists.txt` file. Specifically, it adds a step to set the OpenMP runtime to "llvm" when building with MSVC.

Build system improvement:

* Added logic to set `OpenMP_RUNTIME_MSVC` to "llvm" for MSVC builds in `src/CMakeLists.txt` to ensure compatibility with the OpenMP runtime.