### PR TITLE
Enable parallelization based on number of images in a directory

### DIFF
--- a/meshroom/aliceVision/MaskEroding.py
+++ b/meshroom/aliceVision/MaskEroding.py
@@ -8,7 +8,7 @@ from pyalicevision import parallelization as avpar
 class MaskEroding(desc.AVCommandLineNode):
     commandLine = "aliceVision_maskEroding {allParams}"
 
-    size = avpar.DynamicViewsSize("input")
+    size = avpar.DynamicDirectorySize("input")
     parallelization = desc.Parallelization(blockSize=50)
     commandLineRange = "--rangeIteration {rangeIteration} --rangeBlocksCount {rangeBlocksCount}"
 

--- a/src/aliceVision/image/image.i
+++ b/src/aliceVision/image/image.i
@@ -6,6 +6,8 @@
 
 %module (package="pyalicevision") image
 
+%include <aliceVision/global.i>
+
 %{
   #define SWIG_FILE_WITH_INIT
 %}
@@ -71,6 +73,8 @@ int NumPyType<image::RGBColor>()
 }
 
 %} 
+
+%ignore aliceVision::image::listImages;
 
 %include <OpenImageIO/oiioversion.h>
 %include <aliceVision/image/colorspace.hpp> 
@@ -192,8 +196,22 @@ class oiioParams
     oiio::ParamValueList _myParamList;
 };
 
+PyObject* listImages(const std::string& path)
+{
+    std::vector<std::string> images;
+    bool success = aliceVision::image::listImages(images, path);
+
+    PyObject* image_list = PyList_New(images.size());
+    for (std::size_t i = 0; i < images.size(); ++i)
+        PyList_SET_ITEM(image_list, i, PyUnicode_FromString(images[i].c_str()));
+
+    return PyTuple_Pack(2, PyBool_FromLong(success), image_list);
+}
+
 %}
 std::map<std::string, std::string> readImageMetadataAsMap(const std::string& path);
+
+PyObject* listImages(const std::string& path);
 
 class oiioParams
 {

--- a/src/aliceVision/python/parallelization.py
+++ b/src/aliceVision/python/parallelization.py
@@ -1,7 +1,7 @@
 """Dynamic parallelization strategies for AliceVision processing nodes.
 
 This module provides classes that compute chunk sizes for parallelizing
-AliceVision pipeline nodes based on the number of views in an SfMData file.
+AliceVision pipeline nodes.
 Each class implements a `__call__` method that returns the number of
 parallel chunks a node should be split into.
 """
@@ -143,3 +143,39 @@ class DynamicDividedViewsSize(object):
         size = math.ceil(len(data.getViews()) / valDivider)
 
         return max(1, size)
+
+class DynamicDirectorySize(object):
+    """Compute parallelization size based on the total number of views.
+
+    Returns the total number of views found in the SfMData file referenced
+    by the given node parameter, with a minimum of 1.
+
+    Args:
+        param: Name of the node attribute that holds the path to the SfMData file.
+    """
+
+    def __init__(self, param):
+        self._param = param
+
+    def __call__(self, node):
+        """Compute the number of chunks from the images count in the path.
+
+        Args:
+            node: The processing node whose attribute *param* points to a directory.
+
+        Returns:
+            int: The number of images in the directory (at least 1).
+
+        Raises:
+            RuntimeError: If the Directory can't be parsed.
+        """
+
+        from pyalicevision import image
+
+        param = node.attribute(self._param)
+
+        valid, imlist = image.listImages(param.value)
+        if not valid:
+            raise RuntimeError(f"Failed to load file : {param.value}")
+        
+        return max(1, len(imlist))


### PR DESCRIPTION
This pull request introduces a new parallelization strategy based on directory image count and adds Python bindings for listing images in a directory, while updating relevant code to use these enhancements. The most important changes are summarized below.

### Parallelization enhancements

* Added a new `DynamicDirectorySize` class in `parallelization.py` that computes parallelization chunk sizes based on the number of images in a directory rather than the number of views in an SfMData file.
* Updated `MaskEroding.py` to use `DynamicDirectorySize` instead of `DynamicViewsSize` for its `size` parameter, enabling parallelization based on image count in a directory.

### Python bindings and API improvements

* Added a Python binding for the C++ `listImages` function in `image.i`, exposing it as a `listImages` function that returns a tuple of (success, list of image file names).
* Ensured the new `listImages` function is available in the Python interface by including the relevant header and ignoring the original C++ function to avoid SWIG conflicts. [[1]](diffhunk://#diff-86876fe12e83eeb773a6307ee74162a904d569d602f0143ce92b87ee5e940b6dR9-R10) [[2]](diffhunk://#diff-86876fe12e83eeb773a6307ee74162a904d569d602f0143ce92b87ee5e940b6dR77-R78)

### Documentation

* Updated the module-level docstring in `parallelization.py` to reflect that parallelization strategies are no longer limited to SfMData view counts.