### PR TITLE
Adding Image groups

### DIFF
--- a/meshroom/aliceVision/CameraInit.py
+++ b/meshroom/aliceVision/CameraInit.py
@@ -1,4 +1,4 @@
-__version__ = "12.0"
+__version__ = "12.1"
 
 import os
 import json
@@ -472,6 +472,12 @@ The needed metadata are:
             invalidate=False,
             advanced=True,
             enabled=lambda node: node.viewIdMethod.value == "filename",
+        ),
+        desc.BoolParam(
+            name="isSequence",
+            label="Images are a sequence",
+            description="The images provided as input are part of a sequence with temporal coherency.",
+            value=False,
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/aliceVision/ListImages.py
+++ b/meshroom/aliceVision/ListImages.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -22,6 +22,12 @@ class ListImages(desc.AVCommandLineNode):
             label="Input Files",
             description="Set of paths to image files and/or folders.",
             exposed=True,
+        ),
+        desc.BoolParam(
+            name="isSequence",
+            label="Images are a sequence",
+            description="The images provided as input are part of a sequence with temporal coherency.",
+            value=False,
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/cameraTrackingDepth.mg
+++ b/meshroom/cameraTrackingDepth.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/cameraTrackingLegacy.mg
+++ b/meshroom/cameraTrackingLegacy.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/cameraTrackingRoma.mg
+++ b/meshroom/cameraTrackingRoma.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/cameraTrackingWithoutCalibration.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/colorCalibration.mg
+++ b/meshroom/colorCalibration.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "ColorCheckerCorrection": "2.0",
             "ColorCheckerDetection": "2.0",
             "CopyFiles": "1.3"

--- a/meshroom/distortionCalibration.mg
+++ b/meshroom/distortionCalibration.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "DistortionCalibration": "6.1",
             "ExportDistortion": "2.0",

--- a/meshroom/hdrFusion.mg
+++ b/meshroom/hdrFusion.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "LdrToHdrCalibration": "3.2",
             "LdrToHdrMerge": "4.2",

--- a/meshroom/multi-viewPhotometricStereo.mg
+++ b/meshroom/multi-viewPhotometricStereo.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "Depthmap": "5.1",
             "DepthMapFilter": "4.0",

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/nodalCameraTrackingWithoutCalibration.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "ConvertDistortion": "1.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/panoramaFisheyeHdr.mg
+++ b/meshroom/panoramaFisheyeHdr.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/meshroom/panoramaHdr.mg
+++ b/meshroom/panoramaHdr.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2026.1.0+develop",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/meshroom/photogrammetry.mg
+++ b/meshroom/photogrammetry.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "Depthmap": "5.1",
             "DepthMapFilter": "4.0",

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/photogrammetryAndCameraTrackingLegacy.mg
+++ b/meshroom/photogrammetryAndCameraTrackingLegacy.mg
@@ -4,7 +4,7 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "ApplyCalibration": "1.0",
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CheckerboardDetection": "2.0",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",

--- a/meshroom/photogrammetryDraft.mg
+++ b/meshroom/photogrammetryDraft.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",

--- a/meshroom/photogrammetryLegacy.mg
+++ b/meshroom/photogrammetryLegacy.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "Depthmap": "5.1",
             "DepthMapFilter": "4.0",

--- a/meshroom/photogrammetryObject.mg
+++ b/meshroom/photogrammetryObject.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "Depthmap": "5.1",
             "DepthMapFilter": "4.0",

--- a/meshroom/photogrammetryObjectTurntable.mg
+++ b/meshroom/photogrammetryObjectTurntable.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "Depthmap": "5.1",
             "DepthMapFilter": "4.0",

--- a/meshroom/photogrammetryObjectTwoSides.mg
+++ b/meshroom/photogrammetryObjectTwoSides.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "ConvertSfMFormat": "2.0",
             "CopyFiles": "1.3",
             "Depthmap": "5.1",

--- a/meshroom/photometricStereo.mg
+++ b/meshroom/photometricStereo.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "LightingCalibration": "1.0",
             "PhotometricStereo": "1.0",

--- a/meshroom/rawImageConversion.mg
+++ b/meshroom/rawImageConversion.mg
@@ -3,7 +3,7 @@
         "releaseVersion": "2025.1.0",
         "fileVersion": "2.0",
         "nodesVersions": {
-            "CameraInit": "12.0",
+            "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "ImageProcessing": "4.0"
         },

--- a/pyTests/sfmData/test_imagegroup.py
+++ b/pyTests/sfmData/test_imagegroup.py
@@ -1,0 +1,211 @@
+"""
+Collection of unit tests for the ImageGroup, ImageSet, and ImageSequence classes.
+"""
+
+from pyalicevision import sfmData as av
+
+
+def test_imageset_type_conversion_roundtrip():
+    """ Test converting string to ImageGroup Type enum, and ImageGroup Type enum to string. """
+    # Get Type enum value using stringToType first
+    type_value = av.ImageGroup.stringToType("ImageSet")
+
+    # Verify it returns a valid type object
+    assert type_value is not None, "stringToType should return a valid type"
+
+    # Verify round-trip conversion
+    type_str = av.ImageGroup.typeToString(type_value)
+    assert isinstance(type_str, str), "typeToString should return a string"
+    assert type_str == "ImageSet", "Round-trip conversion should preserve type"
+
+
+def test_imagegroup_create_factory():
+    """ Test creating ImageGroup using the factory method. """
+    type_value = av.ImageGroup.stringToType("ImageSet")
+    image_group = av.ImageGroup.create(type_value)
+    
+    assert image_group is not None, "Factory should create a valid ImageGroup object"
+    # Verify the type by converting back to string
+    actual_type_str = av.ImageGroup.typeToString(image_group.getType())
+    assert actual_type_str == "ImageSet", "Created ImageGroup should have Type ImageSet"
+
+
+def test_imageset_default_constructor():
+    """ Test creating an ImageSet object with default parameters. """
+    image_set = av.ImageSet()
+    
+    assert image_set is not None, "ImageSet default constructor should succeed"
+    # Verify the type by converting to string
+    type_str = av.ImageGroup.typeToString(image_set.getType())
+    assert type_str == "ImageSet", "ImageSet should have Type ImageSet"
+
+
+def test_imageset_get_type():
+    """ Test getting the type of an ImageSet object. """
+    image_set = av.ImageSet()
+    type_value = image_set.getType()
+    
+    # Verify by converting to string
+    type_str = av.ImageGroup.typeToString(type_value)
+    assert type_str == "ImageSet", "ImageSet.getType() should return ImageSet type"
+
+
+def test_imageset_clone():
+    """ Test cloning an ImageSet object. """
+    image_set1 = av.ImageSet()
+    image_set2 = image_set1.clone()
+    
+    assert image_set2 is not None, "Clone should return a valid object"
+    assert image_set1 == image_set2, "Cloned ImageSet should be equal to the original"
+    assert image_set1.getType() == image_set2.getType(), \
+        "Cloned ImageSet should have the same type"
+
+
+def test_imageset_equality_operators():
+    """ Test comparing two ImageSet objects using the '==' and '!=' operators. """
+    image_set1 = av.ImageSet()
+    image_set2 = av.ImageSet()
+
+    # Since ImageSet currently has no distinguishing properties,
+    # two default instances are equal
+    assert image_set1 == image_set2, "Two default ImageSet objects should be equal"
+    assert not (image_set1 != image_set2), \
+        "Two default ImageSet objects should not be unequal"
+
+
+def test_imagegroup_polymorphism():
+    """ Test using ImageSet through ImageGroup interface (polymorphism). """
+    # Create via factory
+    type_value = av.ImageGroup.stringToType("ImageSet")
+    image_group = av.ImageGroup.create(type_value)
+    
+    # Should be able to call ImageGroup methods
+    type_str = av.ImageGroup.typeToString(image_group.getType())
+    assert type_str == "ImageSet", "Polymorphic getType() should work correctly"
+    
+    # Clone should work through base class interface
+    cloned = image_group.clone()
+    assert cloned is not None, "Polymorphic clone should work"
+    cloned_type_str = av.ImageGroup.typeToString(cloned.getType())
+    assert cloned_type_str == "ImageSet", "Cloned object should have correct type"
+
+
+def test_imageset_from_factory_equality():
+    """ Test that ImageSets created different ways are equal. """
+    image_set_direct = av.ImageSet()
+    type_value = av.ImageGroup.stringToType("ImageSet")
+    image_set_factory = av.ImageGroup.create(type_value)
+    
+    # Both should be equal since they have the same type
+    assert image_set_direct == image_set_factory, \
+        "ImageSet created directly should equal one created via factory"
+
+
+# ImageSequence Tests
+
+def test_imagesequence_string_to_type_round_trip():
+    """ Test converting string to ImageSequence Type enum and ImageSequence Type enum to string. """
+    type_value = av.ImageGroup.stringToType("ImageSequence")
+
+    # Verify it returns a valid type object
+    assert type_value is not None, "stringToType should return a valid type"
+
+    # Verify round-trip conversion
+    type_str = av.ImageGroup.typeToString(type_value)
+    assert isinstance(type_str, str), "typeToString should return a string"
+    assert type_str == "ImageSequence", "Round-trip conversion should preserve type"
+
+
+def test_imagesequence_default_constructor():
+    """ Test creating an ImageSequence object with default parameters. """
+    image_seq = av.ImageSequence()
+    
+    assert image_seq is not None, "ImageSequence default constructor should succeed"
+    # Verify the type by converting to string
+    type_str = av.ImageGroup.typeToString(image_seq.getType())
+    assert type_str == "ImageSequence", "ImageSequence should have Type ImageSequence"
+
+
+def test_imagesequence_get_type():
+    """ Test getting the type of an ImageSequence object. """
+    image_seq = av.ImageSequence()
+    type_value = image_seq.getType()
+    
+    # Verify by converting to string
+    type_str = av.ImageGroup.typeToString(type_value)
+    assert type_str == "ImageSequence", "ImageSequence.getType() should return ImageSequence type"
+
+
+def test_imagesequence_clone():
+    """ Test cloning an ImageSequence object. """
+    image_seq1 = av.ImageSequence()
+    image_seq2 = image_seq1.clone()
+    
+    assert image_seq2 is not None, "Clone should return a valid object"
+    assert image_seq1 == image_seq2, "Cloned ImageSequence should be equal to the original"
+    assert image_seq1.getType() == image_seq2.getType(), \
+        "Cloned ImageSequence should have the same type"
+
+
+def test_imagesequence_equality_operators():
+    """ Test comparing two ImageSequence objects using the '==' and  '!=' operators. """
+    image_seq1 = av.ImageSequence()
+    image_seq2 = av.ImageSequence()
+
+    # Since ImageSequence currently has no distinguishing properties,
+    # two default instances are equal
+    assert image_seq1 == image_seq2, "Two default ImageSequence objects should be equal"
+    assert not (image_seq1 != image_seq2), \
+        "Two default ImageSequence objects should not be unequal"
+
+
+def test_imagesequence_from_factory():
+    """ Test creating ImageSequence using the factory method. """
+    type_value = av.ImageGroup.stringToType("ImageSequence")
+    image_seq_factory = av.ImageGroup.create(type_value)
+
+    assert image_seq_factory is not None, "Factory should create a valid ImageSequence object"
+    # Verify the type by converting back to string
+    actual_type_str = av.ImageGroup.typeToString(image_seq_factory.getType())
+    assert actual_type_str == "ImageSequence", "Created ImageGroup should have Type ImageSequence"
+
+    image_seq_direct = av.ImageSequence()
+    # Both should be equal since they have the same type
+    assert image_seq_direct == image_seq_factory, \
+        "ImageSequence created directly should equal one created via factory"
+
+
+# Cross-type Tests
+
+def test_cross_type_comparison():
+    """ Test comparing different ImageGroup types. """
+    image_set = av.ImageSet()
+    image_seq = av.ImageSequence()
+
+    assert image_set != image_seq, "ImageSet and ImageSequence should not be equal"
+    assert not (image_set == image_seq), "ImageSet should not equal ImageSequence"
+
+    # Verify they have different types
+    set_type_str = av.ImageGroup.typeToString(image_set.getType())
+    seq_type_str = av.ImageGroup.typeToString(image_seq.getType())
+
+    assert set_type_str == "ImageSet", "ImageSet should have ImageSet type"
+    assert seq_type_str == "ImageSequence", "ImageSequence should have ImageSequence type"
+
+
+def test_imagegroup_factory_creates_correct_types():
+    """ Test that factory creates different concrete types correctly. """
+    # Create ImageSet via factory
+    set_type = av.ImageGroup.stringToType("ImageSet")
+    image_set = av.ImageGroup.create(set_type)
+    
+    # Create ImageSequence via factory
+    seq_type = av.ImageGroup.stringToType("ImageSequence")
+    image_seq = av.ImageGroup.create(seq_type)
+    
+    # Verify types
+    assert av.ImageGroup.typeToString(image_set.getType()) == "ImageSet"
+    assert av.ImageGroup.typeToString(image_seq.getType()) == "ImageSequence"
+    
+    # Verify they're not equal
+    assert image_set != image_seq, "Different types should not be equal"

--- a/src/aliceVision/sfmData/CMakeLists.txt
+++ b/src/aliceVision/sfmData/CMakeLists.txt
@@ -3,6 +3,9 @@ set(sfmData_files_headers
     SfMData.hpp
     CameraPose.hpp
     Landmark.hpp
+    ImageGroup.hpp
+    ImageSet.hpp
+    ImageSequence.hpp
     View.hpp
     Rig.hpp
     uid.hpp
@@ -25,6 +28,7 @@ set(sfmData_files_sources
     exif.cpp
     ImageInfo.cpp
     Landmark.cpp
+    ImageGroup.cpp
     Observation.cpp
 )
 

--- a/src/aliceVision/sfmData/ImageGroup.cpp
+++ b/src/aliceVision/sfmData/ImageGroup.cpp
@@ -1,0 +1,57 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ImageGroup.hpp"
+#include <aliceVision/sfmData/ImageSet.hpp>
+#include <aliceVision/sfmData/ImageSequence.hpp>
+
+namespace aliceVision {
+namespace sfmData {
+
+std::string ImageGroup::typeToString(Type type)
+{
+    switch (type)
+    {
+        case Type::ImageSet:
+            return "ImageSet";
+        case Type::ImageSequence:
+            return "ImageSequence";
+    }
+
+    throw std::invalid_argument("Invalid ImageGroup::Type enum value");
+}
+
+ImageGroup::Type ImageGroup::stringToType(const std::string& typeStr)
+{
+    if (typeStr == "ImageSet")
+    {
+        return ImageGroup::Type::ImageSet;
+    }
+
+    if (typeStr == "ImageSequence")
+    {
+        return ImageGroup::Type::ImageSequence;
+    }
+    
+    throw std::invalid_argument("Invalid ImageGroup type string: " + typeStr);
+}
+
+ImageGroup::sptr ImageGroup::create(const ImageGroup::Type & type)
+{
+    if (type == ImageGroup::Type::ImageSet)
+    {
+        return std::make_shared<ImageSet>();
+    }
+    else if (type == ImageGroup::Type::ImageSequence)
+    {
+        return std::make_shared<ImageSequence>();
+    }
+
+    throw std::invalid_argument("Invalid ImageGroup Type enum value in ImageGroup::create");
+}
+
+}  // namespace sfmData
+}  // namespace aliceVision

--- a/src/aliceVision/sfmData/ImageGroup.hpp
+++ b/src/aliceVision/sfmData/ImageGroup.hpp
@@ -1,0 +1,95 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/types.hpp>
+#include <memory>
+#include <string>
+#include <stdexcept>
+
+namespace aliceVision {
+namespace sfmData {
+
+class ImageGroup
+{
+public:
+    using ptr = ImageGroup*;
+    using sptr = std::shared_ptr<ImageGroup>;
+
+public:
+    enum class Type : int
+    {
+        ImageSet = 0,
+        ImageSequence = 1
+    };
+
+    /**
+     * @brief Convert Type enum to string
+     * @param type The Type enum value to convert
+     * @return String representation of the type
+     */
+    static std::string typeToString(Type type);
+
+    /**
+     * @brief Convert string to Type enum
+     * @param typeStr The string to convert
+     * @return The corresponding Type enum value
+     * @throw std::invalid_argument if the string doesn't match any Type
+     */
+    static Type stringToType(const std::string& typeStr);
+
+    
+    static ImageGroup::sptr create(const Type & type);
+
+public:
+    /**
+     * @brief Default constructor
+     */
+    ImageGroup() {}
+
+    /**
+     * @brief Virtual destructor to allow safe polymorphic deletion
+     */
+    virtual ~ImageGroup() = default;
+
+    /**
+    * @brief Clone this and return pointer
+    * @return a pointer to the newly created object
+     */
+    virtual ImageGroup::ptr clone() const = 0;
+
+    /**
+     * @brief Equality operator
+     * @param other The image group to compare with
+     * @return true if image groups are equal, false otherwise
+     */
+    bool operator==(const ImageGroup& other) const
+    {
+        if (getType() != other.getType())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Inequality operator
+     * @param other The image group to compare with
+     * @return true if image groups are not equal, false otherwise
+     */
+    inline bool operator!=(const ImageGroup& other) const { return !(*this == other); }
+
+    /**
+    * @brief get the type
+    * @return an element of the enum 'Type'
+    */
+    virtual Type getType() const = 0;
+};
+
+}  // namespace sfmData
+}  // namespace aliceVision

--- a/src/aliceVision/sfmData/ImageGroup.i
+++ b/src/aliceVision/sfmData/ImageGroup.i
@@ -1,0 +1,21 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+%include <std_shared_ptr.i>
+%shared_ptr(aliceVision::sfmData::ImageGroup);
+%shared_ptr(aliceVision::sfmData::ImageSet);
+%shared_ptr(aliceVision::sfmData::ImageSequence);
+
+%include <aliceVision/global.i>
+
+%include <aliceVision/sfmData/ImageGroup.hpp>
+%include <aliceVision/sfmData/ImageSet.hpp>
+%include <aliceVision/sfmData/ImageSequence.hpp>
+
+%{
+#include <aliceVision/sfmData/ImageGroup.hpp>
+#include <aliceVision/sfmData/ImageSet.hpp>
+#include <aliceVision/sfmData/ImageSequence.hpp>
+%}

--- a/src/aliceVision/sfmData/ImageSequence.hpp
+++ b/src/aliceVision/sfmData/ImageSequence.hpp
@@ -1,0 +1,68 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfmData/ImageGroup.hpp>
+#include <aliceVision/types.hpp>
+#include <memory>
+#include <set>
+
+namespace aliceVision {
+namespace sfmData {
+
+/**
+ * @brief ImageSequence class - a concrete implementation of ImageGroup
+ * Represents a set of images with a sequence ordering
+ */
+class ImageSequence : public ImageGroup
+{
+public:
+    using ptr = ImageSequence*;
+    using sptr = std::shared_ptr<ImageSequence>;
+
+public:
+    /**
+     * @brief Default constructor
+     */
+    ImageSequence() = default;
+
+    /**
+     * @brief Clone this and return pointer
+     * @return a pointer to the newly created object
+     */
+    ImageGroup::ptr clone() const
+    {
+        return new ImageSequence(*this);
+    }
+
+    /**
+     * @brief Equality operator
+     * @param other The image group to compare with
+     * @return true if image groups are equal, false otherwise
+     */
+    bool operator==(const ImageGroup& other) const
+    {
+        if (!ImageGroup::operator==(other))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Get the type
+     * @return Type::ImageSet
+     */
+    Type getType() const override 
+    {
+        return Type::ImageSequence;
+    }
+};
+
+}  // namespace sfmData
+}  // namespace aliceVision

--- a/src/aliceVision/sfmData/ImageSet.hpp
+++ b/src/aliceVision/sfmData/ImageSet.hpp
@@ -1,0 +1,68 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfmData/ImageGroup.hpp>
+#include <aliceVision/types.hpp>
+#include <memory>
+#include <set>
+
+namespace aliceVision {
+namespace sfmData {
+
+/**
+ * @brief ImageSet class - a concrete implementation of ImageGroup
+ * Represents a set of image IDs grouped together
+ */
+class ImageSet : public ImageGroup
+{
+public:
+    using ptr = ImageSet*;
+    using sptr = std::shared_ptr<ImageSet>;
+
+public:
+    /**
+     * @brief Default constructor
+     */
+    ImageSet() = default;
+
+    /**
+     * @brief Clone this and return pointer
+     * @return a pointer to the newly created object
+     */
+    ImageGroup::ptr clone() const
+    {
+        return new ImageSet(*this);
+    }
+
+    /**
+     * @brief Equality operator
+     * @param other The image group to compare with
+     * @return true if image groups are equal, false otherwise
+     */
+    bool operator==(const ImageGroup& other) const
+    {
+        if (!ImageGroup::operator==(other))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Get the type
+     * @return Type::ImageSet
+     */
+    Type getType() const override 
+    {
+        return Type::ImageSet;
+    }
+};
+
+}  // namespace sfmData
+}  // namespace aliceVision

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -37,6 +37,7 @@ SfMData::SfMData(const SfMData & other, bool unused)
     _landmarksUncertainty = other._landmarksUncertainty;
     _views = other._views;
     _intrinsics = other._intrinsics;
+    _imageGroups = other._imageGroups;
 }
 
 SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eigen::Vector3d & bbMax)
@@ -54,6 +55,7 @@ SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eig
     _landmarksUncertainty = other._landmarksUncertainty;
     _views = other._views;
     _intrinsics = other._intrinsics;
+    _imageGroups = other._imageGroups;
 
     for (const auto & pl : other._landmarks)
     {
@@ -74,6 +76,12 @@ bool SfMData::operator==(const SfMData& other) const
 {
     // Views
     if (_views != other._views)
+    {
+        return false;
+    }
+
+    // ImageGroups
+    if (_imageGroups != other._imageGroups)
     {
         return false;
     }
@@ -329,6 +337,9 @@ void SfMData::combine(const SfMData& sfmData)
 
     // constraints
     _constraintsPoint.insert(sfmData._constraintsPoint.begin(), sfmData._constraintsPoint.end());
+
+    // image groups
+    _imageGroups.insert(sfmData._imageGroups.begin(), sfmData._imageGroups.end());
 }
 
 void SfMData::clear()
@@ -346,6 +357,7 @@ void SfMData::clear()
     _matchesFolders.clear();
     _poses.clear();
     _rigs.clear();
+    _imageGroups.clear();
 }
 
 void SfMData::resetParameterStates()
@@ -469,12 +481,32 @@ void SfMData::removeUnusedLandmarks()
     });
 }
 
