### PR TITLE
fix(docker/rocky): drop `dnf update -y` to avoid breaking the CUDA toolkit

### DIFF
--- a/docker/Dockerfile_rocky_deps
+++ b/docker/Dockerfile_rocky_deps
@@ -72,8 +72,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
         xerces-c-devel                                                    \
         yaml-cpp                                                          \
         yasm                                                              \
-        ninja-build                                                       \
-    && dnf update -y
+        ninja-build
 
 # =============================================================================
 # Compiler environment (GCC 12 toolset)


### PR DESCRIPTION
## Problem

The Rocky deps image ends its system-package step with a blanket
`dnf update -y`. That upgrade pulls packages from the CUDA repo and now
breaks dependency resolution against the CUDA 12.1.1 base image:

```
package cccl-13-3-13.3.3.3.1 obsoletes cuda-cccl-12-1
 → cuda-cudart-devel-12-1 can no longer be installed
Error: cannot install the best update candidate for cuda-cudart-devel-12-1
```

NVIDIA published `cccl-13.x` (CUDA 13) in the repo; `dnf update -y` tries to
move CUDA packages to it, conflicting with the 12.1 toolkit that ships in the
base image. The build fails at this step (STEP 6/21).

## Fix

Drop the blanket `dnf update -y`. The packages the build needs are already
installed explicitly via the `dnf install` lists just above, and the CUDA
toolkit from the base image is left untouched and consistent.
