### PR TITLE
Better integration of SurveyPoint in the pipeline

### DIFF
--- a/meshroom/aliceVision/SfMSurveyInjecting.py
+++ b/meshroom/aliceVision/SfMSurveyInjecting.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "1.1"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -33,6 +33,12 @@ enforce a known metric scale during bundle adjustment.
             label="Survey",
             description="Input JSON file containing the survey.",
             value="",
+        ),
+        desc.IntParam(
+            name="offset",
+            label="Frame number offset",
+            description="Positive offset to use on the reference file frame number to match the input frame number (or -1 to try auto-detection).",
+            value=-1,
         ),
         desc.ChoiceParam(
             name="verboseLevel",

--- a/src/aliceVision/keyframe/KeyframeSelector.cpp
+++ b/src/aliceVision/keyframe/KeyframeSelector.cpp
@@ -1366,6 +1366,18 @@ bool KeyframeSelector::writeSfMDataFromSfMData(const std::string& mediaPath)
         }
     }
 
+    for (const auto & [viewId, surveyPoints] : inputSfm.getSurveyPoints())
+    {
+        if (keyframesViews.find(viewId) != keyframesViews.end())
+        {
+            _outputSfmKeyframes.getSurveyPoints().emplace(viewId, surveyPoints);
+        }
+        else if (framesViews.find(viewId) != framesViews.end())
+        {
+            _outputSfmFrames.getSurveyPoints().emplace(viewId, surveyPoints);
+        }
+    }
+
     return true;
 }
 

--- a/src/aliceVision/sfmData/SfMData.cpp
+++ b/src/aliceVision/sfmData/SfMData.cpp
@@ -10,6 +10,7 @@
 #include <aliceVision/system/Logger.hpp>
 #include <aliceVision/utils/filesIO.hpp>
 
