### PR TITLE
[sfmData] Add `camera_focal` metadata key for focal length detection

### DIFF
--- a/src/aliceVision/sfmData/ImageInfo.cpp
+++ b/src/aliceVision/sfmData/ImageInfo.cpp
@@ -398,7 +398,7 @@ int ImageInfo::getSensorSize(const std::vector<sensorDB::Datasheet>& sensorDatab
 
 double ImageInfo::getMetadataFocalLength() const
 {
-    double focalLength = getDoubleMetadata({"Exif:FocalLength", "focalLength", "focal length", "lens_focal_length", "focal_length"});
+    double focalLength = getDoubleMetadata({"Exif:FocalLength", "focalLength", "focal length", "lens_focal_length", "focal_length", "camera_focal"});
 
     if (focalLength == -1)
     {


### PR DESCRIPTION
## Description

This PR adds `camera_focal` to the list of keys that the images' metadata are searched with when attempting to retrieve the focal length. (seen on ALEXA 35 cameras)