### PR TITLE
FIX: Remove nullptr dereference from aliceVision_multiview

### DIFF
--- a/src/aliceVision/multiview/triangulation/TriangulationSphericalKernel.hpp
+++ b/src/aliceVision/multiview/triangulation/TriangulationSphericalKernel.hpp
@@ -109,7 +109,10 @@ public:
         sampledPts.push_back(_lifted[idx]);
     }
 
-    _solver.solve(sampledPts, sampledMats, models, *weights);
+    if(weights != nullptr)
+        _solver.solve(sampledPts, sampledMats, models, *weights);
+    else
+        _solver.solve(sampledPts, sampledMats, models);
   }
 
 


### PR DESCRIPTION
There is a guaranteed nullptr dereference in aliceVision_multiview, because `TriangulationSphericalKernel::fitLS()` is at least called once with the default `nullptr` argument (from `iterativeReweightedLeastSquares()` and `localOptimization()`), which is unconditionally dereferenced.

While not always causing an invalid access, it is UB and was identified as such by LLVM UBSanitizer. If we pass down the pointer to the very end, it is properly null-checked.