### PR TITLE
Colmap exporter can create symbolic links instead of copying images

### DIFF
--- a/meshroom/aliceVision/ExportColmap.py
+++ b/meshroom/aliceVision/ExportColmap.py
@@ -26,7 +26,9 @@ class ExportColmap(desc.CommandLineNode):
         desc.BoolParam(
             name="copyImages",
             label="Copy Images",
-            description="Copy original images to the Colmap folder.\n",
+            description="Copy original images to the Colmap folder.\n"
+                        "If disabled, symbolic link(s) will be created for each compatible image,\n"
+                        "or, if unique, for the image folder.",
             value=False,
         ),
         desc.ChoiceParam(

--- a/meshroom/aliceVision/ExportColmap.py
+++ b/meshroom/aliceVision/ExportColmap.py
@@ -1,0 +1,50 @@
+__version__ = "1.0"
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+
+class ExportColmap(desc.CommandLineNode):
+    commandLine = "aliceVision_exportColmap {allParams}"
+
+    category = "Export"
+    documentation = """
+        Export an AliceVision SfMData to a Colmap scene.
+
+        Creates the folder structure and scene files (cameras.txt, images.txt,
+        points3D.txt) that can be used for running a Colmap MVS step.
+    """
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="SfMData file.",
+            value="",
+        ),
+        desc.BoolParam(
+            name="copyImages",
+            label="Copy Images",
+            description="Copy original images to the Colmap folder.\n",
+            value=False,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+            exclusive=True,
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Output",
+            description="Base path where the folder structure is created, holding the "
+                        "cameras.txt, images.txt and points3D.txt files.",
+            value="{nodeCacheFolder}",
+        ),
+    ]

