### PR TITLE
Adapt temporal smoothness to ImageGroups

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -325,3 +325,11 @@ class SfMExpanding(desc.AVCommandLineNode):
             value="{nodeCacheFolder}/cameras.sfm",
         )
     ]
+
+    def onUseTemporalConstraintChanged(self, node):
+        if node.useTemporalConstraint.value:
+            node.useLocalBA.value = False
+
+    def onUseLocalBAChanged(self, node):
+        if node.useLocalBA.value:
+            node.useTemporalConstraint.value = False

--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -59,7 +59,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#575963"
             }
@@ -298,7 +300,7 @@
                 209
             ],
             "inputs": {
-                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "input": "{ApplyCalibration_1.output}",
                 "inputB": "{SfMExpanding_1.output}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"

--- a/meshroom/cameraTrackingDepth.mg
+++ b/meshroom/cameraTrackingDepth.mg
@@ -62,7 +62,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#575963"
             }
@@ -331,7 +333,7 @@
                 215
             ],
             "inputs": {
-                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "input": "{ApplyCalibration_1.output}",
                 "inputB": "{SfMExpanding_1.output}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"

--- a/meshroom/cameraTrackingLegacy.mg
+++ b/meshroom/cameraTrackingLegacy.mg
@@ -53,7 +53,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#575963"
             }
@@ -257,7 +259,7 @@
                 200
             ],
             "inputs": {
-                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "input": "{ApplyCalibration_1.output}",
                 "inputB": "{StructureFromMotion_2.output}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"

--- a/meshroom/cameraTrackingRoma.mg
+++ b/meshroom/cameraTrackingRoma.mg
@@ -52,7 +52,9 @@
                 -216,
                 34
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#575963"
             }

--- a/meshroom/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/cameraTrackingWithoutCalibration.mg
@@ -57,7 +57,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#575963"
             }
@@ -266,7 +268,7 @@
                 200
             ],
             "inputs": {
-                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "input": "{ApplyCalibration_1.output}",
                 "inputB": "{SfMExpanding_1.output}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"

--- a/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
@@ -51,7 +51,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#575963"
             }
@@ -228,7 +230,7 @@
                 200
             ],
             "inputs": {
-                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "input": "{ApplyCalibration_1.output}",
                 "inputB": "{StructureFromMotion_2.output}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -45,7 +45,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#80766f"
             }

--- a/meshroom/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/nodalCameraTrackingWithoutCalibration.mg
@@ -29,7 +29,9 @@
                 -220,
                 2
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "color": "#80766f"
             }

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -58,7 +58,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "label": "InitShot",
                 "color": "#575963"
@@ -351,7 +353,7 @@
                 139
             ],
             "inputs": {
-                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "input": "{ApplyCalibration_1.output}",
                 "inputB": "{SfMExpanding_2.output}",
                 "featuresFolders": "{TracksBuilding_2.featuresFolders}",
                 "method": "VocabularyTree",

--- a/meshroom/photogrammetryAndCameraTrackingLegacy.mg
+++ b/meshroom/photogrammetryAndCameraTrackingLegacy.mg
@@ -51,7 +51,9 @@
                 -200,
                 0
             ],
-            "inputs": {},
+            "inputs": {
+                "isSequence": true
+            },
             "internalInputs": {
                 "label": "InitShot",
                 "color": "#575963"
@@ -313,7 +315,7 @@
                 200
             ],
             "inputs": {
-                "input": "{KeyframeSelection_1.outputSfMDataFrames}",
+                "input": "{ApplyCalibration_1.output}",
                 "inputB": "{StructureFromMotion_2.output}",
                 "featuresFolders": [
                     "{FeatureExtraction_1.output}"

--- a/src/aliceVision/dataio/SfMDataFeed.cpp
+++ b/src/aliceVision/dataio/SfMDataFeed.cpp
@@ -129,8 +129,6 @@ bool SfMDataFeed::FeederImpl::goToNextFrame()
         return false;
 
     return true;
-
-    return true;
 }
 
 /*******************************************************************************/

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -6,6 +6,7 @@
 
 #include "KeyframeSelector.hpp"
 #include <aliceVision/sfmDataIO/viewIO.hpp>
+#include <aliceVision/sfmData/ImageSet.hpp>
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/utils/filesIO.hpp>
 #include <aliceVision/camera/Pinhole.hpp>
@@ -1272,6 +1273,14 @@ bool KeyframeSelector::writeSfMDataFromSfMData(const std::string& mediaPath)
         return false;
     }
 
+    // Copy image groups into imageSets
+    for (const auto & [imageGroupID, _] : inputSfm.getImageGroups())
+    {
+        auto imageGroupPtr = std::make_shared<sfmData::ImageSet>();
+        _outputSfmKeyframes.getImageGroups().emplace(imageGroupID, imageGroupPtr);
+        _outputSfmFrames.getImageGroups().emplace(imageGroupID, imageGroupPtr);
+    }
+
     // Order the views according to the frame ID and the intrinsics serial number
     std::map<std::string, std::vector<std::shared_ptr<sfmData::View>>> viewSequences;
     auto& intrinsics = inputSfm.getIntrinsics();
