### PR TITLE
Removing views in `ImageMatchingMultiSfM` is now an option

### DIFF
--- a/meshroom/aliceVision/ImageMatchingMultiSfM.py
+++ b/meshroom/aliceVision/ImageMatchingMultiSfM.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -90,6 +90,13 @@ Thanks to this node, the FeatureMatching node will only compute the matches betw
                         "- 'a/b' for A with B.",
             value="a/a+a/b",
             values=["a/a+a/b","a/ab", "a/b"],
+        ),
+        desc.BoolParam(
+            name="removeDuplicates",
+            label="Remove duplicates",
+            description="If enabled, views that belong to both A and B will be ignored in A.",
+            value=True,
+            advanced=True
         ),
         desc.IntParam(
             name="minNbImages",

--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -17,7 +17,7 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationSam3": "1.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",

--- a/meshroom/cameraTrackingDepth.mg
+++ b/meshroom/cameraTrackingDepth.mg
@@ -18,7 +18,7 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationSam3": "1.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",

--- a/meshroom/cameraTrackingLegacy.mg
+++ b/meshroom/cameraTrackingLegacy.mg
@@ -17,7 +17,7 @@
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "1.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationBox": "1.0",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",

--- a/meshroom/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/cameraTrackingWithoutCalibration.mg
@@ -16,7 +16,7 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationSam3": "1.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",

--- a/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
+++ b/meshroom/cameraTrackingWithoutCalibrationLegacy.mg
@@ -16,7 +16,7 @@
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "1.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationBox": "1.0",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -17,7 +17,7 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationSam3": "1.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",

--- a/meshroom/photogrammetryAndCameraTrackingLegacy.mg
+++ b/meshroom/photogrammetryAndCameraTrackingLegacy.mg
@@ -17,7 +17,7 @@
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "1.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationBox": "1.0",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",

--- a/meshroom/photogrammetryObjectTwoSides.mg
+++ b/meshroom/photogrammetryObjectTwoSides.mg
@@ -12,7 +12,7 @@
             "FeatureMatching": "2.0",
             "ImageDetectionPrompt": "1.0",
             "ImageMatching": "2.0",
-            "ImageMatchingMultiSfM": "1.0",
+            "ImageMatchingMultiSfM": "1.1",
             "ImageSegmentationBox": "1.0",
             "MeshFiltering": "3.0",
             "Meshing": "7.0",

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -31,7 +31,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 using namespace aliceVision::voctree;
@@ -66,6 +66,8 @@ int aliceVision_main(int argc, char** argv)
     std::string weightsFilepath;
     /// flag for the optional weights file
     bool withWeights = false;
+    /// Do we remove views from A if they belong to B ?
+    bool removeDuplicates = true;
 
     // multiple SfM parameters
 
@@ -119,7 +121,8 @@ int aliceVision_main(int argc, char** argv)
         ("matchingMode", po::value<std::string>(&matchingModeName)->default_value(matchingModeName),
          EImageMatchingMode_description().c_str())
         ("outputCombinedSfM", po::value<std::string>(&outputCombinedSfM)->default_value(outputCombinedSfM),
-         "Output file path for the combined SfMData file (if empty, don't combine).");
+         "Output file path for the combined SfMData file (if empty, don't combine).")
+        ("removeDuplicates", po::value<bool>(&removeDuplicates)->default_value(removeDuplicates), "Do we remove views from A if they belong to B ?");
     // clang-format on
 
     CmdLine cmdline("The objective of this software is to find images that are looking to the same areas of the scene. "
@@ -166,11 +169,14 @@ int aliceVision_main(int argc, char** argv)
         }
 
         // remove duplicated view
-        for (const auto& viewPair : sfmDataB.getViews())
+        if (removeDuplicates)
         {
-            sfmData::Views::iterator it = sfmDataA.getViews().find(viewPair.first);
-            if (it != sfmDataA.getViews().end())
-                sfmDataA.getViews().erase(it);
+            for (const auto& viewPair : sfmDataB.getViews())
+            {
+                sfmData::Views::iterator it = sfmDataA.getViews().find(viewPair.first);
+                if (it != sfmDataA.getViews().end())
+                    sfmDataA.getViews().erase(it);
+            }
         }
     }
 


### PR DESCRIPTION
In ImageMatchingMultiSfm, all views of A which were also in B were removed (not those of B if in A).

I added a flag (default to True) to be able to deactivate this heuristic.

P.S. This looks very messy to me. While it may had an interest to the author for its use case, this looks very ad hoc.