### PR TITLE
[FIX] Use Cpp20 Git tag for LEMON

### DIFF
--- a/src/cmake/DependenciesVersions.cmake
+++ b/src/cmake/DependenciesVersions.cmake
@@ -147,7 +147,7 @@ set(DEP_CLP_GIT_REPO "https://github.com/alicevision/Clp")
 set(DEP_CLP_GIT_TAG  "4da587acebc65343faafea8a134c9f251efab5b9")
 
 set(DEP_LEMON_GIT_REPO "https://github.com/alicevision/lemon.git")
-set(DEP_LEMON_GIT_TAG  "8885b9a8b7a20cdf5588964fe30da89093ec53cd")
+set(DEP_LEMON_GIT_TAG  "Cpp20")
 
 # ── 3D / Geometry ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
A small fix which I regularly encounter when rebuilding with dependencies:

CMake is unable to checkout this specific commit and there is a proper release/tag for C++20 support. This is a regression introduced by specifying `GIT_SHALLOW` in `ExternalProject_Add`, which removes the option to specify a commit hash in `GIT_TAG` (see [the docs](https://cmake.org/cmake/help/latest/module/ExternalProject.html#git)).

Commit https://github.com/alicevision/lemon/commit/8885b9a8b7a20cdf5588964fe30da89093ec53cd will be missing though... so either we don't need this or we should create a new release/tag/branch with this specific commit over at LEMON.