+void SfMData::removeUnusedImageGroups()
+{
+    std::set<IndexT> usedIds;
+
+    for (const auto & [_, view]: getViews().valueRange())
+    {
+        IndexT ig = view.getImageGroupId();
+        if (ig != UndefinedIndexT)
+        {
+            usedIds.insert(ig);
+        }
+    }
+
+    // Erase all image groups that are not used by any view
+    std::erase_if(getImageGroups(), [usedIds](const auto & pair) {
+        return (usedIds.find(pair.first) == usedIds.end());
+    });
+}
+
 void SfMData::repair()
 {
     removeUnusedIntrinsics();
     removeUnusedCameraPoses();
     removeInvalidObservations();
     removeUnusedLandmarks();
+    removeUnusedImageGroups();
 }
 
 bool SfMData::isFullyReconstructed() const

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -14,6 +14,7 @@
 #include <aliceVision/sfmData/ConstraintPoint.hpp>
 #include <aliceVision/sfmData/RotationPrior.hpp>
 #include <aliceVision/sfmData/SurveyPoint.hpp>
+#include <aliceVision/sfmData/ImageGroup.hpp>
 #include <aliceVision/sfmData/View.hpp>
 #include <aliceVision/sfmData/Rig.hpp>
 #include <aliceVision/camera/camera.hpp>
