### PR TITLE
Enhance pose filtering and bundle adjustment with new parameters

### DIFF
--- a/meshroom/aliceVision/SfMTemporalFiltering.py
+++ b/meshroom/aliceVision/SfMTemporalFiltering.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -36,6 +36,14 @@ This node takes the result of SfM and fine-tune the camera poses so that the cam
             value=True,
         ),
         desc.IntParam(
+            name="iterationCount",
+            label="Iteration Count",
+            description="Number of filter iterations.",
+            value=100,
+            range=(0, 1000, 10),
+            advanced=True,
+        ),
+        desc.IntParam(
             name="scaleFactor",
             label="Scale Factor",
             description="Scale factor to increase the filter range.",
@@ -43,13 +51,49 @@ This node takes the result of SfM and fine-tune the camera poses so that the cam
             range=(1, 20, 1),
             advanced=True,
         ),
+        desc.BoolParam(
+            name="limitReprojError",
+            label="Limit Reprojection Error",
+            description="Reduces the number of filter iterations to limit reprojection error.",
+            value=False,
+            advanced=True,
+            commandLineGroup=None,
+        ),
+        desc.FloatParam(
+            name="maxErrorIncreasePos",
+            label="Position Reproj Error Ratio",
+            description="The maximum reprojection error increase ratio for the camera positions.",
+            value=.1,
+            range=(0.0, 1.0, 0.02),
+            advanced=True,
+            enabled=lambda node: node.limitReprojError.value,
+        ),
+        desc.FloatParam(
+            name="maxErrorIncreaseRot",
+            label="Rotation Reproj Error Ratio",
+            description="The maximum reprojection error increase ratio for the camera orientations.",
+            value=.1,
+            range=(0.0, 1.0, 0.02),
+            advanced=True,
+            enabled=lambda node: node.limitReprojError.value,
+        ),
         desc.IntParam(
-            name="iterationCount",
-            label="Iteration Count",
-            description="Number of filter iterations.",
-            value=100,
+            name="minIterationCount",
+            label="Minimum Iteration Count",
+            description="The minimum number of filter iterations to apply at the smallest scales.",
+            value=50,
             range=(0, 1000, 10),
             advanced=True,
+            enabled=lambda node: node.limitReprojError.value,
+        ),
+        desc.IntParam(
+            name="minScaleFactor",
+            label="Minimum Scale Factor",
+            description="The minimum scale to apply the filter with the minimum iteration count.",
+            value=3,
+            range=(1, 20, 1),
+            advanced=True,
+            enabled=lambda node: node.limitReprojError.value,
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -1,4 +1,4 @@
-__version__ = "2.4"
+__version__ = "2.5"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -270,6 +270,14 @@ Bundle adjustment is performed periodically to refine all camera poses and 3D po
             description="Maximum reprojection error in the triangulation process.",
             value=8.0,
             range=(0.1, 10.0, 0.1),
+            advanced=True,
+        ),
+        desc.IntParam(
+            name="maxIterationCount",
+            label="Max Iteration Count",
+            description="Maximum number of solver iterations.",
+            value=50,
+            range=(0, 300, 5),
             advanced=True,
         ),
         desc.BoolParam(

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -112,6 +112,7 @@ alicevision_add_library(aliceVision_sfm_bundle
         aliceVision_geometry
         aliceVision_camera
         aliceVision_sfmData
+        Boost::boost
         ${CERES_LIBRARIES}
 )
 

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -27,6 +27,8 @@
 
 #include <ceres/rotation.h>
 
+#include <boost/format.hpp>
+
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -204,6 +206,7 @@ void BundleAdjustmentCeres::setSolverOptions(ceres::Solver::Options& solverOptio
     solverOptions.sparse_linear_algebra_library_type = _ceresOptions.sparseLinearAlgebraLibraryType;
     solverOptions.minimizer_progress_to_stdout = _ceresOptions.verbose;
     solverOptions.logging_type = ceres::SILENT;
+    solverOptions.update_state_every_iteration = true;
     solverOptions.num_threads = _ceresOptions.nbThreads;
     solverOptions.max_num_iterations = _ceresOptions.maxNumIterations;
     solverOptions.max_num_consecutive_invalid_steps = 10;
@@ -1276,6 +1279,13 @@ void BundleAdjustmentCeres::surveyInfos(const sfmData::SfMData & sfmData) const
     }
 }
 
