### PR TITLE
Apply distance weighting for observations

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -286,6 +286,12 @@ Bundle adjustment is performed periodically to refine all camera poses and 3D po
             description="Bundle adjustment will try to optimize the landmarks positions.",
             value=True,
         ),
+        desc.BoolParam(
+            name="enableObservationsWeighting",
+            label="Enable observations weighting",
+            description="Enable observations weighting to reduce impact of regions with high point density.",
+            value=False,
+        ),
         desc.IntParam(
             name="minNbCamerasToRefinePrincipalPoint",
             label="Min Nb Cameras To Refine Principal Point",

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -81,6 +81,7 @@ set(sfm_files_sources
     pipeline/expanding/SfmTriangulation.cpp
     pipeline/expanding/SfmResection.cpp
     pipeline/expanding/SfmBundle.cpp
+    pipeline/expanding/DistanceWeighting.cpp
     pipeline/expanding/ExpansionHistory.cpp
     pipeline/expanding/ExpansionChunk.cpp
     pipeline/expanding/ExpansionIteration.cpp
@@ -136,6 +137,7 @@ alicevision_add_library(aliceVision_sfm
         Boost::boost
     PRIVATE_LINKS
         ${LEMON_LIBRARY}
+        nanoflann::nanoflann
 )
 
 # Unit tests

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -625,6 +625,12 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                 _linearSolverOrdering.AddElementToGroup(distortionBlockPtr, 2);
             }
 
+            ceres::LossFunction* weightedLossFunction = lossFunction;
+            if (observation.getWeight() != 1.0)
+            {
+                weightedLossFunction = new ceres::ScaledLoss(lossFunction, observation.getWeight(), ceres::TAKE_OWNERSHIP);
+            }
+
             if (view.isPartOfRig() && !view.isPoseIndependant())
             {
                 ceres::CostFunction* costFunction = ProjectionErrorFunctor::createCostFunction(intrinsic, observation);
@@ -639,7 +645,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                 params.push_back(rigBlockPtr);
                 params.push_back(landmarkBlockPtr);
 
-                ceres::ResidualBlockId blockId = problem.AddResidualBlock(costFunction, lossFunction, params);
+                ceres::ResidualBlockId blockId = problem.AddResidualBlock(costFunction, weightedLossFunction, params);
                 blockIds.push_back(blockId);
             }
             else if (referencePoseBlockPtr != nullptr)
@@ -657,7 +663,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                 }
                 params.push_back(landmarkBlockPtr);
 
-                ceres::ResidualBlockId blockId = problem.AddResidualBlock(costFunction, lossFunction, params);
+                ceres::ResidualBlockId blockId = problem.AddResidualBlock(costFunction, weightedLossFunction, params);
                 blockIds.push_back(blockId);
             }
             else
@@ -670,7 +676,7 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
                 params.push_back(poseBlockPtr);
                 params.push_back(landmarkBlockPtr);
 
-                ceres::ResidualBlockId blockId = problem.AddResidualBlock(costFunction, lossFunction, params);
+                ceres::ResidualBlockId blockId = problem.AddResidualBlock(costFunction, weightedLossFunction, params);
                 blockIds.push_back(blockId);
             }
 

