### PR TITLE
[dataio] `SfMDataFeed`: Add `usda` to the list of supported extensions for SfMData files

### DIFF
--- a/src/aliceVision/dataio/SfMDataFeed.cpp
+++ b/src/aliceVision/dataio/SfMDataFeed.cpp
@@ -169,7 +169,7 @@ bool SfMDataFeed::isInit() const { return (_sfmDataFeed->isInit()); }
 bool SfMDataFeed::isSupported(const std::string& extension)
 {
     std::string ext = boost::to_lower_copy(extension);
-    return (ext == ".sfm" || ext == ".abc" || ext == ".json");
+    return (ext == ".sfm" || ext == ".abc" || ext == ".json" || ext == ".usda");
 }
 
 SfMDataFeed::~SfMDataFeed() {}


### PR DESCRIPTION
This PR adds the `usda` file extension to the list of supported extensions for SfMData files.

This allows, for example, the `KeyframeSelection` node to use a `.usda` input file.