### PR TITLE
Update distortion calibration to select the best checkerboard as input

### DIFF
--- a/meshroom/aliceVision/DistortionCalibration.py
+++ b/meshroom/aliceVision/DistortionCalibration.py
@@ -1,4 +1,4 @@
-__version__ = '6.0'
+__version__ = '6.1'
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -30,6 +30,12 @@ class DistortionCalibration(desc.AVCommandLineNode):
             description="model used to estimate undistortion.",
             value="3deanamorphic4",
             values=["3deanamorphic4", "3declassicld", "3deradial4"],
+        ),
+        desc.BoolParam(
+            name="bestOnly",
+            label="Keep best image",
+            description="All detected checkerboards across images sharing the same intrinsic are used for distortion calibration. Once this option is enabled, only the best image is selected to optimize the intrinsics rather than utilizing all available images.",
+            value=False,
         ),
         desc.BoolParam(
             name="handleSqueeze",

--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -10,7 +10,7 @@
             "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
             "ExportImages": "1.1",

--- a/meshroom/cameraTrackingDepth.mg
+++ b/meshroom/cameraTrackingDepth.mg
@@ -11,7 +11,7 @@
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
             "DepthMapTracksInjecting": "1.0",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
             "ExportImages": "1.1",

--- a/meshroom/cameraTrackingLegacy.mg
+++ b/meshroom/cameraTrackingLegacy.mg
@@ -10,7 +10,7 @@
             "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",

--- a/meshroom/cameraTrackingRoma.mg
+++ b/meshroom/cameraTrackingRoma.mg
@@ -8,7 +8,7 @@
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
             "ExportImages": "1.1",

--- a/meshroom/distortionCalibration.mg
+++ b/meshroom/distortionCalibration.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CheckerboardDetection": "2.0",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportDistortion": "2.0",
             "CopyFiles": "1.3"
         },

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -8,7 +8,7 @@
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
             "ExportImages": "1.1",

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -10,7 +10,7 @@
             "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",
             "ExportImages": "1.1",

--- a/meshroom/photogrammetryAndCameraTrackingLegacy.mg
+++ b/meshroom/photogrammetryAndCameraTrackingLegacy.mg
@@ -10,7 +10,7 @@
             "CopyFiles": "1.3",
             "DepthMap": "5.0",
             "DepthMapFilter": "4.0",
-            "DistortionCalibration": "6.0",
+            "DistortionCalibration": "6.1",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",
             "FeatureExtraction": "1.3",

--- a/src/aliceVision/calibration/checkerDetector.cpp
+++ b/src/aliceVision/calibration/checkerDetector.cpp
@@ -1946,5 +1946,34 @@ void CheckerDetector::groupNestedCheckerboards(size_t minConsensus)
     _boards[0] = newboard;
 }
 
+double CheckerDetector::getScore() const
+{
+    double maxScore = 0.0;
+    for (const auto & board :_boards)
+    {
+        size_t countValid = 0;
+        double sumScale = 0.0;
+        for (const auto & item : board.reshaped())
+        {
+            if (item == UndefinedIndexT)
+            {
+                continue;
+            }
+
+            // Scale is between 0 and 1
+            sumScale += _corners[item].scale;
+            countValid++;
+        }
+
+        // The score is the number of valid points in the checkerboard + the mean scale of the corners to disambiguate.
+        double score = (countValid > 0)
+                       ? (double(countValid) + sumScale / double(countValid))
+                       : 0.0;
+        maxScore = std::max(maxScore, score);
+    }
+
+    return maxScore;
+}
+
 }  // namespace calibration
 }  // namespace aliceVision

--- a/src/aliceVision/calibration/checkerDetector.hpp
+++ b/src/aliceVision/calibration/checkerDetector.hpp
@@ -143,6 +143,13 @@ class CheckerDetector
     /// Return a reference to the debug image.
     const image::Image<image::RGBColor>& getDebugImage() const { return _debugImage; }
 
