### PR TITLE
Alignment of two Sfm using a single common view

### DIFF
--- a/meshroom/aliceVision/SfMAlignment.py
+++ b/meshroom/aliceVision/SfMAlignment.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "2.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -43,10 +43,11 @@ The alignment can be based on:
                         " - from_cameras_poseid: Align cameras with same pose ID.\n"
                         " - from_cameras_filepath: Align cameras with a filepath matching, using 'fileMatchingPattern'.\n"
                         " - from_cameras_metadata: Align cameras with matching metadata, using 'metadataMatchingList'.\n"
+                        " - from_single_camera_viewid: Align cameras using a single view. Only work if the reference has exactly one shared reconstructed view.\n"
                         " - from_markers: Align from markers with the same ID.\n"
                         " - from_landmarks: Align from matched features.\n",
             value="from_cameras_viewid",
-            values=["from_cameras_viewid", "from_cameras_poseid", "from_cameras_filepath", "from_cameras_metadata", "from_markers", 'from_landmarks'],
+            values=["from_cameras_viewid", "from_cameras_poseid", "from_cameras_filepath", "from_cameras_metadata", "from_single_camera_viewid", "from_markers", 'from_landmarks'],
         ),
         desc.StringParam(
             name="fileMatchingPattern",

--- a/src/aliceVision/sfm/utils/alignment.cpp
+++ b/src/aliceVision/sfm/utils/alignment.cpp
@@ -148,7 +148,7 @@ bool computeSimilarityFromCommonViews(const sfmData::SfMData& sfmDataA,
     }
 
     ALICEVISION_LOG_INFO("Trajectory seems to be singular. Use another algorithm.");
-    
+
 
     // If point cloud is badly conditioned let's try to add some
     // Points from the axis
@@ -161,11 +161,11 @@ bool computeSimilarityFromCommonViews(const sfmData::SfMData& sfmDataA,
         auto poseA = sfmDataA.getPose(sfmDataA.getView(viewIdPair.first)).getTransform();
         auto poseB = sfmDataB.getPose(sfmDataB.getView(viewIdPair.second)).getTransform();
 
-        
+
         poseA = poseA.transformSRt(S,Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero());
         poseA = poseA.inverse();
         poseB = poseB.inverse();
-        
+
         xA.col(i * 4 + 0) = poseA(Eigen::Vector3d::Zero());
         xA.col(i * 4 + 1) = poseA(Eigen::Vector3d::UnitX());
         xA.col(i * 4 + 2) = poseA(Eigen::Vector3d::UnitY());
@@ -188,10 +188,52 @@ bool computeSimilarityFromCommonViews(const sfmData::SfMData& sfmDataA,
 
     geometry::Pose3 p;
     p = p.transformSRt(S, R, t);
-    
+
     *out_S = S * nS;
     *out_R = nR;
     *out_t = nt;
+
+    return true;
+}
+
+bool computeSimilarityFromCommonCameras_singleViewId(const sfmData::SfMData& sfmDataA,
+                                                     const sfmData::SfMData& sfmDataB,
+                                                     double* out_S,
+                                                     Mat3* out_R,
+                                                     Vec3* out_t)
+{
+    assert(out_S != nullptr);
+    assert(out_R != nullptr);
+    assert(out_t != nullptr);
+
+    std::vector<IndexT> commonViewIds;
+    getCommonViewsWithPoses(sfmDataA, sfmDataB, commonViewIds);
+    ALICEVISION_LOG_DEBUG("Found " << commonViewIds.size() << " common views.");
+
+    std::vector<IndexT> reconstructedCommonViewIds;
+    for (IndexT id : commonViewIds)
+    {
+        if (sfmDataA.isPoseAndIntrinsicDefined(id) && sfmDataB.isPoseAndIntrinsicDefined(id))
+        {
+            reconstructedCommonViewIds.emplace_back(id);
+        }
+    }
+
+    if (reconstructedCommonViewIds.size() != 1)
+    {
+        ALICEVISION_LOG_ERROR("Incompatible number of common reconstructed views ("<<reconstructedCommonViewIds.size()<<")");
+        return false;
+    }
+
+    IndexT viewId = reconstructedCommonViewIds[0];
+
+    geometry::Pose3 poseA = sfmDataA.getPose(sfmDataA.getView(viewId)).getTransform();
+    geometry::Pose3 poseB = sfmDataB.getPose(sfmDataB.getView(viewId)).getTransform();
+
+    geometry::Pose3 result = (poseA.inverse() * poseB).inverse();
+    *out_S = 1.0; // We can't estimate scale here
+    *out_R = result.rotation();
+    *out_t = poseB.center() - result.rotation() * poseA.center();
 
     return true;
 }
@@ -581,7 +623,7 @@ bool computeSimilarityFromCommonLandmarks(const sfmData::SfMData& sfmDataA,
     // Move input point in appropriate container
     Mat xA(3, mapLandmarkAtoLandmarkB.size());
     Mat xB(3, mapLandmarkAtoLandmarkB.size());
-    
+
     int count = 0;
     for (auto & pair : mapLandmarkAtoLandmarkB)
     {
@@ -754,7 +796,7 @@ bool computeSimilarityFromPairs(const std::vector<Vec3> & ptsA,
     // Move input point in appropriate container
     Mat xA(3, ptsA.size());
     Mat xB(3, ptsB.size());
-    
+
     int count = 0;
     for (auto & p : ptsA)
     {
@@ -815,7 +857,7 @@ bool computeNewCoordinateSystemFromPairs(const sfmData::SfMData& sfmDataA,
         for (const auto & pobs : plandmark.second.getObservations())
         {
             IndexT featureId = pobs.second.getFeatureId();
-            
+
             auto found = mapFeatureIdToLandmarkId.find(featureId);
             if (found == mapFeatureIdToLandmarkId.end())
             {
@@ -829,7 +871,7 @@ bool computeNewCoordinateSystemFromPairs(const sfmData::SfMData& sfmDataA,
     // Move input point in appropriate container
     Mat xA(3, mapLandmarkAtoLandmarkB.size());
     Mat xB(3, mapLandmarkAtoLandmarkB.size());
-    
+
     int count = 0;
     for (auto & pair : mapLandmarkAtoLandmarkB)
     {

--- a/src/aliceVision/sfm/utils/alignment.hpp
+++ b/src/aliceVision/sfm/utils/alignment.hpp
@@ -70,8 +70,7 @@ void matchViewsByMetadataMatching(const sfmData::SfMData& sfmDataA,
  *
  * @param[in] sfmDataA
  * @param[in] sfmDataB
- * @param[in] randomNumberGenerator random number generator
- * @param[out] out_S output scale factor
+ * @param[out] out_S output scale factor (set to 1 as it cannot be estimated from a single view)
  * @param[out] out_R output rotation 3x3 matrix
  * @param[out] out_t output translation vector
  * @return true if it finds a similarity transformation
@@ -79,6 +78,24 @@ void matchViewsByMetadataMatching(const sfmData::SfMData& sfmDataA,
 bool computeSimilarityFromCommonCameras_viewId(const sfmData::SfMData& sfmDataA,
                                                const sfmData::SfMData& sfmDataB,
                                                std::mt19937& randomNumberGenerator,
+                                               double* out_S,
+                                               Mat3* out_R,
+                                               Vec3* out_t);
+
+/**
+ * @brief Compute a 5DOF rigid transform between the two set of cameras based on common viewIds.
+ * Assume only one common camera is found.
+ *
+ * @param[in] sfmDataA
+ * @param[in] sfmDataB
+ * @param[in] randomNumberGenerator random number generator
+ * @param[out] out_S output scale factor
+ * @param[out] out_R output rotation 3x3 matrix
+ * @param[out] out_t output translation vector
+ * @return true if it finds a similarity transformation
+ */
+bool computeSimilarityFromCommonCameras_singleViewId(const sfmData::SfMData& sfmDataA,
+                                               const sfmData::SfMData& sfmDataB,
                                                double* out_S,
                                                Mat3* out_R,
                                                Vec3* out_t);

--- a/src/software/utils/main_sfmAlignment.cpp
+++ b/src/software/utils/main_sfmAlignment.cpp
@@ -22,7 +22,7 @@
 
 // These constants define the current software version.
 // They must be updated when the command line is changed.
-#define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
+#define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
 #define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
@@ -41,6 +41,7 @@ enum class EAlignmentMethod : unsigned char
     FROM_CAMERAS_POSEID,
     FROM_CAMERAS_FILEPATH,
     FROM_CAMERAS_METADATA,
+    FROM_SINGLE_CAMERA_VIEWID,
     FROM_MARKERS,
     FROM_LANDMARKS,
     FROM_FEATURE_MATCHES,
@@ -63,6 +64,8 @@ std::string EAlignmentMethod_enumToString(EAlignmentMethod alignmentMethod)
             return "from_cameras_filepath";
         case EAlignmentMethod::FROM_CAMERAS_METADATA:
             return "from_cameras_metadata";
+        case EAlignmentMethod::FROM_SINGLE_CAMERA_VIEWID:
+            return "from_single_camera_viewid";
         case EAlignmentMethod::FROM_MARKERS:
             return "from_markers";
         case EAlignmentMethod::FROM_LANDMARKS:
@@ -91,6 +94,8 @@ EAlignmentMethod EAlignmentMethod_stringToEnum(const std::string& alignmentMetho
         return EAlignmentMethod::FROM_CAMERAS_FILEPATH;
     if (method == "from_cameras_metadata")
         return EAlignmentMethod::FROM_CAMERAS_METADATA;
+    if (method == "from_single_camera_viewid")
+        return EAlignmentMethod::FROM_SINGLE_CAMERA_VIEWID;
     if (method == "from_markers")
         return EAlignmentMethod::FROM_MARKERS;
     if (method == "from_landmarks")
@@ -145,6 +150,7 @@ int aliceVision_main(int argc, char** argv)
          "\t- from_cameras_poseid: Align cameras with same pose ID.\n"
          "\t- from_cameras_filepath: Align cameras with a filepath matching, using --fileMatchingPattern.\n"
          "\t- from_cameras_metadata: Align cameras with matching metadata, using --metadataMatchingList.\n"
+         "\t- from_single_camera_viewid: Align cameras using a single view. Only work if the reference has exactly one shared reconstructed view.\n"
          "\t- from_landmarks: Align using landmarks sharing features.\n"
          "\t- from_markers: Align from markers with the same ID.\n"
          "\t- from_featureMatches: Align using feature matches to find corresponding landmarks, using --matchesFolders.\n")
@@ -221,6 +227,11 @@ int aliceVision_main(int argc, char** argv)
         {
             hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_metadataMatching(
               sfmData, sfmDataInRef, metadataMatchingList, randomNumberGenerator, &S, &R, &t);
+            break;
+        }
+        case EAlignmentMethod::FROM_SINGLE_CAMERA_VIEWID:
+        {
+            hasValidSimilarity = sfm::computeSimilarityFromCommonCameras_singleViewId(sfmData, sfmDataInRef, &S, &R, &t);
             break;
         }
         case EAlignmentMethod::FROM_MARKERS:


### PR DESCRIPTION
- Assume both sfmData inputs share a single common reconstructed view.
- Align the input SfmData such that the common reconstructed view have the same pose.