### PR TITLE
FIX: Add default virtual destructors to various abstract classes

### DIFF
--- a/src/aliceVision/imageProcessing/imageProcessing.hpp
+++ b/src/aliceVision/imageProcessing/imageProcessing.hpp
@@ -28,6 +28,9 @@ namespace imageProcessing {
 class ImageProcess
 {
 public:
+
+    virtual ~ImageProcess() = default;
+
     /**
      * @brief Execute the processing operation in place on the given image.
      * @param[in] sfmData The global SfMData providing scene-wide information (e.g. median exposure).

--- a/src/aliceVision/sfm/bundle/BundleAdjustment.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustment.hpp
@@ -92,6 +92,9 @@ struct TemporalConstraintParams
 class BundleAdjustment
 {
   public:
+
+    virtual ~BundleAdjustment() = default;
+
     /**
      * @brief Defines all the types of parameter adjusted during bundle adjustment.
      */

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicy.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicy.hpp
@@ -19,6 +19,8 @@ public:
     using uptr = std::unique_ptr<ExpansionPolicy>;
 public:
 
+    virtual ~ExpansionPolicy() = default;
+
     /**
      * @brief Initialize policy for an iteration
      * @param sfmData the scene to process

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionPostProcess.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionPostProcess.hpp
@@ -20,6 +20,8 @@ public:
 
 public:
 
+    virtual ~ExpansionPostProcess() = default;
+
     /**
      * @brief Perform post process for an iteration
      * @param sfmData the scene to process

--- a/src/aliceVision/sfm/pipeline/expanding/LbaPolicy.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LbaPolicy.hpp
@@ -21,6 +21,9 @@ public:
     using uptr = std::unique_ptr<LbaPolicy>;
     
 public:
+
+    virtual ~LbaPolicy() = default;
+
     /**
      * @brief Build the policy using a scene
      * @param sfmData the scene to process

--- a/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicy.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/LocalizationValidationPolicy.hpp
@@ -18,6 +18,9 @@ public:
     using uptr = std::unique_ptr<LocalizationValidationPolicy>;
 
 public:
+
+    virtual ~LocalizationValidationPolicy() = default;
+
     /**
      * @brief A function to validate the result of the Ransac process using N inputs
      * @param intrinsic the intrinsic used for the resection


### PR DESCRIPTION
The missing virtual dtors caused a `SIGTRAP` on macOS. Calling `delete` on abstract classes is UB, which is hereby removed. I suspect that the `SIGTRAP` is caused by a memory alignment mismatch because the wrong dtor is running.

Additionally silences a bunch of warnings emitted by Clang.
