### PR TITLE
imageProcessing: guard OpenCV-dependent filters behind ALICEVISION_HA…

### DIFF
--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -522,7 +522,6 @@ void setupSteps(std::list<std::unique_ptr<ImageProcess>> & steps, const Processi
     {
         steps.push_back(std::make_unique<SharpenProcess>(pParams.sharpen.width, pParams.sharpen.contrast, pParams.sharpen.threshold));
     }
-#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
     if (pParams.bilateralFilter.enabled)
     {
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
@@ -547,11 +546,13 @@ void setupSteps(std::list<std::unique_ptr<ImageProcess>> & steps, const Processi
     {
         steps.push_back(std::make_unique<NoiseProcess>(ENoiseMethod_enumToString(pParams.noise.method), pParams.noise.A, pParams.noise.B, pParams.noise.mono));
     }
-#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
     if (pParams.nlmFilter.enabled)
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
     {
         steps.push_back(std::make_unique<NlmFilterProcess>(pParams.nlmFilter.filterStrength, pParams.nlmFilter.filterStrengthColor, pParams.nlmFilter.templateWindowSize, pParams.nlmFilter.searchWindowSize));
     }
+#else
+        ALICEVISION_LOG_ERROR("OpenCV support is not enabled in this AliceVision build. Nlm filter processing is unavailable and will be bypassed.");
 #endif
     if (pParams.applyDcpMetadata || pParams.enableColorTempProcessing)
     {

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -522,6 +522,7 @@ void setupSteps(std::list<std::unique_ptr<ImageProcess>> & steps, const Processi
     {
         steps.push_back(std::make_unique<SharpenProcess>(pParams.sharpen.width, pParams.sharpen.contrast, pParams.sharpen.threshold));
     }
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
     if (pParams.bilateralFilter.enabled)
     {
         steps.push_back(std::make_unique<BilateralFilterProcess>(pParams.bilateralFilter.distance, pParams.bilateralFilter.sigmaColor, pParams.bilateralFilter.sigmaSpace));
@@ -530,6 +531,7 @@ void setupSteps(std::list<std::unique_ptr<ImageProcess>> & steps, const Processi
     {
         steps.push_back(std::make_unique<ClaheFilterProcess>(pParams.claheFilter.tileGridSize, pParams.claheFilter.clipLimit));
     }
+#endif
     if (pParams.fillHoles)
     {
         steps.push_back(std::make_unique<FillHolesProcess>());
@@ -538,10 +540,12 @@ void setupSteps(std::list<std::unique_ptr<ImageProcess>> & steps, const Processi
     {
         steps.push_back(std::make_unique<NoiseProcess>(ENoiseMethod_enumToString(pParams.noise.method), pParams.noise.A, pParams.noise.B, pParams.noise.mono));
     }
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
     if (pParams.nlmFilter.enabled)
     {
         steps.push_back(std::make_unique<NlmFilterProcess>(pParams.nlmFilter.filterStrength, pParams.nlmFilter.filterStrengthColor, pParams.nlmFilter.templateWindowSize, pParams.nlmFilter.searchWindowSize));
     }
+#endif
     if (pParams.applyDcpMetadata || pParams.enableColorTempProcessing)
     {
         steps.push_back(std::make_unique<ColorTemperatureProcess>(pParams.applyDcpMetadata, pParams.useDCPColorMatrixOnly, pParams.enableColorTempProcessing, pParams.correlatedColorTemperature));

--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -525,13 +525,20 @@ void setupSteps(std::list<std::unique_ptr<ImageProcess>> & steps, const Processi
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
     if (pParams.bilateralFilter.enabled)
     {
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
         steps.push_back(std::make_unique<BilateralFilterProcess>(pParams.bilateralFilter.distance, pParams.bilateralFilter.sigmaColor, pParams.bilateralFilter.sigmaSpace));
+#else
+        ALICEVISION_LOG_ERROR("OpenCV support is not enabled in this AliceVision build. Bilateral filter processing is unavailable and will be bypassed.");
+#endif
     }
     if (pParams.claheFilter.enabled)
     {
+#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)
         steps.push_back(std::make_unique<ClaheFilterProcess>(pParams.claheFilter.tileGridSize, pParams.claheFilter.clipLimit));
-    }
+#else
+        ALICEVISION_LOG_ERROR("OpenCV support is not enabled in this AliceVision build. Clahe filter processing is unavailable and will be bypassed.");
 #endif
+    }
     if (pParams.fillHoles)
     {
         steps.push_back(std::make_unique<FillHolesProcess>());


### PR DESCRIPTION
## Summary

Guard the registration of OpenCV-dependent image processing steps behind the `ALICEVISION_HAVE_OPENCV` compile-time flag.

## Motivation

Three filter steps — `BilateralFilter`, `ClaheFilter`, and `NlmFilter` — rely on OpenCV internally. Without this guard, any build configuration that does not include OpenCV will fail at compile time when `setupSteps()` tries to instantiate these classes.

## Changes

- Wrapped `BilateralFilterProcess` and `ClaheFilterProcess` registration under `#if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_OPENCV)` in `main_imageProcessing.cpp`.
- Wrapped `NlmFilterProcess` registration under the same guard.
