### PR TITLE
Update NodalSfm node

### DIFF
--- a/meshroom/aliceVision/NodalSfM.py
+++ b/meshroom/aliceVision/NodalSfM.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "2.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import DESCRIBER_TYPES, VERBOSE_LEVEL
@@ -17,7 +17,9 @@ calibrated rotations but no translational component, suitable for panorama stitc
 
     commandLine = "aliceVision_nodalSfM {allParams}"
     size = desc.DynamicNodeSize("input")
-
+    cpu = desc.Level.INTENSIVE
+    ram = desc.Level.INTENSIVE
+    
     category = "Sparse Reconstruction"
     inputs = [
         desc.File(
@@ -38,6 +40,41 @@ calibrated rotations but no translational component, suitable for panorama stitc
             description="Information on pairs.",
             value="",
         ),
+        desc.FloatParam(
+            name="maxReprojectionError",
+            label="Max Reprojection Error",
+            description="Maximum reprojection error (pixels) to accept a track as a landmark observation.",
+            value=4.0,
+            range=(0.1, 20.0, 0.1),
+        ),
+        desc.IntParam(
+            name="minInliers",
+            label="Min Inliers",
+            description="Minimum number of AC-RANSAC inliers required to localize a view.",
+            value=35,
+            range=(5, 1000, 1),
+        ),
+        desc.IntParam(
+            name="maxRansacIterations",
+            label="Max RANSAC Iterations",
+            description="Maximum number of AC-RANSAC iterations for rotation estimation.",
+            value=1024,
+            range=(100, 10000, 100),
+        ),
+        desc.FloatParam(
+            name="outlierThreshold",
+            label="Outlier Threshold",
+            description="Pixel residual threshold for outlier removal after bundle adjustment.",
+            value=2.0,
+            range=(0.1, 20.0, 0.1),
+        ),
+        desc.IntParam(
+            name="minObservations",
+            label="Min Observations",
+            description="Minimum number of observations required to keep a landmark after outlier removal.",
+            value=2,
+            range=(1, 10, 1),
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",
@@ -54,4 +91,10 @@ calibrated rotations but no translational component, suitable for panorama stitc
             description="Path to the output SfMData file.",
             value="{nodeCacheFolder}/sfm.usda",
         ),
+        desc.File(
+            name="outputViewsAndPoses",
+            label="Views And Poses",
+            description="Path to the output SfMData file with cameras (views and poses).",
+            value="{nodeCacheFolder}/cameras.sfm",
+        )
     ]

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -17,7 +17,7 @@
             "ImageMatching": "2.0",
             "ImageSegmentationSam3": "1.0",
             "IntrinsicsTransforming": "1.1",
-            "NodalSfM": "2.0",
+            "NodalSfM": "2.1",
             "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"

--- a/meshroom/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/nodalCameraTrackingWithoutCalibration.mg
@@ -15,7 +15,7 @@
             "ImageMatching": "2.0",
             "ImageSegmentationSam3": "1.0",
             "IntrinsicsTransforming": "1.1",
-            "NodalSfM": "2.0",
+            "NodalSfM": "2.1",
             "RelativePoseEstimating": "3.1",
             "ScenePreview": "2.0",
             "TracksBuilding": "1.0"

--- a/src/software/pipeline/main_nodalSfM.cpp
+++ b/src/software/pipeline/main_nodalSfM.cpp
@@ -33,6 +33,7 @@
 #include <aliceVision/geometry/lie.hpp>
 #include <aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp>
 
+#include <atomic>
 #include <cstdlib>
 #include <filesystem>
 #include <random>
@@ -47,13 +48,29 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 
 namespace po = boost::program_options;
 namespace fs = std::filesystem;
 
