### PR TITLE
Fix binary incompatibility in depthmap

### DIFF
--- a/meshroom/aliceVision/DepthMap.py
+++ b/meshroom/aliceVision/DepthMap.py
@@ -1,4 +1,4 @@
-__version__ = "5.0"
+__version__ = "5.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -238,13 +238,6 @@ Use a downscale factor of one (full-resolution) only if the quality of the input
                     description="Maximum number of depths in the similarity volume.",
                     value=1500,
                     range=(1, 5000, 1),
-                    advanced=True,
-                ),
-                desc.StringParam(
-                    name="sgmFilteringAxes",
-                    label="Filtering Axes",
-                    description="Define axes for the filtering of the similarity volume.",
-                    value="YX",
                     advanced=True,
                 ),
                 desc.BoolParam(

--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -8,7 +8,7 @@
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.1",
             "ExportAlembic": "1.0",

--- a/meshroom/cameraTrackingDepth.mg
+++ b/meshroom/cameraTrackingDepth.mg
@@ -8,7 +8,7 @@
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "DepthMapTracksInjecting": "1.0",
             "DistortionCalibration": "6.1",

--- a/meshroom/cameraTrackingLegacy.mg
+++ b/meshroom/cameraTrackingLegacy.mg
@@ -8,7 +8,7 @@
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.1",
             "ExportAnimatedCamera": "2.0",

--- a/meshroom/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/cameraTrackingWithoutCalibration.mg
@@ -8,7 +8,7 @@
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "ExportAlembic": "1.0",
             "ExportDistortion": "2.0",

--- a/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
@@ -8,7 +8,7 @@
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "ExportAnimatedCamera": "2.0",
             "ExportDistortion": "2.0",

--- a/meshroom/multi-viewPhotometricStereo.mg
+++ b/meshroom/multi-viewPhotometricStereo.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/meshroom/photogrammetry.mg
+++ b/meshroom/photogrammetry.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "ExportImages": "1.0",
             "FeatureExtraction": "1.3",

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -8,7 +8,7 @@
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.1",
             "ExportAlembic": "1.0",

--- a/meshroom/photogrammetryAndCameraTrackingLegacy.mg
+++ b/meshroom/photogrammetryAndCameraTrackingLegacy.mg
@@ -8,7 +8,7 @@
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "DistortionCalibration": "6.1",
             "ExportAnimatedCamera": "2.0",

--- a/meshroom/photogrammetryLegacy.mg
+++ b/meshroom/photogrammetryLegacy.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/meshroom/photogrammetryObject.mg
+++ b/meshroom/photogrammetryObject.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/meshroom/photogrammetryObjectTurntable.mg
+++ b/meshroom/photogrammetryObjectTurntable.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/meshroom/photogrammetryObjectTwoSides.mg
+++ b/meshroom/photogrammetryObjectTwoSides.mg
@@ -6,7 +6,7 @@
             "CameraInit": "12.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
-            "DepthMap": "5.0",
+            "Depthmap": "5.1",
             "DepthMapFilter": "4.0",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/src/aliceVision/depthMap/Sgm.cpp
+++ b/src/aliceVision/depthMap/Sgm.cpp
@@ -274,7 +274,7 @@ void Sgm::computeSimilarityVolumes(const Tile& tile, const SgmDepthList& tileDep
 
 void Sgm::optimizeSimilarityVolume(const Tile& tile, const SgmDepthList& tileDepthList)
 {
-    ALICEVISION_LOG_INFO(tile << "SGM Optimizing volume (filtering axes: " << _sgmParams.filteringAxes << ").");
+    ALICEVISION_LOG_INFO(tile << "SGM Optimizing volume.");
 
     // downscale the region of interest
     const ROI downscaledRoi = downscaleROI(tile.roi, _sgmParams.scale * _sgmParams.stepXY);

--- a/src/aliceVision/depthMap/SgmParams.hpp
+++ b/src/aliceVision/depthMap/SgmParams.hpp
@@ -31,7 +31,6 @@ struct SgmParams
     double gammaP = 8.0;
     double p1 = 10;
     double p2Weighting = 100.0;
-    std::string filteringAxes = "YX";
     bool useSfmSeeds = true;
     bool depthListPerTile = false;
     bool useConsistentScale = false;

--- a/src/aliceVision/depthMap/cuda/planeSweeping/deviceSimilarityVolume.cu
+++ b/src/aliceVision/depthMap/cuda/planeSweeping/deviceSimilarityVolume.cu
@@ -416,7 +416,8 @@ __host__ void cuda_volumeOptimize(CudaDeviceMemoryPitched<TSim, 3>& out_volSimFi
         {'Y', {0, 1, 2}}, // XYZ
     };
 
-    for(char axis : sgmParams.filteringAxes)
+    const char filteringAxes[2] = {'Y', 'X'};
+    for(char axis : filteringAxes)
     {
         const CudaSize<3>& axisT = mapAxes.at(axis);
         updateAggrVolume(axisT, false); // without transpose

--- a/src/software/pipeline/main_depthMapEstimation.cpp
+++ b/src/software/pipeline/main_depthMapEstimation.cpp
@@ -155,8 +155,6 @@ int aliceVision_main(int argc, char* argv[])
          "Semi Global Matching: P2 weighting parameter for SGM filtering.")
         ("sgmMaxDepths", po::value<int>(&sgmParams.maxDepths)->default_value(sgmParams.maxDepths),
          "Semi Global Matching: Maximum number of depths in the similarity volume.")
-        ("sgmFilteringAxes", po::value<std::string>(&sgmParams.filteringAxes)->default_value(sgmParams.filteringAxes),
-         "Semi Global Matching: Define axes for the filtering of the similarity volume.")
         ("sgmDepthListPerTile", po::value<bool>(&sgmParams.depthListPerTile)->default_value(sgmParams.depthListPerTile),
          "Semi Global Matching: Select the list of depth planes per tile or globally to the image.")
         ("sgmUseConsistentScale", po::value<bool>(&sgmParams.useConsistentScale)->default_value(sgmParams.useConsistentScale),


### PR DESCRIPTION
SgmParams is passed from Cpp to cuda as a function parameter.

The std::string filteringAxes causes a binary incompatibility.

This PR remove the parameter