--- a/src/aliceVision/sfm/pipeline/expanding/DistanceWeighting.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/DistanceWeighting.cpp
@@ -1,0 +1,118 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/sfm/pipeline/expanding/DistanceWeighting.hpp>
+#include "nanoflann.hpp"
+
+#include <algorithm>
+#include <numeric>
+#include <cmath>
+
+namespace aliceVision {
+namespace sfm {
+
+struct PointCloud2D
+{
+    std::vector<sfmData::Observation *> pts;
+
+    // ── mandatory nanoflann interface ──────────
+
+    // Total number of points
+    inline size_t kdtree_get_point_count() const { return pts.size(); }
+
+    // Value of the d-th coordinate of the i-th point
+    inline double kdtree_get_pt(const size_t idx, const size_t dim) const
+    {
+        return dim == 0 ? pts[idx]->getX() : pts[idx]->getY();
+    }
+
+    // Optional bounding-box computation (return false = let nanoflann compute it)
+    template <class BBOX>
+    bool kdtree_get_bbox(BBOX&) const { return false; }
+};
+
+bool weightObservationsFromDistance(sfmData::SfMData & sfmData, size_t neighboorRank, double ratioDefaultArea)
+{
+    const int K = static_cast<int>(neighboorRank);
+
+    sfmData::Landmarks & landmarks = sfmData.getLandmarks();
+
+    std::map<IndexT, PointCloud2D> perViewObservations;
+
+    // Make list of landmark per view
+    for (auto & [_, landmark] : landmarks)
+    {
+        for (auto & [idView, obs] : landmark.getObservations())
+        {
+            perViewObservations[idView].pts.push_back(&obs);
+        }
+    }
+
+    // Loop per view
+    for (auto & [idView, pointCloud] : perViewObservations)
+    {
+        int N = pointCloud.pts.size();
+
+        if (N == 0)
+        {
+            continue;
+        }
+
+        const sfmData::View & v = sfmData.getView(idView);
+        const double viewArea = v.getImage().getWidth() * v.getImage().getHeight();
+
+
+        // average area per feature
+        const double featArea = viewArea / N;
+        const double minSqDist = 1.0;
+        const double maxSqDist = ratioDefaultArea * featArea;
+
+        if (N < 10)
+        {
+            for (size_t i = 0; i < N; ++i)
+            {
+                pointCloud.pts[i]->setWeight(1.0);
+            }
+            continue;
+        }
+
+        using KDTree2D = nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, PointCloud2D>, PointCloud2D, 2>;
+
+        KDTree2D index(2, pointCloud, nanoflann::KDTreeSingleIndexAdaptorParams(10));
+        index.buildIndex();
+
+        std::vector<double> knnSquaredDistance(N);
+
+        // Find the distance to the Kth nearest neighbor
+        #pragma omp parallel
+        {
+            std::vector<unsigned int> indices(K);
+            std::vector<double> sq_dists(K);
+
+            #pragma omp for schedule(static)
+            for (size_t i = 0; i < N; ++i)
+            {
+                const double query[2] = { pointCloud.pts[i]->getX(), pointCloud.pts[i]->getY() };
+                index.knnSearch(query, K, indices.data(), sq_dists.data());
+                knnSquaredDistance[i] = std::clamp(sq_dists[K - 1], minSqDist, maxSqDist);
+            }
+        }
+
+        // Normalize so the mean is 1 (overall influence is 1).what is
+        const double meanNormalizedDistance = std::accumulate(knnSquaredDistance.begin(), knnSquaredDistance.end(), 0.0) / static_cast<double>(N);
+
+        for (size_t i = 0; i < N; ++i)
+        {
+            knnSquaredDistance[i] /= meanNormalizedDistance;
+            pointCloud.pts[i]->setWeight(knnSquaredDistance[i]);
+        }
+    }
+
+    return true;
+}
+
+}
+}

--- a/src/aliceVision/sfm/pipeline/expanding/DistanceWeighting.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/DistanceWeighting.hpp
@@ -1,0 +1,32 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfmData/SfMData.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+/**
+ * @brief Weight observations based on their spatial distribution in the image.
+ * Points that are in sparse areas (far from their neighbors) get a higher weight,
+ * while points in dense clusters get a lower weight. This helps to balance the
+ * influence of features across the image.
+ *
+ * The weight is calculated based on the squared distance to the K-th nearest neighbor (neighboorRank),
+ * clamped to a maximum area (ratioDefaultArea * averageFeatureArea).
+ * Weights are normalized per view so that their mean is 1.0.
+ *
+ * @param[in,out] sfmData The SfM data containing views and landmarks to be weighted.
+ * @param[in] neighboorRank The rank (K) of the neighbor to use for distance calculation.
+ * @param[in] ratioDefaultArea Multiplier for clamping the maximum area to consider for a point.
+ * @return True if successful.
+ */
+bool weightObservationsFromDistance(sfmData::SfMData & sfmData, size_t neighboorRank, double ratioDefaultArea);
+
+}
+}

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -9,7 +9,9 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/sfm/sfmFilters.hpp>
 #include <aliceVision/sfm/utils/poseFilter.hpp>