--- a/src/aliceVision/sfmDataIO/colmap.cpp
+++ b/src/aliceVision/sfmDataIO/colmap.cpp
@@ -22,14 +22,24 @@ namespace sfmDataIO {
 ColmapConfig::ColmapConfig(const std::string& basePath)
   : _basePath(basePath)
 {
-    _sparseDirectory = (fs::path(_basePath) / fs::path("sparse/0")).string();
-    _denseDirectory = (fs::path(_basePath) / fs::path("dense/0")).string();
-    _imagesDirectory = (fs::path(_basePath) / fs::path("images/")).string();
+    _sparseDirectory = (fs::path(_basePath) / "sparse/0").string();
+    _denseDirectory = (fs::path(_basePath) / "dense/0").string();
+    _imagesDirectory = (fs::path(_basePath) / "images").string();
     _camerasTxtPath = (fs::path(_sparseDirectory) / fs::path("cameras.txt")).string();
     _imagesTxtPath = (fs::path(_sparseDirectory) / fs::path("images.txt")).string();
     _points3DPath = (fs::path(_sparseDirectory) / fs::path("points3D.txt")).string();
 }
 
+void create_directories(const std::string& directory)
+{
+    fs::remove_all(directory);
+    const bool ok = fs::create_directories(directory);
+    if (!ok)
+    {
+        ALICEVISION_LOG_ERROR("Cannot create directory " << directory);
+        throw std::runtime_error("Cannot create directory " + directory);
+    }
+}
 
 bool isColmapCompatible(camera::EINTRINSIC intrinsicType, camera::EDISTORTION distortionType)
 {
@@ -365,14 +375,64 @@ void generateColmapImagesTxtFile(const sfmData::SfMData& sfmData, const Compatib
     }
 }
 
-void copyImagesFromSfmData(const sfmData::SfMData& sfmData, const std::string& destinationFolder, const CompatibleList selection)
+void generateImagesFromSfmData(const sfmData::SfMData& sfmData, const std::string& destinationFolder, const CompatibleList selection, bool copyImages)
 {
+    // If we don't do copy, check if all the images are in the same directory.
+    // If they are, we can create a symlink to the directory and not to each image individually.
+    if (!copyImages)
+    {
+        bool first = true;
+        bool unique = true;
+        std::string unique_path;
+
+        if (selection.empty())
+        {
+            return;
+        }
+
+        for (const auto viewId : selection)
+        {
+            const auto view = sfmData.getView(viewId);
+            const auto from = fs::path(view.getImage().getImagePath());
+            const std::string folder = from.parent_path().string();
+            
+            if (first) 
+            {
+                unique_path = folder;
+                first = false;
+            }
+
+            if (unique_path != folder)
+            {
+                unique = false;
+                break;
+            }
+        }
+
+        if (unique)
+        {
+            fs::remove_all(destinationFolder);
+            fs::create_directory_symlink(unique_path, destinationFolder);
+            return;
+        }
+    }
+
+    create_directories(destinationFolder);
+
     for (const auto viewId : selection)
     {
         const auto& view = sfmData.getView(viewId);
-        const auto& from = fs::path(view.getImage().getImagePath());
-        const auto& to = fs::path(destinationFolder) / from.filename();
-        fs::copy_file(from, to);
+        const auto from = fs::path(view.getImage().getImagePath());
+        const auto to = fs::path(destinationFolder) / from.filename();
+
+        if (copyImages)
+        {
+            fs::copy_file(from, to);
+        }
+        else 
+        {
+            fs::create_symlink(from, to);
+        }
     }
 }
 
@@ -426,16 +486,6 @@ void generateColmapSceneFiles(const sfmData::SfMData& sfmData, const CompatibleL
     generateColmapPoints3DTxtFile(sfmData, viewsSelection, colmapParams._points3DPath);
 }
 
-void create_directories(const std::string& directory)
-{
-    const bool ok = fs::create_directories(directory);
-    if (!ok)
-    {
-        ALICEVISION_LOG_ERROR("Cannot create directory " << directory);
-        throw std::runtime_error("Cannot create directory " + directory);
-    }
-}
-
 void convertToColmapScene(const sfmData::SfMData& sfmData, const std::string& colmapBaseDir, bool copyImages)
 {
     // retrieve the views that are compatible with Colmap and that can be exported
@@ -455,13 +505,17 @@ void convertToColmapScene(const sfmData::SfMData& sfmData, const std::string& co
     ALICEVISION_LOG_INFO("Creating Colmap subfolders...");
     create_directories(colmapParams._sparseDirectory);
     create_directories(colmapParams._denseDirectory);
-    create_directories(colmapParams._imagesDirectory);
 
     if (copyImages)
     {
         ALICEVISION_LOG_INFO("Copying source images...");
-        copyImagesFromSfmData(sfmData, colmapParams._imagesDirectory, views2export);
     }
+    else 
+    {
+        ALICEVISION_LOG_INFO("Creating symbolic links to source images...");
+    }
+    
+    generateImagesFromSfmData(sfmData, colmapParams._imagesDirectory, views2export, copyImages);
 
     ALICEVISION_LOG_INFO("Generating Colmap files...");
     generateColmapSceneFiles(sfmData, views2export, colmapParams);

--- a/src/software/export/main_exportColmap.cpp
+++ b/src/software/export/main_exportColmap.cpp
@@ -41,8 +41,8 @@ int aliceVision_main(int argc, char* argv[])
          "The base path where the folder structure will be created with the relevant cameras.txt, images.txt "
          "and points3D.txt files.")
         ("copyImages", po::value<bool>(&copyImages)->default_value(copyImages),
-         "Copy original images to Colmap folder. This is required if your images are not all in the same "
-         "folder.");
+         "Copy original images to the Colmap folder.\n"
+         "If disabled, symbolic link(s) will be created for each compatible image, or, if unique, for the image folder.");
     // clang-format on
 
     CmdLine cmdline("Export an AV SfMData to a Colmap scene, creating the folder structure and "


### PR DESCRIPTION
Colmap file structure requires the images to be in the same directory than the project.

We can choose to copy them or creating symbolic links. (Using the copyImages option).

If all the images come from the same source directory, we create a symbolic link for the whole directory. Otherwise we create a symbolic link per image.