+ceres::CallbackReturnType BundleAdjustmentCeres::IterationInfos::operator()(const ceres::IterationSummary& summary)
+{
+    ALICEVISION_LOG_DEBUG(boost::format("iteration: %3d cost: %8e change: %3.2e")
+                          % summary.iteration % summary.cost % summary.cost_change);
+    return ceres::SOLVER_CONTINUE;
+}
+
 bool BundleAdjustmentCeres::adjust(sfmData::SfMData& sfmData, ERefineOptions refineOptions)
 {
     ALICEVISION_LOG_INFO("BundleAdjustmentCeres::adjust start");
@@ -1308,6 +1318,10 @@ bool BundleAdjustmentCeres::adjust(sfmData::SfMData& sfmData, ERefineOptions ref
     // make Ceres automatically detect the bundle structure.
     ceres::Solver::Options options;
     setSolverOptions(options);
+
+    // Add the logging interface
+    IterationInfos iterationInfos;
+    options.callbacks.push_back(&iterationInfos);
 
     // solve BA
     ceres::Solver::Summary summary;

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
@@ -145,6 +145,18 @@ class BundleAdjustmentCeres : public BundleAdjustment, ceres::EvaluationCallback
      */
     inline const Statistics& getStatistics() const { return _statistics; }
 
+    /**
+     * @brief Custom interface to log the progress of the solver optimization
+     */
+    class IterationInfos : public ceres::IterationCallback
+    {
+      public:
+        explicit IterationInfos() {}
+        ~IterationInfos() {}
+
+        ceres::CallbackReturnType operator()(const ceres::IterationSummary& summary) final;
+    };
+
   private:
     /**
      * @brief Clear structures for a new problem

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -19,6 +19,8 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
     ALICEVISION_LOG_INFO("SfmBundle::process start");
 
     BundleAdjustmentCeres::CeresOptions options;
+    options.maxNumIterations = _maxIterationCount;
+
     BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_NONE;
 
     refineOptions |= BundleAdjustment::REFINE_ROTATION;

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
@@ -79,6 +79,15 @@ public:
     }
 
     /**
+     * @brief set the maximum number of solver iterations
+     * @param maxIterationCount the number of iterations
+    */
+    void setMaxIterationCount(unsigned int maxIterationCount)
+    {
+        _maxIterationCount = maxIterationCount;
+    }
+
+    /**
      * @brief Set whether to enable structure refinement in bundle adjustment
      * @param flag true to enable structure refinement, false to disable it
     */
@@ -134,6 +143,7 @@ private:
     size_t _minPointsPerPose = 30;
     size_t _bundleAdjustmentMaxOutlier = 50;
     size_t _minNbCamerasToRefinePrincipalPoint = 3;
+    unsigned int _maxIterationCount = 50;
     bool _useLBA = true;
     bool _bundleTemporalConstraint = false;
     aliceVision::sfm::TemporalConstraintParams _tempConstrParams;

--- a/src/aliceVision/sfm/utils/poseFilter.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter.cpp
@@ -12,11 +12,15 @@
 #include <aliceVision/sfm/sfmFilters.hpp>
 
 #include <ceres/rotation.h>
+#include <algorithm>
+#include <cmath>
 
 namespace aliceVision {
 namespace sfm {
 
-bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int iterationCount, const int scaleFactor)
+bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation,
+                 const int maxIterationCount, const int maxScaleFactor, const double maxErrorIncreasePos,
+                 const double maxErrorIncreaseRot, const int minIterationCount, const int minScaleFactor)
 {
     using namespace Eigen;
 
@@ -71,14 +75,20 @@ bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, c
         if (filterPosition)
         {
             ALICEVISION_LOG_INFO("Apply a temporal filter to view positions");
-            viewCenters = tFilter.applyMultiscale(viewCenters, scaleFactor, iterationCount, false);
+            viewCenters = (maxErrorIncreasePos < 0) ?
+                          tFilter.applyMultiscale(viewCenters, maxScaleFactor, maxIterationCount, false) :
+                          applyLimitedFilter(sfmData, imageGroupID, viewIdIndices, viewCenters, viewRotations, PoseParamType::Positions,
+                                             maxIterationCount, minIterationCount, maxScaleFactor, minScaleFactor, maxErrorIncreasePos);
         }
 
         // Apply a temporal filter to view orientations
         if (filterRotation)
         {
             ALICEVISION_LOG_INFO("Apply a temporal filter to view orientations");
-            viewRotations = tFilter.applyMultiscale(viewRotations, scaleFactor, iterationCount, true);
+            viewRotations = (maxErrorIncreaseRot < 0) ?
+                            tFilter.applyMultiscale(viewRotations, maxScaleFactor, maxIterationCount, true) :
+                            applyLimitedFilter(sfmData, imageGroupID, viewIdIndices, viewCenters, viewRotations, PoseParamType::Rotations,
+                                                maxIterationCount, minIterationCount, maxScaleFactor, minScaleFactor, maxErrorIncreaseRot);
         }
 
         // Save the temporally filtered poses
@@ -93,6 +103,151 @@ bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, c
 
     ALICEVISION_LOG_INFO("poseFilter::process end");
     return true;
+}
+
+
+Eigen::MatrixXd poseFilter::applyLimitedFilter(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::map<IndexT, IndexT>& viewIdIndices,
+                   const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, PoseParamType paramToFilter, const int maxIterationCount,
+                   const int minIterationCount, const int maxScaleFactor, const int minScaleFactor, const double maxErrorIncrease)
+{
+    using namespace Eigen;
+    using namespace indexing;
+
+    std::string poseParamString = poseParamType_enumToString(paramToFilter);
+
+    // Compute the reprojection error before any filtering
+    double reprojError_0 = reprojectionError(sfmData, imageGroupID, viewIdIndices, viewCenters, viewRotations);
+    ALICEVISION_LOG_INFO("Reprojection error before " << poseParamString << " filtering: " << reprojError_0);
+    ALICEVISION_LOG_DEBUG("Target reprojection error for " << poseParamString << ": " << (1. + maxErrorIncrease) * reprojError_0);
+
+    // The multi-scale filter applies filtering at decreasing scales
+    // controlled by the following constant
+    const double SCALE_REDUCTION_FACTOR = 1.4;
+
+    IndexT viewCount = viewCenters.cols();
+
+    tempFilter tFilter;
+
+    tFilter.init();
+
+    MatrixXd filteredParam(paramToFilter == PoseParamType::Positions ? viewCenters : viewRotations);
+
+    bool isAngle = paramToFilter == PoseParamType::Rotations;
+    // Apply pose parameter filtering using the max iteration and scale factor values
+    filteredParam = tFilter.applyMultiscale(filteredParam, maxScaleFactor, maxIterationCount, isAngle);
+
+    auto paramReprojError = [&sfmData, &imageGroupID, &viewIdIndices, &viewCenters,
+                             &viewRotations, &paramToFilter](const MatrixXd &filteredParam) {
+                                    switch (paramToFilter)
+                                    {
+                                        case PoseParamType::Positions:
+                                            return reprojectionError(sfmData, imageGroupID, viewIdIndices, filteredParam, viewRotations);
+                                        case PoseParamType::Rotations:
+                                            return reprojectionError(sfmData, imageGroupID, viewIdIndices, viewCenters, filteredParam);
+                                    }
+                                    throw std::out_of_range("Invalid PoseParamType enum");
+                                };
+
+    // Compute the reprojection error after filtering using the max iteration and scale factor values
+    double reprojError_1 = paramReprojError(filteredParam);
+
+    if (maxErrorIncrease >= 0 && reprojError_1 > (1. + maxErrorIncrease) * reprojError_0)
+    {
+        // Reset the values to filter
+        filteredParam = paramToFilter == PoseParamType::Positions ? viewCenters : viewRotations;
+
+        int iterationCount = maxIterationCount;
+        // For the biggest scales, the number of iterations is limited by the reprojection error
+        // This number of iterations is determined at the biggest scale
+        bool optimumFound = false;
+
+        for (int scaleF = maxScaleFactor; scaleF >= 1; scaleF = (scaleF > 1) ? std::round(double(scaleF) / SCALE_REDUCTION_FACTOR) : 0)
+        {
+            if (viewCount < scaleF)
+            {
+                continue;
+            }
+
+            std::vector<MatrixXd> filteredParamsList;
+            if (!optimumFound && scaleF > minScaleFactor)
+            {
+                filteredParamsList.reserve(maxIterationCount+1);
+                filteredParamsList.push_back(filteredParam);
+            }
+
+            // Apply at least a minimum number of iterations at the smallest scales in all cases
+            if (scaleF <= minScaleFactor && (!optimumFound || iterationCount < minIterationCount) )
+            {
+                iterationCount = minIterationCount;
+            }
+
+            // Computing the reprojection error can be expensive, so that we first compute the filtered signal
+            // and save it at each iteration. Then we search for the optimum iteration using a bisection algorithm,
+            // lower_bound(), which computes the reprojection error on a limited number of iterations
+
+            for (int iterFilter = 0; iterFilter < iterationCount; iterFilter++)
+            {
+                for (int phase = 0; phase < scaleF; phase++)
+                {
+                    MatrixXd scaledSignal(filteredParam(all, seq(phase, last, scaleF)));
+                    scaledSignal = tFilter.apply(scaledSignal, isAngle);
+                    filteredParam(all, seq(phase, last, scaleF)) = scaledSignal;
+                }
+                if (!optimumFound && scaleF > minScaleFactor)
+                {
+                    // Early stopping in case the maximum is exceeded at the first iteration
+                    if (iterFilter == 0 && paramReprojError(filteredParam) > (1. + maxErrorIncrease) * reprojError_0)
+                    {
+                        break;
+                    }
+                    // Save the filtered values at each iteration to search for the optimum later on
+                    filteredParamsList.push_back(filteredParam);
+                }
+            }
+
+            int effectiveIterCount = iterationCount;
+            if (!optimumFound && scaleF > minScaleFactor)
+            {
+                if (filteredParamsList.size()==1)  // in case of the early stopping
+                {
+                    effectiveIterCount = 0;
+                    filteredParam = filteredParamsList[0];
+                }
+                else
+                {
+                    // Find the biggest iteration with a reprojection error below (1. + maxErrorIncrease) * reprojError_0
+                    // The reprojection error function may not necessarily be monotonically increasing, but since it is
+                    // the case in most cases, it is a good trade-off
+                    auto it = std::lower_bound(filteredParamsList.begin(), filteredParamsList.end(),
+                                               (1. + maxErrorIncrease) * reprojError_0,
+                                               [&paramReprojError](const MatrixXd &M, double val) {
+                                                  return paramReprojError(M) < val;
+                                                });
+                    effectiveIterCount = std::distance(filteredParamsList.begin(), it);
+                    filteredParam = (it == filteredParamsList.begin()) ? *it : *std::prev(it);
+                }
+
+                if (effectiveIterCount > 1)
+                {
+                    iterationCount = effectiveIterCount = effectiveIterCount - 1;
+                    optimumFound = true;
+                }
+                else
+                {
+                    effectiveIterCount = 0;
+                }
+            }
+            double reprojError = paramReprojError(filteredParam);
+            ALICEVISION_LOG_INFO("Reprojection error after " << effectiveIterCount << " iteration(s) of " << poseParamString <<
+                                 " filtering at scale " << scaleF << ": " << reprojError);
+        }
+        // Compute the reprojection error after pose position filtering
+        reprojError_1 = paramReprojError(filteredParam);
+    }
+
+    ALICEVISION_LOG_INFO("Reprojection error after " << poseParamString << " filtering: " << reprojError_1);
+
+    return filteredParam;
 }
 
 
@@ -459,6 +614,63 @@ bool getOrderedPoseIds(const sfmData::SfMData& sfmData, const IndexT imageGroupI
     return true;
 }
 
+inline double huberLoss(const double delta, const double x)
+{
+    double abs_x = std::abs(x);
+
+    if (abs_x <= delta)
+    {
+        return .5 * x * x;
+    }
+    else
+    {
+        return delta * (abs_x - .5 * delta);
+    }
+}
+
+
+double reprojectionError(const sfmData::SfMData& sfmData, const IndexT imageGroupID, const std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations)
+{
+    using namespace Eigen;
+
+    double delta = Square(4.0);  // taken from BundleAdjustmentCeres::CeresOptions::lossFunction: HuberLoss(Square(4.0))
+
+    std::vector<double> vecResiduals;
+
+    // Compute the residual for each observation
+    for (const auto& [landmarkId, landmark]: sfmData.getLandmarks())
+    {
+        for (const auto& [viewId, observation]: landmark.getObservations())
+        {
+            const auto& view = sfmData.getView(viewId);
+            geometry::Pose3 pose;
+
+            if (view.getImageGroupId() != imageGroupID)
+            {
+               pose = sfmData.getPose(view).getTransform();
+            }
+            else
+            {
+                IndexT frameIdx = viewIdIndices.at(viewId);
+                AngleAxisd aa(viewRotations(0, frameIdx), viewRotations(seqN(1,3), frameIdx));
+                pose = geometry::Pose3(aa.toRotationMatrix(), viewCenters.col(frameIdx));
+            }
+
+            const auto& intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
+            const Vec2 residual = intrinsic.residual(pose, landmark.getX().homogeneous(), observation.getCoordinates());
+            const double scale = (observation.getScale() > 1e-12) ? observation.getScale() : 1.0;
+            vecResiduals.push_back(huberLoss(delta, residual.norm() / scale));
+        }
+    }
+
+    ALICEVISION_LOG_DEBUG("Number of residuals : " << vecResiduals.size());
+
+    const Eigen::Map<Eigen::VectorXd> residuals(vecResiduals.data(), vecResiduals.size());
+
+    return residuals.sum();
+}
+
+
 } // namespace sfm
 } // namespace aliceVision
 
