### PR TITLE
Dynamic chunks for lidar meshing

### DIFF
--- a/meshroom/aliceVision/LidarDecimating.py
+++ b/meshroom/aliceVision/LidarDecimating.py
@@ -2,6 +2,7 @@ __version__ = "1.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
+from pyalicevision import parallelization as avpar
 
 class LidarDecimating(desc.AVCommandLineNode):
     """
@@ -15,7 +16,7 @@ It processes multiple input meshes in parallel using a range-based parallelizati
 
     commandLine = "aliceVision_lidarDecimating {allParams}"
 
-    size = desc.StaticNodeSize(10)
+    size = avpar.DynamicJsonListSize("input")
     parallelization = desc.Parallelization(blockSize=1)
     commandLineRange = "--rangeStart {rangeStart} --rangeSize {rangeFullSize}"
 

--- a/meshroom/aliceVision/LidarMeshing.py
+++ b/meshroom/aliceVision/LidarMeshing.py
@@ -2,13 +2,14 @@ __version__ = "1.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
+from pyalicevision import parallelization as avpar
 
 class LidarMeshing(desc.AVCommandLineNode):
     """This node creates a dense geometric surface representation of the Lidar measurements."""
 
     commandLine = "aliceVision_lidarMeshing {allParams}"
 
-    size = desc.StaticNodeSize(10)
+    size = avpar.DynamicJsonListSize("input")
     parallelization = desc.Parallelization(blockSize=1)
     commandLineRange = "--rangeStart {rangeStart} --rangeSize {rangeFullSize}"
 

--- a/src/aliceVision/dataio/E57Reader.hpp
+++ b/src/aliceVision/dataio/E57Reader.hpp
@@ -129,6 +129,27 @@ class E57Reader
         unsigned int readCount = 0;
         while ((readCount = datareader.read()) > 0)
         {
+            ALICEVISION_LOG_DEBUG("cartesianInvalidState pointer: " << static_cast<void*>(data3DPoints.cartesianInvalidState));
+            ALICEVISION_LOG_DEBUG("cartesianX pointer: " << static_cast<void*>(data3DPoints.cartesianX));
+            ALICEVISION_LOG_DEBUG("cartesianY pointer: " << static_cast<void*>(data3DPoints.cartesianY));
+            ALICEVISION_LOG_DEBUG("cartesianZ pointer: " << static_cast<void*>(data3DPoints.cartesianZ));
+            ALICEVISION_LOG_DEBUG("colorBlue pointer: " << static_cast<void*>(data3DPoints.colorBlue));
+            ALICEVISION_LOG_DEBUG("colorGreen pointer: " << static_cast<void*>(data3DPoints.colorGreen));
+            ALICEVISION_LOG_DEBUG("colorRed pointer: " << static_cast<void*>(data3DPoints.colorRed));
+            ALICEVISION_LOG_DEBUG("columnIndex pointer: " << static_cast<void*>(data3DPoints.columnIndex));
+            ALICEVISION_LOG_DEBUG("intensity pointer: " << static_cast<void*>(data3DPoints.intensity));
+            ALICEVISION_LOG_DEBUG("isColorInvalid pointer: " << static_cast<void*>(data3DPoints.isColorInvalid));
+            ALICEVISION_LOG_DEBUG("isIntensityInvalid pointer: " << static_cast<void*>(data3DPoints.isIntensityInvalid));
+            ALICEVISION_LOG_DEBUG("isTimeStampInvalid pointer: " << static_cast<void*>(data3DPoints.isTimeStampInvalid));
+            ALICEVISION_LOG_DEBUG("returnCount pointer: " << static_cast<void*>(data3DPoints.returnCount));
+            ALICEVISION_LOG_DEBUG("returnIndex pointer: " << static_cast<void*>(data3DPoints.returnIndex));
+            ALICEVISION_LOG_DEBUG("rowIndex pointer: " << static_cast<void*>(data3DPoints.rowIndex));
+            ALICEVISION_LOG_DEBUG("sphericalAzimuth pointer: " << static_cast<void*>(data3DPoints.sphericalAzimuth));
+            ALICEVISION_LOG_DEBUG("sphericalElevation pointer: " << static_cast<void*>(data3DPoints.sphericalElevation));
+            ALICEVISION_LOG_DEBUG("sphericalInvalidState pointer: " << static_cast<void*>(data3DPoints.sphericalInvalidState));
+            ALICEVISION_LOG_DEBUG("sphericalRange pointer: " << static_cast<void*>(data3DPoints.sphericalRange));
+            ALICEVISION_LOG_DEBUG("timeStamp pointer: " << static_cast<void*>(data3DPoints.timeStamp));
+
             // Check input compatibility
             if (data3DPoints.sphericalRange != nullptr)
             {
@@ -141,6 +162,7 @@ class E57Reader
                 ALICEVISION_LOG_ERROR("Data contains no cartesian coordinates");
                 continue;
             }
+            
 
             if (data3DPoints.columnIndex == nullptr)
             {
@@ -162,7 +184,7 @@ class E57Reader
 
             for (unsigned int pos = 0; pos < readCount; pos++)
             {
-                if (data3DPoints.cartesianInvalidState[pos])
+                if (data3DPoints.cartesianInvalidState && data3DPoints.cartesianInvalidState[pos])
                 {
                     continue;
                 }

--- a/src/aliceVision/dataio/E57Reader.hpp
+++ b/src/aliceVision/dataio/E57Reader.hpp
@@ -31,6 +31,7 @@ class E57Reader
       : _paths(paths),
         _idPath(-1),
         _idMesh(-1),
+        _idMeshInFile(-1),
         _countMeshesForFile(0),
         _requiredIntensity(0.0)
     {}
@@ -39,19 +40,23 @@ class E57Reader
     {
         _idPath = -1;
         _idMesh = -1;
+        _idMeshInFile = -1;
         _countMeshesForFile = 0;
     }
 
     bool getNext(Eigen::Vector3d& sensorPosition, std::vector<PointInfo>& vertices, Eigen::Matrix<size_t, -1, -1>& grid)
     {
         // Go to next mesh of current file
+        _idMeshInFile++;
+
+        // Keep a unique counter for all files
         _idMesh++;
 
         // Load next file if needed
-        if (_idMesh >= static_cast<int>(_countMeshesForFile))
+        if (_idMeshInFile >= static_cast<int>(_countMeshesForFile))
         {
             _idPath++;
-            _idMesh = 0;
+            _idMeshInFile = 0;
             if (_idPath >= static_cast<int>(_paths.size()))
             {
                 return false;
@@ -74,7 +79,7 @@ class E57Reader
             _countMeshesForFile = _reader->GetData3DCount();
         }
 
-        if (_idMesh >= static_cast<int>(_countMeshesForFile))
+        if (_idMeshInFile >= static_cast<int>(_countMeshesForFile))
         {
             return false;
         }
@@ -86,9 +91,9 @@ class E57Reader
 
         // Get header
         e57::Data3D scanHeader;
-        if (!_reader->ReadData3D(_idMesh, scanHeader))
+        if (!_reader->ReadData3D(_idMeshInFile, scanHeader))
         {
-            ALICEVISION_LOG_ERROR("Error reading mesh #" << _idMesh);
+            ALICEVISION_LOG_ERROR("Error reading mesh #" << _idMeshInFile);
             return false;
         }
 
@@ -109,14 +114,14 @@ class E57Reader
         int64_t maxGroupSize = 0;
         bool isColumnIndex;
 
-        if (!_reader->GetData3DSizes(0, maxRows, maxColumns, countPoints, countGroups, maxGroupSize, isColumnIndex))
+        if (!_reader->GetData3DSizes(_idMeshInFile, maxRows, maxColumns, countPoints, countGroups, maxGroupSize, isColumnIndex))
         {
-            ALICEVISION_LOG_ERROR("Error reading content of mesh #" << _idMesh);
+            ALICEVISION_LOG_ERROR("Error reading content of mesh #" << _idMeshInFile);
             return false;
         }
 
         e57::Data3DPointsFloat data3DPoints(scanHeader);
-        e57::CompressedVectorReader datareader = _reader->SetUpData3DPointsData(_idMesh, countPoints, data3DPoints);
+        e57::CompressedVectorReader datareader = _reader->SetUpData3DPointsData(_idMeshInFile, countPoints, data3DPoints);
 
         // Prepare list of vertices
         vertices.clear();
@@ -181,6 +186,7 @@ class E57Reader
                 ALICEVISION_LOG_ERROR("Data contains no intensities");
                 continue;
             }
+            
 
             for (unsigned int pos = 0; pos < readCount; pos++)
             {
@@ -209,6 +215,7 @@ class E57Reader
                 vertices.push_back(pi);
             }
         }
+        datareader.close();
 
         sensorPosition = t;
 
@@ -218,13 +225,16 @@ class E57Reader
     bool getNext(Eigen::Vector3d& sensorPosition)
     {
         // Go to next mesh of current file
+        _idMeshInFile++;
+
+        // Keep a unique counter for all files
         _idMesh++;
 
         // Load next file if needed
-        if (_idMesh >= static_cast<int>(_countMeshesForFile))
+        if (_idMeshInFile >= static_cast<int>(_countMeshesForFile))
         {
             _idPath++;
-            _idMesh = 0;
+            _idMeshInFile = 0;
             if (_idPath >= static_cast<int>(_paths.size()))
             {
                 return false;
@@ -247,7 +257,7 @@ class E57Reader
             _countMeshesForFile = _reader->GetData3DCount();
         }
 
-        if (_idMesh >= static_cast<int>(_countMeshesForFile))
+        if (_idMeshInFile >= static_cast<int>(_countMeshesForFile))
         {
             return false;
         }
@@ -259,9 +269,9 @@ class E57Reader
 
         // Get header
         e57::Data3D scanHeader;
-        if (!_reader->ReadData3D(_idMesh, scanHeader))
+        if (!_reader->ReadData3D(_idMeshInFile, scanHeader))
         {
-            ALICEVISION_LOG_ERROR("Error reading mesh #" << _idMesh);
+            ALICEVISION_LOG_ERROR("Error reading mesh #" << _idMeshInFile);
             return false;
         }
 
@@ -286,6 +296,7 @@ class E57Reader
 
     int _idPath;
     int _idMesh;
+    int _idMeshInFile;
     size_t _countMeshesForFile;
     double _requiredIntensity;
 };

--- a/src/aliceVision/fuseCut/Octree.hpp
+++ b/src/aliceVision/fuseCut/Octree.hpp
@@ -136,6 +136,14 @@ class SimpleNode
             return;
         }
 
+        for (auto& item : _nodes)
+        {
+            if (item)
+            {
+                item->regroup(maxPointsPerNode);
+            }
+        }
+
         if (count < maxPointsPerNode)
         {
             _count = count;
@@ -147,14 +155,6 @@ class SimpleNode
             }
 
             return;
-        }
-
-        for (auto& item : _nodes)
-        {
-            if (item)
-            {
-                item->regroup(maxPointsPerNode);
-            }
         }
     }
 

--- a/src/aliceVision/python/parallelization.py
+++ b/src/aliceVision/python/parallelization.py
@@ -179,3 +179,43 @@ class DynamicDirectorySize(object):
             raise RuntimeError(f"Failed to load file : {param.value}")
         
         return max(1, len(imlist))
+
+class DynamicJsonListSize(object):
+    """Compute parallelization size based on a JSON file containing an array of items.
+
+    Reads the JSON file referenced by the given node parameter and returns the
+    number of elements in the root-level array. Returns 1 if the file cannot be
+    read, is not valid JSON, or its root element is not an array.
+
+    Args:
+        param: Name of the node attribute that holds the path to the JSON file.
+    """
+
+    def __init__(self, param):
+        self._param = param
+
+    def __call__(self, node):
+        """Compute the number of chunks from the JSON array size.
+
+        Args:
+            node: The processing node whose attribute *param* points to a JSON file.
+
+        Returns:
+            int: The number of elements in the root JSON array, or 1 if the file
+                cannot be loaded or the root is not an array.
+        """
+
+        import json
+
+        param = node.attribute(self._param)
+
+        try:
+            with open(param.value, 'r') as f:
+                data = json.load(f)
+        except Exception:
+            return 1
+
+        if not isinstance(data, list):
+            return 1
+
+        return max(1, len(data))

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -192,10 +192,10 @@ int aliceVision_main(int argc, char** argv)
     std::map<int, Eigen::Vector3d> cameras;
     while (reader.getNext(sensorPosition))
     {
-        cameras[reader.getIdMesh()] = sensorPosition;
-
         // Create pose for sfmData
         const int idMesh = reader.getIdMesh();
+
+        cameras[idMesh] = sensorPosition;
 
         Eigen::Vector3d correctedSensorPosition;
         correctedSensorPosition.x() = sensorPosition.x();

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -352,7 +352,7 @@ int aliceVision_main(int argc, char** argv)
     std::vector<fuseCut::SimpleNode::ptr> list;
     octree.visit(list);
 
-    ALICEVISION_LOG_INFO("Generating " << list.size() << "sub regions");
+    ALICEVISION_LOG_INFO("Generating " << list.size() << " sub regions");
 
     fuseCut::InputSet inputs;
 


### PR DESCRIPTION
# E57 multi-file fix and dynamic LiDAR meshing chunks

## Summary

This PR fixes several bugs in E57 point cloud reading when handling files containing multiple scans, adds debug instrumentation for E57 data pointers, and introduces dynamic parallelization chunk sizing for LiDAR meshing nodes.

---

## Changes

### Fix E57 multi-scan file reading (`E57Reader.hpp`, `main_importE57.cpp`)

The core bug: `_idMesh` was used both as a **per-file scan index** (passed to libE57's `ReadData3D`, `GetData3DSizes`, `SetUpData3DPointsData`) and as a **global unique mesh counter** (used as the map key in the SfM cameras map). When iterating over multiple files, `_idMesh` was reset to `0` on each new file, causing all reads after the first file to always read scan `#0`.

- Introduced a dedicated `_idMeshInFile` counter for addressing scans within the current file.
- `_idMesh` now acts as a strictly increasing global counter across all files.
- Fixed `GetData3DSizes` which was always passing hardcoded `0` instead of `_idMeshInFile`.
- Added `datareader.close()` after reading each scan's point data.
- Fixed `Octree::regroup()`: child nodes are now recursively regrouped **before** the leaf compaction check, ensuring bottom-up tree consolidation.
- Fixed a missing space in a log message (`"Generating Nsub regions"` → `"Generating N sub regions"`).

### E57 debug logging (`E57Reader.hpp`)

- Added `ALICEVISION_LOG_DEBUG` statements logging all `Data3DPointsFloat` field pointers (cartesian, color, intensity, spherical, row/column indices, timestamps) on each read batch to help diagnose E57 file compatibility issues.
- Added a null-pointer guard before accessing `cartesianInvalidState[pos]`, fixing a potential crash on E57 files that do not provide that field.

### Dynamic parallelization for LiDAR meshing (`LidarMeshing.py`, `LidarDecimating.py`, `parallelization.py`)

Replaced the hardcoded `StaticNodeSize(10)` in `LidarMeshing` and `LidarDecimating` with a new `DynamicJsonListSize` callable. This class reads the JSON file referenced by the node's `input` attribute at graph evaluation time and returns the number of elements in the root array, so the number of parallel chunks matches the actual number of input regions rather than a fixed constant.
