### PR TITLE
Fix metadatas in resize process

### DIFF
--- a/src/aliceVision/imageProcessing/imageProcessing.cpp
+++ b/src/aliceVision/imageProcessing/imageProcessing.cpp
@@ -327,11 +327,10 @@ bool ResizeProcess::processInternal(const sfmData::SfMData & sfmData, sfmData::V
 
 	view.getImage().setWidth(image.width());
 	view.getImage().setHeight(image.height());
+	view.getImage().addMetadata("PixelAspectRatio", "1");
 
 	if (camera)
 	{
-		camera->setWidth(nw);
-		camera->setHeight(nh);
 		camera->rescale(widthScaleFactor, heightScaleFactor);
 	}
 


### PR DESCRIPTION
When applying PixelAspectRatio in imageProcessing application, the pixelAspectRatio metadata was not updated, and the "intrinsic" size was changed twice. 

Now, the metadata is updated, and the intrinsic has the correct value.