### PR TITLE
fix(cmake): don't use GIT_SHALLOW when a dependency is pinned to a commit

### DIFF
--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -460,8 +460,12 @@ macro(av_add_cmake_dep)
         if(_D_GIT_TAG)
             list(APPEND _D_SRC_ARGS GIT_TAG      ${_D_GIT_TAG})
         endif()
-        # Shallow clone : plus rapide, économise le réseau
-        list(APPEND _D_SRC_ARGS GIT_SHALLOW TRUE)
+        # Shallow clone only fetches the default-branch tip: a GIT_TAG that is
+        # a commit hash not at that tip fails to check out. Use it only for
+        # named refs (branches/tags), not for pinned commits.
+        if(NOT "${_D_GIT_TAG}" MATCHES "^[0-9a-fA-F]+$")
+            list(APPEND _D_SRC_ARGS GIT_SHALLOW TRUE)
+        endif()
     endif()
 
     ExternalProject_Add(${_D_TARGET}


### PR DESCRIPTION
## Problem

`av_add_cmake_dep` (in `src/cmake/Helpers.cmake`) enabled `GIT_SHALLOW TRUE`
for **every** git dependency.

A shallow clone (`git clone --depth 1`) only fetches the tip of the remote's
default branch. When `GIT_TAG` is a **commit hash that is not that tip**, the
subsequent checkout fails:

```
fatal: unable to read tree <sha>
CMake Error: Failed to checkout tag: '<sha>'
```

The commit is not actually missing — it is fetchable — but the shallow clone
never downloads it, so the checkout cannot find it.

### Impact

This breaks `ALICEVISION_BUILD_DEPENDENCIES` for any dependency pinned to a
commit that is not the default-branch tip. Concretely, the dependency build
fails on **popsift** and **cctag**. Dependencies pinned to a hash that happens
to be the default-branch tip only built by luck.

Dependencies referenced by a **named** branch/tag (`v4.5.1`, `main`, …) are
unaffected.

## Fix

Enable `GIT_SHALLOW` only when `GIT_TAG` is a named branch/tag, not a raw
commit hash:

```cmake
if(NOT _D_GIT_TAG MATCHES "^[0-9a-fA-F]+$")
    list(APPEND _D_SRC_ARGS GIT_SHALLOW TRUE)
endif()
```

- Named refs keep the shallow-clone speedup.
- Commit-pinned deps get a full clone and check out reliably.

## Notes

Regression introduced in `634581fb4` ("modernize Docker/CMake infrastructure"),
which added the unconditional `GIT_SHALLOW TRUE`.

Verified by a full `ALICEVISION_BUILD_DEPENDENCIES` Docker build (Rocky 9 +
CUDA 12.1.1): with this change, popsift and cctag clone and build correctly,
and the whole dependency set builds to completion.