+#include <algorithm>
 #include <filesystem>
 
 namespace aliceVision {
@@ -27,6 +28,7 @@ SfMData::SfMData(const SfMData & other, bool unused)
     _landmarks = other._landmarks;
     _constraints2d = other._constraints2d;
     _constraintsPoint = other._constraintsPoint;
+    _surveyPoints = other._surveyPoints;
     _rotationpriors = other._rotationpriors;
     _absolutePath = other._absolutePath;
     _featuresFolders = other._featuresFolders;
@@ -45,6 +47,7 @@ SfMData::SfMData(const SfMData & other, const Eigen::Vector3d & bbMin, const Eig
     //First copy all the non pointers
     _constraints2d = other._constraints2d;
     _constraintsPoint = other._constraintsPoint;
+    _surveyPoints = other._surveyPoints;
     _rotationpriors = other._rotationpriors;
     _absolutePath = other._absolutePath;
     _featuresFolders = other._featuresFolders;
@@ -155,6 +158,27 @@ bool SfMData::operator==(const SfMData& other) const
     for (; constraintPointIt != _constraintsPoint.end() && otherconstraintPointIt != other._constraintsPoint.end(); ++constraintPointIt, ++otherconstraintPointIt)
     {
         if (*constraintPointIt != *otherconstraintPointIt)
+        {
+            return false;
+        }
+    }
+
+    if (_surveyPoints.size() != other._surveyPoints.size())
+    {
+        return false;
+    }
+
+    for (const auto& [viewId, surveyVec] : _surveyPoints)
+    {
+        auto it = other._surveyPoints.find(viewId);
+        if (it == other._surveyPoints.end())
+        {
+            return false;
+        }
+
+        // There is no way to guarantee the order as it is a vector.
+        // So just make sure the content is equal up to a permutation.
+        if (!std::is_permutation(surveyVec.begin(), surveyVec.end(), it->second.begin(), it->second.end()))
         {
             return false;
         }
@@ -338,6 +362,35 @@ void SfMData::combine(const SfMData& sfmData)
     // constraints
     _constraintsPoint.insert(sfmData._constraintsPoint.begin(), sfmData._constraintsPoint.end());
 
+    // Survey points
+    for (const auto & [viewId, surveyPoints] : sfmData._surveyPoints)
+    {
+        if (_surveyPoints.find(viewId) == _surveyPoints.end())
+        {
+            _surveyPoints[viewId] = surveyPoints;
+            continue;
+        }
+
+        // We have to manually check for non duplicate.
+        for (const auto & item : surveyPoints)
+        {
+            bool found = false;
+            for (const auto & existingItem : _surveyPoints.at(viewId))
+            {
+                if (item == existingItem)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                _surveyPoints[viewId].push_back(item);
+            }
+        }
+    }
+
     // image groups
     for (const auto & [imageGroupID, imageGroupPtr] : sfmData._imageGroups)
     {
@@ -359,6 +412,7 @@ void SfMData::clear()
     _landmarksUncertainty.clear();
     _constraints2d.clear();
     _constraintsPoint.clear();
+    _surveyPoints.clear();
     _rotationpriors.clear();
     _absolutePath.clear();
     _featuresFolders.clear();
@@ -508,6 +562,15 @@ void SfMData::removeUnusedImageGroups()
     });
 }
 
+void SfMData::removeUnusedSurveyPoints()
+{
+    std::erase_if(_surveyPoints, [this](const auto & item)
+    {
+        // If current viewId not found in _views
+        return (_views.find(item.first) == _views.end());
+    });
+}
+
 void SfMData::repair()
 {
     removeUnusedIntrinsics();
@@ -515,6 +578,7 @@ void SfMData::repair()
     removeInvalidObservations();
     removeUnusedLandmarks();
     removeUnusedImageGroups();
+    removeUnusedSurveyPoints();
 }
 
 bool SfMData::isFullyReconstructed() const

--- a/src/aliceVision/sfmData/SfMData.hpp
+++ b/src/aliceVision/sfmData/SfMData.hpp
@@ -752,6 +752,11 @@ class SfMData
     void removeInvalidObservations();
 
     /**
+    * @brief Remove SurveyPoints pointing to invalid views
+    */
+    void removeUnusedSurveyPoints();
+
+    /**
     * @brief Remove landmarks without any observations
     */
     void removeUnusedLandmarks();

--- a/src/software/utils/main_sfmSurveyInjecting.cpp
+++ b/src/software/utils/main_sfmSurveyInjecting.cpp
@@ -24,28 +24,28 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 1
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 0
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 1
 
 using namespace aliceVision;
 namespace po = boost::program_options;
 
 // Internal structures for json reading
 
-struct Position3D 
+struct Position3D
 {
     double x;
     double y;
     double z;
 };
 
-struct ImagePoint 
+struct ImagePoint
 {
     int frame;
     double x;
     double y;
 };
 
-struct Point 
+struct Point
 {
     std::string point_id;
     std::string point_name;
@@ -56,32 +56,32 @@ struct Point
     std::vector<ImagePoint> image_points;
 };
 
-struct Survey 
+struct Survey
 {
     std::string pgroup_name;
     std::string camera_name;
     std::vector<Point> points;
 };
 
-Position3D tag_invoke(boost::json::value_to_tag<Position3D>, boost::json::value const& jv) 
+Position3D tag_invoke(boost::json::value_to_tag<Position3D>, boost::json::value const& jv)
 {
     if (!jv.is_object())
     {
         throw std::invalid_argument("Position3D: Expected JSON object");
     }
-    
+
     boost::json::object const& obj = jv.as_object();
-    
+
     if (!obj.contains("x") || !obj.contains("y") || !obj.contains("z"))
     {
         throw std::invalid_argument("Position3D: Missing required fields (x, y, z)");
     }
-    
+
     if (!obj.at("x").is_number() || !obj.at("y").is_number() || !obj.at("z").is_number())
     {
         throw std::invalid_argument("Position3D: x, y, z must be numeric values");
     }
-    
+
     return Position3D{
         boost::json::value_to<double>(obj.at("x")),
         boost::json::value_to<double>(obj.at("y")),
@@ -89,36 +89,36 @@ Position3D tag_invoke(boost::json::value_to_tag<Position3D>, boost::json::value 
     };
 }
 
-ImagePoint tag_invoke(boost::json::value_to_tag<ImagePoint>, boost::json::value const& jv) 
+ImagePoint tag_invoke(boost::json::value_to_tag<ImagePoint>, boost::json::value const& jv)
 {
     if (!jv.is_object())
     {
         throw std::invalid_argument("ImagePoint: Expected JSON object");
     }
-    
+
     boost::json::object const& obj = jv.as_object();
-    
+
     if (!obj.contains("frame") || !obj.contains("x") || !obj.contains("y"))
     {
         throw std::invalid_argument("ImagePoint: Missing required fields (frame, x, y)");
     }
-    
+
     if (!obj.at("frame").is_number())
     {
         throw std::invalid_argument("ImagePoint: frame must be a numeric value");
     }
-    
+
     if (!obj.at("x").is_number() || !obj.at("y").is_number())
     {
         throw std::invalid_argument("ImagePoint: x and y must be numeric values");
     }
-    
+
     int frame = boost::json::value_to<int>(obj.at("frame"));
     if (frame < 0)
     {
         throw std::invalid_argument("ImagePoint: frame must be positive");
     }
-    
+
     return ImagePoint{
         frame,
         boost::json::value_to<double>(obj.at("x")),
@@ -126,34 +126,34 @@ ImagePoint tag_invoke(boost::json::value_to_tag<ImagePoint>, boost::json::value 
     };
 }
 
-Point tag_invoke(boost::json::value_to_tag<Point>, boost::json::value const& jv) 
+Point tag_invoke(boost::json::value_to_tag<Point>, boost::json::value const& jv)
 {
     if (!jv.is_object())
     {
         throw std::invalid_argument("Point: Expected JSON object");
     }
-    
+
     boost::json::object const& obj = jv.as_object();
-    
-    if (!obj.contains("point_id") || !obj.contains("point_name") || 
+
+    if (!obj.contains("point_id") || !obj.contains("point_name") ||
         !obj.contains("calc_mode") || !obj.contains("survey_mode") ||
-        !obj.contains("calc_3d") || !obj.contains("survey_3d") || 
+        !obj.contains("calc_3d") || !obj.contains("survey_3d") ||
         !obj.contains("image_points"))
     {
         throw std::invalid_argument("Point: Missing required fields (point_id, point_name, calc_mode, survey_mode, calc_3d, survey_3d, image_points)");
     }
-    
+
     if (!obj.at("point_id").is_string() || !obj.at("point_name").is_string() ||
         !obj.at("calc_mode").is_string() || !obj.at("survey_mode").is_string())
     {
         throw std::invalid_argument("Point: point_id, point_name, calc_mode, and survey_mode must be strings");
     }
-    
+
     if (!obj.at("image_points").is_array())
     {
         throw std::invalid_argument("Point: image_points must be an array");
     }
-    
+
     Point pt;
     pt.point_id = boost::json::value_to<std::string>(obj.at("point_id"));
     pt.point_name = boost::json::value_to<std::string>(obj.at("point_name"));
@@ -161,55 +161,55 @@ Point tag_invoke(boost::json::value_to_tag<Point>, boost::json::value const& jv)
     pt.survey_mode = boost::json::value_to<std::string>(obj.at("survey_mode"));
     pt.calc_3d = boost::json::value_to<Position3D>(obj.at("calc_3d"));
     pt.survey_3d = boost::json::value_to<Position3D>(obj.at("survey_3d"));
-    
+
     boost::json::array const& img_points = obj.at("image_points").as_array();
-    for (auto const& ip : img_points) 
+    for (auto const& ip : img_points)
     {
         pt.image_points.push_back(boost::json::value_to<ImagePoint>(ip));
     }
-    
+
     return pt;
 }
 
-Survey tag_invoke(boost::json::value_to_tag<Survey>, boost::json::value const& jv) 
+Survey tag_invoke(boost::json::value_to_tag<Survey>, boost::json::value const& jv)
 {
     if (!jv.is_object())
     {
         throw std::invalid_argument("Survey: Expected JSON object");
     }
-    
+
     boost::json::object const& obj = jv.as_object();
-    
+
     if (!obj.contains("pgroup_name") || !obj.contains("camera_name") || !obj.contains("points"))
     {
         throw std::invalid_argument("Survey: Missing required fields (pgroup_name, camera_name, points)");
     }
-    
+
     if (!obj.at("pgroup_name").is_string() || !obj.at("camera_name").is_string())
     {
         throw std::invalid_argument("Survey: pgroup_name and camera_name must be strings");
     }
-    
+
     if (!obj.at("points").is_array())
     {
         throw std::invalid_argument("Survey: points must be an array");
     }
-    
+
     Survey survey;
     survey.pgroup_name = boost::json::value_to<std::string>(obj.at("pgroup_name"));
     survey.camera_name = boost::json::value_to<std::string>(obj.at("camera_name"));
-    
+
     boost::json::array const& points = obj.at("points").as_array();
     if (points.empty())
     {
         throw std::invalid_argument("Survey: points array cannot be empty");
     }
-    
-    for (auto const& pt : points) 
+
+    for (auto const& pt : points)
     {
         survey.points.push_back(boost::json::value_to<Point>(pt));
     }
-    
+
     return survey;
 }
 
@@ -230,13 +230,13 @@ bool getSurveysFromJson(const std::string& surveyFilename, Survey & output)
 
     std::stringstream buffer;
     buffer << inputfile.rdbuf();
-    
+
     std::string jsonContent = buffer.str();
     if (jsonContent.empty())
     {
         throw std::runtime_error("JSON file is empty: " + surveyFilename);
     }
-    
+
     boost::json::value jv;
     try
     {
@@ -265,6 +265,7 @@ int aliceVision_main(int argc, char** argv)
     std::string sfmDataFilename;
     std::string sfmDataOutputFilename;
     std::string surveyFilename;
+    int offset = -1;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -277,7 +278,9 @@ int aliceVision_main(int argc, char** argv)
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
         ("surveyFilename,p", po::value<std::string>(&surveyFilename)->default_value(surveyFilename),
-        "JSON file containing the survey to inject.");
+        "JSON file containing the survey to inject.")
+        ("offset", po::value<int>(&offset)->default_value(offset),
+        "Positive offset to use on the reference file frame number to match the input frame number (or -1 to try auto-detection).");
     // clang-format on
 
     CmdLine cmdline("AliceVision SfM Survey injecting");
@@ -288,7 +291,7 @@ int aliceVision_main(int argc, char** argv)
     {
         return EXIT_FAILURE;
     }
-    
+
 
     // Set maxThreads
     HardwareContext hwc = cmdline.getHardwareContext();
@@ -316,7 +319,14 @@ int aliceVision_main(int argc, char** argv)
     }
     ALICEVISION_LOG_INFO("Minimal frame id in sfmData is " << minFrameId << ".");
 
-    // Read survey points in an intermediate structure 
+    if (offset >= 0)
+    {
+        minFrameId = offset;
+    }
+
+    ALICEVISION_LOG_INFO("Using an offset between input frameId and real frameId of " << minFrameId << ".");
+
+    // Read survey points in an intermediate structure
     Survey survey;
     try
     {
@@ -374,7 +384,7 @@ int aliceVision_main(int argc, char** argv)
                 p.survey.y() = (1.0 - image_point.y) * intrinsic.h();
 
                 // Compute residual
-                Vec2 obsEstimated = intrinsic.transformProject(pose, p.point3d.homogeneous(), true);                
+                Vec2 obsEstimated = intrinsic.transformProject(pose, p.point3d.homogeneous(), true);
                 p.residual.x() = p.survey.x() - obsEstimated.x();
                 p.residual.y() = p.survey.y() - obsEstimated.y();
 


### PR DESCRIPTION
# Better integration of SurveyPoints in SfMData

## Summary

This PR improves the lifecycle management of `SurveyPoints` across the SfMData structure and exposes a manual frame-number offset in the survey-injecting tool.

---

## Changes

### `src/aliceVision/sfmData/SfMData.cpp` / `.hpp`

`SurveyPoints` were previously not handled by several core `SfMData` operations. This PR brings them in line with all other data members:

- **Copy constructors** (plain and bounding-box variant): `_surveyPoints` is now copied.
- **`operator==`**: survey points are compared using `std::is_permutation` (order-independent, since the per-view vector has no guaranteed ordering).
- **`combine()`**: survey points from the source `SfMData` are merged with deduplication (per-view, element-wise).
- **`clear()`**: `_surveyPoints` is now cleared.
- **`removeUnusedSurveyPoints()` (new)**: removes entries whose viewId no longer exists in the views map. Called by `repair()`.

### `src/aliceVision/keyframe/KeyframeSelector.cpp`

`writeSfMDataFromSfMData` now propagates survey points from the input SfMData to the appropriate output (`_outputSfmKeyframes` or `_outputSfmFrames`) based on viewId membership.

### `src/software/utils/main_sfmSurveyInjecting.cpp`

Added an `--offset` command-line parameter (default `-1` = auto-detect). When set to a non-negative value, it overrides the auto-detected `minFrameId` used to align the survey reference frame numbers with the input SfMData frame numbers.

### `meshroom/aliceVision/SfMSurveyInjecting.py`

Exposes the new `offset` parameter as an `IntParam` in the Meshroom node (version bumped to `1.1`, binary version minor bumped to `1`).