@@ -673,7 +885,7 @@ Eigen::MatrixXd tempFilter::applyMultiscale(Eigen::MatrixXd& inputSignal, const 
     bool useMask = posesMask.rows() != 0;
     MatrixX<bool> mask;
 
-    for (int scaleF = scaleFactor; scaleF >= 1; scaleF = (scaleF > 1) ? round(double(scaleF) / SCALE_REDUCTION_FACTOR) : 0)
+    for (int scaleF = scaleFactor; scaleF >= 1; scaleF = (scaleF > 1) ? std::round(double(scaleF) / SCALE_REDUCTION_FACTOR) : 0)
     {
         ALICEVISION_LOG_DEBUG(" Filter scale factor : " << scaleF);
 

--- a/src/aliceVision/sfm/utils/poseFilter.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter.cpp
@@ -16,59 +16,80 @@
 namespace aliceVision {
 namespace sfm {
 
-bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int scaleFactor, const int iterationCount)
+bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int iterationCount, const int scaleFactor)
 {
     using namespace Eigen;
 
     ALICEVISION_LOG_INFO("poseFilter::process start");
 
-    const int viewCount = sfmData.getViews().size();
-
-    std::vector<IndexT> viewIdsVec(viewCount);
-
-    // Get the temporally ordered view IDs in viewIdsVec
-    if (viewCount == 0 || !getOrderedViewIds(sfmData, viewIdsVec))
+    for (const auto & [imageGroupID, imageGroup] : sfmData.getImageGroups().valueRange())
     {
-        return false;
+        if (imageGroup.getType() != sfmData::ImageGroup::Type::ImageSequence)
+        {
+            continue;
+        }
+
+        const sfmData::Views& sfmViews = sfmData.getViews();
+
+        const int viewCount = std::count_if(sfmViews.begin(), sfmViews.end(),
+                                [&imageGroupID](const auto& viewPair) {
+                                    return viewPair.second->getImageGroupId() == imageGroupID;
+                                });
+
+        if (viewCount == 0)
+        {
+            continue;
+        }
+
+        std::vector<IndexT> viewIdsVec(viewCount);
+        std::map<IndexT, IndexT> viewIdIndices;
+
+        // Get the temporally ordered view IDs in viewIdsVec
+        if (!getOrderedViewIds(sfmData, imageGroupID, viewIdsVec, viewIdIndices))
+        {
+            return false;
+        }
+
+        tempFilter tFilter;
+
+        tFilter.init();
+
+        MatrixXd viewRotations(4, viewCount);
+        MatrixXd viewCenters(3, viewCount);
+
+        // Get the temporally ordered view positions and orientations
+        for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
+        {
+            const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
+            const sfmData::CameraPose framePose = sfmData.getPose(frameView);
+            viewCenters.col(frameIdx) = framePose.getTransform().center();
+            AngleAxisd aa(framePose.getTransform().rotation());
+            viewRotations.col(frameIdx) << aa.angle(), aa.axis();
+        }
+
+        // Apply a temporal filter to view positions
+        if (filterPosition)
+        {
+            ALICEVISION_LOG_INFO("Apply a temporal filter to view positions");
+            viewCenters = tFilter.applyMultiscale(viewCenters, scaleFactor, iterationCount, false);
+        }
+
+        // Apply a temporal filter to view orientations
+        if (filterRotation)
+        {
+            ALICEVISION_LOG_INFO("Apply a temporal filter to view orientations");
+            viewRotations = tFilter.applyMultiscale(viewRotations, scaleFactor, iterationCount, true);
+        }
+
+        // Save the temporally filtered poses
+        for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
+        {
+            AngleAxisd aa(viewRotations(0, frameIdx), viewRotations(seqN(1,3), frameIdx));
+            geometry::Pose3 newPose(aa.toRotationMatrix(), viewCenters.col(frameIdx));
+            const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
+            sfmData.setPose(frameView, sfmData::CameraPose(newPose));
+        }
     }
-
-    tempFilter tFilter;
-
-    tFilter.init();
-
-    MatrixXd viewRotations(4, viewCount);
-    MatrixXd viewCenters(3, viewCount);
-
-    // Get the temporally ordered view positions and orientations
-    for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
-    {
-        const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
-        const sfmData::CameraPose framePose = sfmData.getPose(frameView);
-        viewCenters.col(frameIdx) = framePose.getTransform().center();
-        AngleAxisd aa(framePose.getTransform().rotation());
-        viewRotations.col(frameIdx) << aa.angle(), aa.axis();
-    }
-
-    // Apply a temporal filter to view positions
-    if (filterPosition)
-    {
-        viewCenters = tFilter.applyMultiscale(viewCenters, scaleFactor, iterationCount, false);
-    }
-
-    // Apply a temporal filter to view orientations
-    if (filterRotation)
-    {
-        viewRotations = tFilter.applyMultiscale(viewRotations, scaleFactor, iterationCount, true);
-    }
-
-    // Save the temporally filtered poses
-    for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
-    {
-        AngleAxisd aa(viewRotations(0, frameIdx), viewRotations(seqN(1,3), frameIdx));
-        geometry::Pose3 newPose(aa.toRotationMatrix(), viewCenters.col(frameIdx));
-        const sfmData::View& frameView = sfmData.getView(viewIdsVec[frameIdx]);
-        sfmData.setPose(frameView, sfmData::CameraPose(newPose));
-   }
 
     ALICEVISION_LOG_INFO("poseFilter::process end");
     return true;
@@ -83,9 +104,9 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
 
     bool noInterpolationDone = true;
 
-    for (const auto & [imageGroupID, imageGroupPtr] : sfmData.getImageGroups())
+    for (const auto & [imageGroupID, imageGroup] : sfmData.getImageGroups().valueRange())
     {
-        if (imageGroupPtr.get()->getType() != sfmData::ImageGroup::Type::ImageSequence)
+        if (imageGroup.getType() != sfmData::ImageGroup::Type::ImageSequence)
         {
             continue;
         }
@@ -97,7 +118,7 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
             return viewPair.second->getImageGroupId() == imageGroupID;
         });
 
-        ALICEVISION_LOG_INFO("imageGroupID " << imageGroupID << " has " << viewCount << " views.");
+        ALICEVISION_LOG_INFO("imageGroup " << imageGroupID << " has " << viewCount << " views.");
 
         if (viewCount <= 1)
         {
@@ -169,7 +190,7 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
 
             if (!sfmData.existsPose(*viewPtr))
             {
-                ALICEVISION_LOG_INFO(" frameId in imageGroupID " << imageGroupID  << " without pose: " << frameId);
+                ALICEVISION_LOG_INFO(" frame in imageGroup " << imageGroupID  << " without pose: " << frameId);
             }
         }
 
@@ -254,22 +275,27 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
 }
 
 
-bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, std::vector<IndexT>& viewIdsVec)
+bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& viewIdsVec, std::map<IndexT, IndexT>& viewIdIndices)
 {
-    const int viewCount = sfmData.getViews().size();
-
-    IndexT firstViewFrameId = sfmData.getViews().begin()->second->getFrameId();
-    IndexT minFrameId = firstViewFrameId;  // Arbitrary frameId init
-    IndexT maxFrameId = firstViewFrameId;  // Arbitrary frameId init
+    IndexT minFrameId = UndefinedIndexT;
+    IndexT maxFrameId = UndefinedIndexT;
     IndexT minFrameIdWithPose;
 
+    IndexT viewCount = 0;
     bool existingPoseFound = false;
 
     // Get the frameIDs range and the frameID of the first view with an existing pose
     for (const auto& [viewID, viewPtr] : sfmData.getViews())
     {
+        if (viewPtr->getImageGroupId() != imageGroupID)
+        {
+            continue;
+        }
+
+        viewCount++;
+
         const IndexT frameId = viewPtr->getFrameId();
-        if (frameId < minFrameId)
+        if (frameId < minFrameId || minFrameId == UndefinedIndexT)
         {
             minFrameId = frameId;
         }
@@ -278,7 +304,7 @@ bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, std::vector<IndexT
             existingPoseFound = true;
             minFrameIdWithPose = frameId;
         }
-        if (frameId > maxFrameId)
+        if (frameId > maxFrameId || maxFrameId == UndefinedIndexT)
         {
             maxFrameId = frameId;
         }
@@ -298,12 +324,18 @@ bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, std::vector<IndexT
     // Store the temporally ordered view IDs
     for (const auto& [viewID, viewPtr] : sfmData.getViews())
     {
+        if (viewPtr->getImageGroupId() != imageGroupID)
+        {
+            continue;
+        }
+
         const IndexT frameId = viewPtr->getFrameId();
         viewIdsVec[frameId-minFrameId] = viewID;
+        viewIdIndices[viewID] = frameId - minFrameId;
 
         if (!sfmData.existsPose(*viewPtr))
         {
-            ALICEVISION_LOG_INFO(" frameId without pose : " << frameId);
+            ALICEVISION_LOG_INFO(" frame in imageGroup " << imageGroupID  << " without pose: " << frameId);
         }
     }
 
@@ -638,7 +670,7 @@ Eigen::MatrixXd tempFilter::applyMultiscale(Eigen::MatrixXd& inputSignal, const 
     const double SCALE_REDUCTION_FACTOR = 1.4;
 
     // An optional mask can be used to apply the filter just on some poses
-    bool useMask = posesMask.cols() != 0;
+    bool useMask = posesMask.rows() != 0;
     MatrixX<bool> mask;
 
     for (int scaleF = scaleFactor; scaleF >= 1; scaleF = (scaleF > 1) ? round(double(scaleF) / SCALE_REDUCTION_FACTOR) : 0)

--- a/src/aliceVision/sfm/utils/poseFilter.hpp
+++ b/src/aliceVision/sfm/utils/poseFilter.hpp
@@ -12,6 +12,24 @@
 namespace aliceVision {
 namespace sfm {
 
+enum class PoseParamType
+{
+    Positions,
+    Rotations,
+};
+
+inline std::string poseParamType_enumToString(const PoseParamType poseParam)
+{
+    switch (poseParam)
+    {
+        case PoseParamType::Positions:
+            return "pose position";
+        case PoseParamType::Rotations:
+            return "pose rotation";
+    }
+    throw std::out_of_range("Invalid PoseParamType enum");
+}
+
 class poseFilter
 {
 public:
@@ -23,11 +41,15 @@ public:
      * @param sfmData the scene description
      * @param filterPosition specify whether to filter camera positions
      * @param filterRotation specify whether to filter camera orientations
-     * @param iterationCount the number of filter iterations
-     * @param scaleFactor integer factor to increase the filter range
+     * @param maxIterationCount the maximum number of filter iterations
+     * @param maxScaleFactor integer factor to increase the filter range
+     * @param maxErrorIncreasePos the maximum reprojection error increase ratio for the camera positions (-1 to bypass this reprojection error test)
+     * @param maxErrorIncreaseRot the maximum reprojection error increase ratio for the camera orientations (-1 to bypass this reprojection error test)
+     * @param minIterationCount the minimum number of filter iterations to apply at the smallest scales (in case the filter is limited by the reprojection error)
+     * @param minScaleFactor the minimum scale to apply the filter with the minimum iteration count (in case the filter is limited by the reprojection error)
      * @return false if an error occurred
     */
-    bool process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int iterationCount, const int scaleFactor);
+    bool process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int maxIterationCount, const int maxScaleFactor, const double maxErrorIncreasePos, const double maxErrorIncreaseRot, const int minIterationCount, const int minScaleFactor);
 
     /**
      * @brief Interpolate poses for views without poses using temporal filtering.
@@ -39,6 +61,7 @@ public:
 
 private:
     bool getOrderedViewIds(sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& viewIdsVec, std::map<IndexT, IndexT>& viewIdIndices);
+    Eigen::MatrixXd applyLimitedFilter(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, const PoseParamType paramToFilter, const int maxIterationCount, const int minIterationCount, const int maxScaleFactor, const int minScaleFactor, const double maxErrorIncrease);
 };
 
 /**
@@ -55,6 +78,20 @@ private:
  * @return true if at least one pose was found and the output parameters were set, false otherwise.
  */
 bool getOrderedPoseIds(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& poseIdsVec, IndexT& firstViewWithPose, IndexT& lastViewWithPose);
+
+/**
+ * @brief Compute the reprojection error for all observations corresponding to an imageGroup in a SfMData,
+ * and the camera poses from provided camera positions and rotations
+ *
+ * @param[in]  sfmData            The scene description containing views and observations.
+ * @param[in]  imageGroupID       The imageGroupID of the views to consider.
+ * @param[in]  viewIdIndices      A map from viewID to indices in the view positions/rotations vectors
+ * @param[in]  viewCenters        Vector of view positions.
+ * @param[in]  viewRotations      Vector of view rotations.
+ * @return the sum of the reprojection errors.
+ */
+double reprojectionError(const sfmData::SfMData& sfmData, const IndexT imageGroupID, const std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations);
+
 } // namespace sfm
 } // namespace aliceVision
 

--- a/src/aliceVision/sfm/utils/poseFilter.hpp
+++ b/src/aliceVision/sfm/utils/poseFilter.hpp
@@ -23,11 +23,11 @@ public:
      * @param sfmData the scene description
      * @param filterPosition specify whether to filter camera positions
      * @param filterRotation specify whether to filter camera orientations
-     * @param scaleFactor integer factor to increase the filter range
      * @param iterationCount the number of filter iterations
+     * @param scaleFactor integer factor to increase the filter range
      * @return false if an error occurred
     */
-    bool process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int scaleFactor, const int iterationCount);
+    bool process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int iterationCount, const int scaleFactor);
 
     /**
      * @brief Interpolate poses for views without poses using temporal filtering.
@@ -38,7 +38,7 @@ public:
     bool interpolateMissingPoses(sfmData::SfMData& sfmData, const bool ignoreFirstAndLast);
 
 private:
-    bool getOrderedViewIds(sfmData::SfMData& sfmData, std::vector<IndexT>& viewIdsVec);
+    bool getOrderedViewIds(sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& viewIdsVec, std::map<IndexT, IndexT>& viewIdIndices);
 };
 
 /**

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -30,7 +30,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 4
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 5
 
 using namespace aliceVision;
 
@@ -60,6 +60,7 @@ int aliceVision_main(int argc, char** argv)
     double minAngleForLandmark = 2.0;
     double maxReprojectionError = 4.0;
     double maxTriangulationError = 8.0;
+    unsigned int maxIterationCount = 50;
     bool lockAllIntrinsics = false;
     bool enableStructureRefinement = true;
     int minNbCamerasToRefinePrincipalPoint = 3;
@@ -120,6 +121,7 @@ int aliceVision_main(int argc, char** argv)
     ("minAngleForLandmark", po::value<double>(&minAngleForLandmark)->default_value(minAngleForLandmark), "Minimum angle for landmark.")
     ("maxTriangulationError", po::value<double>(&maxTriangulationError)->default_value(maxTriangulationError), "Maximum reprojection error in the triangulation process.")
     ("maxReprojectionError", po::value<double>(&maxReprojectionError)->default_value(maxReprojectionError), "Maximum reprojection error in the bundle verification step.")
+    ("maxIterationCount", po::value<unsigned int>(&maxIterationCount)->default_value(maxIterationCount), "Maximum number of solver iterations.")
     ("lockAllIntrinsics", po::value<bool>(&lockAllIntrinsics)->default_value(lockAllIntrinsics), "Force lock of all camera intrinsic parameters, so they will not be refined during Bundle Adjustment.")
     ("enableStructureRefinement", po::value<bool>(&enableStructureRefinement)->default_value(enableStructureRefinement), "Bundle adjustment will try to optimize the landmarks positions.")
     ("minNbCamerasToRefinePrincipalPoint", po::value<int>(&minNbCamerasToRefinePrincipalPoint)->default_value(minNbCamerasToRefinePrincipalPoint),
@@ -210,6 +212,7 @@ int aliceVision_main(int argc, char** argv)
     sfmBundle->setMaxReprojectionError(maxReprojectionError);
     sfmBundle->setMinNbCamerasToRefinePrincipalPoint(minNbCamerasToRefinePrincipalPoint);
     sfmBundle->setIsStructureRefinementEnabled(enableStructureRefinement);
+    sfmBundle->setMaxIterationCount(maxIterationCount);
     sfmBundle->setTemporalConstraintParams(tempConstrParams, useTemporalConstraint);
 
     sfmData::PointFetcher::sptr pointFetcherHandler;

--- a/src/software/pipeline/main_sfmTemporalFiltering.cpp
+++ b/src/software/pipeline/main_sfmTemporalFiltering.cpp
@@ -18,7 +18,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
@@ -34,8 +34,12 @@ int aliceVision_main(int argc, char** argv)
 
     bool filterPosition = true;
     bool filterRotation = true;
-    int iterationCount = 100;
-    int scaleFactor = 3;
+    int maxIterationCount = 100;
+    int maxScaleFactor = 3;
+    double maxErrorIncreasePos = -1.;
+    double maxErrorIncreaseRot = -1.;
+    int minIterationCount = 50;
+    int minScaleFactor = 3;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -47,9 +51,13 @@ int aliceVision_main(int argc, char** argv)
     optionalParams.add_options()
         ("filterPosition", po::value<bool>(&filterPosition)->default_value(filterPosition), "Whether to filter camera positions.")
         ("filterRotation", po::value<bool>(&filterRotation)->default_value(filterRotation), "Whether to filter camera orientations.")
-        ("scaleFactor", po::value<int>(&scaleFactor)->default_value(scaleFactor), "Scale factor to increase the filter range.")
-        ("iterationCount", po::value<int>(&iterationCount)->default_value(iterationCount), "Number of filter iterations.")
-        ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).");
+        ("iterationCount", po::value<int>(&maxIterationCount)->default_value(maxIterationCount), "Number of filter iterations.")
+        ("scaleFactor", po::value<int>(&maxScaleFactor)->default_value(maxScaleFactor), "Scale factor to increase the filter range.")
+        ("maxErrorIncreasePos", po::value<double>(&maxErrorIncreasePos)->default_value(maxErrorIncreasePos), "The maximum reprojection error increase ratio for the camera positions. (-1 to bypass this reprojection error test)")
+        ("maxErrorIncreaseRot", po::value<double>(&maxErrorIncreaseRot)->default_value(maxErrorIncreaseRot), "The maximum reprojection error increase ratio for the camera orientations. (-1 to bypass this reprojection error test)")
+        ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).")
+        ("minIterationCount", po::value<int>(&minIterationCount)->default_value(minIterationCount), "The minimum number of filter iterations to apply at the smallest scales. (in case the filter is limited by the reprojection error)")
+        ("minScaleFactor", po::value<int>(&minScaleFactor)->default_value(minScaleFactor), "The minimum scale to apply the filter with the minimum iteration count. (in case the filter is limited by the reprojection error)");
     // clang-format on
 
     CmdLine cmdline("AliceVision SfM Temporal Filtering");
@@ -75,7 +83,10 @@ int aliceVision_main(int argc, char** argv)
 
     sfm::poseFilter::uptr poseFilter = std::make_unique<sfm::poseFilter>();
 
-    if (!poseFilter->process(sfmData, filterPosition, filterRotation, scaleFactor, iterationCount))
+    if (!poseFilter->process(sfmData, filterPosition, filterRotation,
+                             maxIterationCount, maxScaleFactor,
+                             maxErrorIncreasePos, maxErrorIncreaseRot,
+                             minIterationCount, minScaleFactor))
     {
         ALICEVISION_LOG_INFO("Error processing sfmData");
         return EXIT_FAILURE;


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Structure-from-Motion (SfM) temporal filtering and bundle adjustment modules, focusing on enhanced configurability, improved logging, and better control over solver iterations and reprojection error management. The most significant changes are grouped below by theme.

### Add support for imageGroup to SfM Temporal Filtering
* The pose filter is now only applied on image sequences imageGroups.

### SfM Temporal Filtering Enhancements

* Added advanced parameters to the `SfMTemporalFiltering` node, allowing users to limit reprojection error during filtering. New parameters include `limitReprojError`, `maxErrorIncreasePos`, `maxErrorIncreaseRot`, `minIterationCount`, and `minScaleFactor`, all of which provide finer control over the filtering process. The command-line interface and node UI have been updated accordingly.
* Updated the pose filter utility to support the new filtering options, including error-limited filtering and new reprojection error computation utilities.

### Bundle Adjustment and Solver Iteration Control

* Introduced a `maxIterationCount` parameter to the expanding SfM pipeline, allowing users to limit the number of solver iterations in bundle adjustment. This is exposed in the command-line interface and propagated through the pipeline.
* Improved bundle adjustment logging by adding a custom Ceres solver iteration callback (`IterationInfos`) that logs the cost and cost change at each iteration, and ensured that solver progress is updated every iteration.

### Version Updates

* Bumped version numbers for `SfMTemporalFiltering`, `SfmExpanding`, and their corresponding main pipeline files to reflect the new features and command-line changes.

These changes collectively provide users with more robust and flexible tools for SfM workflows, particularly in controlling the quality and stability of camera pose filtering and bundle adjustment processes.