### PR TITLE
fix(exposure): avoid degenerate EV compensation when images lack exposure metadata

### DIFF
--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -12,6 +12,8 @@
 #include <aliceVision/mvsUtils/common.hpp>
 #include <aliceVision/mvsUtils/MultiViewParams.hpp>
 
+#include <cmath>
+
 namespace aliceVision {
 namespace mvsUtils {
 
@@ -417,6 +419,14 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
         {
             exposureCompensation = 1.0f;
             ALICEVISION_LOG_INFO("Cannot compensate exposure. PrepareDenseScene needs to be update");
+        }
+        else if (!std::isfinite(exposureCompensation) || exposureCompensation <= 0.f)
+        {
+            // reject a degenerate compensation factor (-inf/nan/0/negative) that an upstream node may write when the
+            // source images lack exposure metadata; applying it would crush the texture to black, so fall back to neutral
+            ALICEVISION_LOG_WARNING("Invalid EV compensation (" << exposureCompensation << ") for image " << camId + 1
+                                                                << "; resetting to neutral 1.0.");
+            exposureCompensation = 1.0f;
         }
         else
         {

--- a/src/aliceVision/mvsUtils/fileIO.cpp
+++ b/src/aliceVision/mvsUtils/fileIO.cpp
@@ -438,9 +438,9 @@ void loadImage(const std::string& path, const MultiViewParams& mp, int camId, Im
                 img(i)[1] *= exposureCompensation;
                 img(i)[2] *= exposureCompensation;
             }
-
-            imageAlgo::colorconvert(img, image::EImageColorSpace::LINEAR, colorspace);
         }
+
+        imageAlgo::colorconvert(img, image::EImageColorSpace::LINEAR, colorspace);
     }
 
     // scale chosen by the user and apply during the process

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -595,6 +595,11 @@ class SfMData
             }
         }
 
+        // no view has usable exposure metadata (e.g. video frames without EXIF), so the list is empty; avoid the
+        // out-of-bounds read below and return a default ExposureSetting (its getExposure() yields the -1 missing sentinel)
+        if (cameraExposureList.empty())
+            return ExposureSetting();
+
         std::nth_element(cameraExposureList.begin(), cameraExposureList.begin() + cameraExposureList.size() / 2, cameraExposureList.end());
         const ExposureSetting& ceMedian = cameraExposureList[cameraExposureList.size() / 2];
 

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -130,7 +130,9 @@ bool prepareDenseScene(const SfMData& sfmData,
 
     // for exposure correction
     const double medianCameraExposure = sfmData.getMedianCameraExposureSetting().getExposure();
-    ALICEVISION_LOG_INFO("Median Camera Exposure: " << medianCameraExposure << ", Median EV: " << std::log2(1.0 / medianCameraExposure));
+    // guard the log2 as above: a missing-metadata median (-1 sentinel) would otherwise print a NaN Median EV
+    const double medianEV = (medianCameraExposure > 0.0) ? std::log2(1.0 / medianCameraExposure) : 0.0;
+    ALICEVISION_LOG_INFO("Median Camera Exposure: " << medianCameraExposure << ", Median EV: " << medianEV);
 
 #pragma omp parallel for num_threads(3)
     for (int i = 0; i < viewIds.size(); ++i)

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -245,7 +245,10 @@ bool prepareDenseScene(const SfMData& sfmData,
             // add exposure values to images metadata
             const double cameraExposure = view->getImage().getCameraExposureSetting().getExposure();
             const double ev = std::log2(1.0 / cameraExposure);
-            const float exposureCompensation = float(medianCameraExposure / cameraExposure);
+            // only a strictly positive median and camera exposure give a meaningful factor; otherwise getExposure()
+            // returned the -1 sentinel (missing metadata) and dividing would write a degenerate (-inf) EVComp
+            const float exposureCompensation =
+                (medianCameraExposure > 0.0 && cameraExposure > 0.0) ? float(medianCameraExposure / cameraExposure) : 1.0f;
             metadata.push_back(oiio::ParamValue("AliceVision:EV", float(ev)));
             metadata.push_back(oiio::ParamValue("AliceVision:EVComp", exposureCompensation));
 

--- a/src/software/pipeline/main_prepareDenseScene.cpp
+++ b/src/software/pipeline/main_prepareDenseScene.cpp
@@ -244,9 +244,9 @@ bool prepareDenseScene(const SfMData& sfmData,
 
             // add exposure values to images metadata
             const double cameraExposure = view->getImage().getCameraExposureSetting().getExposure();
-            const double ev = std::log2(1.0 / cameraExposure);
-            // only a strictly positive median and camera exposure give a meaningful factor; otherwise getExposure()
-            // returned the -1 sentinel (missing metadata) and dividing would write a degenerate (-inf) EVComp
+            // getExposure() returns the -1 sentinel when metadata is missing; guard both derived values so we never
+            // write a degenerate EV (log2 of a negative -> NaN) or EVComp (division -> -inf) into the image metadata
+            const double ev = (cameraExposure > 0.0) ? std::log2(1.0 / cameraExposure) : 0.0;
             const float exposureCompensation =
                 (medianCameraExposure > 0.0 && cameraExposure > 0.0) ? float(medianCameraExposure / cameraExposure) : 1.0f;
             metadata.push_back(oiio::ParamValue("AliceVision:EV", float(ev)));


### PR DESCRIPTION
**Problem**

`PrepareDenseScene` writes `AliceVision:EVComp = medianExposure / cameraExposure`
into each undistorted EXR, but `getExposure()` returns a `-1` sentinel for views
with no shutter/fnumber (e.g. video frames extracted with ffmpeg). The division
trusts that sentinel, so every such view gets a degenerate `EVComp`. With
`correctEV` enabled, `Texturing` multiplies every texel by it and the atlas comes
out black.

When *all* views lack metadata there is an additional issue: the candidate list in
`getMedianCameraExposureSetting()` is empty and `cameraExposureList[size()/2]` is
read out of bounds, so the median is garbage. That makes the result
nondeterministic — `EVComp` lands on `-inf` or `1` depending on heap contents,
which with PrepareDenseScene's per-chunk parallelism produces the characteristic
per-block split.

**Fix** (defense in depth)

- `main_prepareDenseScene.cpp`: only compute the ratio when median and camera
  exposure are both strictly positive; otherwise write a neutral `1.0`.
- `SfMData::getMedianCameraExposureSetting()`: return a default `ExposureSetting`
  when no view has usable metadata, instead of indexing an empty vector.
- `fileIO.cpp` (`loadImage`): reject a non-finite / non-positive `EVComp` at read
  time and fall back to `1.0`, mirroring the existing "missing metadata" branch.
