### PR TITLE
[ci] Acceleration of Linux CI on github

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,6 +29,7 @@ jobs:
         working-directory: ./build
         run: |
           cmake .. \
+           -G Ninja \
            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
            -DBUILD_SHARED_LIBS=ON \
            -DCMAKE_PREFIX_PATH="${DEPS_INSTALL_DIR}" \
@@ -52,18 +53,18 @@ jobs:
       - name: Build
         working-directory: ./build
         run: |
-          make -j$(nproc)
+          cmake --build . -j$(nproc)
 
       - name: Install
         working-directory: ./build
         run: |
-          make install
+          cmake --install .
 
       - name: Unit Tests
         working-directory: ./build
         run: |
           export LD_LIBRARY_PATH=${ALICEVISION_ROOT}/lib:${ALICEVISION_ROOT}/lib64:${DEPS_INSTALL_DIR}/lib64:${DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
-          make test
+          cmake --build . --target test
 
       - name: Build As Third Party
         working-directory: ./build_as_3rdparty
@@ -71,7 +72,7 @@ jobs:
           cmake ../src/software/utils/aliceVisionAs3rdParty \
            -DBUILD_SHARED_LIBS:BOOL=ON \
            -DCMAKE_PREFIX_PATH:PATH="$PWD/../../AV_install;${DEPS_INSTALL_DIR}"
-          make -j$(nproc)
+          cmake --build . -j$(nproc)
 
       - name: Functional Tests - PanoramaFisheyeHdr Pipeline
         working-directory: ./functional_tests

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,6 +18,17 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          # Isolate writes per ref (branch/PR) to reduce cross-PR cache contamination.
+          key: ccache-${{ runner.os }}-rocky9-cuda12.1.1-${{ github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'src/CMakeLists.txt', 'vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/build-linux.yml') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-rocky9-cuda12.1.1-${{ github.ref_name }}-
+            ccache-${{ runner.os }}-rocky9-cuda12.1.1-develop-
+            ccache-${{ runner.os }}-
+          max-size: "1000M"
+
       - name: Prepare File Tree
         run: |
           mkdir ./build
@@ -30,6 +41,8 @@ jobs:
         run: |
           cmake .. \
            -G Ninja \
+           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
            -DBUILD_SHARED_LIBS=ON \
            -DCMAKE_PREFIX_PATH="${DEPS_INSTALL_DIR}" \


### PR DESCRIPTION
This pull request updates the Linux build workflow in `.github/workflows/build-linux.yml` to improve build performance and modernize the build process. The main changes involve introducing `ccache` for faster compilation, switching from `make` to `cmake` build commands, and enabling the Ninja build system.

**Build performance improvements:**
* Added a step to set up `ccache` using the `ccache-action`, and configured CMake to use `ccache` as the compiler launcher for both C and C++ compilers. [[1]](diffhunk://#diff-bfc3aeacfea5c320a79818465fb6d4b9901e2c1fc26af712702cae54db219bdcR21-R26) [[2]](diffhunk://#diff-bfc3aeacfea5c320a79818465fb6d4b9901e2c1fc26af712702cae54db219bdcR38-R40)

**Build system modernization:**
* Switched from the default Makefile generator to the Ninja build system by adding `-G Ninja` to the CMake configuration.
* Replaced all `make` commands with equivalent `cmake --build` and `cmake --install` commands for building, installing, and running tests, ensuring better compatibility with the Ninja generator and a more consistent workflow.