### PR TITLE
CI: Install Meshroom plugin

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -159,8 +159,6 @@ jobs:
                             -DALICEVISION_USE_CCTAG=OFF
                             -DALICEVISION_USE_POPSIFT=OFF
                             -DALICEVISION_USE_ALEMBIC=ON
-                            -DALICEVISION_BUILD_PHOTOMETRICSTEREO=OFF
-                            -DALICEVISION_BUILD_SEGMENTATION=OFF
                             -DALICEVISION_BUILD_SWIG_BINDING=ON
                             -DBOOST_NO_CXX11=ON
                             -DVCPKG_MANIFEST_MODE=OFF

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -156,8 +156,8 @@ jobs:
                             -DALICEVISION_BUILD_TESTS=ON
                             -DALICEVISION_USE_OPENCV=ON
                             -DALICEVISION_USE_CUDA=ON
-                            -DALICEVISION_USE_CCTAG=OFF
-                            -DALICEVISION_USE_POPSIFT=OFF
+                            -DALICEVISION_USE_CCTAG=ON
+                            -DALICEVISION_USE_POPSIFT=ON
                             -DALICEVISION_USE_ALEMBIC=ON
                             -DALICEVISION_BUILD_SWIG_BINDING=ON
                             -DBOOST_NO_CXX11=ON

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -162,7 +162,6 @@ jobs:
                             -DALICEVISION_BUILD_PHOTOMETRICSTEREO=OFF
                             -DALICEVISION_BUILD_SEGMENTATION=OFF
                             -DALICEVISION_BUILD_SWIG_BINDING=ON
-                            -DALICEVISION_INSTALL_MESHROOM_PLUGIN=OFF
                             -DBOOST_NO_CXX11=ON
                             -DVCPKG_MANIFEST_MODE=OFF
                             -DPython3_EXECUTABLE=${{ env.Python3_ROOT_DIR }}\python.exe


### PR DESCRIPTION
## Description
As we are now producing the nightly build, the Meshroom folder must be installed to use the resulting build in Meshroom.