@@ -28,6 +29,9 @@ namespace sfmData {
 
 /// Define a collection of View
 using Views = SharedPtrMap<View>;
+
+/// Define a collection of ImageGroup
+using ImageGroups = SharedPtrMap<ImageGroup>;
 
 /// Define a collection of Image Info
 using ImageInfos = SharedPtrMap<ImageInfo>;
@@ -168,6 +172,13 @@ class SfMData
      */
     const RotationPriors& getRotationPriors() const { return _rotationpriors; }
     RotationPriors& getRotationPriors() { return _rotationpriors; }
+
+    /**
+     * @brief Get ImageGroups
+     * @return ImageGroups
+     */
+    const ImageGroups& getImageGroups() const { return _imageGroups; }
+    ImageGroups& getImageGroups() { return _imageGroups; }
 
     /**
      * @brief Get relative features folder paths
@@ -721,6 +732,11 @@ class SfMData
     void clear();
 
     /**
+    * @brief Remove image groups which are unused
+    */
+    void removeUnusedImageGroups();
+
+    /**
     * @brief Remove intrinsics which are unused
     */
     void removeUnusedIntrinsics();
@@ -791,6 +807,8 @@ class SfMData
     RotationPriors _rotationpriors;
     /// Survey points
     SurveyPoints _surveyPoints;
+    /// Image groups
+    ImageGroups _imageGroups;
 
     /**
      * @brief Get Rig pose of a given camera view

--- a/src/aliceVision/sfmData/SfMData.i
+++ b/src/aliceVision/sfmData/SfMData.i
@@ -19,6 +19,7 @@
 %include <aliceVision/sfmData/RotationPrior.i>
 %include <aliceVision/sfmData/View.i>
 %include <aliceVision/sfmData/Landmark.i>
+%include <aliceVision/sfmData/ImageGroup.i>
 
 %include <aliceVision/sfmData/SfMData.hpp>
 

--- a/src/aliceVision/sfmData/View.hpp
+++ b/src/aliceVision/sfmData/View.hpp
@@ -89,7 +89,7 @@ class View
     {
         // image paths can be different
         return _viewId == other._viewId && _intrinsicId == other._intrinsicId && _poseId == other._poseId && _rigId == other._rigId &&
-               _subPoseId == other._subPoseId;
+               _subPoseId == other._subPoseId && _imageGroupId == other._imageGroupId;
     }
 
     inline bool operator!=(const View& other) const { return !(*this == other); }
@@ -117,6 +117,12 @@ class View
      * @return view id
      */
     IndexT getViewId() const { return _viewId; }
+
+    /**
+     * @brief Get the image group id
+     * @return image group id
+     */
+    IndexT getImageGroupId() const { return _imageGroupId; }
 
     /**
      * @brief Get the intrinsic id
@@ -173,6 +179,12 @@ class View
      * @param[in] viewId The given view id
      */
     void setViewId(IndexT viewId) { _viewId = viewId; }
+
+    /**
+     * @brief Set the given image group id
+     * @param[in] imageGroupId The given image group id
+     */
+    void setImageGroupId(IndexT imageGroupId) { _imageGroupId = imageGroupId; }
 
     /**
      * @brief Set the given intrinsic id
@@ -257,6 +269,8 @@ class View
     IndexT _rigId;
     /// corresponding sub-pose id or undefined
     IndexT _subPoseId;
+    /// image group id
+    IndexT _imageGroupId = UndefinedIndexT;
     /// corresponding frame id for synchronized views
     IndexT _frameId = UndefinedIndexT;
     /// resection id

--- a/src/aliceVision/sfmData/uid.cpp
+++ b/src/aliceVision/sfmData/uid.cpp
@@ -191,5 +191,17 @@ void regenerateViewUIDs(Views& views, std::map<std::size_t, std::size_t>& oldIdT
     views.swap(newViews);
 }
 
+IndexT computeGlobalId(const Views & views)
+{
+    std::size_t uid = 0;
+
+    for (const auto & [id, _]: views)
+    {
+        stl::hash_combine(uid, id);
+    }
+
+    return uid;
+}
+
 }  // namespace sfmData
 }  // namespace aliceVision

--- a/src/aliceVision/sfmData/uid.hpp
+++ b/src/aliceVision/sfmData/uid.hpp
@@ -59,5 +59,12 @@ void regenerateUID(SfMData& sfmdata, std::map<std::size_t, std::size_t>& oldIdTo
  */
 void regenerateViewUIDs(Views& views, std::map<std::size_t, std::size_t>& oldIdToNew);
 
+/**
+* @brief compute a unique id associated to a set of views. This id will change if the views set change.
+* @param views The set of views used to compute the unique id
+* @return unique id
+ */
+IndexT computeGlobalId(const Views & views);
+
 }  // namespace sfmData
 }  // namespace aliceVision

