### PR TITLE
Adding new node for triangulation for new pipelines

### DIFF
--- a/meshroom/aliceVision/SfMTriangulating.py
+++ b/meshroom/aliceVision/SfMTriangulating.py
@@ -1,0 +1,71 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class SfMTriangulating(desc.AVCommandLineNode):
+    commandLine = "aliceVision_sfmTriangulating {allParams}"
+    size = desc.DynamicNodeSize("input")
+
+    category = "Sparse Reconstruction"
+    documentation = """
+This node performs keypoint triangulation on its input data.
+Contrary to the StructureFromMotion node, this node does not infer the camera poses, therefore they must be given in the SfMData input.
+"""
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="SfMData",
+            description="SfMData file. Must contain the camera calibration.",
+            value="",
+        ),
+        desc.File(
+            name="tracksFilename",
+            label="Tracks File",
+            description="Tracks file.",
+            value="",
+        ),
+        desc.IntParam(
+            name="minNumberOfObservationsForTriangulation",
+            label="Min Observations For Triangulation",
+            description="Minimum number of observations to triangulate a point.\n"
+                        "Setting it to 3 (or more) reduces drastically the noise in the point cloud.",
+            value=2,
+            range=(2, 10, 1),
+            advanced=True,
+        ),
+        desc.FloatParam(
+            name="minAngleForTriangulation",
+            label="Min Angle For Triangulation",
+            description="Minimum angle for triangulation.",
+            value=3.0,
+            range=(0.1, 10.0, 0.1),
+            advanced=True,
+        ),
+        desc.FloatParam(
+            name="maxTriangulationError",
+            label="Max Triangulation Error",
+            description="Maximum reprojection error in the triangulation process (in pixels).",
+            value=8.0,
+            range=(0.1, 10.0, 0.1),
+            advanced=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="SfMData",
+            description="Path to the output SfMData file.",
+            value="{nodeCacheFolder}/sfm.abc",
+        )
+    ]

--- a/src/software/pipeline/CMakeLists.txt
+++ b/src/software/pipeline/CMakeLists.txt
@@ -269,6 +269,19 @@ if (ALICEVISION_BUILD_SFM)
               Boost::program_options
     )
 
