### PR TITLE
Adding threshold on number of inliers in geometricFilterEstimating

### DIFF
--- a/meshroom/aliceVision/GeometricFilterEstimating.py
+++ b/meshroom/aliceVision/GeometricFilterEstimating.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
@@ -76,6 +76,14 @@ then it checks the number of features that validates this model and iterate thro
             description="Maximum error (in pixels) allowed for features matching during geometric verification",
             value=0.0,
             range=(0.0, 10.0, 0.1),
+            advanced=True,
+        ),
+        desc.IntParam(
+            name="minMatches",
+            label="Min Matches",
+            description="Minimum number of matches to accept a pair of images (or 0 to disable limit).",
+            value=0,
+            range=(0, 10000, 1),
             advanced=True,
         ),
         desc.IntParam(

--- a/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
+++ b/src/aliceVision/matchingImageCollection/GeometricFilter.hpp
@@ -14,6 +14,7 @@
 #include <aliceVision/matchingImageCollection/GeometricFilterMatrix.hpp>
 #include <aliceVision/system/ProgressDisplay.hpp>
 #include <aliceVision/matchingImageCollection/GeometricInfo.hpp>
+#include <aliceVision/system/Logger.hpp>
 
 #include <map>
 #include <random>
@@ -98,6 +99,7 @@ void robustModelEstimation(PairwiseMatches& out_geometricMatches,
  * @param[in] functor
  * @param[in] putativeMatches
  * @param[in] randomNumberGenerator
+ * @param minMatches Minimum number of matches to accept a pair of images (or 0 to disable limit).
  */
 template<typename GeometryFunctor>
 void robustModelEstimation(PairwiseGeometricInfo& out_geometricInfos,
@@ -105,7 +107,8 @@ void robustModelEstimation(PairwiseGeometricInfo& out_geometricInfos,
                            const feature::RegionsPerView& regionsPerView,
                            const GeometryFunctor& functor,
                            const PairwiseMatches& putativeMatches,
-                           std::mt19937& randomNumberGenerator)
+                           std::mt19937& randomNumberGenerator,
+                           size_t minMatches = 0)
 {
     out_geometricInfos.clear();
 
@@ -125,8 +128,16 @@ void robustModelEstimation(PairwiseGeometricInfo& out_geometricInfos,
         {
             MatchesPerDescType inliers;
             GeometryFunctor geometricFilter = functor;  // use a copy since we are in a multi-thread context
-            const EstimationStatus state =
-              geometricFilter.geometricEstimation(sfmData, regionsPerView, imagePair, putativeMatchesPerType, randomNumberGenerator, inliers);
+            const EstimationStatus state = geometricFilter.geometricEstimation(sfmData, regionsPerView, imagePair, putativeMatchesPerType, randomNumberGenerator, inliers);
+            
+            ALICEVISION_LOG_DEBUG("Pair " << imagePair.first << ", " << imagePair.second << " : " << inliers.getNbAllMatches() << " inliers");
+
+            //Filter out pairs that do not have enough inliers
+            if (minMatches > 0 && inliers.getNbAllMatches() < minMatches)
+            {
+                ALICEVISION_LOG_DEBUG("Filtered by minMatches threshold");
+                continue;
+            }
 
             if (state.hasStrongSupport)
             {

--- a/src/software/pipeline/main_geometricFilterEstimating.cpp
+++ b/src/software/pipeline/main_geometricFilterEstimating.cpp
@@ -26,7 +26,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 namespace po = boost::program_options;
@@ -43,6 +43,7 @@ int aliceVision_main(int argc, char** argv)
     size_t numMatchesToKeep = 0;
     double geometricErrorMax = 0.0;
     int maxIteration = 50000;
+    size_t minMatches = 0;
 
     std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
 
@@ -66,8 +67,10 @@ int aliceVision_main(int argc, char** argv)
     optionalParams.add_options()
         ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
          feature::EImageDescriberType_informations().c_str())
+        ("minMatches", po::value<std::size_t>(&minMatches)->default_value(minMatches),
+         "Minimum number of matches to accept a pair of images (or 0 to disable limit).")
         ("maxMatches", po::value<std::size_t>(&numMatchesToKeep)->default_value(numMatchesToKeep),
-         "Maximum number pf matches to keep.")
+         "Maximum number of matches to keep.")
         ("geometricError", po::value<double>(&geometricErrorMax)->default_value(geometricErrorMax),
          "Maximum error (in pixels) allowed for features matching during geometric verification. "
          "If set to 0, it lets the ACRansac select an optimal value.")
@@ -179,7 +182,8 @@ int aliceVision_main(int argc, char** argv)
       regionPerView,
       matchingImageCollection::GeometricFilterMatrix_F_AC(geometricErrorMax, maxIteration, robustEstimation::ERobustEstimator::ACRANSAC),
       filteredMatches,
-      randomNumberGenerator);
+      randomNumberGenerator,
+      minMatches);
 
     ALICEVISION_LOG_INFO(geometricInfos.size() << "/" << filteredMatches.size() << " pairs have been matched");
     for (const auto& [pair, info] : geometricInfos)


### PR DESCRIPTION
This pull request adds a new feature to allow users to specify a minimum number of matches required to accept a pair of images during geometric filtering. The change is implemented across the command-line interface, Python bindings, and the underlying C++ logic. This helps filter out weak image pairs and improves the robustness of the matching process.

**Parameter and Interface Updates:**

* Added a new `minMatches` parameter to the `GeometricFilterEstimating` node in the Python pipeline, allowing users to set the minimum number of matches required for image pairs.
* Updated the command-line interface in `main_geometricFilterEstimating.cpp` to accept a `--minMatches` argument, with appropriate documentation and default value. [[1]](diffhunk://#diff-0bbcde5d54d4bd31f00adef570216802ba625ae6408dff69c26a6f9e167585c2R46) [[2]](diffhunk://#diff-0bbcde5d54d4bd31f00adef570216802ba625ae6408dff69c26a6f9e167585c2R70-R73)

**Core Algorithm Enhancements:**

* Modified the `robustModelEstimation` function in `GeometricFilter.hpp` to accept a `minMatches` parameter, and added logic to skip image pairs that do not meet the minimum inlier threshold. Also added debug logging for the number of inliers per pair. [[1]](diffhunk://#diff-2a6e66fc90b0ccc04a17cff4a2fd9da8a9f947d64c327cd11fd15093987b9080R102-R111) [[2]](diffhunk://#diff-2a6e66fc90b0ccc04a17cff4a2fd9da8a9f947d64c327cd11fd15093987b9080L128-R139)
* Included the logger header in `GeometricFilter.hpp` to support new debug messages.