--- a/src/aliceVision/sfmDataIO/AlembicExporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.cpp
@@ -67,6 +67,7 @@ struct AlembicExporter::DataImpl
                    const sfmData::CameraPose* pose = nullptr,
                    std::shared_ptr<camera::IntrinsicBase> intrinsic = nullptr,
                    const Vec6* uncertainty = nullptr,
+                   const sfmData::ImageGroup * imageGroup = nullptr,
                    Alembic::Abc::OObject* parent = nullptr);
 
     void addAncestor(const std::string& name, std::shared_ptr<sfmData::ImageInfo> ancestor = nullptr, Alembic::Abc::OObject* parent = nullptr);
@@ -95,6 +96,7 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
                                           const sfmData::CameraPose* pose,
                                           std::shared_ptr<camera::IntrinsicBase> intrinsic,
                                           const Vec6* uncertainty,
+                                          const sfmData::ImageGroup * imageGroup,
                                           Alembic::Abc::OObject* parent)
 {
     if (parent == nullptr)
@@ -162,6 +164,17 @@ void AlembicExporter::DataImpl::addCamera(const std::string& name,
 
     if (view.getFrameId() != UndefinedIndexT)
         OUInt32Property(userProps, "mvg_frameId").set(view.getFrameId());
+
+    if (view.getImageGroupId() != UndefinedIndexT)
+    {
+        OUInt32Property(userProps, "mvg_imageGroupId").set(view.getImageGroupId());
+    }
+
+    if (imageGroup)
+    {
+        sfmData::ImageGroup::Type type = imageGroup->getType();
+        OStringProperty(userProps, "mvg_imageGroupType").set(sfmData::ImageGroup::typeToString(type));
+    }
 
     if (view.isPoseIndependant() == false)
         OBoolProperty(userProps, "mvg_poseIndependant").set(view.isPoseIndependant());
@@ -410,10 +423,21 @@ void AlembicExporter::addSfMSingleCamera(const sfmData::SfMData& sfmData, const 
     const std::shared_ptr<camera::IntrinsicBase> intrinsic =
       (flagsPart & ESfMData::INTRINSICS) ? sfmData.getIntrinsicSharedPtr(view.getIntrinsicId()) : nullptr;
 
+      
+    std::shared_ptr<const sfmData::ImageGroup> group = nullptr;
+    if (view.getImageGroupId() != UndefinedIndexT)
+    {
+        const auto & groups = sfmData.getImageGroups();
+        if (groups.find(view.getImageGroupId()) != groups.end())
+        {
+            group = groups.at(view.getImageGroupId());
+        }
+    }
+
     if (sfmData.isPoseAndIntrinsicDefined(view) && (flagsPart & ESfMData::EXTRINSICS))
-        _dataImpl->addCamera(name, view, pose, intrinsic, nullptr, &_dataImpl->_mvgCameras);
+        _dataImpl->addCamera(name, view, pose, intrinsic, nullptr, group.get(), &_dataImpl->_mvgCameras);
     else
-        _dataImpl->addCamera(name, view, pose, intrinsic, nullptr, &_dataImpl->_mvgCamerasUndefined);
+        _dataImpl->addCamera(name, view, pose, intrinsic, nullptr, group.get(), &_dataImpl->_mvgCamerasUndefined);
 }
 
 void AlembicExporter::addSfMCameraRig(const sfmData::SfMData& sfmData, IndexT rigId, const std::vector<IndexT>& viewIds, ESfMData flagsPart)
@@ -494,7 +518,8 @@ void AlembicExporter::addSfMCameraRig(const sfmData::SfMData& sfmData, IndexT ri
                 OBoolProperty(userProps, "mvg_rigPoseLocked").set(rigPoseLocked);
             }
         }
-        _dataImpl->addCamera(name, view, subPosePtr.get(), intrinsic, nullptr, &(rigObj.at(isReconstructed)));
+
+        _dataImpl->addCamera(name, view, subPosePtr.get(), intrinsic, nullptr, nullptr, &(rigObj.at(isReconstructed)));
     }
 }
 