+    /**
+     * @brief Compute a score for the last processed image
+     * The score is a way to sort images according to their detected checkerboards
+     * @return the score for the last processed image
+     */
+    double getScore() const;
+
   private:
     /**
      * @brief Extract corners positions from the image at the given scale.

--- a/src/software/pipeline/main_distortionCalibration.cpp
+++ b/src/software/pipeline/main_distortionCalibration.cpp
@@ -262,6 +262,7 @@ int aliceVision_main(int argc, char* argv[])
     std::string sfmOutputDataFilepath;
     bool handleSqueeze = true;
     bool isDesqueezed = false;
+    bool bestOnly = false;
     double forcedPixelAspectRatio = 0.0;
 
     std::string undistortionModelName = "3deanamorphic4";
@@ -284,6 +285,11 @@ int aliceVision_main(int argc, char* argv[])
          "Estimate squeeze after estimating distortion")
         ("isDesqueezed", po::value<bool>(&isDesqueezed)->default_value(isDesqueezed),
          "Is the image already desqueezed")
+        ("bestOnly", po::value<bool>(&bestOnly)->default_value(bestOnly),
+         "All detected checkerboards are grouped by intrinsic. Distortion parameters are estimated per intrinsic. "
+         "The default behavior is to use all the detected checkerboards in all the images sharing the same intrinsic"
+         " to calibrate the distortion. By checking this option, the application will only keep one image per intrinsic."
+         " This unique image will be selected automatically based on a quality score.")
         ("forcedPixelAspectRatio", po::value<double>(&forcedPixelAspectRatio)->default_value(forcedPixelAspectRatio),
          "Force pixel aspect ratio value, overriding metadatas. Ignored if less than or equal 0.0.");
     // clang-format on
@@ -401,18 +407,62 @@ int aliceVision_main(int argc, char* argv[])
 
         undistortion->setPixelAspectRatio(pixelAspectRatio);
         undistortion->setDesqueezed(isDesqueezed);
+        
+        std::set<IndexT> usedViews;
+
+        if (!bestOnly)
+        {
+            //Keep all boards from the same intrinsic
+            for (auto& [viewId, view] : sfmData.getViews())
+            {
+                if (view->getIntrinsicId() != intrinsicId)
+                {
+                    continue;
+                }
+
+                usedViews.insert(viewId);
+            }
+        }
+        else 
+        {
+            IndexT bestView = UndefinedIndexT;
+            double bestScore = 0.0;
+
+            for (auto& [viewId, view] : sfmData.getViews())
+            {
+                if (view->getIntrinsicId() != intrinsicId)
+                {
+                    continue;
+                }
+
+                double score = boardsAllImages[viewId].getScore();
+                if (score > bestScore)
+                {
+                    bestView = viewId;
+                    bestScore = score;
+                }
+            }
+            
+            
+            if (bestView != UndefinedIndexT)
+            {
+                ALICEVISION_LOG_INFO("Selecting view #" << bestView << " for intrinsic #" << intrinsicId << ".");
+                usedViews.insert(bestView);
+            }
+        }
+
+        if (usedViews.size() == 0)
+        {
+            ALICEVISION_LOG_INFO("An intrinsic has no associated checkerboard.");
+            continue;
+        }
 
         // Transform checkerboards to line With points
         std::vector<calibration::LineWithPoints> allLinesWithPoints;
-        for (auto& pv : sfmData.getViews())
+        for (auto & viewId : usedViews)
         {
-            if (pv.second->getIntrinsicId() != intrinsicId)
-            {
-                continue;
-            }
-
             std::vector<calibration::LineWithPoints> linesWithPoints;
-            if (!retrieveLines(linesWithPoints, boardsAllImages[pv.first]))
+            if (!retrieveLines(linesWithPoints, boardsAllImages[viewId]))
             {
                 continue;
             }


### PR DESCRIPTION
This pull request updates the distortion calibration pipeline to add a new option for selecting only the best image per intrinsic based on a quality score, rather than using all detected checkerboards. It also introduces the scoring logic for checkerboard detection and propagates the new option through the Python node and command-line interface. The version of `DistortionCalibration` is incremented to reflect these changes, and all relevant workflow files are updated accordingly.

New feature: Best image selection for distortion calibration

* Added a new `bestOnly` boolean parameter to the `DistortionCalibration` node in `DistortionCalibration.py`, allowing users to select only the highest-scoring image per intrinsic for distortion calibration.
* Updated the command-line interface and main pipeline logic in `main_distortionCalibration.cpp` to support the `bestOnly` option, including logic to compute scores and select the best image using the new `CheckerDetector::getScore()` method. [[1]](diffhunk://#diff-40356d5f3115fb54078cb13765962e29e9cfabae0e9e2c31a84d7d2b0d074830R265) [[2]](diffhunk://#diff-40356d5f3115fb54078cb13765962e29e9cfabae0e9e2c31a84d7d2b0d074830R288-R292) [[3]](diffhunk://#diff-40356d5f3115fb54078cb13765962e29e9cfabae0e9e2c31a84d7d2b0d074830L405-R455)

Checkerboard scoring implementation

* Added the `getScore()` method to the `CheckerDetector` class in `checkerDetector.cpp` and `checkerDetector.hpp`, which computes a quality score for each detected checkerboard in an image. [[1]](diffhunk://#diff-fdf564f5a027267dd59ce14701e2a4b546390fef30012d5b20a762c61dc3b2e8R1917-R1943) [[2]](diffhunk://#diff-e321151d4dcf181cb373ff9a8bd275b91fc4eedd9eb1a2e455e7f981f0885fb2R145-R151)

Version updates

* Incremented the `DistortionCalibration` node version from `6.0` to `6.1` in the Python module and all relevant workflow files to reflect the new functionality. [[1]](diffhunk://#diff-af5d86fa66e3f93c74c24897dec99507a974a42d52cef59283fd693a51ceb763L1-R1) [[2]](diffhunk://#diff-1956e2ddf23a2a08431e19e8c686126f68c55670741b2b938cdf1f55a0ff8081L13-R13) [[3]](diffhunk://#diff-02370d29d564d70df350f27995bf654aa9e431b5a2a93564abf367cf5c25292cL14-R14) [[4]](diffhunk://#diff-6f74e403d1aaec380b44fdd225f6537ab411d0ad7aa33508caf558ed2957f97eL13-R13) [[5]](diffhunk://#diff-bd0bdecca3730a846f73acd4403529766730c15347c3cf359b37917961b3e52cL11-R11) [[6]](diffhunk://#diff-812c5b06588fcbb3af41cd86e38bd9cabf555723e353fa062465a77b364dfb7dL8-R8) [[7]](diffhunk://#diff-d5b4dc5c2c4fb2372c050c5f2961b08aae60c241f6b8f8d212694bf1c5134408L11-R11) [[8]](diffhunk://#diff-def57ede267f04a6a1c57d2eb35fc81c01e696309a15e5cac3c2f1882c56f457L13-R13) [[9]](diffhunk://#diff-035c28cc5ecba2753e2c6262c6ea6f48705363c1030cc72c091af6456d91f86fL13-R13)