### PR TITLE
Fix conversion of images when no processing to do

### DIFF
--- a/src/software/utils/main_imageProcessing.cpp
+++ b/src/software/utils/main_imageProcessing.cpp
@@ -941,12 +941,6 @@ int aliceVision_main(int argc, char* argv[])
         extChunkEnd = selectedViews.size();
     }
 
-    if (steps.size() == 0)
-    {
-        extChunkStart = 0;
-        extChunkEnd = 0;
-    }
-
     // Loop over selected views for this chunk
     for (int pos = extChunkStart; pos < extChunkEnd; pos++)
     {


### PR DESCRIPTION
Old behavior : 

- If there is no processing step, early exit
- Execute processing steps
- Save/convert image to output directory

New behavior : 

- Execute processing steps
- Save/convert image to output directory

The early exit was incorrect as it disabled output of images in the output directory for a simple conversion/color conversion.