@@ -689,9 +714,10 @@ void AlembicExporter::addCamera(const std::string& name,
                                 const sfmData::View& view,
                                 const sfmData::CameraPose* pose,
                                 std::shared_ptr<camera::IntrinsicBase> intrinsic,
-                                const Vec6* uncertainty)
+                                const Vec6* uncertainty,
+                                const sfmData::ImageGroup * imageGroup)
 {
-    _dataImpl->addCamera(name, view, pose, intrinsic, uncertainty);
+    _dataImpl->addCamera(name, view, pose, intrinsic, uncertainty, imageGroup);
 }
 
 void AlembicExporter::initAnimatedCamera(const std::string& cameraName, std::size_t startFrame, double frameRate)

--- a/src/aliceVision/sfmDataIO/AlembicExporter.hpp
+++ b/src/aliceVision/sfmDataIO/AlembicExporter.hpp
@@ -76,13 +76,15 @@ class AlembicExporter
      * @param[in] pose The camera pose (nullptr if undefined)
      * @param[in] intrinsic The camera intrinsic (nullptr if undefined)
      * @param[in] uncertainty The camera uncertainty values (nullptr if undefined)
+     * @param[in] imageGroup The image group  for this view (nullptr if undefined)
      * @param[in,out] parent The Alembic parent node
      */
     void addCamera(const std::string& name,
                    const sfmData::View& view,
                    const sfmData::CameraPose* pose = nullptr,
                    std::shared_ptr<camera::IntrinsicBase> intrinsic = nullptr,
-                   const Vec6* uncertainty = nullptr);
+                   const Vec6* uncertainty = nullptr,
+                   const sfmData::ImageGroup * imageGroup = nullptr);
 
     /**
      * @brief Add a keyframe to the animated camera

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -15,6 +15,7 @@
 #include <aliceVision/system/Logger.hpp>
 
 #include <aliceVision/camera/Equidistant.hpp>
+#include <aliceVision/sfmData/ImageSet.hpp>
 
 namespace aliceVision {
 namespace sfmDataIO {
@@ -538,6 +539,8 @@ bool readCamera(const Version& abcVersion,
     IndexT subPoseId = UndefinedIndexT;
     IndexT frameId = UndefinedIndexT;
     IndexT resectionId = UndefinedIndexT;
+    IndexT imageGroupId = UndefinedIndexT;
+    std::string mvg_imageGroupType = sfmData::ImageGroup::typeToString(sfmData::ImageGroup::Type::ImageSet);
     bool intrinsicLocked = false;
     bool poseLocked = false;
     bool rotationOnly = false;
@@ -586,6 +589,10 @@ bool readCamera(const Version& abcVersion,
             if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_frameId"))
             {
                 frameId = getAbcProp_uint(userProps, *propHeader, "mvg_frameId", sampleFrame);
+            }
+            if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_imageGroupId"))
+            {
+                imageGroupId = getAbcProp_uint(userProps, *propHeader, "mvg_imageGroupId", sampleFrame);
             }
             if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_resectionId"))
             {
@@ -657,6 +664,10 @@ bool readCamera(const Version& abcVersion,
             else
             {
                 sensorSize_mm = {24.0, 36.0};
+            }
+            if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_imageGroupType"))
+            {
+                mvg_imageGroupType = getAbcProp<Alembic::Abc::IStringProperty>(userProps, *propHeader, "mvg_imageGroupType", sampleFrame);
             }
             if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_intrinsicType"))
             {
@@ -884,6 +895,7 @@ bool readCamera(const Version& abcVersion,
     {
         view->setResectionId(resectionId);
         view->setFrameId(frameId);
+        view->setImageGroupId(imageGroupId);
         view->setIndependantPose(poseIndependant);
 
         // set metadata
@@ -899,6 +911,13 @@ bool readCamera(const Version& abcVersion,
         }
 
         sfmData.getViews().emplace(viewId, view);
+    }
+
+    if (flagsPart & ESfMData::VIEWS && imageGroupId != UndefinedIndexT)
+    {
+        sfmData::ImageGroup::Type type = sfmData::ImageGroup::stringToType(mvg_imageGroupType);
+        sfmData::ImageGroup::sptr group = sfmData::ImageGroup::create(type);
+        sfmData.getImageGroups().emplace(imageGroupId, group);
     }
 
     if ((flagsPart & ESfMData::EXTRINSICS) && isReconstructed)

--- a/src/aliceVision/sfmDataIO/alembicIO_test.cpp
+++ b/src/aliceVision/sfmDataIO/alembicIO_test.cpp
@@ -43,6 +43,7 @@ SfMData createTestScene(IndexT singleViewsCount, IndexT pointCount, IndexT rigCo
         view->getImage().addMetadata("A", "A");
         view->getImage().addMetadata("B", "B");
         view->getImage().addMetadata("C", "C");
+        view->setImageGroupId(156);
 
         view->addAncestor(static_cast<IndexT>(11));
         view->addAncestor(static_cast<IndexT>(22));
@@ -69,6 +70,8 @@ SfMData createTestScene(IndexT singleViewsCount, IndexT pointCount, IndexT rigCo
               i, camera::createPinhole(camera::EDISTORTION::DISTORTION_NONE, camera::EUNDISTORTION::UNDISTORTION_NONE, 1000, 1000, 36.0, 36.0, std::rand() % 10000, std::rand() % 10000));
         }
     }
+
+    sfm_data.getImageGroups().emplace(156, sfmData::ImageGroup::create(sfmData::ImageGroup::Type::ImageSet));
 
     sfmData::ImageInfo ancestorImg_1("path_1.jpg", 1024, 640);
     ancestorImg_1.addMetadata("D", "D");

--- a/src/aliceVision/sfmDataIO/jsonIO.cpp
+++ b/src/aliceVision/sfmDataIO/jsonIO.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/camera/camera.hpp>
 #include <aliceVision/camera/Equidistant.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
+#include <aliceVision/sfmData/ImageGroup.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 
@@ -37,6 +38,9 @@ void saveView(const std::string& name, const sfmData::View& view, bpt::ptree& pa
 
     if (view.getFrameId() != UndefinedIndexT)
         viewTree.put("frameId", view.getFrameId());
+
+    if (view.getImageGroupId() != UndefinedIndexT)
+        viewTree.put("imageGroupId", view.getImageGroupId());
 
     if (view.getIntrinsicId() != UndefinedIndexT)
         viewTree.put("intrinsicId", view.getIntrinsicId());
@@ -90,6 +94,7 @@ void loadView(sfmData::View& view, bpt::ptree& viewTree)
     }
 
     view.setFrameId(viewTree.get<IndexT>("frameId", UndefinedIndexT));
+    view.setImageGroupId(viewTree.get<IndexT>("imageGroupId", UndefinedIndexT));
     view.setIntrinsicId(viewTree.get<IndexT>("intrinsicId", UndefinedIndexT));
     view.setResectionId(viewTree.get<IndexT>("resectionId", UndefinedIndexT));
     view.setIndependantPose(viewTree.get<bool>("isPoseIndependant", true));
@@ -144,6 +149,24 @@ void loadAncestor(IndexT& ancestorId, std::shared_ptr<sfmData::ImageInfo>& ances
     if (ancestorTree.count("metadata"))
         for (bpt::ptree::value_type& metaDataNode : ancestorTree.get_child("metadata"))
             ancestor->addMetadata(metaDataNode.first, metaDataNode.second.data());
+}
+
+void saveImageGroup(const std::string& name, IndexT imageGroupId, const sfmData::ImageGroup & group, bpt::ptree& parentTree)
+{
+    bpt::ptree imageGroupTree;
+    imageGroupTree.put("imageGroupId", imageGroupId);
+    imageGroupTree.put("imageGroupType", sfmData::ImageGroup::typeToString(group.getType()));
+    parentTree.push_back(std::make_pair(name, imageGroupTree));
+}
+
+void loadImageGroup(sfmData::ImageGroups & groups, bpt::ptree& imageGroupTree)
+{
+    IndexT imageGroupId = imageGroupTree.get<IndexT>("imageGroupId");
+    std::string typeString = imageGroupTree.get<std::string>("imageGroupType");
+    sfmData::ImageGroup::Type type = sfmData::ImageGroup::stringToType(typeString);
+
+    sfmData::ImageGroup::sptr group = sfmData::ImageGroup::create(type);
+    groups.emplace(imageGroupId, group);
 }
 
 void saveIntrinsic(const std::string& name, IndexT intrinsicId, const std::shared_ptr<camera::IntrinsicBase>& intrinsic, bpt::ptree& parentTree)
@@ -688,9 +711,24 @@ bool saveJSON(const sfmData::SfMData& sfmData, const std::string& filename, ESfM
         bpt::ptree viewsTree;
 
         for (const auto& viewPair : sfmData.getViews())
+        {
             saveView("", *(viewPair.second), viewsTree);
+        }
 
         fileTree.add_child("views", viewsTree);
+    }
+
+    // imageGroups
+    if (saveViews && !sfmData.getImageGroups().empty())
+    {
+        bpt::ptree igTree;
+
+        for (const auto& [idImageGroup, imageGroup] : sfmData.getImageGroups().valueRange())
+        {
+            saveImageGroup("", idImageGroup, imageGroup, igTree);
+        }
+
+        fileTree.add_child("imageGroups", igTree);
     }
 
     // ancestors
@@ -908,6 +946,18 @@ bool loadJSON(sfmData::SfMData& sfmData,
                 loadView(*view, viewNode.second);
                 views.emplace(view->getViewId(), view);
             }
+        }
+    }
+
+    // imageGroups
+    if (loadViews && fileTree.count("imageGroups"))
+    {
+        sfmData::ImageGroups & groups = sfmData.getImageGroups();     
+        
+        for (bpt::ptree::value_type& igNode : fileTree.get_child("imageGroups"))
+        {
+            bpt::ptree& igTree = igNode.second;
+            loadImageGroup(groups, igTree);
         }
     }
 

--- a/src/software/pipeline/main_cameraInit.cpp
+++ b/src/software/pipeline/main_cameraInit.cpp
@@ -6,6 +6,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <aliceVision/sfmData/SfMData.hpp>
+#include <aliceVision/sfmData/uid.hpp>
 #include <aliceVision/alicevision_omp.hpp>
 #include <aliceVision/sfmDataIO/jsonIO.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
@@ -18,6 +19,7 @@
 #include <aliceVision/image/io.cpp>
 #include <aliceVision/image/dcp.hpp>
 #include <aliceVision/camera/Pinhole.hpp>
+#include <aliceVision/sfmData/ImageGroup.hpp>
 
 #include <boost/atomic/atomic_ref.hpp>
 #include <boost/program_options.hpp>
@@ -40,7 +42,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 12
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
@@ -186,6 +188,7 @@ int aliceVision_main(int argc, char** argv)
     bool errorOnMissingColorProfile = true;
     image::ERawColorInterpretation rawColorInterpretation = image::ERawColorInterpretation::LibRawWhiteBalancing;
     bool lensCorrectionProfileSearchIgnoreCameraModel = true;
+    bool isSequence = false;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -239,7 +242,9 @@ int aliceVision_main(int argc, char** argv)
          "Rise an error if a DCP color profiles database is specified but no DCP file matches with the camera model (maker+name) extracted from metadata (only for raw images).")
         ("allowSingleView", po::value<bool>(&allowSingleView)->default_value(allowSingleView),
          "Allow the program to process a single view.\n"
-         "Warning: if a single view is process, the output file can't be use in many other programs.");
+         "Warning: if a single view is processed, the output file cannot be used in many other programs.")
+        ("isSequence", po::value<bool>(&isSequence)->default_value(isSequence),
+         "The images provided as input are part of a sequence with temporal coherency.");
     // clang-format on
 
     CmdLine cmdline("AliceVision cameraInit");
@@ -924,6 +929,20 @@ int aliceVision_main(int argc, char** argv)
     {
         ALICEVISION_LOG_ERROR("Multiple frames have the same frame id.");
         return EXIT_FAILURE;
+    }
+
+    // Set the unique image group id for all the views of the sfmData
+    IndexT imageGroupId = computeGlobalId(sfmData.getViews());
+    for (auto & [_, view]: sfmData.getViews().valueRange())
+    {
+        view.setImageGroupId(imageGroupId);
+    }
+    
+    if (sfmData.getViews().size() > 0)
+    {
+        // Create the image group
+        auto ptrImageGroup = sfmData::ImageGroup::create(isSequence ? sfmData::ImageGroup::Type::ImageSequence : sfmData::ImageGroup::Type::ImageSet);
+        sfmData.getImageGroups().emplace(imageGroupId, ptrImageGroup);
     }
 
     // store SfMData views & intrinsic data

--- a/src/software/utils/main_listImages.cpp
+++ b/src/software/utils/main_listImages.cpp
@@ -11,6 +11,8 @@
 #include <aliceVision/system/Parallelization.hpp>
 #include <aliceVision/sfmDataIO/viewIO.hpp>
 #include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/sfmData/uid.hpp>
+#include <aliceVision/sfmData/ImageGroup.hpp>
 #include <boost/program_options.hpp>
 
 #include <filesystem>
@@ -19,7 +21,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
@@ -30,6 +32,7 @@ int aliceVision_main(int argc, char** argv)
     // command-line parameters
     std::vector<std::string> inputPaths;
     std::string outSfMDataFilepath;
+    bool isSequence = false;
     
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -38,7 +41,8 @@ int aliceVision_main(int argc, char** argv)
     ("output,o", po::value<std::string>(&outSfMDataFilepath)->required(), "Path to the output SfMData file.");
         
     po::options_description optionalParams("Optional parameters");
-    optionalParams.add_options();
+    optionalParams.add_options()
+    ("isSequence", po::value<bool>(&isSequence)->default_value(isSequence), "The images provided as input are part of a sequence with temporal coherency.");
     // clang-format on
 
     CmdLine cmdline("AliceVision listImages");
@@ -99,6 +103,20 @@ int aliceVision_main(int argc, char** argv)
         {
             views.emplace(view->getViewId(), view);
         }
+    }
+
+    // Set the unique image group id for all the views of the sfmData
+    IndexT imageGroupId = computeGlobalId(sfmData.getViews());
+    for (auto & [_, view]: sfmData.getViews().valueRange())
+    {
+        view.setImageGroupId(imageGroupId);
+    }
+
+    if (sfmData.getViews().size() > 0)
+    {
+        // Create the image group
+        auto ptrImageGroup = sfmData::ImageGroup::create(isSequence ? sfmData::ImageGroup::Type::ImageSequence : sfmData::ImageGroup::Type::ImageSet);
+        sfmData.getImageGroups().emplace(imageGroupId, ptrImageGroup);
     }
 
     // store SfMData views & intrinsic data


### PR DESCRIPTION
Add an imageGroup concept in the sfmData.

This imageGroup may be ImageSet or ImageSequence.

The views are grouped by imageGroup. One view will be linked to only one image group.

Each view will contains its image group id.

For the moment, each view is grouped with the other views inserted in the same cameraInit/listImages.

**Parameter Additions:**

* Added a new boolean parameter `isSequence` to the `CameraInit` node in `meshroom/aliceVision/CameraInit.py` to indicate if input images are part of a temporally coherent sequence.
* Added a new boolean parameter `isSequence` to the `ListImages` node in `meshroom/aliceVision/ListImages.py` with similar semantics.