### PR TITLE
fix(bundle): fix MakeBundle and RPATH issues on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,7 +147,7 @@ if (ALICEVISION_USE_RPATH)
             "@executable_path/../Frameworks"
         )
     elseif (UNIX)
-        set(CMAKE_INSTALL_RPATH "\\$ORIGIN/../${CMAKE_INSTALL_LIBDIR};\\$ORIGIN")
+        set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR};\$ORIGIN")
     endif()
 endif()
 

--- a/src/cmake/MakeBundle.cmake
+++ b/src/cmake/MakeBundle.cmake
@@ -213,11 +213,15 @@ if(UNIX)
 
     file(GLOB _LIBS_TO_MOVE "${_bundle_bindir}/lib*.so*")
     if(_LIBS_TO_MOVE)
-        message(STATUS "  Moving ${CMAKE_LIST_LENGTH} stray libs from bin/ to lib/")
-        file(COPY ${_LIBS_TO_MOVE}
-             DESTINATION "${_bundle_libdir}"
-             USE_SOURCE_PERMISSIONS)
-        file(REMOVE ${_LIBS_TO_MOVE})
+        list(LENGTH _LIBS_TO_MOVE _n_libs)
+        message(STATUS "  Moving ${_n_libs} stray libs from bin/ to lib/")
+        # Move with RENAME (not COPY): it relocates symlinks as-is instead of
+        # dereferencing them. fixup_bundle may leave a dangling symlink in bin/
+        # (its target left in lib/), which file(COPY) cannot duplicate.
+        foreach(_lib IN LISTS _LIBS_TO_MOVE)
+            get_filename_component(_lib_name "${_lib}" NAME)
+            file(RENAME "${_lib}" "${_bundle_libdir}/${_lib_name}")
+        endforeach()
     endif()
 endif()
 

--- a/src/cmake/MakeBundle.cmake
+++ b/src/cmake/MakeBundle.cmake
@@ -182,7 +182,24 @@ foreach(_dir
         "${CMAKE_INSTALL_FULL_BINDIR}"
         "${CMAKE_INSTALL_FULL_LIBDIR}"
         "${CMAKE_INSTALL_FULL_DATADIR}")
-    if(EXISTS "${_dir}")
+    if(IS_SYMLINK "${_dir}")
+        # Symlink directory (e.g. lib64 -> lib): file(COPY) would reproduce the
+        # dangling symlink without its target. Copy the real directory instead,
+        # then recreate the symlink so both names are valid in the bundle.
+        get_filename_component(_link_name "${_dir}" NAME)
+        get_filename_component(_real      "${_dir}" REALPATH)
+        get_filename_component(_real_name "${_real}" NAME)
+        if(EXISTS "${_real}")
+            file(COPY "${_real}"
+                 DESTINATION "${BUNDLE_INSTALL_PREFIX}"
+                 USE_SOURCE_PERMISSIONS)
+        endif()
+        if(NOT EXISTS "${BUNDLE_INSTALL_PREFIX}/${_link_name}")
+            file(CREATE_LINK "${_real_name}"
+                 "${BUNDLE_INSTALL_PREFIX}/${_link_name}" SYMBOLIC)
+            message(STATUS "  Created symlink: ${_link_name} -> ${_real_name}")
+        endif()
+    elseif(EXISTS "${_dir}")
         file(COPY "${_dir}"
              DESTINATION "${BUNDLE_INSTALL_PREFIX}"
              USE_SOURCE_PERMISSIONS)


### PR DESCRIPTION
## Summary

Three bugs affecting the `bundle` target on Linux (Rocky/RHEL):

- **Stray libs in `bin/`**: `fixup_bundle` may leave dangling symlinks (e.g. `libAlembic.so.1.8`) in `bin/` because their targets remain in `lib/`. `file(COPY)` cannot duplicate dangling symlinks; replaced with `file(RENAME)` in a `foreach` loop.

- **`lib64 -> lib` symlink broken in bundle**: on systems where `CMAKE_INSTALL_LIBDIR` resolves to `lib64` (a symlink to `lib`), `file(COPY)` reproduced the symlink without copying its target, leaving a dangling `lib64 -> lib` in the bundle. Now detects `IS_SYMLINK`, copies the real directory, and recreates the symlink.

- **`$ORIGIN` RPATH written as `\$ORIGIN`**: `\\$ORIGIN` in the CMake string produced a literal `\$ORIGIN` in the ELF RPATH, which the dynamic linker does not recognise as the executable-relative token. Changed to `\$ORIGIN` (single backslash) which produces the correct `$ORIGIN` in the binary.

## Test plan

- [ ] Build AliceVision with `-DALICEVISION_BUILD_DEPENDENCIES=OFF` against pre-built deps on a Rocky 9 / RHEL system
- [ ] Run `cmake --build . --target bundle` and verify it completes without errors
- [ ] Confirm `readelf -d <bundle>/bin/aliceVision_* | grep RPATH` shows `$ORIGIN/../lib64:$ORIGIN`
- [ ] Confirm `bundle/lib64` is a valid symlink pointing to an existing `bundle/lib/`
- [ ] Run a bundled executable outside the install prefix to verify runtime linking