### PR TITLE
[Docs/CMake] Set CMake minimum to 3.30 everywhere

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ For specific build instructions for macOS see [INSTALL_macOS.md](./INSTALL_macOS
 ## Build instructions
 
 Required tools:
-* CMake >= 3.11
+* CMake >= 3.30
 * Git
 * C/C++ compiler (gcc or Visual Studio or clang) with C++17 support (i.e. gcc >= 7, clang >= 5, msvc >= 19.15, cuda >= 11.0).
 

--- a/INSTALL_macOS.md
+++ b/INSTALL_macOS.md
@@ -42,7 +42,7 @@ These differ slightly depending on the target architecture you want to build for
 ### arm64 (Apple Silicon Macs, M-CPUs)
 
 - [x] A working C/C++ compiler with C++20 support (e.g., Xcode/Xcode Command Line Tools)[^6]
-- [x] cmake >= 3.25 but < 4.0 (some dependencies do not support CMake 4)
+- [x] cmake >= 3.30 but < 4.0 (some dependencies do not support CMake 4)
 - [x] make (included in Xcode/Xcode Command Line Tools)
 - [x] autoconf (Homebrew, MacPorts, Nix)
 - [x] automake (Homebrew, MacPorts, Nix)

--- a/src/cmake/MakeBundle.cmake
+++ b/src/cmake/MakeBundle.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 # Perform bundle fixup on all executables of an install directory
 # and generates a standalone bundle with all required runtime dependencies.
 #


### PR DESCRIPTION
Just a small fix (especially for docs) to accomodate for the change introduced in https://github.com/alicevision/AliceVision/commit/a2fea489eba6a2927503c55dea2007d689b2161b, which set the minimum CMake version to 3.30.

Something we could consider is to hard-error on any CMake 4.X, because at least when building some embedded dependencies it can cause problems. However, I don't know if *AliceVision itself* can handle CMake 4.X and I cannot really test that, because I only have a Mac and must always build all dependencies. I therefore left it as-is and only kept the upper bound for building on Apple platforms.