+#include <aliceVision/sfm/sfmStatistics.hpp>
 #include <aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp>
+#include <aliceVision/sfm/pipeline/expanding/DistanceWeighting.hpp>
 
 namespace aliceVision {
 namespace sfm {
@@ -51,6 +53,11 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
     //Repeat until nothing change
     do
     {
+        // Compute statistics on residuals
+        double mean, median;
+        computeResidualsMeanMedian(sfmData, mean, median);
+        ALICEVISION_LOG_INFO("SfmBundle statistics before minimization - mean " << mean << ", median " << median);
+
         if (!initializeIteration(sfmData, tracksHandler, viewIds))
         {
             return false;
@@ -61,6 +68,9 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
         {
             return false;
         }
+
+        computeResidualsMeanMedian(sfmData, mean, median);
+        ALICEVISION_LOG_INFO("SfmBundle statistics after minimization - mean " << mean << ", median " << median);
     }
     while (cleanup(sfmData));
 
@@ -119,6 +129,11 @@ bool SfmBundle::initializeIteration(sfmData::SfMData & sfmData, const track::Tra
     else
     {
         sfmData.resetParameterStates();
+    }
+
+    if (_enableObservationsWeighting)
+    {
+        weightObservationsFromDistance(sfmData, 15, 5.0);
     }
 
     return true;

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
@@ -88,6 +88,15 @@ public:
     }
 
     /**
+     * @brief Set whether to enable weighting of observations
+     * @param flag true to enable observations weighting, false to disable it
+    */
+    void setIsObservationsWeightingEnabled(bool flag)
+    {
+        _enableObservationsWeighting = flag;
+    }
+
+    /**
      * @brief Get the number of valid points per pose required
      * @return the threshold used to discriminate a valid pose
     */
@@ -141,6 +150,7 @@ private:
     size_t _LBAGraphDistanceLimit = 1;
     size_t _LBAMinNbOfMatches = 50;
     bool _isStructureRefinementEnabled = true;
+    bool _enableObservationsWeighting = false;
 };
 
 } // namespace sfm

--- a/src/aliceVision/sfm/sfmStatistics.cpp
+++ b/src/aliceVision/sfm/sfmStatistics.cpp
@@ -73,6 +73,51 @@ void computeResidualsHistogram(const sfmData::SfMData& sfmData,
     }
 }
 