@@ -1506,7 +1515,7 @@ std::shared_ptr<camera::IntrinsicBase> KeyframeSelector::createIntrinsic(const s
     {
         mode = camera::EInitMode::UNKNOWN;
     }
-    
+
     auto intrinsic = sfmDataIO::getViewIntrinsic(view, mode, focalLength, sensorWidth);
     if (imageRatio > 1.0 && sensorWidth > -1.0)
     {

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -571,7 +571,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
             landmarkBlock[0] = refX.x();
             landmarkBlock[1] = refX.y();
             landmarkBlock[2] = refX.z();
-            
+
             referencePoseBlockPtr = _posesBlocks.at(refview.getPoseId()).data();
         }
 
@@ -714,7 +714,7 @@ void BundleAdjustmentCeres::addSurveyPointsToProblem(const sfmData::SfMData& sfm
         {
             continue;
         }
-        
+
         const IndexT intrinsicId = view.getIntrinsicId();
         const IndexT poseId = view.getPoseId();
 
@@ -736,7 +736,7 @@ void BundleAdjustmentCeres::addSurveyPointsToProblem(const sfmData::SfMData& sfm
         const auto& pose = sfmData.getPose(view);
 
         // needed parameters to create a residual block (K, pose)
-        
+
         double* poseBlockPtr = _posesBlocks.at(view.getPoseId()).data();
         double* intrinsicBlockPtr = _intrinsicsBlocks.at(intrinsicId).data();
         const std::shared_ptr<IntrinsicBase> intrinsic = _intrinsicObjects[intrinsicId];
@@ -843,7 +843,7 @@ void BundleAdjustmentCeres::addConstraints2DToProblem(const sfmData::SfMData& sf
                                                                                         (poseBlockPtr_1 == poseBlockPtr_2),
                                                                                         (rigBlockPtr_1 == rigBlockPtr_2));
         std::vector<double*> params;
-        params.push_back(intrinsicBlockPtr_1);        
+        params.push_back(intrinsicBlockPtr_1);
         params.push_back(distortionBlockPtr_1);
 
         if (intrinsicBlockPtr_1 != intrinsicBlockPtr_2)
@@ -931,100 +931,115 @@ void BundleAdjustmentCeres::addTemporalSmoothnessToProblem(const sfmData::SfMDat
         return;
     }
 
-    // set a LossFunction to be less penalized by false measurements.
-    // note: set it to NULL if you don't want use a lossFunction.
-    ceres::LossFunction* lossFunction = nullptr;
-
-    double focalScale = meanFocalLength(sfmData);
-
-    TemporalConstraintParams tempConstrParams = _ceresOptions.temporalConstraintParams;
-
-    double positionWeight = focalScale * tempConstrParams.positionWeight;
-    double orientationWeight = focalScale * tempConstrParams.orientationWeight;
-
-    const double c0pWeight = tempConstrParams.c0positionWeight;
-    const double c1pWeight = tempConstrParams.c1positionWeight;
-    const double c2pWeight = tempConstrParams.c2positionWeight;
-    const double c0oWeight = tempConstrParams.c0orientationWeight;
-    const double c1oWeight = tempConstrParams.c1orientationWeight;
-    const double c2oWeight = tempConstrParams.c2orientationWeight;
-
-    double land2ViewsRegWeight = tempConstrParams.land2ViewsRegWeight;
-    double trajLengthRegWeight = tempConstrParams.trajLengthRegWeight;
-
-    std::vector<IndexT> poseIdsVec;
-    IndexT firstViewWithPose;
-    IndexT lastViewWithPose;
-    if (!getOrderedPoseIds(sfmData, poseIdsVec, firstViewWithPose, lastViewWithPose))
+    for (const auto & [imageGroupID, imageGroupPtr] : sfmData.getImageGroups())
     {
-        ALICEVISION_THROW_ERROR("Unable to get ordered frameIDs.");
-    }
 
-    std::vector<double*> poseBlockPtrs;
-
-    for (IndexT frameIdx = firstViewWithPose; frameIdx <= lastViewWithPose; frameIdx++)
-    {
-        poseBlockPtrs.push_back(_posesBlocks.at(poseIdsVec.at(frameIdx)).data());
-        _linearSolverOrdering.AddElementToGroup(poseBlockPtrs[frameIdx-firstViewWithPose], 1);
-    }
-
-    double trajectoryLength = cameraTrajectoryLength(poseBlockPtrs);
-
-    // The camera track length is equal to zero in case all cameras are at a same position
-    // In this case, the temporal constraint is disabled for the positions
-    if (trajectoryLength == 0)
-        positionWeight = 0;
-
-    ceres::ResidualBlockId blockId;
-
-    for (IndexT frameIdx = firstViewWithPose + 3; frameIdx <= lastViewWithPose; frameIdx++)
-    {
-        std::vector<double*> posesParams(poseBlockPtrs.begin()+frameIdx-firstViewWithPose-3,
-                                         poseBlockPtrs.begin()+frameIdx-firstViewWithPose+1);
-
-        // Add constraint for the first views
-        if (frameIdx == firstViewWithPose+3)
+        if (imageGroupPtr.get()->getType() != sfmData::ImageGroup::Type::ImageSequence)
         {
-            ceres::CostFunction* costFunction1 = TemporalConstraintFunctor::createCostFunction(
-                positionWeight, orientationWeight, c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight, 1);
-            blockId = problem.AddResidualBlock(costFunction1, lossFunction, posesParams);
-            blockIds.push_back(blockId);
+            continue;
+        }
 
-            ceres::CostFunction* costFunction2 = TemporalConstraintFunctor::createCostFunction(
-                positionWeight, orientationWeight, c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight, 2);
-            blockId = problem.AddResidualBlock(costFunction2, lossFunction, posesParams);
+        // set a LossFunction to be less penalized by false measurements.
+        // note: set it to NULL if you don't want use a lossFunction.
+        ceres::LossFunction* lossFunction = nullptr;
+
+        double focalScale = meanFocalLength(sfmData, imageGroupID);
+
+        TemporalConstraintParams tempConstrParams = _ceresOptions.temporalConstraintParams;
+
+        double positionWeight = focalScale * tempConstrParams.positionWeight;
+        double orientationWeight = focalScale * tempConstrParams.orientationWeight;
+
+        const double c0pWeight = tempConstrParams.c0positionWeight;
+        const double c1pWeight = tempConstrParams.c1positionWeight;
+        const double c2pWeight = tempConstrParams.c2positionWeight;
+        const double c0oWeight = tempConstrParams.c0orientationWeight;
+        const double c1oWeight = tempConstrParams.c1orientationWeight;
+        const double c2oWeight = tempConstrParams.c2orientationWeight;
+
+        double land2ViewsRegWeight = tempConstrParams.land2ViewsRegWeight;
+        double trajLengthRegWeight = tempConstrParams.trajLengthRegWeight;
+
+        std::vector<IndexT> poseIdsVec;
+        IndexT firstViewWithPose = 0;
+        IndexT lastViewWithPose = 1;
+        if (!getOrderedPoseIds(sfmData, imageGroupID, poseIdsVec, firstViewWithPose, lastViewWithPose))
+        {
+            if (firstViewWithPose==lastViewWithPose)
+            {
+                ALICEVISION_LOG_WARNING("Unable to get ordered frameIDs for imageGroup " << imageGroupID <<
+                                        ". Temporal smoothness will be skipped for this group.");
+                continue;
+            }
+            ALICEVISION_THROW_ERROR("Unable to get ordered frameIDs for imageGroup " << imageGroupID << ".");
+        }
+
+        std::vector<double*> poseBlockPtrs;
+
+        for (IndexT frameIdx = firstViewWithPose; frameIdx <= lastViewWithPose; frameIdx++)
+        {
+            poseBlockPtrs.push_back(_posesBlocks.at(poseIdsVec.at(frameIdx)).data());
+            _linearSolverOrdering.AddElementToGroup(poseBlockPtrs[frameIdx-firstViewWithPose], 1);
+        }
+
+        double trajectoryLength = cameraTrajectoryLength(poseBlockPtrs);
+
+        // The camera track length is equal to zero in case all cameras are at a same position
+        // In this case, the temporal constraint is disabled for the positions
+        if (trajectoryLength == 0)
+            positionWeight = 0;
+
+        ceres::ResidualBlockId blockId;
+
+        for (IndexT frameIdx = firstViewWithPose + 3; frameIdx <= lastViewWithPose; frameIdx++)
+        {
+            std::vector<double*> posesParams(poseBlockPtrs.begin()+frameIdx-firstViewWithPose-3,
+                                            poseBlockPtrs.begin()+frameIdx-firstViewWithPose+1);
+
+            // Add constraint for the first views
+            if (frameIdx == firstViewWithPose+3)
+            {
+                ceres::CostFunction* costFunction1 = TemporalConstraintFunctor::createCostFunction(
+                    positionWeight, orientationWeight, c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight, 1);
+                blockId = problem.AddResidualBlock(costFunction1, lossFunction, posesParams);
+                blockIds.push_back(blockId);
+
+                ceres::CostFunction* costFunction2 = TemporalConstraintFunctor::createCostFunction(
+                    positionWeight, orientationWeight, c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight, 2);
+                blockId = problem.AddResidualBlock(costFunction2, lossFunction, posesParams);
+                blockIds.push_back(blockId);
+            }
+
+            ceres::CostFunction* costFunction = TemporalConstraintFunctor::createCostFunction(
+                positionWeight, orientationWeight, c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight, 0);
+            blockId = problem.AddResidualBlock(costFunction, lossFunction, posesParams);
             blockIds.push_back(blockId);
         }
 
-        ceres::CostFunction* costFunction = TemporalConstraintFunctor::createCostFunction(
-            positionWeight, orientationWeight, c0pWeight, c1pWeight, c2pWeight, c0oWeight, c1oWeight, c2oWeight, 0);
-        blockId = problem.AddResidualBlock(costFunction, lossFunction, posesParams);
-        blockIds.push_back(blockId);
-    }
+        if (land2ViewsRegWeight != 0.)
+        {
+            std::vector<double*> landmarks;
 
-    if (land2ViewsRegWeight != 0.)
-    {
-        std::vector<double*> landmarks;
+            for (auto& [landmarkID, landmarkPtr] : _landmarksBlocks)
+                landmarks.push_back(landmarkPtr.data());
 
-        for (auto& [landmarkID, landmarkPtr] : _landmarksBlocks)
-            landmarks.push_back(landmarkPtr.data());
+            std::vector<double> meanLandmarks2viewsVector(3);
 
-        std::vector<double> meanLandmarks2viewsVector(3);
+            meanLandmarks2viewsPose(landmarks, poseBlockPtrs, meanLandmarks2viewsVector);
 
-        meanLandmarks2viewsPose(landmarks, poseBlockPtrs, meanLandmarks2viewsVector);
+            ceres::CostFunction* regFunction = Landmarks2viewsRegularizationFunctor::createCostFunction
+                            (land2ViewsRegWeight, landmarks, meanLandmarks2viewsVector, poseBlockPtrs.size());
+            ceres::LossFunction* reg_loss_function = nullptr;
+            problem.AddResidualBlock(regFunction, reg_loss_function, poseBlockPtrs);
+        }
 
-        ceres::CostFunction* regFunction = Landmarks2viewsRegularizationFunctor::createCostFunction
-                        (land2ViewsRegWeight, landmarks, meanLandmarks2viewsVector, poseBlockPtrs.size());
-        ceres::LossFunction* reg_loss_function = nullptr;
-        problem.AddResidualBlock(regFunction, reg_loss_function, poseBlockPtrs);
-    }
-
-    if (trajLengthRegWeight != 0.)
-    {
-        ceres::CostFunction* regFunction = TrajectoryLengthRegularizationFunctor::createCostFunction
-                                                (trajLengthRegWeight, trajectoryLength, poseBlockPtrs.size());
-        ceres::LossFunction* reg_loss_function = nullptr;
-        problem.AddResidualBlock(regFunction, reg_loss_function, poseBlockPtrs);
+        if (trajLengthRegWeight != 0.)
+        {
+            ceres::CostFunction* regFunction = TrajectoryLengthRegularizationFunctor::createCostFunction
+                                                    (trajLengthRegWeight, trajectoryLength, poseBlockPtrs.size());
+            ceres::LossFunction* reg_loss_function = nullptr;
+            problem.AddResidualBlock(regFunction, reg_loss_function, poseBlockPtrs);
+        }
     }
 
     ALICEVISION_LOG_INFO("SfmBundle::Temporal Smoothness added to problem");
@@ -1169,7 +1184,7 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
             sfmData::Landmark& landmark = sfmData.getLandmarks().at(idLandmark);
 
             std::array<double, 3> lblock = block;
-            
+
             if (landmark.getReferenceViewIndex() != UndefinedIndexT)
             {
                 if (landmark.getPointFetcher())
@@ -1178,7 +1193,7 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
                     const geometry::Pose3 refPose = sfmData.getPose(refview).getTransform();
 
                     const Vec3 origin = refPose.center();
-                    
+
                     Vec3 rdir;
                     rdir.x() = block[0];
                     rdir.y() = block[1];
@@ -1186,14 +1201,14 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
 
                     rdir = rdir / rdir.norm();
                     const Vec3 wdir = refPose.rotation().transpose() * rdir;
-                    
+
                     Vec3 point, normal;
                     if (!landmark.getPointFetcher()->getPointAndNormal(point, normal, origin, wdir))
                     {
                         ALICEVISION_LOG_DEBUG("A mesh-based landmark has no intersection with the mesh.");
                         continue;
                     }
-                    
+
                     lblock[0] = point.x();
                     lblock[1] = point.y();
                     lblock[2] = point.z();
@@ -1241,7 +1256,7 @@ void BundleAdjustmentCeres::surveyInfos(const sfmData::SfMData & sfmData) const
         if (!sfmData.isPoseAndIntrinsicDefined(view))
         {
             continue;
-        } 
+        }
 
         const auto & intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
         const auto pose = sfmData.getPose(view);

--- a/src/aliceVision/sfm/utils/poseFilter.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter.cpp
@@ -81,132 +81,172 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
 
     ALICEVISION_LOG_INFO("poseFilter::interpolateMissingPoses start");
 
-    const int viewCount = sfmData.getViews().size();
+    bool noInterpolationDone = true;
 
-    std::vector<IndexT> viewIdsVec(viewCount);
-
-    IndexT firstViewFrameId = sfmData.getViews().begin()->second->getFrameId();
-    IndexT minFrameId = firstViewFrameId;  // Arbitrary frameId init
-    IndexT maxFrameId = firstViewFrameId;  // Arbitrary frameId init
-    IndexT minFrameIdWithPose;
-    IndexT maxFrameIdWithPose;
-
-    bool existingPoseFound = false;
-
-    // Get the frameIDs range and the frameID of the first and last views with an existing pose
-    for (const auto& [viewID, viewPtr] : sfmData.getViews())
+    for (const auto & [imageGroupID, imageGroupPtr] : sfmData.getImageGroups())
     {
-        const IndexT frameId = viewPtr->getFrameId();
-        if (frameId < minFrameId)
-        {
-            minFrameId = frameId;
-        }
-        if (frameId > maxFrameId)
-        {
-            maxFrameId = frameId;
-        }
-        if ( sfmData.existsPose(*viewPtr) )
-        {
-            if (!existingPoseFound || frameId < minFrameIdWithPose)
-            {
-                minFrameIdWithPose = frameId;
-            }
-
-            if (!existingPoseFound || frameId > maxFrameIdWithPose)
-            {
-                maxFrameIdWithPose = frameId;
-            }
-
-            existingPoseFound = true;
-        }
-    }
-
-    const int frameIdRange = maxFrameId - minFrameId + 1;
-
-    if ( !existingPoseFound || (frameIdRange != viewCount) )
-    {
-        return false;
-    }
-
-    // Store the temporally ordered view IDs
-    for (const auto& [viewID, viewPtr] : sfmData.getViews())
-    {
-        const IndexT frameId = viewPtr->getFrameId();
-        viewIdsVec[frameId-minFrameId] = viewID;
-
-        if (!sfmData.existsPose(*viewPtr))
-        {
-            ALICEVISION_LOG_INFO(" frameId without pose : " << frameId);
-        }
-    }
-
-    const sfmData::View& lastValidView = sfmData.getView(viewIdsVec[minFrameIdWithPose-minFrameId]);
-    sfmData::CameraPose lastValidPose = sfmData.getPose(lastValidView);
-
-    VectorX<bool> missingPosesMask(viewCount);
-    missingPosesMask.setZero();
-
-    // Initialize the pose of the views without pose
-    for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
-    {
-        IndexT frameViewID = viewIdsVec[frameIdx];
-        const sfmData::View& currentView = sfmData.getView(frameViewID);
-
-        if (!sfmData.existsPose(currentView))
-        {
-            // Create a binary mask to be able to restore the original values
-            missingPosesMask(frameIdx) = true;
-
-            if (!ignoreFirstAndLast || (minFrameIdWithPose < (frameIdx + minFrameId) && (frameIdx + minFrameId) < maxFrameIdWithPose) )
-            {
-                sfmData.setPose(currentView, lastValidPose);
-            }
-        }
-        else
-        {
-            lastValidPose = sfmData.getPose(currentView);
-        }
-    }
-
-    tempFilter tFilter;
-
-    tFilter.init();
-
-    MatrixXd viewRotations(4, viewCount);
-    MatrixXd viewCenters(3, viewCount);
-
-    // Get the temporally ordered view positions and orientations
-    for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
-    {
-        const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
-        const sfmData::CameraPose framePose = sfmData.getPose(frameView);
-        viewCenters.col(frameIdx) = framePose.getTransform().center();
-        AngleAxisd aa(framePose.getTransform().rotation());
-        viewRotations.col(frameIdx) << aa.angle(), aa.axis();
-    }
-
-    int scaleFactor = 8;
-    int iterationCount = 1000;
-
-    // Apply a temporal filter to view positions
-    viewCenters = tFilter.applyMultiscale(viewCenters, scaleFactor, iterationCount, false, missingPosesMask);
-
-    // Apply a temporal filter to view orientations
-    viewRotations = tFilter.applyMultiscale(viewRotations, scaleFactor, iterationCount, true, missingPosesMask);
-
-    // Save the temporally filtered poses
-    for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
-    {
-        if (!missingPosesMask(frameIdx))
+        if (imageGroupPtr.get()->getType() != sfmData::ImageGroup::Type::ImageSequence)
         {
             continue;
         }
 
-        IndexT frameViewID = viewIdsVec[frameIdx];
-        AngleAxisd aa(viewRotations(0, frameIdx), viewRotations(seqN(1,3), frameIdx));
-        geometry::Pose3 newPose(aa.toRotationMatrix(), viewCenters.col(frameIdx));
-        const sfmData::View& frameView = sfmData.getView(frameViewID);
-        sfmData.setPose(frameView, sfmData::CameraPose(newPose));
+        const sfmData::Views& sfmViews = sfmData.getViews();
+
+        const int viewCount = std::count_if(sfmViews.begin(), sfmViews.end(), [&imageGroupID](const auto& viewPair)
+        {
+            return viewPair.second->getImageGroupId() == imageGroupID;
+        });
+
+        ALICEVISION_LOG_INFO("imageGroupID " << imageGroupID << " has " << viewCount << " views.");
+
+        if (viewCount <= 1)
+        {
+            continue;
+        }
+
+        std::vector<IndexT> viewIdsVec(viewCount);
+
+        IndexT minFrameId = UndefinedIndexT;
+        IndexT maxFrameId = UndefinedIndexT;
+        IndexT minFrameIdWithPose;
+        IndexT maxFrameIdWithPose;
+
+        bool existingPoseFound = false;
+
+        // Get the frameIDs range and the frameID of the first and last views with an existing pose
+        for (const auto& [viewID, viewPtr] : sfmData.getViews())
+        {
+            if (viewPtr->getImageGroupId() != imageGroupID)
+            {
+                continue;
+            }
+
+            const IndexT frameId = viewPtr->getFrameId();
+            if (frameId < minFrameId || minFrameId == UndefinedIndexT)
+            {
+                minFrameId = frameId;
+            }
+            if (frameId > maxFrameId || maxFrameId == UndefinedIndexT)
+            {
+                maxFrameId = frameId;
+            }
+            if ( sfmData.existsPose(*viewPtr) )
+            {
+                if (!existingPoseFound || frameId < minFrameIdWithPose)
+                {
+                    minFrameIdWithPose = frameId;
+                }
+
+                if (!existingPoseFound || frameId > maxFrameIdWithPose)
+                {
+                    maxFrameIdWithPose = frameId;
+                }
+
+                existingPoseFound = true;
+            }
+        }
+
+        const int frameIdRange = maxFrameId - minFrameId + 1;
+
+        if ( !existingPoseFound || (frameIdRange != viewCount) )
+        {
+            ALICEVISION_LOG_WARNING("Invalid imageSequence found (with missing view(s) or missing pose(s))");
+            return false;
+        }
+
+        noInterpolationDone = false;
+
+        // Store the temporally ordered view IDs
+        for (const auto& [viewID, viewPtr] : sfmData.getViews())
+        {
+            if (viewPtr->getImageGroupId() != imageGroupID)
+            {
+                continue;
+            }
+
+            const IndexT frameId = viewPtr->getFrameId();
+            viewIdsVec[frameId-minFrameId] = viewID;
+
+            if (!sfmData.existsPose(*viewPtr))
+            {
+                ALICEVISION_LOG_INFO(" frameId in imageGroupID " << imageGroupID  << " without pose: " << frameId);
+            }
+        }
+
+        const sfmData::View& lastValidView = sfmData.getView(viewIdsVec[minFrameIdWithPose-minFrameId]);
+        sfmData::CameraPose lastValidPose = sfmData.getPose(lastValidView);
+
+        VectorX<bool> missingPosesMask(viewCount);
+        missingPosesMask.setZero();
+
+        // Initialize the pose of the views without pose
+        for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
+        {
+            IndexT frameViewID = viewIdsVec[frameIdx];
+            const sfmData::View& currentView = sfmData.getView(frameViewID);
+
+            if (!sfmData.existsPose(currentView))
+            {
+                // Create a binary mask to be able to restore the original values
+                missingPosesMask(frameIdx) = true;
+
+                if (!ignoreFirstAndLast || (minFrameIdWithPose < (frameIdx + minFrameId) && (frameIdx + minFrameId) < maxFrameIdWithPose) )
+                {
+                    sfmData.setPose(currentView, lastValidPose);
+                }
+            }
+            else
+            {
+                lastValidPose = sfmData.getPose(currentView);
+            }
+        }
+
+        tempFilter tFilter;
+
+        tFilter.init();
+
+        MatrixXd viewRotations(4, viewCount);
+        MatrixXd viewCenters(3, viewCount);
+
+        // Get the temporally ordered view positions and orientations
+        for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
+        {
+            const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
+            const sfmData::CameraPose framePose = sfmData.getPose(frameView);
+            viewCenters.col(frameIdx) = framePose.getTransform().center();
+            AngleAxisd aa(framePose.getTransform().rotation());
+            viewRotations.col(frameIdx) << aa.angle(), aa.axis();
+        }
+
+        int scaleFactor = 8;
+        int iterationCount = 1000;
+
+        // Apply a temporal filter to view positions
+        viewCenters = tFilter.applyMultiscale(viewCenters, scaleFactor, iterationCount, false, missingPosesMask);
+
+        // Apply a temporal filter to view orientations
+        viewRotations = tFilter.applyMultiscale(viewRotations, scaleFactor, iterationCount, true, missingPosesMask);
+
+        // Save the temporally filtered poses
+        for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
+        {
+            if (!missingPosesMask(frameIdx))
+            {
+                continue;
+            }
+
+            IndexT frameViewID = viewIdsVec[frameIdx];
+            AngleAxisd aa(viewRotations(0, frameIdx), viewRotations(seqN(1,3), frameIdx));
+            geometry::Pose3 newPose(aa.toRotationMatrix(), viewCenters.col(frameIdx));
+            const sfmData::View& frameView = sfmData.getView(frameViewID);
+            sfmData.setPose(frameView, sfmData::CameraPose(newPose));
+        }
+    }
+
+    if (noInterpolationDone)
+    {
+        ALICEVISION_LOG_WARNING("No valid imageSequence found");
+        return false;
     }
 
     ALICEVISION_LOG_INFO("poseFilter::interpolateMissingPoses end");
@@ -294,20 +334,32 @@ bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, std::vector<IndexT
 }
 
 
-bool getOrderedPoseIds(const sfmData::SfMData& sfmData, std::vector<IndexT>& poseIdsVec, IndexT& firstViewWithPose, IndexT& lastViewWithPose)
+bool getOrderedPoseIds(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& poseIdsVec, IndexT& firstViewWithPose, IndexT& lastViewWithPose)
 {
     std::map<std::string, std::vector<IndexT>> candidateViewIdLists;
     std::map<std::string, std::vector<IndexT>> candidateFrameIdLists;
 
+    IndexT viewCount = 0;
     // Group views by common filename pattern
     for (const auto& [viewID, viewPtr] : sfmData.getViews())
     {
+        if (viewPtr->getImageGroupId() != imageGroupID)
+        {
+            continue;
+        }
         const std::filesystem::path imagePath = std::filesystem::path(viewPtr->getImage().getImagePath());
         std::string parentPath = imagePath.parent_path().string();
         // Remove every digit in the filename
         std::string filePattern = std::regex_replace(imagePath.filename().string(), std::regex("\\d"), "");
         candidateViewIdLists[parentPath+filePattern].push_back(viewID);
         candidateFrameIdLists[parentPath+filePattern].push_back(viewPtr->getFrameId());
+        viewCount++;
+    }
+
+    if (viewCount <= 1)
+    {
+        firstViewWithPose = lastViewWithPose = 0;
+        return false;
     }
 
     IndexT minFrameId;

--- a/src/aliceVision/sfm/utils/poseFilter.hpp
+++ b/src/aliceVision/sfm/utils/poseFilter.hpp
@@ -48,12 +48,13 @@ private:
  * and identifies the first and last view IDs with valid poses.
  *
  * @param[in]  sfmData            The scene description containing views and poses.
+ * @param[in]  imageGroupID       The imageGroupID of the views to consider.
  * @param[out] poseIdsVec         Vector to be filled with the ordered pose IDs.
  * @param[out] firstViewWithPose  The ID of the first view with a valid pose.
  * @param[out] lastViewWithPose   The ID of the last view with a valid pose.
  * @return true if at least one pose was found and the output parameters were set, false otherwise.
  */
-bool getOrderedPoseIds(const sfmData::SfMData& sfmData, std::vector<IndexT>& poseIdsVec, IndexT& firstViewWithPose, IndexT& lastViewWithPose);
+bool getOrderedPoseIds(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& poseIdsVec, IndexT& firstViewWithPose, IndexT& lastViewWithPose);
 } // namespace sfm
 } // namespace aliceVision
 

--- a/src/aliceVision/sfm/utils/statistics.cpp
+++ b/src/aliceVision/sfm/utils/statistics.cpp
@@ -71,13 +71,34 @@ double computeAreaScore(const std::vector<Eigen::Vector2d>& refPts, const std::v
     return score;
 }
 
-const double meanFocalLength(const sfmData::SfMData& sfmData)
+const double meanFocalLength(const sfmData::SfMData& sfmData, const aliceVision::IndexT imageGroupID)
 {
     std::vector<double> focalLengths;
 
-    for (const auto& [intrinsicId, intrinsic] : sfmData.getIntrinsics())
+    for (const auto& [viewID, viewPtr] : sfmData.getViews())
     {
-        const auto& iso = std::dynamic_pointer_cast<const camera::IntrinsicScaleOffset>(intrinsic);
+        if (viewPtr->getImageGroupId() != imageGroupID)
+        {
+            continue;
+        }
+
+        if (!sfmData.isIntrinsicDefined(*viewPtr))
+        {
+            continue;
+        }
+
+        std::shared_ptr<camera::IntrinsicBase> intrinsic = sfmData.getIntrinsicSharedPtr(viewPtr->getIntrinsicId());
+        if (!intrinsic)
+        {
+            continue;
+        }
+
+        const auto iso = std::dynamic_pointer_cast<const camera::IntrinsicScaleOffset>(intrinsic);
+        if (!iso)
+        {
+            continue;
+        }
+
         focalLengths.push_back(iso->getFocalLength());
     }
 

--- a/src/aliceVision/sfm/utils/statistics.hpp
+++ b/src/aliceVision/sfm/utils/statistics.hpp
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <Eigen/Dense>
+#include <aliceVision/types.hpp>
 
 namespace aliceVision {
 
@@ -35,17 +36,16 @@ double RMSE(const sfmData::SfMData& sfmData);
  * @param nextWidth the next image width
  * @param nextHeight the next image height
  * @return score
- * 
-*/
+ */
 double computeAreaScore(const std::vector<Eigen::Vector2d>& refPts, const std::vector<Eigen::Vector2d>& nextPts, size_t refWidth, size_t refHeight, size_t nextWidth, size_t nextHeight);
 
 /**
- * @brief Compute the mean focal length across all intrinsics in the given SfMData.
- * @param sfmData The sfm data containing camera intrinsics.
+ * @brief Compute the mean focal length for the views belonging to the specified imageGroup.
+ * @param sfmData The sfm data containing the views and the associated camera intrinsics.
+ * @param imageGroupID The imageGroupID of the views to consider.
  * @return The mean focal length in physical units (not pixels). Returns 1.0 if no intrinsics are present.
  */
-const double meanFocalLength(const sfmData::SfMData& sfmData);
-
+const double meanFocalLength(const sfmData::SfMData& sfmData, const IndexT imageGroupID);
 
 /**
  * @brief Compute the total length of the camera trajectory defined by the given poses.

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -339,7 +339,15 @@ void SfMData::combine(const SfMData& sfmData)
     _constraintsPoint.insert(sfmData._constraintsPoint.begin(), sfmData._constraintsPoint.end());
 
     // image groups
-    _imageGroups.insert(sfmData._imageGroups.begin(), sfmData._imageGroups.end());
+    for (const auto & [imageGroupID, imageGroupPtr] : sfmData._imageGroups)
+    {
+        auto imageGroup = _imageGroups.find(imageGroupID);
+        // Priority is given to ImageSequence over ImageSet
+        if (imageGroup == _imageGroups.end() || imageGroupPtr.get()->getType() == sfmData::ImageGroup::Type::ImageSequence)
+        {
+            _imageGroups.insert_or_assign(imageGroupID, imageGroupPtr);
+        }
+    }
 }
 
 void SfMData::clear()
@@ -406,7 +414,7 @@ IndexT SfMData::findView(const std::string & imageName) const
     {
         const auto & v = viewPair.second;
 
-        if (imageName == std::to_string(v->getViewId()) || 
+        if (imageName == std::to_string(v->getViewId()) ||
             imageName == fs::path(v->getImage().getImagePath()).filename().string() ||
             imageName == v->getImage().getImagePath())
         {

--- a/src/aliceVision/sfmDataIO/sceneSample.cpp
+++ b/src/aliceVision/sfmDataIO/sceneSample.cpp
@@ -5,7 +5,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "sceneSample.hpp"
+#include <aliceVision/stl/hash.hpp>
 #include <aliceVision/camera/Pinhole.hpp>
+#include <aliceVision/sfmData/ImageSequence.hpp>
 
 namespace aliceVision {
 namespace sfmDataIO {
@@ -129,12 +131,18 @@ void generateSphereScene(sfmData::SfMData& output, int pointsNb, int posesNb)
 {
     // Generate random points on a sphere
 
+    size_t sphereSceneHash = 4546135487;
+
     const int w = 4092;
     const int h = 2048;
     const double focalLengthPixX = 10000.0;
     const double focalLengthPixY = 20000.0;
     output.getIntrinsics().emplace(
       0, camera::createPinhole(camera::DISTORTION_NONE, camera::UNDISTORTION_NONE, w, h, focalLengthPixX, focalLengthPixY, 0, 0));
+
+    size_t imageGroupID = sphereSceneHash;
+    stl::hash_combine(imageGroupID, pointsNb);
+    stl::hash_combine(imageGroupID, posesNb);
 
     // Generate poses on a circle
     for (IndexT idPV = 0; idPV < posesNb; idPV++)
@@ -147,7 +155,11 @@ void generateSphereScene(sfmData::SfMData& output, int pointsNb, int posesNb)
         output.getPoses().assign(idPV, sfmData::CameraPose(pose));
         output.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, w, h));
         output.getView(idPV).setFrameId(idPV);
+        output.getView(idPV).setImageGroupId(imageGroupID);
     }
+
+    auto imageGroupPtr = std::make_shared<sfmData::ImageSequence>();
+    output.getImageGroups().emplace(imageGroupID, imageGroupPtr);
 
     // Generate random points on a sphere and corresponding observations in each view
     const double arbitraryScale = 1.0;

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -87,7 +87,7 @@ inline std::ostream& operator<<(std::ostream& os, EMergeMethod e) { return os <<
 }  // namespace
 
 /**
- * @brief Merge two sfmData assuming 0 duplicates. 
+ * @brief Merge two sfmData assuming 0 duplicates.
  * simply copy from one to another
  * @param [in, out] sfmData1 the first sfmData
  * @param [in] sfmData2 the second sfmData
@@ -105,6 +105,19 @@ bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2,
         if (views1.size() < totalSize && !ignoreDuplicates)
         {
             ALICEVISION_LOG_ERROR("Unhandled error: common view ID between both SfMData");
+            return false;
+        }
+    }
+
+    {
+        auto& groups1 = sfmData1.getImageGroups();
+        auto& groups2 = sfmData2.getImageGroups();
+        const size_t totalSize = groups1.size() + groups2.size();
+
+        groups1.insert(groups2.begin(), groups2.end());
+        if (groups1.size() < totalSize && !ignoreDuplicates)
+        {
+            ALICEVISION_LOG_ERROR("Unhandled error: common imageGroup ID between both SfMData");
             return false;
         }
     }
@@ -131,7 +144,7 @@ bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2,
                         ALICEVISION_LOG_ERROR("Unhandled error: common intrinsic ID with different parameters between both SfMData");
                         return false;
                     }
-                } 
+                }
             }
         }
 
@@ -158,7 +171,7 @@ bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2,
                     ALICEVISION_LOG_ERROR("Unhandled error: common rig ID with different parameters between both SfMData");
                     return false;
                 }
-            } 
+            }
         }
 
         rigs1.insert(rigs2.begin(), rigs2.end());
@@ -185,7 +198,7 @@ bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2,
 
 
 /**
- * @brief Merge two sfmData 
+ * @brief Merge two sfmData
  * Align using common landmarks
  * @param [in, out] sfmData1 the first sfmData
  * @param [in] sfmData2 the second sfmData
@@ -200,7 +213,7 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
         for (const auto & pobs : plandmark.second.getObservations())
         {
             IndexT featureId = pobs.second.getFeatureId();
-            
+
             std::pair<IndexT, IndexT> pairViewFeature;
             pairViewFeature.first = pobs.first;
             pairViewFeature.second = featureId;
@@ -213,7 +226,7 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
         for (const auto & pobs : plandmark.second.getObservations())
         {
             IndexT featureId = pobs.second.getFeatureId();
-            
+
             std::pair<IndexT, IndexT> pairViewFeature;
             pairViewFeature.first = pobs.first;
             pairViewFeature.second = featureId;
@@ -221,7 +234,7 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
             mapFeatureIdToLandmarkId[pairViewFeature] = plandmark.first;
         }
     }
- 
+
     std::set<std::pair<IndexT, IndexT>> landmarkUniquePairs;
     //For all pairs:
     for (const auto & pairMatches : pairwiseMatches)
@@ -243,7 +256,7 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
             for (const auto & match : pDescMatches.second)
             {
                 Pair lookup;
-                
+
                 //Check if the first feature is associated to a landmark
                 lookup.first = pairViews.first;
                 lookup.second = match._i;
@@ -263,16 +276,16 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
                 }
 
                 std::pair<IndexT, IndexT> pairOfLandmarks;
-                
+
                 if (reverse)
                 {
                     pairOfLandmarks = std::make_pair(itl1->second, itl2->second);
                 }
-                else 
+                else
                 {
                     pairOfLandmarks = std::make_pair(itl2->second, itl1->second);
                 }
-                
+
                 landmarkUniquePairs.insert(pairOfLandmarks);
             }
         }
@@ -290,7 +303,7 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
     // Move input point in appropriate container
     Mat xA(3, landmarkPairs.size());
     Mat xB(3, landmarkPairs.size());
-    
+
     int count = 0;
     for (auto & pair : landmarkPairs)
     {
@@ -352,7 +365,7 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
             landmarks1[availableId] = landmark;
             availableId++;
         }
-        else 
+        else
         {
             auto & obs1 = landmarks1[l1id].getObservations();
             const auto & obs2 = landmark.getObservations();
@@ -361,8 +374,8 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
     }
 
     ALICEVISION_LOG_INFO("Result sfmData landmarks : " << sfmData1.getLandmarks().size());
-    
-    
+
+
     // Simple merge of views
     auto& views1 = sfmData1.getViews();
     auto& views2 = sfmData2.getViews();
@@ -371,6 +384,17 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
     if (views1.size() != totalSize)
     {
         ALICEVISION_LOG_ERROR("Non Unique views");
+        return false;
+    }
+
+    // Simple merge of groups
+    auto& groups1 = sfmData1.getImageGroups();
+    auto& groups2 = sfmData2.getImageGroups();
+    totalSize = groups1.size() + groups2.size();
+    groups1.insert(groups2.begin(), groups2.end());
+    if (groups1.size() != totalSize)
+    {
+        ALICEVISION_LOG_ERROR("Non Unique imageGroups");
         return false;
     }
 
@@ -409,7 +433,7 @@ int aliceVision_main(int argc, char** argv)
          "Path to sfmDatas to merge.")
         ("output,o", po::value<std::string>(&outSfMDataFilename)->required(),
          "Output SfMData scene.");
-        
+
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
         ("method", po::value<EMergeMethod>(&mergeMethod)->default_value(mergeMethod),
@@ -466,7 +490,7 @@ int aliceVision_main(int argc, char** argv)
                 return EXIT_FAILURE;
             }
         }
-        else 
+        else
         {
             // get imageDescriber type
             const std::vector<feature::EImageDescriberType> describerTypes = feature::EImageDescriberType_stringToEnums(describerTypesName);
@@ -482,7 +506,7 @@ int aliceVision_main(int argc, char** argv)
                 }
 
                 ALICEVISION_LOG_WARNING(ss.str());
-                
+
                 return EXIT_FAILURE;
             }
 
@@ -492,7 +516,7 @@ int aliceVision_main(int argc, char** argv)
             }
         }
     }
-  
+
 
     if (!sfmDataIO::save(outputSfmData, outSfMDataFilename, sfmDataIO::ESfMData::ALL))
     {


### PR DESCRIPTION
This pull request introduces significant improvements to how image groups are handled throughout the Structure-from-Motion (SfM) pipeline, enabling better support for operations on multiple image sequences. The changes ensure that functions such as pose interpolation, bundle adjustment, and data merging are now image group-aware, improving robustness and flexibility when working with datasets containing multiple image groups.

Key changes include:

**Image Group Awareness for Bundle Adjustment Temporal Smoothness:**

* Updated pose interpolation (`poseFilter::interpolateMissingPoses`) to process each image group separately, ensuring that missing poses are interpolated within the context of each image sequence. This includes updating frame ID calculations and logging for clarity. [[1]](diffhunk://#diff-2563b7dd0e80824e7ce4b3281b1c1b0a2f41c3eef8a92a20da5f8bba7c23da78L84-R103) [[2]](diffhunk://#diff-2563b7dd0e80824e7ce4b3281b1c1b0a2f41c3eef8a92a20da5f8bba7c23da78R112-R122) [[3]](diffhunk://#diff-2563b7dd0e80824e7ce4b3281b1c1b0a2f41c3eef8a92a20da5f8bba7c23da78R152-R162) [[4]](diffhunk://#diff-2563b7dd0e80824e7ce4b3281b1c1b0a2f41c3eef8a92a20da5f8bba7c23da78R234)
* Modified bundle adjustment temporal smoothness (`BundleAdjustmentCeres::addTemporalSmoothnessToProblem`) to iterate over image groups of type `ImageSequence`, applying constraints and calculations (such as mean focal length and pose ordering) per group. [[1]](diffhunk://#diff-6c41f29d2d32f1d6de3437051fcfcad3a72d5bc7777b3dee96bc1c4c185e6bdcR934-R946) [[2]](diffhunk://#diff-6c41f29d2d32f1d6de3437051fcfcad3a72d5bc7777b3dee96bc1c4c185e6bdcL958-R966) [[3]](diffhunk://#diff-6c41f29d2d32f1d6de3437051fcfcad3a72d5bc7777b3dee96bc1c4c185e6bdcR1037)

**API and Utility Updates:**

* Changed the signature of `getOrderedPoseIds` to require an `imageGroupID` parameter, and updated its implementation and documentation to filter views by image group. [[1]](diffhunk://#diff-2563b7dd0e80824e7ce4b3281b1c1b0a2f41c3eef8a92a20da5f8bba7c23da78L297-R332) [[2]](diffhunk://#diff-779117770eb14dfbe1cfafef93ca2c12d0de40697640d8fb6a8bb559b9547668R51-R57)
* Updated the `meanFocalLength` utility to compute the mean only over views belonging to a specified image group, ensuring accurate statistics for each sequence. [[1]](diffhunk://#diff-faec0608c87aac708ded62e02ed90da06d46bf814bd7a768ec86faf1b848aa62L74-R85) [[2]](diffhunk://#diff-8fecc900e0beba0fc50f6b1584d9c5a3d397b09c3f4f811a9512fee84a386b95R46-R49)

**Data Handling and Merging:**

* Ensured that image groups are copied during keyframe selection and preserved/merged correctly in SfM data merge operations, with error handling for duplicate group IDs. [[1]](diffhunk://#diff-33982c0ed43fa661d95042b969e1616ace0bdbf0691f184439a94ed4ba5b856dR1275-R1278) [[2]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3R112-R124) [[3]](diffhunk://#diff-9809512c57c645ca00be0491c79ad143f50995bb15e4997564787e02cd0c33f3R390-R400)

**Minor Cleanup:**

* Removed unreachable code in `SfMDataFeed::FeederImpl::goToNextFrame()`.
* Added necessary includes for `IndexT` type usage.

These updates collectively improve the robustness and scalability of the SfM pipeline, particularly for projects involving multiple sequences or complex datasets.