+/**
+ * @brief Robustly estimate a pure rotation between two sets of unit-sphere rays using AC-RANSAC.
+ *
+ * Applies the Rotation3PSolver inside an AC-RANSAC loop to find the rotation matrix R
+ * that best aligns corresponding bearing vectors x1 and x2 (i.e. x2 ≈ R * x1),
+ * while identifying inliers based on angular reprojection error.
+ *
+ * @param[out] R                    Estimated 3x3 rotation matrix (world-to-camera).
+ * @param[out] vecInliers           Indices (into the columns of x1/x2) of inlier correspondences.
+ * @param[in]  x1                   3×N matrix of unit-sphere bearing vectors in the reference frame.
+ * @param[in]  x2                   3×N matrix of unit-sphere bearing vectors in the next frame.
+ * @param[in]  randomNumberGenerator Seeded Mersenne-Twister PRNG used by AC-RANSAC.
+ * @param[in]  maxIterationCount    Maximum number of RANSAC iterations.
+ * @param[in]  minInliers           Minimum number of inliers required to consider the estimation successful.
+ * @return true if a valid rotation was found with at least @p minInliers inliers, false otherwise.
+ */
 bool robustRotation(Mat3& R,
                     std::vector<size_t>& vecInliers,
                     const Mat& x1,
@@ -62,8 +79,7 @@ bool robustRotation(Mat3& R,
                     const size_t maxIterationCount,
                     const size_t minInliers)
 {
-    using KernelType = multiview::
-      RelativePoseSphericalKernel<multiview::relativePose::Rotation3PSolver, multiview::relativePose::RotationError, robustEstimation::Mat3Model>;
+    using KernelType = multiview::RelativePoseSphericalKernel<multiview::relativePose::Rotation3PSolver, multiview::relativePose::RotationError, robustEstimation::Mat3Model>;
 
     KernelType kernel(x1, x2);
 
@@ -71,7 +87,7 @@ bool robustRotation(Mat3& R,
     vecInliers.clear();
 
     // robustly estimation of the Essential matrix and its precision
-    robustEstimation::ACRANSAC(kernel, randomNumberGenerator, vecInliers, 1024, &model, std::numeric_limits<double>::infinity());
+    robustEstimation::ACRANSAC(kernel, randomNumberGenerator, vecInliers, maxIterationCount, &model, std::numeric_limits<double>::infinity());
 
     if (vecInliers.size() < minInliers)
     {
@@ -83,10 +99,31 @@ bool robustRotation(Mat3& R,
     return true;
 }
 
+/**
+ * @brief Bootstrap the reconstruction from a single pre-computed image pair.
+ *
+ * Sets the reference view pose to identity and the next view pose to the relative
+ * rotation provided by @p pair. For every track observed in both views, the bearing
+ * vector of the reference view (lifted to the unit sphere) is used as the 3-D point
+ * position (world frame = reference camera frame). A landmark is created only when
+ * the reprojection of that bearing vector into the next view is within maxReprojectionError pixels of
+ * the actual observation, providing a basic geometric consistency check.
+ *
+ * @param[in,out] sfmData       Scene to initialise; poses and landmarks are written here.
+ * @param[in]     pair          Pre-computed pair carrying the reference/next view ids,
+ *                              the relative rotation and a quality score.
+ * @param[in]     tracksPerView Map from view id to the sorted list of track ids visible
+ *                              in that view.
+ * @param[in]     trackMap             Full track map (track id → Track) with per-view feature
+ *                                   observations (coordinates, feature id, scale).
+ * @param[in]     maxReprojectionError Maximum allowed reprojection error (pixels) for a track
+ *                                   to be accepted as a landmark observation.
+ */
 void buildInitialWorld(sfmData::SfMData& sfmData,
                        const sfm::ReconstructedPair& pair,
                        const track::TracksPerView& tracksPerView,
-                       const track::TracksMap& trackMap)
+                       const track::TracksMap& trackMap,
+                       const double maxReprojectionError)
 {
     const sfmData::View& refView = sfmData.getView(pair.reference);
     const sfmData::View& nextView = sfmData.getView(pair.next);
@@ -118,11 +155,13 @@ void buildInitialWorld(sfmData::SfMData& sfmData,
 
         Vec3 refP = refIntrinsics->toUnitSphere(refIntrinsics->ima2cam(refIntrinsics->getUndistortedPixel(refV)));
         Vec3 tP = pair.pose.rotation() * refP;
+
         Vec2 nextp = nextIntrinsics->getUndistortedPixel(nextV);
         Vec2 estp = nextIntrinsics->cam2ima((tP.head(2) / tP(2)));
-        double dist = (nextp - estp).norm();
 
-        if (dist > 4.0)
+        //Ignore too bad reprojections
+        double dist = (nextp - estp).norm();
+        if (dist > maxReprojectionError)
         {
             continue;
         }
@@ -136,51 +175,149 @@ void buildInitialWorld(sfmData::SfMData& sfmData,
     }
 }
 
-IndexT findBestNext(sfmData::SfMData& sfmData,
+/**
+ * @brief Select the unlocalized view that observes the most already-reconstructed landmarks.
+ *
+ * Iterates over all views that have not yet been assigned a pose and are not in
+ * @p visitedViews. For each candidate view the number of its tracks that correspond
+ * to an existing landmark is counted via a linear merge of two sorted lists.
+ * The view with the highest such count is returned. The count step is parallelized
+ * with OpenMP, using thread-local best candidates and a critical-section merge.
+ *
+ * @param[in] sfmData       Current scene; used to query existing poses, views, and landmarks.
+ * @param[in] tracksPerView Map from view id to the sorted list of track ids visible in that view.
+ * @param[in] visitedViews  Set of view ids that have already been attempted (and failed) and
+ *                          must be skipped.
+ * @return The id of the best candidate view, or @c UndefinedIndexT if no suitable view exists.
+ */
+IndexT findBestNext(const sfmData::SfMData& sfmData,
                     const track::TracksPerView& tracksPerView,
-                    const track::TracksMap& trackMap,
                     const std::set<IndexT>& visitedViews)
 {
-    // Retrieve the set of tracks with an associated landmark
-    std::set<size_t> tracksWithPoint;
-    std::transform(
-      sfmData.getLandmarks().begin(), sfmData.getLandmarks().end(), std::inserter(tracksWithPoint, tracksWithPoint.begin()), stl::RetrieveKey());
+    // Pre-allocate and build tracks with points as a sorted vector (once)
+    const auto& landmarks = sfmData.getLandmarks();
+    std::vector<size_t> tracksWithPoint;
+    tracksWithPoint.reserve(landmarks.size());
 
-    // Find the view with most observed landmarks
+    for (const auto& landmark : landmarks)
+    {
+        tracksWithPoint.push_back(landmark.first);
+    }
+
+    // Already sorted by key due to std::map nature
+    assert(std::is_sorted(tracksWithPoint.begin(), tracksWithPoint.end()));
+
+    // Convert views to vector for efficient parallel access
+    std::vector<IndexT> viewIds;
+    for (const auto& [viewId, view] : sfmData.getViews())
+    {
+        viewIds.push_back(viewId);
+    }
+
+    // Find the view with most observed landmarks.
+    // Each thread tracks its own best; a single critical section merges results,
+    // avoiding the race condition that arises from updating two separate atomics.
     size_t bestCount = 0;
     IndexT bestId = UndefinedIndexT;
-    for (const auto& pV : sfmData.getViews())
+
+    #pragma omp parallel
     {
-        if (sfmData.isPoseAndIntrinsicDefined(pV.first))
+        size_t localBestCount = 0;
+        IndexT localBestId = UndefinedIndexT;
+
+        #pragma omp for nowait
+        for (size_t idx = 0; idx < viewIds.size(); ++idx)
         {
-            continue;
+            IndexT viewId = viewIds[idx];
+
+            if (sfmData.isPoseAndIntrinsicDefined(viewId) || visitedViews.count(viewId))
+            {
+                continue;
+            }
+
+            auto it = tracksPerView.find(viewId);
+            if (it == tracksPerView.end())
+            {
+                continue;
+            }
+
+            // Assume the trackIdSet is sorted !
+            const auto& nextTracks = it->second;
+
+            // Count matches without allocating intermediate vector
+            size_t count = 0;
+            auto it1 = tracksWithPoint.begin();
+            auto it2 = nextTracks.begin();
+
+            while (it1 != tracksWithPoint.end() && it2 != nextTracks.end())
+            {
+                if (*it1 == *it2)
+                {
+                    ++count;
+                    ++it1;
+                    ++it2;
+                }
+                else if (*it1 < *it2)
+                {
+                    ++it1;
+                }
+                else
+                {
+                    ++it2;
+                }
+            }
+
+            if (count > localBestCount)
+            {
+                localBestCount = count;
+                localBestId = viewId;
+            }
         }
 
-        if (visitedViews.find(pV.first) != visitedViews.end())
+        // Merge thread-local results: both fields are updated together under a lock,
+        // so there is no window where bestCount and bestId can refer to different views.
+        #pragma omp critical
         {
-            continue;
-        }
-
-        std::vector<size_t> nextTracks = tracksPerView.at(pV.first);
-
-        std::vector<IndexT> observedTracks;
-        std::set_intersection(
-          tracksWithPoint.begin(), tracksWithPoint.end(), nextTracks.begin(), nextTracks.end(), std::back_inserter(observedTracks));
-
-        if (observedTracks.size() > bestCount)
-        {
-            bestCount = observedTracks.size();
-            bestId = pV.first;
+            if (localBestCount > bestCount)
+            {
+                bestCount = localBestCount;
+                bestId = localBestId;
+            }
         }
     }
 
     return bestId;
 }
 
+/**
+ * @brief Estimate and register the pose of a new view against the current reconstruction.
+ *
+ * Collects all tracks that are visible in @p newViewId and already have an associated
+ * landmark (3-D point). The corresponding bearing vectors (unit-sphere projections of
+ * the new view's observations) and the existing landmark positions are assembled into
+ * two matrices and passed to @c robustRotation. On success the estimated rotation is
+ * stored as the view's pose (pure rotation, zero translation) and inlier observations
+ * are appended to their respective landmarks.
+ *
+ * @param[in,out] sfmData       Current scene; the new view's pose and landmark observations
+ *                              are written here on success.
+ * @param[in]     tracksPerView Map from view id to the sorted list of track ids visible
+ *                              in that view.
+ * @param[in]     trackMap      Full track map (track id → Track) with per-view feature
+ *                              observations (coordinates, feature id, scale).
+ * @param[in]     newViewId           Id of the view to localize.
+ * @param[in]     minInliers          Minimum number of RANSAC inliers required to accept the pose.
+ * @param[in]     maxRansacIterations Maximum number of AC-RANSAC iterations.
+ * @param[in,out] randomNumberGenerator Seeded Mersenne-Twister PRNG passed through to AC-RANSAC.
+ * @return true if the view was successfully localized (enough inliers found), false otherwise.
+ */
 bool localizeNext(sfmData::SfMData& sfmData,
                   const track::TracksPerView& tracksPerView,
                   const track::TracksMap& trackMap,
-                  const IndexT newViewId)
+                  const IndexT newViewId,
+                  const size_t minInliers,
+                  const size_t maxRansacIterations,
+                  std::mt19937& randomNumberGenerator)
 {
     // Retrieve the set of tracks with an associated landmark
     std::set<size_t> tracksWithPoint;
@@ -205,7 +342,6 @@ bool localizeNext(sfmData::SfMData& sfmData,
         const track::Track& track = trackMap.at(trackId);
         const track::TrackItem & trackItem = track.featPerView.at(newViewId);
 
-        IndexT newViewFeatureId = trackItem.featureId;
         Vec2 nvV = trackItem.coords;
         Vec3 camP = newViewIntrinsics->toUnitSphere(newViewIntrinsics->ima2cam(newViewIntrinsics->getUndistortedPixel(nvV)));
 
@@ -217,9 +353,7 @@ bool localizeNext(sfmData::SfMData& sfmData,
 
     Mat3 R;
     std::vector<size_t> vecInliers;
-    const size_t minInliers = 35;
-    std::mt19937 randomNumberGenerator(0);
-    const bool relativeSuccess = robustRotation(R, vecInliers, refX, newX, randomNumberGenerator, 1024, minInliers);
+    const bool relativeSuccess = robustRotation(R, vecInliers, refX, newX, randomNumberGenerator, maxRansacIterations, minInliers);
     if (!relativeSuccess)
     {
         return false;
@@ -229,9 +363,9 @@ bool localizeNext(sfmData::SfMData& sfmData,
     sfmData.setPose(newView, sfmData::CameraPose(geometry::Pose3(R, Vec3::Zero())));
 
     // Add observations
-    for (size_t pos : vecInliers)
+    for (size_t posInlier : vecInliers)
     {
-        IndexT trackId = observedTracks[pos];
+        IndexT trackId = observedTracks[posInlier];
         const track::Track& track = trackMap.at(trackId);
         const track::TrackItem & trackItem = track.featPerView.at(newViewId);
         IndexT newViewFeatureId = trackItem.featureId;
@@ -241,10 +375,34 @@ bool localizeNext(sfmData::SfMData& sfmData,
     return true;
 }
 
+/**
+ * @brief Triangulate new landmarks visible in a newly localized view and add them to the scene.
+ *
+ * For each track that is visible in @p newViewId but does not yet have a reconstructed
+ * landmark, the function looks for co-observations in every already-localized view.
+ * When such a pair is found, the bearing vector from the new view is rotated into the
+ * world frame and reprojected into the reference view. If the reprojection error is
+ * within maxReprojectionError pixels the track is accepted: a new landmark is created
+ * with its 3-D position  expressed in the world frame (world_R_new * newP) and observations
+ * are recorded for both the new view and the reference view.
+ *
+ * @param[in,out] sfmData       Current scene; new landmarks and their observations are
+ *                              appended to the landmark map on success.
+ * @param[in]     tracksPerView Map from view id to the sorted list of track ids visible
+ *                              in that view.
+ * @param[in]     trackMap      Full track map (track id → Track) with per-view feature
+ *                              observations (coordinates, feature id, scale).
+ * @param[in]     newViewId     Id of the newly localized view whose unreconstructed tracks
+ *                              are to be triangulated.
+ * @param[in]     maxReprojectionError Maximum allowed reprojection error (pixels) for a track
+ *                                     to be accepted as a new landmark.
+ * @return Always true (errors are silently skipped per track).
+ */
 bool addPoints(sfmData::SfMData& sfmData,
                const track::TracksPerView& tracksPerView,
                const track::TracksMap& trackMap,
-               const IndexT newViewId)
+               const IndexT newViewId,
+               const double maxReprojectionError)
 {
     sfmData::Landmarks& landmarks = sfmData.getLandmarks();
 
@@ -302,8 +460,8 @@ bool addPoints(sfmData::SfMData& sfmData,
 
             Vec2 newPix = refViewIntrinsics->cam2ima(refP.head(2) / refP(2));
             Vec2 refPix = refViewIntrinsics->getUndistortedPixel(refV);
-            double dist = (newPix - newPix).norm();
-            if (dist > 4.0)
+            double dist = (newPix - refPix).norm();
+            if (dist > maxReprojectionError)
             {
                 continue;
             }
@@ -325,16 +483,16 @@ int aliceVision_main(int argc, char** argv)
     // command-line parameters
     std::string sfmDataFilename;
     std::string sfmDataOutputFilename;
-    std::vector<std::string> featuresFolders;
     std::string tracksFilename;
     std::string pairsDirectory;
+    std::string outputSfMViewsAndPoses;
 
     // user optional parameters
-    std::string describerTypesName = feature::EImageDescriberType_enumToString(feature::EImageDescriberType::SIFT);
-    std::pair<std::string, std::string> initialPairString("", "");
-
-    const double maxEpipolarDistance = 4.0;
-    const double minAngle = 5.0;
+    double maxReprojectionError = 4.0;
+    size_t minInliers = 35;
+    size_t maxRansacIterations = 1024;
+    double outlierThreshold = 2.0;
+    int minObservations = 2;
 
     int randomSeed = std::mt19937::default_seed;
 
@@ -349,11 +507,26 @@ int aliceVision_main(int argc, char** argv)
          "Tracks file.")
         ("pairs,p", po::value<std::string>(&pairsDirectory)->required(),
          "Path to the pairs directory.");
+
+    po::options_description optionalParams("Optional parameters");
+    optionalParams.add_options()
+        ("maxReprojectionError", po::value<double>(&maxReprojectionError)->default_value(maxReprojectionError),
+         "Maximum reprojection error (pixels) to accept a track as a landmark observation.")
+        ("minInliers", po::value<size_t>(&minInliers)->default_value(minInliers),
+         "Minimum number of AC-RANSAC inliers required to localize a view.")
+        ("maxRansacIterations", po::value<size_t>(&maxRansacIterations)->default_value(maxRansacIterations),
+         "Maximum number of AC-RANSAC iterations for rotation estimation.")
+        ("outlierThreshold", po::value<double>(&outlierThreshold)->default_value(outlierThreshold),
+         "Pixel residual threshold for outlier removal after bundle adjustment.")
+        ("minObservations", po::value<int>(&minObservations)->default_value(minObservations),
+         "Minimum number of observations required to keep a landmark after outlier removal.")
+        ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).");
     // clang-format on
 
     CmdLine cmdline("AliceVision Nodal SfM");
 
     cmdline.add(requiredParams);
+    cmdline.add(optionalParams);
     if (!cmdline.execute(argc, argv))
     {
         return EXIT_FAILURE;
@@ -396,68 +569,99 @@ int aliceVision_main(int argc, char** argv)
     }
     track::computeTracksPerView(mapTracks, mapTracksPerView);
 
-    // Because the reconstructed pairs information was processed in chunks
-    // There are potentially multiple files describing the pairs.
-    // Here we merge all the files in memory
-    std::vector<sfm::ReconstructedPair> reconstructedPairs;
-    // Assuming the filename is pairs_ + a number with json extension
-    const std::regex regex("pairs\\_[0-9]+\\.json");
-    for (auto const& file : fs::directory_iterator{pairsDirectory})
+    if (sfmData.getValidViews().size() == 0)
     {
-        if (!std::regex_search(file.path().string(), regex))
+        // Because the reconstructed pairs information was processed in chunks
+        // There are potentially multiple files describing the pairs.
+        // Here we merge all the files in memory
+        std::vector<sfm::ReconstructedPair> reconstructedPairs;
+        // Assuming the filename is pairs_ + a number with json extension
+        const std::regex regex("pairs\\_[0-9]+\\.json");
+        for (auto const& file : fs::directory_iterator{pairsDirectory})
         {
-            continue;
+            if (!std::regex_search(file.path().string(), regex))
+            {
+                continue;
+            }
+
+            // Load the file content
+            // This is a vector of sfm::ReconstructedPair
+            std::ifstream inputfile(file.path().string());
+            boost::system::error_code ec;
+            std::vector<boost::json::value> values = readJsons(inputfile, ec);
+            for (const boost::json::value& value : values)
+            {
+                std::vector<sfm::ReconstructedPair> localVector = boost::json::value_to<std::vector<sfm::ReconstructedPair>>(value);
+                reconstructedPairs.insert(reconstructedPairs.end(), localVector.begin(), localVector.end());
+            }
         }
 
-        // Load the file content
-        // This is a vector of sfm::ReconstructedPair
-        std::ifstream inputfile(file.path().string());
-        boost::system::error_code ec;
-        std::vector<boost::json::value> values = readJsons(inputfile, ec);
-        for (const boost::json::value& value : values)
+        if (reconstructedPairs.size() == 0)
         {
-            std::vector<sfm::ReconstructedPair> localVector = boost::json::value_to<std::vector<sfm::ReconstructedPair>>(value);
-            reconstructedPairs.insert(reconstructedPairs.end(), localVector.begin(), localVector.end());
+            ALICEVISION_LOG_ERROR("No precomputed pairs found");
+            return EXIT_FAILURE;
+        }
+
+        // Sort reconstructedPairs by quality
+        std::sort(reconstructedPairs.begin(), reconstructedPairs.end(), [](const sfm::ReconstructedPair& p1, const sfm::ReconstructedPair& p2) {
+            return p1.score > p2.score;
+        });
+
+        // Using two views, create an initial map and pair of cameras
+        buildInitialWorld(sfmData, reconstructedPairs[0], mapTracksPerView, mapTracks, maxReprojectionError);
+    }
+    else
+    {
+        sfmData.getLandmarks().clear();
+
+        ALICEVISION_LOG_INFO("Rebuilding points");
+        for (const auto viewId: sfmData.getValidViews())
+        {
+            if (!addPoints(sfmData, mapTracksPerView, mapTracks, viewId, maxReprojectionError))
+            {
+                ALICEVISION_LOG_INFO("Not able to add points");
+                break;
+            }
         }
     }
-
-    if (reconstructedPairs.size() == 0)
-    {
-        ALICEVISION_LOG_ERROR("No precomputed pairs found");
-        return EXIT_FAILURE;
-    }
-
-    // Sort reconstructedPairs by quality
-    std::sort(reconstructedPairs.begin(), reconstructedPairs.end(), [](const sfm::ReconstructedPair& p1, const sfm::ReconstructedPair& p2) {
-        return p1.score > p2.score;
-    });
-
-    // Using two views, create an initial map and pair of cameras
-    buildInitialWorld(sfmData, reconstructedPairs[0], mapTracksPerView, mapTracks);
 
     // Loop until termination of the process using the current bootstrapped map
+    std::mt19937 randomNumberGenerator(randomSeed);
     std::set<IndexT> visited;
-    while (1)
+    while (true)
     {
         // Find the optimal next view to localize
-        IndexT next = findBestNext(sfmData, mapTracksPerView, mapTracks, visited);
+        ALICEVISION_LOG_INFO("Select next view");
+        IndexT next = findBestNext(sfmData, mapTracksPerView, visited);
         if (next == UndefinedIndexT)
         {
+            ALICEVISION_LOG_INFO("Not able to findBestNext");
             break;
         }
 
         // Localize the selected view
-        if (!localizeNext(sfmData, mapTracksPerView, mapTracks, next))
+        ALICEVISION_LOG_INFO("Localize next view");
+        if (!localizeNext(sfmData, mapTracksPerView, mapTracks, next, minInliers, maxRansacIterations, randomNumberGenerator))
         {
-            break;
+            ALICEVISION_LOG_INFO("Not able to localize next view " << next << ", skipping");
+            visited.insert(next);
+            continue;
         }
 
         // Add points to the map in the frame of the first bootstrapping camera
-        if (!addPoints(sfmData, mapTracksPerView, mapTracks, next))
+        ALICEVISION_LOG_INFO("Add points from next view to map");
+        if (!addPoints(sfmData, mapTracksPerView, mapTracks, next, maxReprojectionError))
         {
-            break;
+            ALICEVISION_LOG_INFO("Not able to add points for view " << next << ", skipping");
+            visited.insert(next);
+            continue;
         }
+
+        ALICEVISION_LOG_INFO("View " << sfmData.getValidViews().size() << "/" << sfmData.getViews().size() << " localized");
     }
+
+    // TODO Add a step to remove singleton points before the bundle adjustment
+    // (addPoints adds all points of each new view, which can lead to singleton points)
 
     // Refinement options
     sfm::BundleAdjustmentCeres::CeresOptions options;
@@ -476,10 +680,22 @@ int aliceVision_main(int argc, char** argv)
     {
         sfm::BundleAdjustmentCeres BA(options, 3);
         const bool success = BA.adjust(sfmData, refineOptions);
-        countRemoved = sfm::removeOutliersWithPixelResidualError(sfmData, sfm::EFeatureConstraint::SCALE, 2.0, 2);
+        if (!success)
+        {
+            ALICEVISION_LOG_ERROR("Failure in bundle adjustment.");
+            return EXIT_FAILURE;
+        }
+
+        countRemoved = sfm::removeOutliersWithPixelResidualError(sfmData, sfm::EFeatureConstraint::SCALE, outlierThreshold, minObservations);
     } while (countRemoved > 0);
 
     sfmDataIO::save(sfmData, sfmDataOutputFilename, sfmDataIO::ESfMData::ALL);
+    if (!outputSfMViewsAndPoses.empty())
+    {
+        sfmDataIO::save(sfmData, outputSfMViewsAndPoses,
+            sfmDataIO::ESfMData(sfmDataIO::VIEWS | sfmDataIO::EXTRINSICS | sfmDataIO::INTRINSICS)
+        );
+    }
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
# PR: Update NodalSfM Node (v2.0 → v2.1)

## Summary

This PR updates the **NodalSfM** pipeline node and its underlying C++ implementation (`main_nodalSfM.cpp`) with new tunable parameters, performance improvements, bug fixes, and better robustness.

---

## Changes

### `meshroom/aliceVision/NodalSfM.py`

- **Version bump**: `2.0` → `2.1`
- **Resource hints**: added `cpu = desc.Level.INTENSIVE` and `ram = desc.Level.INTENSIVE` to inform the scheduler.
- **New input parameters**:
  | Parameter | Type | Default | Description |
  |---|---|---|---|
  | `maxReprojectionError` | float | 4.0 px | Maximum reprojection error to accept a track as a landmark observation |
  | `minInliers` | int | 35 | Minimum AC-RANSAC inliers required to localize a view |
  | `maxRansacIterations` | int | 1024 | Maximum AC-RANSAC iterations for rotation estimation |
  | `outlierThreshold` | float | 2.0 px | Pixel residual threshold for outlier removal after bundle adjustment |
  | `minObservations` | int | 2 | Minimum observations to keep a landmark after outlier removal |
- **New output**: `outputViewsAndPoses` — an additional SfMData file exporting only cameras (views + poses).

### `meshroom/nodalCameraTracking.mg` & `meshroom/nodalCameraTrackingWithoutCalibration.mg`

- Updated `NodalSfM` version reference from `2.0` to `2.1`.

### `src/software/pipeline/main_nodalSfM.cpp`

#### New features
- All previously hard-coded thresholds (`maxReprojectionError`, `minInliers`, `maxRansacIterations`, `outlierThreshold`, `minObservations`) are now exposed as command-line options via Boost.ProgramOptions.
- Added `--outputViewsAndPoses` option to optionally export a lightweight cameras-only SfMData file.
- **Incremental restart**: when the input SfMData already contains valid (localized) views, landmarks are cleared and rebuilt from the existing poses instead of running full initialization from pairs — enabling warm-restart workflows.
- `findBestNext` is now **parallelized with OpenMP** using thread-local best-tracking and a single `#pragma omp critical` merge, eliminating race conditions while avoiding per-iteration locking overhead.

#### Bug fixes
- `addPoints`: fixed a copy-paste bug where `(newPix - newPix).norm()` was always 0; corrected to `(newPix - refPix).norm()`.
- `localizeNext`: removed a stale local `minInliers`/`randomNumberGenerator` that shadowed the caller-provided values; the PRNG is now created once in `aliceVision_main` and threaded through.
- `localizeNext` / main loop: failed localization or point-addition no longer aborts the entire reconstruction — the offending view is added to `visited` and the loop continues to the next best candidate.
- Bundle adjustment failure now returns `EXIT_FAILURE` instead of silently continuing.

#### Code quality
- Added `<atomic>` include.
- Added comprehensive Doxygen docstrings to `robustRotation`, `buildInitialWorld`, `findBestNext`, `localizeNext`, and `addPoints`.
- Renamed loop variable `pos` → `posInlier` for clarity.
- Replaced `while (1)` with `while (true)`.
- Added `ALICEVISION_LOG_INFO` progress messages throughout the main reconstruction loop.
- `findBestNext` signature changed to `const sfmData::SfMData&` (read-only), and the unused `trackMap` parameter was removed.

---

## Testing

- [ ] Nodal camera tracking pipeline runs end-to-end with default parameters.
- [ ] Nodal camera tracking without calibration runs end-to-end.
- [ ] Warm-restart (pre-localized input) correctly rebuilds landmarks.
- [ ] New parameters are correctly forwarded from Meshroom to the binary.
- [ ] `outputViewsAndPoses` file is produced when the path is set.

---

## Author
Fabien Servant <fabien.servant@technicolor.com>

## Date
2026-07-15
