### PR TITLE
Fix build against nanoflann >= 1.10 and SYCL+GCC libomp linkage

### DIFF
--- a/src/aliceVision/fuseCut/Kdtree.hpp
+++ b/src/aliceVision/fuseCut/Kdtree.hpp
@@ -47,12 +47,14 @@ struct PointVectorAdaptator
 typedef nanoflann::L2_Simple_Adaptor<double, PointVectorAdaptator> KdTreeDist;
 typedef nanoflann::KDTreeSingleIndexAdaptor<KdTreeDist, PointVectorAdaptator, 3> KdTree;
 
-template<typename _DistanceType, typename IndexType = size_t>
+template<typename _DistanceType, typename _IndexType = size_t>
 class SmallerPixSizeInRadius
 {
   public:
     // Necessary since nanoflann 1.7.0: https://github.com/jlblancoc/nanoflann/commit/9c84c4c32c2bfa7077cc8873dd3b5bcbb557da90
     using DistanceType = _DistanceType;
+    // Necessary since nanoflann 1.10.0: result sets must expose an IndexType typedef
+    using IndexType = _IndexType;
     const DistanceType radius;
 
     const std::vector<double>& m_pixSizePrepare;
@@ -81,7 +83,7 @@ class SmallerPixSizeInRadius
      * Called during search to add an element matching the criteria.
      * @return true if the search should be continued, false if the results are sufficient
      */
-    inline bool addPoint(DistanceType dist, IndexType index)
+    inline bool addPoint(DistanceType dist, _IndexType index)
     {
         if (dist < radius)
         {

--- a/src/cmake/Helpers.cmake
+++ b/src/cmake/Helpers.cmake
@@ -51,7 +51,28 @@ function(alicevision_add_library library_name)
     if (LIBRARY_USE_SYCL)
         add_sycl_to_target(TARGET ${library_name} SOURCES ${LIBRARY_SOURCES})
         if(CMAKE_COMPILER_IS_GNUCXX)
-          target_link_options(${library_name} PUBLIC "-lomp")
+          # When AliceVision is built with GCC, the SYCL sources are still compiled
+          # by AdaptiveCpp/clang with -fopenmp and depend on LLVM's OpenMP runtime
+          # (libomp: __kmpc_* symbols). GCC-linked consumers (e.g. the executables
+          # linking this library) do not pull libomp in automatically, so a bare
+          # "-lomp" link option is not always enough to resolve those symbols at
+          # final link time. Resolve libomp to a full path (searching the
+          # AdaptiveCpp/ROCm LLVM lib dirs when known) and link it explicitly so it
+          # propagates to consumers; fall back to "-lomp" if it cannot be located.
+          set(_acpp_omp_hints "")
+          if(DEFINED AdaptiveCpp_DIR)
+            get_filename_component(_acpp_root "${AdaptiveCpp_DIR}" DIRECTORY)
+            list(APPEND _acpp_omp_hints "${_acpp_root}/../lib" "${_acpp_root}/../../lib")
+          endif()
+          if(DEFINED ROCM_PATH)
+            list(APPEND _acpp_omp_hints "${ROCM_PATH}/lib" "${ROCM_PATH}/llvm/lib")
+          endif()
+          find_library(ACPP_LIBOMP NAMES omp libomp HINTS ${_acpp_omp_hints})
+          if(ACPP_LIBOMP)
+            target_link_libraries(${library_name} PUBLIC ${ACPP_LIBOMP})
+          else()
+            target_link_options(${library_name} PUBLIC "-lomp")
+          endif()
         endif()
     endif()
 

--- a/src/software/convert/main_importE57.cpp
+++ b/src/software/convert/main_importE57.cpp
@@ -61,12 +61,14 @@ struct PointInfoVectorAdaptator
 using PointInfoKdTree =
   nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, PointInfoVectorAdaptator>, PointInfoVectorAdaptator, 3>;
 
-template<typename _DistanceType, typename IndexType = size_t>
+template<typename _DistanceType, typename _IndexType = size_t>
 class BestPointInRadius
 {
   public:
     // Necessary since nanoflann 1.7.0: https://github.com/jlblancoc/nanoflann/commit/9c84c4c32c2bfa7077cc8873dd3b5bcbb557da90
     using DistanceType = _DistanceType;
+    // Necessary since nanoflann 1.10.0: result sets must expose an IndexType typedef
+    using IndexType = _IndexType;
     const DistanceType m_radius;
     const std::vector<dataio::E57Reader::PointInfo>& m_points;
     const std::map<int, Eigen::Vector3d>& m_cameras;
@@ -99,7 +101,7 @@ class BestPointInRadius
      * Called during search to add an element matching the criteria.
      * @return true if the search should be continued, false if the results are sufficient
      */
-    inline bool addPoint(DistanceType dist, IndexType index)
+    inline bool addPoint(DistanceType dist, _IndexType index)
     {
         if (index == m_i)
         {


### PR DESCRIPTION
## Description

Two small, independent build fixes needed to compile AliceVision (`develop`) against current toolchains/dependencies. Both are isolated and behavior-preserving.

### 1. `fix(deps)`: expose `IndexType` in custom nanoflann result sets

nanoflann **1.10.0** casts the accessor to `typename RESULTSET::IndexType` in `KDTreeBaseClass::searchLevel()`:

```cpp
if (!result_set.addPoint(
        static_cast<typename RESULTSET::DistanceType>(dist),
        static_cast<typename RESULTSET::IndexType>(accessor)))   // <-- requires IndexType typedef
```

Two custom result-set classes only carried `IndexType` as a *template parameter* and did not publish it as a member typedef, so building against nanoflann ≥ 1.10 fails with:

```
error: no type named 'IndexType' in 'class aliceVision::fuseCut::SmallerPixSizeInRadius<double, long unsigned int>'
error: no type named 'IndexType' in 'class BestPointInRadius<double, long unsigned int>'
```

Fix: rename the template parameter to `_IndexType` and expose `using IndexType = _IndexType;` (mirroring the existing `DistanceType` typedef added for nanoflann 1.7). No behavior change.

Affected files:
- `src/aliceVision/fuseCut/Kdtree.hpp` (`SmallerPixSizeInRadius`)
- `src/software/convert/main_importE57.cpp` (`BestPointInRadius`)

### 2. `fix(cmake)`: link `libomp` by full path for SYCL libraries built with GCC

When AliceVision is built with **GCC** but the SYCL depthmap sources are compiled by **AdaptiveCpp/clang** (`-fopenmp`), the resulting `aliceVision_depthMap_sycl` library depends on LLVM's OpenMP runtime (`libomp`, `__kmpc_*` symbols). The existing `target_link_options(... "-lomp")` does not reliably propagate to GCC-linked consumers, so linking executables fails:

```
libaliceVision_depthMap_sycl.so: undefined reference to `__kmpc_fork_call'
libaliceVision_depthMap_sycl.so: undefined reference to `__kmpc_push_num_threads'
libaliceVision_depthMap_sycl.so: undefined reference to `__kmpc_global_thread_num'
```

Fix: resolve `libomp` to a full path (searching the AdaptiveCpp/ROCm LLVM lib dirs via `AdaptiveCpp_DIR` / `ROCM_PATH` when available) and link it with `target_link_libraries(... PUBLIC ...)` so it propagates transitively. Falls back to `-lomp` if not found.

Affected file:
- `src/cmake/Helpers.cmake`

## Testing

Built `develop` end-to-end on Arch Linux (GCC 16, nanoflann 1.10.1, AdaptiveCpp 25.10 + ROCm 7.2, SYCL depthmap backend) — full build now completes and produces working `aliceVision_*` binaries including `aliceVision_depthMapEstimation`.

## Notes

Marking as draft for maintainer review; happy to adjust the libomp discovery logic if there's a preferred pattern already used elsewhere in the CMake.