+void computeResidualsMeanMedian(const sfmData::SfMData& sfmData,
+                            double & mean,
+                            double & median,
+                            const std::set<IndexT>& specificViews)
+{
+    mean = 0;
+    median = 0;
+
+    if (sfmData.getLandmarks().empty())
+    {
+        return;
+    }
+
+    // Collect residuals for each observation
+    std::vector<double> vecResiduals;
+    vecResiduals.reserve(sfmData.getLandmarks().size());
+
+    for (const auto& track : sfmData.getLandmarks())
+    {
+        const aliceVision::sfmData::Observations& observations = track.second.getObservations();
+        for (const auto& obs : observations)
+        {
+            if (!specificViews.empty() && specificViews.count(obs.first) == 0)
+            {
+                continue;
+            }
+
+            const sfmData::View& view = sfmData.getView(obs.first);
+            const aliceVision::geometry::Pose3 pose = sfmData.getPose(view).getTransform();
+            const aliceVision::camera::IntrinsicBase& intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
+            const Vec2 residual = intrinsic.residual(pose, track.second.getX().homogeneous(), obs.second.getCoordinates());
+            vecResiduals.push_back(residual.norm());
+        }
+    }
+
+    if (vecResiduals.empty())
+    {
+        return;
+    }
+
+    BoxStats<double> stats(vecResiduals.begin(), vecResiduals.end());
+    mean = stats.mean;
+    median = stats.median;
+}
+
 void computeObservationsLengthsHistogram(const sfmData::SfMData& sfmData,
                                          BoxStats<double>& outStats,
                                          int& overallNbObservations,

--- a/src/aliceVision/sfm/sfmStatistics.hpp
+++ b/src/aliceVision/sfm/sfmStatistics.hpp
@@ -30,6 +30,18 @@ void computeResidualsHistogram(const sfmData::SfMData& sfmData,
                                const std::set<IndexT>& specificViews = std::set<IndexT>());
 
 /**
+ * @brief Compute histogram of residual values between landmarks and features in all the views specified
+ * @param[in] sfmData : scene containing the features and the landmarks
+ * @param[in] specificViews: Limit stats to specific views. If empty, compute stats for all views.
+ * @param[out] mean : mean of residuals
+ * @param[out] median : median of residuals
+ */
+void computeResidualsMeanMedian(const sfmData::SfMData& sfmData,
+                            double & mean,
+                            double & median,
+                            const std::set<IndexT>& specificViews = std::set<IndexT>());
+
+/**
  * @brief Compute histogram of observations lengths
  * @param[in] sfmData: containing the observations
  * @param[out] out_stats: stats containing the observations lengths

--- a/src/aliceVision/sfmData/Observation.hpp
+++ b/src/aliceVision/sfmData/Observation.hpp
@@ -103,6 +103,18 @@ class Observation
     void setScale(double scale) { _scale = scale; }
 
     /**
+    * @brief Get the weight of the feature
+    * @return the weight of the feature
+    */
+    double getWeight() const { return _weight; }
+
+    /**
+    * @brief Set the weight of the feature
+    * @param weight a custom weight depending on the context or choice
+    */
+    void setWeight(double weight) { _weight = weight; }
+
+    /**
     * @brief Get the measured depth (Depth meaning is camera type dependent)
     * @return The optional measured depth, or less than 0 if non used
     */
@@ -119,6 +131,7 @@ class Observation
     Vec2 _coordinates = { 0.0, 0.0 };
     IndexT _idFeature = UndefinedIndexT;
     double _scale = 0.0;
+    double _weight = 1.0;
 
     //Optional measured 'depth'
     double _depth = -1.0;

--- a/src/cmake/DependenciesVersions.cmake
+++ b/src/cmake/DependenciesVersions.cmake
@@ -135,7 +135,7 @@ set(DEP_FLANN_GIT_REPO "https://github.com/alicevision/flann")
 set(DEP_FLANN_GIT_TAG  "46e72429ef60ce9c413fa926ac7729f8dee96395")
 
 set(DEP_NANOFLANN_GIT_REPO "https://github.com/jlblancoc/nanoflann")
-set(DEP_NANOFLANN_GIT_TAG  "419c26c498d12231817ada6488e2fd2442dbc68d")
+set(DEP_NANOFLANN_GIT_TAG  "92911c0bc382e4b287330219bc720ca2b30b2857")
 
 set(DEP_COINUTILS_GIT_REPO "https://github.com/alicevision/CoinUtils")
 set(DEP_COINUTILS_GIT_TAG  "b29532e31471d26dddee99095da3340e80e8c60c")

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -68,6 +68,7 @@ int aliceVision_main(int argc, char** argv)
     int weakResectionSize = 100;
     bool enableDepthPrior = true;
     bool ignoreMultiviewOnPrior = false;
+    bool enableObservationsWeighting = false;
 
     int randomSeed = std::mt19937::default_seed;
 
@@ -129,6 +130,7 @@ int aliceVision_main(int argc, char** argv)
          "If minNbCamerasToRefinePrincipalPoint==1, the principal point is always refined.")
     ("useRigConstraint", po::value<bool>(&useRigConstraint)->default_value(useRigConstraint), "Enable/Disable rig constraint.")
     ("rigMinNbCamerasForCalibration", po::value<int>(&minNbCamerasForRigCalibration)->default_value(minNbCamerasForRigCalibration),"Minimal number of cameras to start the calibration of the rig.")
+    ("enableObservationsWeighting", po::value<bool>(&enableObservationsWeighting)->default_value(enableObservationsWeighting), "Enable observations weighting to reduce impact of regions with high point density.")
     ("meshFilename,t", po::value<std::string>(&meshFilename)->default_value(meshFilename), "Mesh file.");
     ;
      // clang-format on