+    # SfM Triangulation
+    alicevision_add_software(aliceVision_sfmTriangulating
+        SOURCE main_sfmTriangulating.cpp
+        FOLDER ${FOLDER_SOFTWARE_PIPELINE}
+        LINKS aliceVision_system
+              aliceVision_cmdline
+              aliceVision_track
+              aliceVision_sfm
+              aliceVision_sfmData
+              aliceVision_sfmDataIO
+              Boost::program_options
+    )
+
     # Global SfM
     alicevision_add_software(aliceVision_globalSfM
         SOURCE main_globalSfM.cpp

--- a/src/software/pipeline/main_sfmTriangulating.cpp
+++ b/src/software/pipeline/main_sfmTriangulating.cpp
@@ -1,0 +1,128 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/cmdline/cmdline.hpp>
+#include <aliceVision/types.hpp>
+#include <aliceVision/system/main.hpp>
+#include <aliceVision/alicevision_omp.hpp>
+#include <aliceVision/sfmDataIO/sfmDataIO.hpp>
+#include <aliceVision/track/trackIO.hpp>
+#include <aliceVision/track/TracksHandler.hpp>
+#include <aliceVision/sfm/pipeline/expanding/SfmTriangulation.hpp>
+
+#include <boost/program_options.hpp>
+
+
+// These constants define the current software version.
+// They must be updated when the command line is changed.
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+
+using namespace aliceVision;
+
+namespace po = boost::program_options;
+
+int aliceVision_main(int argc, char** argv)
+{
+    std::string sfmDataFilename;
+    std::string sfmDataOutputFilename;
+    std::string tracksFilename;
+
+    double minAngleForTriangulation = 1.0;
+    size_t minNbObservationsForTriangulation = 0;
+    double maxTriangulationError = 8.0;
+
+    // clang-format off
+    po::options_description requiredParams("Required parameters");
+    requiredParams.add_options()
+        ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file, must contain the camera calibration.")
+        ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(), "Path to the output SfMData file.")
+        ("tracksFilename,t", po::value<std::string>(&tracksFilename)->required(), "Tracks file.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("maxTriangulationError", po::value<double>(&maxTriangulationError)->default_value(maxTriangulationError), "Maximum reprojection error in the triangulation process (in pixels).")
+        ("minAngleForTriangulation", po::value<double>(&minAngleForTriangulation)->default_value(minAngleForTriangulation), "Minimum angle for triangulation in degrees.")
+        ("minNumberOfObservationsForTriangulation", po::value<std::size_t>(&minNbObservationsForTriangulation)->default_value(minNbObservationsForTriangulation), "Minimum number of observations to triangulate a point.");
+    // clang-format on
+
+    CmdLine cmdline("AliceVision SfM Triangulation");
+    cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
+    if (!cmdline.execute(argc, argv))
+    {
+        return EXIT_FAILURE;
+    }
+
+    // set maxThreads
+    HardwareContext hwc = cmdline.getHardwareContext();
+    omp_set_num_threads(hwc.getMaxThreads());
+
+    // load input SfMData scene
+    sfmData::SfMData sfmData;
+    if(!sfmDataIO::load(sfmData, sfmDataFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    // Load tracks
+    ALICEVISION_LOG_INFO("Load tracks");
+    track::TracksHandler tracksHandler;
+    if (!tracksHandler.load(tracksFilename, sfmData.getValidViews()))
+    {
+        ALICEVISION_LOG_ERROR("The input tracks file '" + tracksFilename + "' cannot be read.");
+        return EXIT_FAILURE;
+    }
+
+    std::set<IndexT> evaluatedTracks;
+    std::map<IndexT, sfmData::Landmark> outputLandmarks;
+    std::mt19937 randomNumberGenerator;
+
+
+    // Effectively triangulate tracks
+    sfm::SfmTriangulation sfmTriangulation(minNbObservationsForTriangulation, maxTriangulationError);
+    if (!sfmTriangulation.process(sfmData, tracksHandler.getAllTracks(), tracksHandler.getTracksPerView(), 
+                            randomNumberGenerator, sfmData.getValidViews(), 
+                            evaluatedTracks, outputLandmarks, false))
+    {
+        ALICEVISION_LOG_ERROR("Triangulation failed.");
+        return EXIT_FAILURE;
+    }
+
+    auto & landmarks = sfmData.getLandmarks();
+    landmarks.clear();
+
+    for (const auto & [landmarkId, outputLandmark] : outputLandmarks)
+    {
+        if (outputLandmark.getObservations().size() < minNbObservationsForTriangulation)
+        {
+            continue;
+        }
+
+        if (!sfm::SfmTriangulation::checkChierality(sfmData, outputLandmark))
+        {
+            continue;
+        }
+
+        double maxAngle = sfm::SfmTriangulation::getMaximalAngle(sfmData, outputLandmark);
+        if (maxAngle < minAngleForTriangulation)
+        {
+            continue;
+        }
+
+        landmarks[landmarkId] = outputLandmark;
+    }
+
+    // Save output
+    if (!sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData::ALL))
+    {
+        ALICEVISION_LOG_ERROR("An error occurred while trying to save '" << sfmDataOutputFilename << "'");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -123,6 +123,19 @@ bool simpleMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sfmData2,
     }
 
     {
+        auto& poses1 = sfmData1.getPoses();
+        auto& poses2 = sfmData2.getPoses();
+        const size_t totalSize = poses1.size() + poses2.size();
+
+        poses1.insert(poses2.begin(), poses2.end());
+        if (poses1.size() < totalSize && !ignoreDuplicates)
+        {
+            ALICEVISION_LOG_ERROR("Unhandled error: common Poses ID between both SfMData");
+            return false;
+        }
+    }
+
+    {
         auto& intrinsics1 = sfmData1.getIntrinsics();
         auto& intrinsics2 = sfmData2.getIntrinsics();
         const size_t totalSize = intrinsics1.size() + intrinsics2.size();

--- a/src/software/utils/main_sfmMerge.cpp
+++ b/src/software/utils/main_sfmMerge.cpp
@@ -414,13 +414,11 @@ bool fromLandmarksMerge(sfmData::SfMData & sfmData1, const sfmData::SfMData & sf
     // Simple merge of intrinsics
     auto& intrinsics1 = sfmData1.getIntrinsics();
     auto& intrinsics2 = sfmData2.getIntrinsics();
-    totalSize = intrinsics1.size() + intrinsics2.size();
     intrinsics1.insert(intrinsics2.begin(), intrinsics2.end());
 
     // Simple merge of poses
     auto& poses1 = sfmData1.getPoses();
     auto& poses2 = sfmData2.getPoses();
-    totalSize = poses1.size() + poses2.size();
     poses1.insert(poses2.begin(), poses2.end());
 
     sfmData1.addFeaturesFolders(sfmData2.getRelativeFeaturesFolders());


### PR DESCRIPTION
This pull request introduces a new SfM Triangulation feature to the AliceVision pipeline. It adds a new command-line tool for triangulating keypoints using existing camera poses, updates the build system to include this tool, and provides a corresponding Meshroom node for integration into workflows. Additionally, it improves the merging logic for SfMData poses to handle duplicates more robustly.

**New SfM Triangulation Feature:**

* Added a new command-line tool `aliceVision_sfmTriangulating` for triangulating keypoints based on existing camera poses, including argument parsing, triangulation logic, and output handling.
* Integrated the new tool into the CMake build system, ensuring it is built with the correct dependencies.
* Implemented a new Meshroom node `SfMTriangulating` in `SfMTriangulating.py` to expose the triangulation functionality to the Meshroom GUI, with configurable parameters for triangulation.

**Improvements to SfMData Merging:**

* Enhanced the `simpleMerge` function to merge pose data from two SfMData objects, checking for duplicate pose IDs and reporting errors if duplicates are found and not ignored.