### PR TITLE
Allow ignoring duplicates in sfmMerge

### DIFF
--- a/meshroom/aliceVision/SfMMerge.py
+++ b/meshroom/aliceVision/SfMMerge.py
@@ -54,6 +54,13 @@ class SfMMerge(desc.AVCommandLineNode):
             value="simple_copy",
             values=["simple_copy", 'from_landmarks'],
         ),
+        desc.BoolParam(
+            name="ignoreDuplicates",
+            label="Ignore duplicates",
+            description="If disabled, an error will be thrown if a duplicate view or intrinsic is found.",
+            enabled=lambda node: node.method.value == "simple_copy",
+            value=False,
+        ),
         desc.ListAttribute(
             elementDesc=desc.File(
                 name="matchesFolder",

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -91,9 +91,10 @@ inline std::ostream& operator<<(std::ostream& os, EMergeMethod e) { return os <<
  * simply copy from one to another
  * @param [in, out] sfmData1 the first sfmData
  * @param [in] sfmData2 the second sfmData
+ * @param [in] ignoreDuplicates will ignore the duplicates instead of throwing an error
  * @return true if no duplicate found
 */
-bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2)
+bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2, bool ignoreDuplicates)
 {
     {
         auto& views1 = sfmData1.getViews();
@@ -101,7 +102,7 @@ bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2)
         const size_t totalSize = views1.size() + views2.size();
 
         views1.insert(views2.begin(), views2.end());
-        if (views1.size() < totalSize)
+        if (views1.size() < totalSize && !ignoreDuplicates)
         {
             ALICEVISION_LOG_ERROR("Unhandled error: common view ID between both SfMData");
             return false;
@@ -113,22 +114,25 @@ bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2)
         auto& intrinsics2 = sfmData2.getIntrinsics();
         const size_t totalSize = intrinsics1.size() + intrinsics2.size();
 
-        //If both sfm share a common intrinsicId
-        //Make sure there is no ambiguity and the  content is the same
-        for (const auto & [key, intrinsic] : intrinsics1)
+        if (!ignoreDuplicates)
         {
-            const auto & itIntrinsicOther = intrinsics2.find(key);
-            if (itIntrinsicOther != intrinsics2.end())
+            //If both sfm share a common intrinsicId
+            //Make sure there is no ambiguity and the  content is the same
+            for (const auto & [key, intrinsic] : intrinsics1)
             {
-                const auto & obj1 = *intrinsic;
-                const auto & obj2 = *(itIntrinsicOther->second);
-
-                if (!(obj1 == obj2))
+                const auto & itIntrinsicOther = intrinsics2.find(key);
+                if (itIntrinsicOther != intrinsics2.end())
                 {
-                    ALICEVISION_LOG_ERROR("Unhandled error: common intrinsic ID with different parameters between both SfMData");
-                    return false;
-                }
-            } 
+                    const auto & obj1 = *intrinsic;
+                    const auto & obj2 = *(itIntrinsicOther->second);
+
+                    if (!(obj1 == obj2))
+                    {
+                        ALICEVISION_LOG_ERROR("Unhandled error: common intrinsic ID with different parameters between both SfMData");
+                        return false;
+                    }
+                } 
+            }
         }
 
         intrinsics1.insert(intrinsics2.begin(), intrinsics2.end());
@@ -396,6 +400,7 @@ int aliceVision_main(int argc, char** argv)
     EMergeMethod mergeMethod = EMergeMethod::SIMPLE_COPY;
     std::vector<std::string> matchesFolders;
     std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
+    bool ignoreDuplicates = false;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -414,7 +419,9 @@ int aliceVision_main(int argc, char** argv)
         ("matchesFolders,m", po::value<std::vector<std::string>>(&matchesFolders)->multitoken(),
          "Path to folder(s) in which computed matches are stored.")
         ("describerTypes,d", po::value<std::string>(&describerTypesName)->default_value(describerTypesName),
-         feature::EImageDescriberType_informations().c_str());
+         feature::EImageDescriberType_informations().c_str())
+        ("ignoreDuplicates", po::value<bool>(&ignoreDuplicates)->default_value(ignoreDuplicates),
+         "If false, an error will be thrown if a duplicate view or intrinsic is found. Only valid for simple_copy method.");
     // clang-format on
 
     CmdLine cmdline("AliceVision sfmMerge");
@@ -454,7 +461,7 @@ int aliceVision_main(int argc, char** argv)
 
         if (mergeMethod == EMergeMethod::SIMPLE_COPY)
         {
-            if (!simpleMerge(outputSfmData, sfmData))
+            if (!simpleMerge(outputSfmData, sfmData, ignoreDuplicates))
             {
                 return EXIT_FAILURE;
             }


### PR DESCRIPTION
This pull request introduces an option to ignore duplicate views or intrinsics during the SfM data merge process, both in the command-line interface and the Python node definition. This allows users to choose whether to throw an error or silently skip duplicates when using the `simple_copy` merge method.

**Feature: Duplicate Handling in SfM Merge**

* Added a new `ignoreDuplicates` boolean parameter to the `SfMMerge` node in `SfMMerge.py`, allowing users to specify whether to ignore or error on duplicate views/intrinsics when using the `simple_copy` method.
* Updated the `simpleMerge` function in `main_sfmMerge.cpp` to accept an `ignoreDuplicates` parameter, skipping errors for duplicates if set to true. [[1]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3R94-R105) [[2]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3R117-R118) [[3]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3R136)
* Added a corresponding `--ignoreDuplicates` command-line option to the `sfmMerge` utility, with logic to pass this parameter through to the merge function. [[1]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3R403) [[2]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3L417-R424) [[3]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3L457-R464)