### PR TITLE
Add Roma describer type

### DIFF
--- a/src/aliceVision/feature/CMakeLists.txt
+++ b/src/aliceVision/feature/CMakeLists.txt
@@ -12,6 +12,7 @@ set(features_files_headers
     sift/ImageDescriber_SIFT_vlfeatFloat.hpp
     sift/ImageDescriber_DSPSIFT_vlfeat.hpp
     sift/SIFT.hpp
+    virtual/ImageDescriber_Roma.hpp
     Descriptor.hpp
     feature.hpp
     FeaturesPerView.hpp
@@ -34,6 +35,7 @@ set(features_files_sources
     akaze/ImageDescriber_AKAZE.cpp
     sift/SIFT.cpp
     sift/ImageDescriber_DSPSIFT_vlfeat.cpp
+    virtual/ImageDescriber_Roma.cpp
     FeaturesPerView.cpp
     ImageDescriber.cpp
     imageDescriberCommon.cpp

--- a/src/aliceVision/feature/ImageDescriber.cpp
+++ b/src/aliceVision/feature/ImageDescriber.cpp
@@ -12,6 +12,7 @@
 #include <aliceVision/feature/sift/ImageDescriber_SIFT_vlfeatFloat.hpp>
 #include <aliceVision/feature/sift/ImageDescriber_DSPSIFT_vlfeat.hpp>
 #include <aliceVision/feature/akaze/ImageDescriber_AKAZE.hpp>
+#include <aliceVision/feature/virtual/ImageDescriber_Roma.hpp>
 #include <aliceVision/utils/filesIO.hpp>
 
 #if ALICEVISION_IS_DEFINED(ALICEVISION_HAVE_CCTAG)
@@ -254,6 +255,10 @@ std::unique_ptr<ImageDescriber> createImageDescriber(EImageDescriberType imageDe
             describerPtr.reset(new ImageDescriber_AKAZE_OCV());
             break;
 #endif  // ALICEVISION_HAVE_OPENCV
+
+        case EImageDescriberType::ROMA:
+            describerPtr.reset(new ImageDescriber_Roma());
+            break;
 
         default:
             throw std::out_of_range("Invalid imageDescriber enum");

--- a/src/aliceVision/feature/feature.i
+++ b/src/aliceVision/feature/feature.i
@@ -39,5 +39,6 @@ using namespace aliceVision::feature;
 %template(CLASS##Descriptors) std::vector<aliceVision::feature::Descriptor<TYPE, LEN>>;
 %enddef
 
-%region_typemaps(Fake, unsigned char, 1)
+%region_typemaps(Fake, float, 1)
 %region_typemaps(Sift, unsigned char, 128)
+%region_typemaps(Roma, unsigned char, 1)

--- a/src/aliceVision/feature/imageDescriberCommon.cpp
+++ b/src/aliceVision/feature/imageDescriberCommon.cpp
@@ -23,6 +23,7 @@ std::string EImageDescriberType_informations()
            "* sift: Scale-invariant feature transform.\n"
            "* sift_float: SIFT stored as float.\n"
            "* sift_upright: SIFT with upright feature.\n"
+           "* roma: Deep dense matcher.\n"
            "* akaze: A-KAZE with floating point descriptors.\n"
            "* akaze_liop: A-KAZE with Local Intensity Order Pattern descriptors.\n"
            "* akaze_mldb: A-KAZE with Modified-Local Difference Binary descriptors.\n"
@@ -84,6 +85,8 @@ std::string EImageDescriberType_enumToString(EImageDescriberType imageDescriberT
             return "akaze_ocv";
 #endif  // ALICEVISION_HAVE_OPENCV
 
+        case EImageDescriberType::ROMA:
+            return "roma";
         case EImageDescriberType::UNKNOWN:
             return "unknown";
         case EImageDescriberType::UNINITIALIZED:
@@ -134,7 +137,8 @@ EImageDescriberType EImageDescriberType_stringToEnum(const std::string& imageDes
     if (type == "akaze_ocv")
         return EImageDescriberType::AKAZE_OCV;
 #endif  // ALICEVISION_HAVE_OPENCV
-
+    if (type == "roma")
+        return EImageDescriberType::ROMA;
     if (type == "unknown")
         return EImageDescriberType::UNKNOWN;
     // UNINITIALIZED should throw an error.

--- a/src/aliceVision/feature/imageDescriberCommon.hpp
+++ b/src/aliceVision/feature/imageDescriberCommon.hpp
@@ -48,6 +48,8 @@ enum class EImageDescriberType : unsigned char
     ,
     APRILTAG16H5 = 50
 #endif
+    ,
+    ROMA = 100
 };
 
 /**
@@ -131,7 +133,8 @@ inline float getStrongSupportCoeff(EImageDescriberType imageDescriberType)
         case EImageDescriberType::AKAZE_OCV:
             return 0.14f;
 #endif  // ALICEVISION_HAVE_OPENCV
-
+        case EImageDescriberType::ROMA:
+            return 0.14f;
         case EImageDescriberType::UNKNOWN:
             return 1.0f;
         case EImageDescriberType::UNINITIALIZED:

--- a/src/aliceVision/feature/regionsFactory.hpp
+++ b/src/aliceVision/feature/regionsFactory.hpp
@@ -29,5 +29,8 @@ using AKAZE_Liop_Regions = ScalarRegions<unsigned char, 144>;
 /// Define the AKAZE Keypoint (with a binary descriptor saved in an uchar array)
 using AKAZE_BinaryRegions = BinaryRegions<64>;
 
+/// Define the Roma deep dense keypoint (1-dimensional float descriptor)
+using ROMA_Regions = ScalarRegions<float, 1>;
+
 }  // namespace feature
 }  // namespace aliceVision

--- a/src/aliceVision/feature/virtual/ImageDescriber_Roma.cpp
+++ b/src/aliceVision/feature/virtual/ImageDescriber_Roma.cpp
@@ -1,0 +1,31 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ImageDescriber_Roma.hpp"
+#include <aliceVision/system/Logger.hpp>
+
+namespace aliceVision {
+namespace feature {
+
+
+void ImageDescriber_Roma::setConfigurationPreset(ConfigurationPreset preset) { }
+
+void ImageDescriber_Roma::allocate(std::unique_ptr<Regions>& regions) const { regions.reset(new ROMA_Regions); }
+
+bool ImageDescriber_Roma::describe(const image::Image<unsigned char>& image,
+                                   std::unique_ptr<Regions>& regions,
+                                   const image::Image<unsigned char>* mask)
+{
+    // Roma feature extraction is performed externally (e.g. via a Python pipeline).
+    // This virtual describer only provides the AliceVision interface to load/save
+    // pre-computed Roma regions. Direct extraction is therefore not supported here.
+    throw std::logic_error("ImageDescriber_Roma::describe() is not implemented. "
+                           "Roma features must be extracted externally and loaded from disk.");
+    return false;
+}
+
+}  // namespace feature
+}  // namespace aliceVision

--- a/src/aliceVision/feature/virtual/ImageDescriber_Roma.hpp
+++ b/src/aliceVision/feature/virtual/ImageDescriber_Roma.hpp
@@ -1,0 +1,94 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/feature/imageDescriberCommon.hpp>
+#include <aliceVision/feature/ImageDescriber.hpp>
+#include <aliceVision/feature/regionsFactory.hpp>
+#include <aliceVision/types.hpp>
+
+#include <iostream>
+
+namespace aliceVision {
+namespace feature {
+
+/**
+ * @brief Create an ImageDescriber interface for Roma deep dense feature extractor.
+ *
+ * This is a "virtual" describer: it does not perform extraction itself but
+ * provides the AliceVision interface to load/save pre-computed Roma regions.
+ * Actual feature extraction is expected to be performed externally (e.g. via
+ * a dedicated Python pipeline) and the resulting .feat/.desc files consumed
+ * through this describer.
+ */
+class ImageDescriber_Roma : public ImageDescriber
+{
+  public:
+    ImageDescriber_Roma() = default;
+
+    ~ImageDescriber_Roma() override = default;
+
+    /**
+     * @brief Check if the image describer uses CUDA
+     * @return False – extraction is performed externally
+     */
+    bool useCuda() const override { return false; }
+
+    /**
+     * @brief Check if the image describer uses a float image
+     * @return False – extraction is performed externally
+     */
+    bool useFloatImage() const override { return false; }
+
+    /**
+     * @brief Get the corresponding EImageDescriberType
+     * @return EImageDescriberType::ROMA
+     */
+    EImageDescriberType getDescriberType() const override { return EImageDescriberType::ROMA; }
+
+    /**
+     * @brief Get the total amount of RAM needed for a feature extraction of an
+     *        image of the given dimension.
+     * @param[in] width  The image width
+     * @param[in] height The image height
+     * @return total amount of memory needed (conservative upper bound)
+     */
+    std::size_t getMemoryConsumption(std::size_t width, std::size_t height) const override
+    {
+        return 3 * width * height * sizeof(unsigned char);
+    }
+
+    /**
+     * @brief Use a preset to control the number of detected regions
+     * @param[in] preset The preset configuration
+     */
+    void setConfigurationPreset(ConfigurationPreset preset) override;
+
+    /**
+     * @brief Detect regions on the 8-bit image and compute their attributes.
+     *
+     * For this virtual describer the function is a no-op stub: Roma features
+     * are expected to be pre-computed externally. Calling this will throw.
+     *
+     * @param[in]  image   Input 8-bit grayscale image (unused)
+     * @param[out] regions Output regions (unused)
+     * @param[in]  mask    Optional keypoint mask (unused)
+     * @return False – not implemented
+     */
+    bool describe(const image::Image<unsigned char>& image,
+                  std::unique_ptr<Regions>& regions,
+                  const image::Image<unsigned char>* mask = nullptr) override;
+
+    /**
+     * @brief Allocate Regions type for Roma
+     * @param[in,out] regions
+     */
+    void allocate(std::unique_ptr<Regions>& regions) const override;
+};
+
+}  // namespace feature
+}  // namespace aliceVision

--- a/src/aliceVision/matching/svgVisualization.cpp
+++ b/src/aliceVision/matching/svgVisualization.cpp
@@ -29,7 +29,8 @@ std::string describerTypeColor(feature::EImageDescriberType descType)
             return "yellow";
         case feature::EImageDescriberType::DSPSIFT:
             return "yellow";
-
+        case feature::EImageDescriberType::ROMA:
+            return "green";
         case feature::EImageDescriberType::AKAZE:
             return "purple";
         case feature::EImageDescriberType::AKAZE_LIOP:


### PR DESCRIPTION
See also https://github.com/alicevision/Meshroom/pull/3074

This pull request introduces support for the "Roma" deep dense feature matcher as a new image describer type in AliceVision. The Roma describer is implemented as a "virtual" describer, meaning it does not perform feature extraction itself but provides an interface to load and manage precomputed Roma features generated externally (e.g., by a Python pipeline). The changes add the necessary type, class, and integration points for Roma support throughout the feature extraction and matching pipeline.

**Roma Feature Describer Integration**

* Added the new `ImageDescriber_Roma` class in `virtual/ImageDescriber_Roma.hpp` and `virtual/ImageDescriber_Roma.cpp`, which implements a stub describer for Roma features, allowing only loading/saving of externally computed features and throwing if direct extraction is attempted. [[1]](diffhunk://#diff-ffd768ad3b21bf852d09a950592323735798993511c0455be7904018df6f513dR1-R94) [[2]](diffhunk://#diff-3eb67a4b8dbde1d31ef4ca849a3c129911cf61ca9b54e90eda3a2431a965f093R1-R31)
* Registered the Roma describer type in the `EImageDescriberType` enum, updated string conversion functions, and set a default strong support coefficient for Roma. [[1]](diffhunk://#diff-b334b918918b32e21d3fae72f09d3a0f567af35a7b5aebb87429c91d92c23be7R51-R52) [[2]](diffhunk://#diff-0edbdf0fd3d5ede3c96203c6c3f0ae6eccce91e6802e206833d516aed27c0efcR88-R89) [[3]](diffhunk://#diff-0edbdf0fd3d5ede3c96203c6c3f0ae6eccce91e6802e206833d516aed27c0efcL137-R141) [[4]](diffhunk://#diff-b334b918918b32e21d3fae72f09d3a0f567af35a7b5aebb87429c91d92c23be7L134-R137)
* Updated the `createImageDescriber` factory to instantiate `ImageDescriber_Roma` when the Roma type is requested.
* Added Roma to the list of describer types and descriptions in user-facing documentation and help strings.

**Build System and Type Support**

* Registered Roma source and header files in the CMake build system. [[1]](diffhunk://#diff-50e0abf6e513c10938142b19d38f26ce711d08d7f9bc6c02a8638ed535cd9a9fR15) [[2]](diffhunk://#diff-50e0abf6e513c10938142b19d38f26ce711d08d7f9bc6c02a8638ed535cd9a9fR38)
* Added a `ROMA_Regions` typedef for the Roma feature descriptor type.
* Updated SWIG typemaps and visualization color mapping to support Roma features. [[1]](diffhunk://#diff-d09cc3451e74b2e8bc316043b7110339edc64929dd2ae7b97f594b8bc3656d80R43) [[2]](diffhunk://#diff-9365f0243a8d55f60c114bc688a49f1706f61d4bdb4ebf943eee55d5104b6f12L32-R33)