@@ -211,6 +213,7 @@ int aliceVision_main(int argc, char** argv)
     sfmBundle->setMinNbCamerasToRefinePrincipalPoint(minNbCamerasToRefinePrincipalPoint);
     sfmBundle->setIsStructureRefinementEnabled(enableStructureRefinement);
     sfmBundle->setTemporalConstraintParams(tempConstrParams, useTemporalConstraint);
+    sfmBundle->setIsObservationsWeightingEnabled(enableObservationsWeighting);
 
     sfmData::PointFetcher::sptr pointFetcherHandler;
     if (!meshFilename.empty())


### PR DESCRIPTION
This pull request introduces an option to enable per-observation weighting in the SfM expanding pipeline to reduce the impact of high-density regions in images. The main changes add a new parameter and command-line option, implement the observation weighting algorithm, and propagate the weights through the bundle adjustment process. This helps to improve the robustness of reconstruction in scenes with uneven feature distributions.

**Observation Weighting Feature:**
* Added a new parameter `enableObservationsWeighting` to the `SfMExpanding` node and exposed it as a command-line option in `main_sfmExpanding.cpp` to allow users to enable or disable observation weighting. [[1]](diffhunk://#diff-b36f82a55bf559f41f08693e937a475c92ba4afd6f83c9b2e3ecde2de7c06843R279-R284) [[2]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R71) [[3]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R133)
* Implemented the observation weighting algorithm in the new files `DistanceWeighting.cpp` and `DistanceWeighting.hpp`, which computes weights for each observation based on local 2D feature density using k-NN and normalizes them. [[1]](diffhunk://#diff-fe3d0a107beb7d43f2c84cef47568756792b19164208e4fad7ff93023210c4e5R1-R132) [[2]](diffhunk://#diff-c9af0ae2ee7b0aa0c473eeea28440a856963a9609912c9c9da9fd75b6c25d2b8R1-R27)
* Integrated the weighting algorithm into the SfM pipeline by calling it from `SfmBundle` when enabled, and added support for toggling this feature via the `SfmBundle` API and internal state. [[1]](diffhunk://#diff-096633d8d9d01c7d41501b6d3c0ec2ad9fb599a6167bad9123d7e69483ce759aR13) [[2]](diffhunk://#diff-096633d8d9d01c7d41501b6d3c0ec2ad9fb599a6167bad9123d7e69483ce759aR125-R129) [[3]](diffhunk://#diff-96a08aeb5178f0dbeeccdb2f60f6481b7ede09373e813cfe0397072b67240b7fR90-R98) [[4]](diffhunk://#diff-96a08aeb5178f0dbeeccdb2f60f6481b7ede09373e813cfe0397072b67240b7fR153) [[5]](diffhunk://#diff-91ab4967395b79f6a5e79bea841df6869765340d772ec31cfbd32091057bb4e2R216)

**Propagation and Usage of Weights:**
* Extended the `Observation` class to store and access a per-feature weight, defaulting to 1.0. [[1]](diffhunk://#diff-6e6e1aa61b5c7be0bf22db46a261550fd4b65b4a9dcb1b414555683324d934d8R105-R116) [[2]](diffhunk://#diff-6e6e1aa61b5c7be0bf22db46a261550fd4b65b4a9dcb1b414555683324d934d8R134)
* Modified the bundle adjustment cost function (`intrinsicsProject.hpp`) to scale residuals and Jacobians by the square root of the observation weight, ensuring that weighted observations influence optimization appropriately.

**Dependencies and Build System:**
* Added `DistanceWeighting.cpp` to the CMake build and linked the `nanoflann` library, updating the nanoflann dependency version for k-NN search. [[1]](diffhunk://#diff-50e7fbc9016bb0b9a8dd173a6937d28a10a4b4c50dd20686b9ca7213c62f07e5R84) [[2]](diffhunk://#diff-50e7fbc9016bb0b9a8dd173a6937d28a10a4b4c50dd20686b9ca7213c62f07e5R140) [[3]](diffhunk://#diff-06679445fcf62f2a5c1fa9bc51288af1a69d2653ec3df4288ed3dd343b2efb03L138-R138)

These changes collectively add robust support for observation weighting in the SfM expanding pipeline, improving results in challenging scenarios with non-uniform feature distributions.