### PR TITLE
Add Sonarqube to GitHub CI

### DIFF
--- a/.github/workflows/build-sonarqube.yml
+++ b/.github/workflows/build-sonarqube.yml
@@ -1,0 +1,84 @@
+name: Build Linux
+
+on:
+  workflow_call:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: "alicevision/alicevision-deps:2026.03.30-rocky9-cuda12.1.1"
+    env:
+      DEPS_INSTALL_DIR: /opt/AliceVision_install
+      BUILD_TYPE: Release
+      CTEST_OUTPUT_ON_FAILURE: 1
+      ALICEVISION_ROOT: ${{ github.workspace }}/../AV_install
+      ALICEVISION_SENSOR_DB: ${{ github.workspace }}/../AV_install/share/aliceVision/cameraSensors.db
+      ALICEVISION_LENS_PROFILE_INFO: ""
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          # Isolate writes per ref (branch/PR) to reduce cross-PR cache contamination.
+          key: ccache-${{ runner.os }}-sonarqube-${{ github.ref_name }}-${{ hashFiles('CMakeLists.txt', 'src/CMakeLists.txt', 'vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/build-linux.yml') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-sonarqube-${{ github.ref_name }}-
+            ccache-${{ runner.os }}-sonarqube-develop-
+            ccache-${{ runner.os }}-
+          max-size: "1000M"
+
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7.1
+
+      - name: Prepare File Tree
+        run: |
+          mkdir ./build
+          mkdir ../AV_install
+          mkdir -p ${{ github.workspace }}/bw-output
+          mkdir -p ${{ github.workspace }}/analysisCache
+
+      - name: Cache SonarCloud CFamily (incremental analysis)
+        uses: actions/cache@v4
+        with:
+          path: /root/.sonar/cache
+          key: ${{ runner.os }}-cfamily-${{ hashFiles('src/**/*.cpp', 'src/**/*.hpp', '**/CMakeLists.txt') }}
+          restore-keys: ${{ runner.os }}-cfamily-
+
+      - name: Configure CMake
+        working-directory: ./build
+        run: |
+          cmake .. \
+           -G Ninja \
+           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+           -DBUILD_SHARED_LIBS=ON \
+           -DCMAKE_PREFIX_PATH="${DEPS_INSTALL_DIR}" \
+           -DCMAKE_INSTALL_PREFIX="${ALICEVISION_ROOT}" \
+           -DTARGET_ARCHITECTURE=core \
+           -DALICEVISION_BUILD_TESTS=OFF \
+           -DALICEVISION_BUILD_SWIG_BINDING=OFF \
+           -DALICEVISION_USE_OPENCV=ON \
+           -DALICEVISION_USE_CUDA=OFF \
+           -DALICEVISION_USE_CCTAG=OFF \
+           -DALICEVISION_USE_POPSIFT=OFF \
+           -DALICEVISION_USE_ALEMBIC=ON \
+           -DALICEVISION_USE_USD=ON \
+           -DOpenCV_DIR="${DEPS_INSTALL_DIR}/share/OpenCV" \
+           -DCeres_DIR="${DEPS_INSTALL_DIR}/share/Ceres" \
+           -DAlembic_DIR="${DEPS_INSTALL_DIR}/lib/cmake/Alembic" 
+
+      - name: Build
+        working-directory: ./build
+        run: |
+          build-wrapper-linux-x86-64 --out-dir ${{ github.workspace }}/bw-output cmake --build . -j$(nproc)
+        
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            --define sonar.cfamily.compile-commands=${{ github.workspace }}/bw-output/compile_commands.json

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - bits/macos-infra-v2
     # Skip jobs when only documentation files are changed
     paths-ignore:
       - '**.md'
@@ -26,4 +25,8 @@ jobs:
 
   build-windows:
     uses: ./.github/workflows/build-windows.yml
+    secrets: inherit
+
+  build-sonarqube:
+    uses: ./.github/workflows/build-sonarqube.yml
     secrets: inherit

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=alicevision_AliceVision
+sonar.organization=alicevision
+
+sonar.projectName=AliceVision
+sonar.projectVersion=1.0
+
+# Source & test directories
+sonar.sources=src
+
+# Exclusions
+sonar.exclusions=**/build/**,**/third_party/**,**/*.pb.cc,**/*.pb.h
+
+# Cache for faster analysis
+sonar.cfamily.cache.enabled=true
+sonar.cfamily.analysisCache.mode=fs 
+sonar.cfamily.analysisCache.path=/root/.sonar/cache 
+sonar.cfamily.threads=4
+
+#sonar.verbose=true


### PR DESCRIPTION
This pull request adds SonarQube static analysis integration to the CI pipeline. It introduces a new workflow for building and analyzing the project with SonarQube, updates the main CI workflow to include this new job, and adds a configuration file for SonarQube analysis.

**SonarQube Integration:**

* Added a new workflow file (`.github/workflows/build-sonarqube.yml`) to build the project in a Linux container and run SonarQube analysis, including caching and build wrapper setup.
* Added a SonarQube configuration file (`sonar-project.properties`) specifying project metadata, source directories, exclusions, and CFamily analysis options.

**CI Workflow Updates:**

* Updated `.github/workflows/continuous-integration.yml` to call the new `build-sonarqube` workflow as part of the CI jobs.
* Removed a branch-specific filter (`bits/macos-infra-v2`) from the CI workflow triggers to simplify branch targeting.