### PR TITLE
sfm : Refining center instead of translation

### DIFF
--- a/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
+++ b/src/aliceVision/multiview/resection/resectionLORansac_test.cpp
@@ -65,7 +65,7 @@ bool refinePoseAsItShouldbe(const Mat& pt3D,
     BundleAdjustmentCeres bundle_adjustment_obj;
     BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_NONE;
     if (b_refine_pose)
-        refineOptions |= sfm::BundleAdjustment::REFINE_ROTATION | sfm::BundleAdjustment::REFINE_TRANSLATION;
+        refineOptions |= sfm::BundleAdjustment::REFINE_ROTATION | sfm::BundleAdjustment::REFINE_CENTER;
     if (b_refine_intrinsic)
         refineOptions |= sfm::BundleAdjustment::REFINE_INTRINSICS_ALL;
     const bool b_BA_Status = bundle_adjustment_obj.adjust(sfm_data, refineOptions);

--- a/src/aliceVision/sfm/bundle/BundleAdjustment.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustment.hpp
@@ -112,7 +112,7 @@ class BundleAdjustment
     {
         REFINE_NONE = 0,
         REFINE_ROTATION = 1,                                  //< refine pose rotations
-        REFINE_TRANSLATION = 2,                               //< refine pose translations
+        REFINE_CENTER = 2,                                    //< refine pose centers
         REFINE_STRUCTURE = 4,                                 //< refine structure (i.e. 3D points)
         REFINE_INTRINSICS_FOCAL = 8,                          //< refine the focal length
         REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS = 16,          //< refine the optical offset from the center
@@ -123,7 +123,7 @@ class BundleAdjustment
         /// Refine all intrinsics parameters
         REFINE_INTRINSICS_ALL = REFINE_INTRINSICS_FOCAL | REFINE_INTRINSICS_OPTICALOFFSET_IF_ENOUGH_DATA | REFINE_INTRINSICS_DISTORTION,
         /// Refine all parameters
-        REFINE_ALL = REFINE_ROTATION | REFINE_TRANSLATION | REFINE_INTRINSICS_ALL | REFINE_STRUCTURE,
+        REFINE_ALL = REFINE_ROTATION | REFINE_CENTER | REFINE_INTRINSICS_ALL | REFINE_STRUCTURE,
     };
 
     /**

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -226,21 +226,21 @@ void BundleAdjustmentCeres::addExtrinsicsToProblem(const sfmData::SfMData& sfmDa
                                                    BundleAdjustment::ERefineOptions refineOptions,
                                                    ceres::Problem& problem)
 {
-    const bool refineTranslation = refineOptions & BundleAdjustment::REFINE_TRANSLATION;
+    const bool refineCenter = refineOptions & BundleAdjustment::REFINE_CENTER;
     const bool refineRotation = refineOptions & BundleAdjustment::REFINE_ROTATION;
 
     const auto addPose = [&](const sfmData::CameraPose& cameraPose, bool isConstant, std::array<double, 6>& poseBlock) {
         const Mat3& R = cameraPose.getTransform().rotation();
-        const Vec3& t = cameraPose.getTransform().translation();
+        const Vec3& c = cameraPose.getTransform().center();
 
         double angleAxis[3];
         ceres::RotationMatrixToAngleAxis(static_cast<const double*>(R.data()), angleAxis);
         poseBlock.at(0) = angleAxis[0];
         poseBlock.at(1) = angleAxis[1];
         poseBlock.at(2) = angleAxis[2];
-        poseBlock.at(3) = t(0);
-        poseBlock.at(4) = t(1);
-        poseBlock.at(5) = t(2);
+        poseBlock.at(3) = c(0);
+        poseBlock.at(4) = c(1);
+        poseBlock.at(5) = c(2);
 
         double* poseBlockPtr = poseBlock.data();
         problem.AddParameterBlock(poseBlockPtr, 6);
@@ -249,7 +249,7 @@ void BundleAdjustmentCeres::addExtrinsicsToProblem(const sfmData::SfMData& sfmDa
         _allParametersBlocks.push_back(poseBlockPtr);
 
         // keep the camera extrinsics constants
-        if (cameraPose.isLocked() || isConstant || (!refineTranslation && !refineRotation))
+        if (cameraPose.isLocked() || isConstant || (!refineCenter && !refineRotation))
         {
             // set the whole parameter block as constant.
             _statistics.addState(EParameter::POSE, EEstimatorParameterState::CONSTANT);
@@ -269,7 +269,7 @@ void BundleAdjustmentCeres::addExtrinsicsToProblem(const sfmData::SfMData& sfmDa
         }
 
         // don't refine translations
-        if (!refineTranslation)
+        if (!refineCenter)
         {
             constantExtrinsic.push_back(3);
             constantExtrinsic.push_back(4);
@@ -1095,7 +1095,7 @@ void BundleAdjustmentCeres::resetProblem()
 
 void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefineOptions refineOptions) const
 {
-    const bool refinePoses = (refineOptions & REFINE_ROTATION) || (refineOptions & REFINE_TRANSLATION);
+    const bool refinePoses = (refineOptions & REFINE_ROTATION) || (refineOptions & REFINE_CENTER);
     const bool refineIntrinsicsOpticalCenter =
       (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_ALWAYS) || (refineOptions & REFINE_INTRINSICS_OPTICALOFFSET_IF_ENOUGH_DATA);
     const bool refineIntrinsics =
@@ -1130,10 +1130,11 @@ void BundleAdjustmentCeres::updateFromSolution(sfmData::SfMData& sfmData, ERefin
 
                 Mat3 R_refined;
                 ceres::AngleAxisToRotationMatrix(subPoseBlock.data(), R_refined.data());
-                const Vec3 t_refined(subPoseBlock.at(3), subPoseBlock.at(4), subPoseBlock.at(5));
+                const Vec3 c_refined(subPoseBlock.at(3), subPoseBlock.at(4), subPoseBlock.at(5));
 
                 // update the sub-pose
-                subPose.pose = poseFromRT(R_refined, t_refined);
+                subPose.pose.setRotation(R_refined);
+                subPose.pose.setCenter(c_refined);
             }
         }
     }

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
@@ -261,7 +261,7 @@ class BundleAdjustmentCeres : public BundleAdjustment, ceres::EvaluationCallback
     /// all parameters blocks pointers
     std::vector<double*> _allParametersBlocks;
     /// poses blocks wrapper
-    /// block: ceres angleAxis(3) + translation(3)
+    /// block: ceres angleAxis(3) + center(3)
     std::map<IndexT, std::array<double, 6>> _posesBlocks;  // TODO : maybe we can use boost::flat_map instead of std::map ?
     /// intrinsics blocks wrapper
     /// block: intrinsics params

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_Enhanced_test.cpp
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(test_poses)
         }
 
         sfm::BundleAdjustmentCeres::CeresOptions options;
-        sfm::BundleAdjustment::ERefineOptions refineOptions = sfm::BundleAdjustment::REFINE_ROTATION | sfm::BundleAdjustment::REFINE_TRANSLATION;
+        sfm::BundleAdjustment::ERefineOptions refineOptions = sfm::BundleAdjustment::REFINE_ROTATION | sfm::BundleAdjustment::REFINE_CENTER;
         options.summary = false;
 
         double rmseBefore = sfm::RMSE(sfmData);

--- a/src/aliceVision/sfm/bundle/bundleAdjustment_temporalConstraint_test.cpp
+++ b/src/aliceVision/sfm/bundle/bundleAdjustment_temporalConstraint_test.cpp
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(BA_temporalConstraint)
     sfm::BundleAdjustment::ERefineOptions refineOptions;
     refineOptions = sfm::BundleAdjustment::REFINE_ROTATION
                   | sfm::BundleAdjustment::REFINE_STRUCTURE
-                  | sfm::BundleAdjustment::REFINE_TRANSLATION
+                  | sfm::BundleAdjustment::REFINE_CENTER
                   | sfm::BundleAdjustment::REFINE_INTRINSICS_ALL;
     options.summary = false;
 

--- a/src/aliceVision/sfm/bundle/costfunctions/depth.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/depth.hpp
@@ -32,14 +32,16 @@ struct DepthErrorFunctor
         // Apply external parameters (Pose)
         //--
         const T* cam_R = parameter_pose;
-        const T* cam_t = &parameter_pose[3];
+        const T* cam_c = &parameter_pose[3];
         
+        T centeredPoint[3];
+        centeredPoint[0] = parameter_point[0] - cam_c[0];
+        centeredPoint[1] = parameter_point[1] - cam_c[1];
+        centeredPoint[2] = parameter_point[2] - cam_c[2];
+
         T transformedPoint[3];
         // Rotate the point according the camera rotation
-        ceres::AngleAxisRotatePoint(cam_R, parameter_point, transformedPoint);
-
-        // Apply the camera translation
-        transformedPoint[2] += cam_t[2];
+        ceres::AngleAxisRotatePoint(cam_R, centeredPoint, transformedPoint);
 
         residuals[0] = T(1.0 / _depthVariance) * (transformedPoint[2] - T(_depth));
 

--- a/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/projection.hpp
@@ -40,16 +40,16 @@ struct ProjectionSimpleErrorFunctor
         // Apply external parameters (Pose)
         //--
         const T* cam_R = parameter_pose;
-        const T* cam_t = &parameter_pose[3];
+        const T* cam_c = &parameter_pose[3];
         
+        T centeredPoint[3];
+        centeredPoint[0] = parameter_point[0] - cam_c[0];
+        centeredPoint[1] = parameter_point[1] - cam_c[1];
+        centeredPoint[2] = parameter_point[2] - cam_c[2];
+
         T transformedPoint[3];
         // Rotate the point according the camera rotation
-        ceres::AngleAxisRotatePoint(cam_R, parameter_point, transformedPoint);
-
-        // Apply the camera translation
-        transformedPoint[0] += cam_t[0];
-        transformedPoint[1] += cam_t[1];
-        transformedPoint[2] += cam_t[2];
+        ceres::AngleAxisRotatePoint(cam_R, centeredPoint, transformedPoint);
 
         const T * innerParameters[3];
         innerParameters[0] = parameter_intrinsics;
@@ -112,29 +112,28 @@ struct ProjectionErrorFunctor
         T transformedPoint[3];
         {
             const T* cam_R = parameter_pose;
-            const T* cam_t = &parameter_pose[3];
+            const T* cam_c = &parameter_pose[3];
+
+            T centeredPoint[3];
+            centeredPoint[0] = parameter_point[0] - cam_c[0];
+            centeredPoint[1] = parameter_point[1] - cam_c[1];
+            centeredPoint[2] = parameter_point[2] - cam_c[2];
 
             // Rotate the point according the camera rotation
-            ceres::AngleAxisRotatePoint(cam_R, parameter_point, transformedPoint);
-
-            // Apply the camera translation
-            transformedPoint[0] += cam_t[0];
-            transformedPoint[1] += cam_t[1];
-            transformedPoint[2] += cam_t[2];
+            ceres::AngleAxisRotatePoint(cam_R, centeredPoint, transformedPoint);
         }
 
         {
             const T* cam_R = parameter_subpose;
-            const T* cam_t = &parameter_subpose[3];
+            const T* cam_c = &parameter_subpose[3];
+
+            T centeredPoint[3];
+            centeredPoint[0] = transformedPoint[0] - cam_c[0];
+            centeredPoint[1] = transformedPoint[1] - cam_c[1];
+            centeredPoint[2] = transformedPoint[2] - cam_c[2];
 
             // Rotate the point according to the camera rotation
-            T transformedPointBuf[3] = {transformedPoint[0], transformedPoint[1], transformedPoint[2]};
-            ceres::AngleAxisRotatePoint(cam_R, transformedPointBuf, transformedPoint);
-
-            // Apply the camera translation
-            transformedPoint[0] += cam_t[0];
-            transformedPoint[1] += cam_t[1];
-            transformedPoint[2] += cam_t[2];
+            ceres::AngleAxisRotatePoint(cam_R, centeredPoint, transformedPoint);
         }
 
         const T * innerParameters[3];
@@ -212,6 +211,12 @@ struct ProjectionRelativeErrorFunctor
             const T* parameter_refpose = parameters[3];
             const T* parameter_relativepoint = parameters[4];
 
+            /// (cam_T_world) * (ref_T_world)^-1 * ref_p
+            /// cam_R_world * (ref_R_world^T * ref_p - ref_R_world^T * ref_t_world) + cam_t_world
+            /// cam_R_world * (ref_R_world^T * ref_p + ref_c_world) + cam_t_world
+            /// cam_R_world * (ref_R_world^T * ref_p + ref_c_world) - cam_R_world * cam_c_world
+            /// cam_R_world * (ref_R_world^T * ref_p + ref_c_world - cam_c_world)
+
             //Retrieve point
             T relpoint[3];
             relpoint[0] = parameter_relativepoint[0];
@@ -219,15 +224,11 @@ struct ProjectionRelativeErrorFunctor
             relpoint[2] = parameter_relativepoint[2];
 
             const T* refcam_R = parameter_refpose;
-            const T* refcam_t = &parameter_refpose[3];
+            const T* refcam_c = &parameter_refpose[3];
             
             // Apply transformation such that the point
             // Which was defined in the camera geometric frame
             // is now defined in the world frame
-            relpoint[0] = relpoint[0] - refcam_t[0];
-            relpoint[1] = relpoint[1] - refcam_t[1];
-            relpoint[2] = relpoint[2] - refcam_t[2];
-
             T invrefcam_R[3];
             invrefcam_R[0] = -refcam_R[0];
             invrefcam_R[1] = -refcam_R[1];
@@ -236,20 +237,22 @@ struct ProjectionRelativeErrorFunctor
             T absolutePoint[3];  
             ceres::AngleAxisRotatePoint(invrefcam_R, relpoint, absolutePoint);
 
+            absolutePoint[0] += refcam_c[0];
+            absolutePoint[1] += refcam_c[1];
+            absolutePoint[2] += refcam_c[2];
+
             //--
             // Apply external parameters (Pose)
             //--
             const T* cam_R = parameter_pose;
-            const T* cam_t = &parameter_pose[3];
+            const T* cam_c = &parameter_pose[3];
             
-            
+            absolutePoint[0] -= cam_c[0];
+            absolutePoint[1] -= cam_c[1];
+            absolutePoint[2] -= cam_c[2];
+
             // Rotate the point according the camera rotation
             ceres::AngleAxisRotatePoint(cam_R, absolutePoint, transformedPoint);
-
-            // Apply the camera translation
-            transformedPoint[0] += cam_t[0];
-            transformedPoint[1] += cam_t[1];
-            transformedPoint[2] += cam_t[2];
         }
 
         const T * innerParameters[3];

--- a/src/aliceVision/sfm/bundle/costfunctions/projectionMesh.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/projectionMesh.hpp
@@ -29,27 +29,27 @@ struct ProjectionMeshErrorFunctor
     explicit ProjectionMeshErrorFunctor(const sfmData::Observation& obs
     , const std::shared_ptr<camera::IntrinsicBase>& intrinsics
     , sfmData::PointFetcher::sptr fetcher
-    , bool samePose)        
+    , bool samePose)
     : _intrinsicFunctor(new CostIntrinsicsProject(obs, intrinsics))
     , _meshIntersectFunctor(new CostMeshIntersector(fetcher))
     , _samePose(samePose)
-    {        
+    {
     }
 
     template<typename T>
     bool operator()(T const* const* parameters, T* residuals) const
-    {       
+    {
         const T* parameter_intrinsics = parameters[0];
         const T* parameter_distortion = parameters[1];
         const T* parameter_currentPose = parameters[2];
         const T* parameter_referencePose = _samePose ? parameter_currentPose : parameters[3];
         const T* parameter_point = _samePose ? parameters[3] : parameters[4];
 
-        
+
         const T* refcam_r_world = parameter_referencePose;
-        const T* refcam_t_world = &parameter_referencePose[3];
+        const T* world_t_refcam = &parameter_referencePose[3];
         const T* curcam_r_world = parameter_currentPose;
-        const T* curcam_t_world = &parameter_currentPose[3];
+        const T* world_t_curcam = &parameter_currentPose[3];
 
         T world_r_refcam[3];
         world_r_refcam[0] = -refcam_r_world[0];
@@ -64,21 +64,14 @@ struct ProjectionMeshErrorFunctor
         refcam_point[1] = parameter_point[1] / norm;
         refcam_point[2] = 1.0 / norm;
 
-        // Compute c = - R^t * t
-        T c[3];
-        ceres::AngleAxisRotatePoint(world_r_refcam, refcam_t_world, c);
-        c[0] = -c[0];
-        c[1] = -c[1];
-        c[2] = -c[2];
-
-        // Compute direction = R^t reference_point 
+        // Compute direction = R^t reference_point
         T direction[3];
         ceres::AngleAxisRotatePoint(world_r_refcam, refcam_point, direction);
 
-       
+
         T worldPoint[3];
         const T * intersectParameters[2];
-        intersectParameters[0] = c;
+        intersectParameters[0] = world_t_refcam;
         intersectParameters[1] = direction;
         if (!_meshIntersectFunctor(intersectParameters, worldPoint))
         {
@@ -87,10 +80,10 @@ struct ProjectionMeshErrorFunctor
 
         // Compute point in camera coordinates
         T transformedPoint[3];
+        worldPoint[0] -= world_t_curcam[0];
+        worldPoint[1] -= world_t_curcam[1];
+        worldPoint[2] -= world_t_curcam[2];
         ceres::AngleAxisRotatePoint(curcam_r_world, worldPoint, transformedPoint);
-        transformedPoint[0] += curcam_t_world[0];
-        transformedPoint[1] += curcam_t_world[1];
-        transformedPoint[2] += curcam_t_world[2];
 
         // Project
         const T * innerParameters[3];
@@ -109,13 +102,13 @@ struct ProjectionMeshErrorFunctor
      * @return cost functor
      */
     inline static ceres::CostFunction* createCostFunction(
-        const std::shared_ptr<camera::IntrinsicBase> intrinsic, 
+        const std::shared_ptr<camera::IntrinsicBase> intrinsic,
         const sfmData::Observation& observation,
         sfmData::PointFetcher::sptr fetcher,
         bool samePose)
     {
         auto costFunction = new ceres::DynamicAutoDiffCostFunction<ProjectionMeshErrorFunctor>(new ProjectionMeshErrorFunctor(observation, intrinsic, fetcher, samePose));
-        
+
         // Estimate distortion size from intrinsics
         int distortionSize = 1;
         auto isod = camera::IntrinsicScaleOffsetDisto::cast(intrinsic);

--- a/src/aliceVision/sfm/bundle/costfunctions/survey.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/survey.hpp
@@ -39,16 +39,16 @@ struct SurveyErrorFunctor
         // Apply external parameters (Pose)
         //--
         const T* cam_R = parameter_pose;
-        const T* cam_t = &parameter_pose[3];
+        const T* cam_c = &parameter_pose[3];
         
+        T centeredPoint[3];
+        centeredPoint[0] = parameter_point[0] - cam_c[0];
+        centeredPoint[1] = parameter_point[1] - cam_c[1];
+        centeredPoint[2] = parameter_point[2] - cam_c[2];
+
         T transformedPoint[3];
         // Rotate the point according the camera rotation
-        ceres::AngleAxisRotatePoint(cam_R, parameter_point, transformedPoint);
-
-        // Apply the camera translation
-        transformedPoint[0] += cam_t[0];
-        transformedPoint[1] += cam_t[1];
-        transformedPoint[2] += cam_t[2];
+        ceres::AngleAxisRotatePoint(cam_R, centeredPoint, transformedPoint);
 
         const T * innerParameters[3];
         innerParameters[0] = parameter_intrinsics;

--- a/src/aliceVision/sfm/bundle/costfunctions/temporalConstraint.hpp
+++ b/src/aliceVision/sfm/bundle/costfunctions/temporalConstraint.hpp
@@ -60,22 +60,18 @@ struct TemporalConstraintFunctor
             invQuaternion[3] = -quaternion[3];
         };
 
-        const auto viewPreProcess = [&](const T* angleAxis, const T* translation, T* viewCenter, T* quaternion)
-        {
-            T invQuaternion[4];
-            ceres::AngleAxisToQuaternion(angleAxis, quaternion);
-            // Inverse the rotation to compute the camera position
-            quaternionConjugate(quaternion, invQuaternion);
-            ceres::QuaternionRotatePoint(invQuaternion, translation, viewCenter);
-        };
 
-        T viewCenter0[3], viewCenter1[3], viewCenter2[3], viewCenter3[3];
+
         T quaternion0[4], quaternion1[4], quaternion2[4], quaternion3[4];
+        ceres::AngleAxisToQuaternion(&para0[0], quaternion0);
+        ceres::AngleAxisToQuaternion(&para1[0], quaternion1);
+        ceres::AngleAxisToQuaternion(&para2[0], quaternion2);
+        ceres::AngleAxisToQuaternion(&para3[0], quaternion3);
 
-        viewPreProcess(&para0[0], &para0[3], viewCenter0, quaternion0);
-        viewPreProcess(&para1[0], &para1[3], viewCenter1, quaternion1);
-        viewPreProcess(&para2[0], &para2[3], viewCenter2, quaternion2);
-        viewPreProcess(&para3[0], &para3[3], viewCenter3, quaternion3);
+        const T * viewCenter0 = &para0[3];
+        const T * viewCenter1 = &para1[3];
+        const T * viewCenter2 = &para2[3];
+        const T * viewCenter3 = &para3[3];
 
         const auto computeAngleDiff = [&](const T* quaternionA, const T* quaternionB, T* angleAxisDiff, T* quaternionDiff)
         {

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -22,7 +22,7 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
     BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_NONE;
 
     refineOptions |= BundleAdjustment::REFINE_ROTATION;
-    refineOptions |= BundleAdjustment::REFINE_TRANSLATION;
+    refineOptions |= BundleAdjustment::REFINE_CENTER;
 
     if (_isStructureRefinementEnabled)
     {

--- a/src/aliceVision/sfm/pipeline/expanding/SfmResection.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmResection.cpp
@@ -180,7 +180,7 @@ bool SfmResection::internalRefinement(
     }
 
     BundleAdjustmentCeres BA;
-    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION;
+    BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_CENTER;
 
     const bool success = BA.adjust(tinyScene, refineOptions);
     if(!success)

--- a/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
+++ b/src/aliceVision/sfm/pipeline/global/GlobalSfMTranslationAveragingSolver.cpp
@@ -721,7 +721,7 @@ bool GlobalSfMTranslationAveragingSolver::estimateTTriplet(const SfMData& sfmDat
     BundleAdjustmentCeres::BA_options options(false, false);
     options._linear_solver_type = ceres::SPARSE_SCHUR;
     BundleAdjustmentCeres bundleAdjustmentObj(options);
-    if (bundleAdjustmentObj.Adjust(tiny_scene, REFINE_TRANSLATION | REFINE_STRUCTURE))
+    if (bundleAdjustmentObj.adjust(tinyScene, REFINE_CENTER | REFINE_STRUCTURE))
     {
         // export scene for visualization
         std::ostringstream os;

--- a/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/global/ReconstructionEngine_globalSfM.cpp
@@ -375,8 +375,8 @@ bool ReconstructionEngine_globalSfM::adjust()
     options.useParametersOrdering = false;  // disable parameters ordering
 
     BundleAdjustmentCeres BA(options);
-    // - refine only Structure and translations
-    bool success = BA.adjust(_sfmData, BundleAdjustment::REFINE_TRANSLATION | BundleAdjustment::REFINE_STRUCTURE);
+    // - refine only Structure and centers
+    bool success = BA.adjust(_sfmData, BundleAdjustment::REFINE_CENTER | BundleAdjustment::REFINE_STRUCTURE);
     if (success)
     {
         if (!_loggingFile.empty())
@@ -385,7 +385,7 @@ bool ReconstructionEngine_globalSfM::adjust()
                             sfmDataIO::ESfMData(sfmDataIO::EXTRINSICS | sfmDataIO::STRUCTURE));
 
         // refine only structure and rotations & translations
-        success = BA.adjust(_sfmData, BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION | BundleAdjustment::REFINE_STRUCTURE);
+        success = BA.adjust(_sfmData, BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_CENTER | BundleAdjustment::REFINE_STRUCTURE);
 
         if (success && !_loggingFile.empty())
             sfmDataIO::save(_sfmData,
@@ -437,7 +437,7 @@ bool ReconstructionEngine_globalSfM::adjust()
     }
 
     BundleAdjustment::ERefineOptions refineOptions =
-      BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION | BundleAdjustment::REFINE_STRUCTURE;
+      BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_CENTER | BundleAdjustment::REFINE_STRUCTURE;
     if (!_lockAllIntrinsics)
         refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;
     success = BA.adjust(_sfmData, refineOptions);
@@ -611,7 +611,7 @@ void ReconstructionEngine_globalSfM::computeRelativeRotations(rotationAveraging:
                 options.linearSolverType = ceres::DENSE_SCHUR;
                 BundleAdjustmentCeres bundleAdjustmentObj(options);
                 if (bundleAdjustmentObj.adjust(
-                      tinyScene, BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION | BundleAdjustment::REFINE_STRUCTURE))
+                      tinyScene, BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_CENTER | BundleAdjustment::REFINE_STRUCTURE))
                 {
                     // --> to debug: save relative pair geometry on disk
                     // std::ostringstream os;

--- a/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
+++ b/src/aliceVision/sfm/pipeline/localization/SfMLocalizer.cpp
@@ -216,7 +216,7 @@ bool SfMLocalizer::refinePose(camera::IntrinsicBase* intrinsics,
     BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_NONE;
 
     if (refinePose)
-        refineOptions |= BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION;
+        refineOptions |= BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_CENTER;
     if (refineIntrinsic)
         refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;
 

--- a/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
+++ b/src/aliceVision/sfm/pipeline/sequential/ReconstructionEngine_sequentialSfM.cpp
@@ -687,7 +687,7 @@ bool ReconstructionEngine_sequentialSfM::bundleAdjustment(std::set<IndexT>& newR
 
     BundleAdjustmentCeres::CeresOptions options;
     BundleAdjustment::ERefineOptions refineOptions =
-      BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION | BundleAdjustment::REFINE_STRUCTURE;
+      BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_CENTER | BundleAdjustment::REFINE_STRUCTURE;
 
     if (!isInitialPair && !_params.lockAllIntrinsics)
         refineOptions |= BundleAdjustment::REFINE_INTRINSICS_ALL;

--- a/src/aliceVision/sfmData/CameraPose.hpp
+++ b/src/aliceVision/sfmData/CameraPose.hpp
@@ -128,12 +128,12 @@ class CameraPose
         }
         
         const Vec3 r_refined(data.at(0), data.at(1), data.at(2));
-        const Vec3 t_refined(data.at(3), data.at(4), data.at(5));
+        const Vec3 c_refined(data.at(3), data.at(4), data.at(5));
 
         const Mat3 R_refined = SO3::expm(r_refined);
 
         // update the pose
-        setTransform(geometry::poseFromRT(R_refined, t_refined));
+        setTransform(geometry::Pose3(R_refined, c_refined));
     }
 
   private:

--- a/src/software/pipeline/main_checkerboardCalibration.cpp
+++ b/src/software/pipeline/main_checkerboardCalibration.cpp
@@ -344,7 +344,7 @@ bool estimateIntrinsicsPoses(sfmData::SfMData& sfmData, std::map<IndexT, calibra
         options.summary = true;
         sfm::BundleAdjustmentCeres ba(options);
         sfm::BundleAdjustment::ERefineOptions boptions = sfm::BundleAdjustment::ERefineOptions::REFINE_ROTATION |
-                                                         sfm::BundleAdjustment::ERefineOptions::REFINE_TRANSLATION |
+                                                         sfm::BundleAdjustment::ERefineOptions::REFINE_CENTER |
                                                          sfm::BundleAdjustment::ERefineOptions::REFINE_INTRINSICS_ALL;
         if (!ba.adjust(sfmData, boptions))
         {
@@ -426,7 +426,7 @@ bool estimateRigs(sfmData::SfMData& sfmData)
         options.summary = true;
         sfm::BundleAdjustmentCeres ba(options);
         sfm::BundleAdjustment::ERefineOptions boptions = sfm::BundleAdjustment::ERefineOptions::REFINE_ROTATION |
-                                                         sfm::BundleAdjustment::ERefineOptions::REFINE_TRANSLATION |
+                                                         sfm::BundleAdjustment::ERefineOptions::REFINE_CENTER |
                                                          sfm::BundleAdjustment::ERefineOptions::REFINE_INTRINSICS_ALL;
         if (!ba.adjust(sfmData, boptions))
         {

--- a/src/software/utils/main_computeUncertainty.cpp
+++ b/src/software/utils/main_computeUncertainty.cpp
@@ -81,7 +81,7 @@ int aliceVision_main(int argc, char** argv)
     {
         BundleAdjustmentCeres bundleAdjustmentObj;
         BundleAdjustment::ERefineOptions refineOptions =
-          BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_TRANSLATION | BundleAdjustment::REFINE_STRUCTURE;
+          BundleAdjustment::REFINE_ROTATION | BundleAdjustment::REFINE_CENTER | BundleAdjustment::REFINE_STRUCTURE;
         bundleAdjustmentObj.createJacobian(sfmData, refineOptions, jacobian);
     }
 


### PR DESCRIPTION
This PR updates AliceVision’s bundle adjustment to refine camera **centers** (C) rather than camera **translations** (t), aligning the optimized pose parameterization with `geometry::Pose3`’s center-based representation. This is intended to keep convergence behavior similar while enabling future work (e.g., covariance estimation) that benefits from center refinement.

**Changes:**
- Replaced `REFINE_TRANSLATION` with `REFINE_CENTER` across SfM pipelines/utilities/tests and the BA refine-options enum.
- Updated BA parameter blocks and cost functions to interpret pose blocks as `[angleAxis(3), center(3)]` and apply projections as `R * (X - C)`.
- Adjusted pose update paths (`CameraPose`, rig sub-poses) to write back refined centers correctly.
