### PR TITLE
[meshroom] ExtractMetadata: Remove unused import

### DIFF
--- a/meshroom/aliceVision/ExtractMetadata.py
+++ b/meshroom/aliceVision/ExtractMetadata.py
@@ -4,7 +4,6 @@ from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 from pathlib import Path
 
-import distutils.dir_util as du
 import shutil
 import glob
 import os


### PR DESCRIPTION
Removed unused import of distutils.dir_util.
