### PR TITLE
Refactor PoseFilter to use explicit pose interpolation

### DIFF
--- a/meshroom/aliceVision/SfMTemporalFiltering.py
+++ b/meshroom/aliceVision/SfMTemporalFiltering.py
@@ -95,6 +95,15 @@ This node takes the result of SfM and fine-tune the camera poses so that the cam
             advanced=True,
             enabled=lambda node: node.limitReprojError.value,
         ),
+        desc.FloatParam(
+            name="lossParameter",
+            label="Loss Parameter",
+            description="Huber loss threshold, as used in bundle adjustment.",
+            value=4.0,
+            range=(0.0, 100.0, 1.0),
+            advanced=True,
+            enabled=lambda node: node.limitReprojError.value,
+        ),
         desc.ChoiceParam(
             name="verboseLevel",
             label="Verbose Level",

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -42,7 +42,7 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
         // Fill in the blanks in the views by interpolating new poses (position and orientation)
 
         sfm::poseFilter poseFilter;
-        if (!poseFilter.interpolateMissingPoses(sfmData, false))
+        if (!poseFilter.interpolateMissingPoses(sfmData))
         {
             return false;
         }

--- a/src/aliceVision/sfm/utils/poseFilter.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter.cpp
@@ -26,6 +26,9 @@ bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, c
 
     ALICEVISION_LOG_INFO("poseFilter::process start");
 
+    // Fill in the blanks by interpolating new poses (so that every view gets a pose)
+    interpolateMissingPoses(sfmData, false);
+
     for (const auto & [imageGroupID, imageGroup] : sfmData.getImageGroups().valueRange())
     {
         if (imageGroup.getType() != sfmData::ImageGroup::Type::ImageSequence)

--- a/src/aliceVision/sfm/utils/poseFilter.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter.cpp
@@ -20,7 +20,8 @@ namespace sfm {
 
 bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation,
                  const int maxIterationCount, const int maxScaleFactor, const double maxErrorIncreasePos,
-                 const double maxErrorIncreaseRot, const int minIterationCount, const int minScaleFactor)
+                 const double maxErrorIncreaseRot, const int minIterationCount, const int minScaleFactor,
+                 const double lossParameter)
 {
     using namespace Eigen;
 
@@ -81,7 +82,8 @@ bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, c
             viewCenters = (maxErrorIncreasePos < 0) ?
                           tFilter.applyMultiscale(viewCenters, maxScaleFactor, maxIterationCount, false) :
                           applyLimitedFilter(sfmData, imageGroupID, viewIdIndices, viewCenters, viewRotations, PoseParamType::Positions,
-                                             maxIterationCount, minIterationCount, maxScaleFactor, minScaleFactor, maxErrorIncreasePos);
+                                             maxIterationCount, minIterationCount, maxScaleFactor, minScaleFactor, maxErrorIncreasePos,
+                                             lossParameter);
         }
 
         // Apply a temporal filter to view orientations
@@ -91,7 +93,8 @@ bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, c
             viewRotations = (maxErrorIncreaseRot < 0) ?
                             tFilter.applyMultiscale(viewRotations, maxScaleFactor, maxIterationCount, true) :
                             applyLimitedFilter(sfmData, imageGroupID, viewIdIndices, viewCenters, viewRotations, PoseParamType::Rotations,
-                                                maxIterationCount, minIterationCount, maxScaleFactor, minScaleFactor, maxErrorIncreaseRot);
+                                                maxIterationCount, minIterationCount, maxScaleFactor, minScaleFactor, maxErrorIncreaseRot,
+                                                lossParameter);
         }
 
         // Save the temporally filtered poses
@@ -111,7 +114,7 @@ bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, c
 
 Eigen::MatrixXd poseFilter::applyLimitedFilter(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::map<IndexT, IndexT>& viewIdIndices,
                    const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, PoseParamType paramToFilter, const int maxIterationCount,
-                   const int minIterationCount, const int maxScaleFactor, const int minScaleFactor, const double maxErrorIncrease)
+                   const int minIterationCount, const int maxScaleFactor, const int minScaleFactor, const double maxErrorIncrease, const double lossParameter)
 {
     using namespace Eigen;
     using namespace indexing;
@@ -119,7 +122,7 @@ Eigen::MatrixXd poseFilter::applyLimitedFilter(const sfmData::SfMData& sfmData, 
     std::string poseParamString = poseParamType_enumToString(paramToFilter);
 
     // Compute the reprojection error before any filtering
-    double reprojError_0 = reprojectionError(sfmData, imageGroupID, viewIdIndices, viewCenters, viewRotations);
+    double reprojError_0 = reprojectionError(sfmData, imageGroupID, viewIdIndices, viewCenters, viewRotations, lossParameter);
     ALICEVISION_LOG_INFO("Reprojection error before " << poseParamString << " filtering: " << reprojError_0);
     ALICEVISION_LOG_DEBUG("Target reprojection error for " << poseParamString << ": " << (1. + maxErrorIncrease) * reprojError_0);
 
@@ -139,14 +142,14 @@ Eigen::MatrixXd poseFilter::applyLimitedFilter(const sfmData::SfMData& sfmData, 
     // Apply pose parameter filtering using the max iteration and scale factor values
     filteredParam = tFilter.applyMultiscale(filteredParam, maxScaleFactor, maxIterationCount, isAngle);
 
-    auto paramReprojError = [&sfmData, &imageGroupID, &viewIdIndices, &viewCenters,
-                             &viewRotations, &paramToFilter](const MatrixXd &filteredParam) {
+    auto paramReprojError = [&sfmData, &imageGroupID, &viewIdIndices, &viewCenters, &viewRotations, &lossParameter,
+                             &paramToFilter](const MatrixXd &filteredParam) {
                                     switch (paramToFilter)
                                     {
                                         case PoseParamType::Positions:
-                                            return reprojectionError(sfmData, imageGroupID, viewIdIndices, filteredParam, viewRotations);
+                                            return reprojectionError(sfmData, imageGroupID, viewIdIndices, filteredParam, viewRotations, lossParameter);
                                         case PoseParamType::Rotations:
-                                            return reprojectionError(sfmData, imageGroupID, viewIdIndices, viewCenters, filteredParam);
+                                            return reprojectionError(sfmData, imageGroupID, viewIdIndices, viewCenters, filteredParam, lossParameter);
                                     }
                                     throw std::out_of_range("Invalid PoseParamType enum");
                                 };
@@ -519,11 +522,9 @@ inline double huberLoss(const double delta, const double x)
 }
 
 
-double reprojectionError(const sfmData::SfMData& sfmData, const IndexT imageGroupID, const std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations)
+double reprojectionError(const sfmData::SfMData& sfmData, const IndexT imageGroupID, const std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, const double lossParameter)
 {
     using namespace Eigen;
-
-    double delta = Square(4.0);  // taken from BundleAdjustmentCeres::CeresOptions::lossFunction: HuberLoss(Square(4.0))
 
     std::vector<double> vecResiduals;
 
@@ -549,7 +550,7 @@ double reprojectionError(const sfmData::SfMData& sfmData, const IndexT imageGrou
             const auto& intrinsic = sfmData.getIntrinsic(view.getIntrinsicId());
             const Vec2 residual = intrinsic.residual(pose, landmark.getX().homogeneous(), observation.getCoordinates());
             const double scale = (observation.getScale() > 1e-12) ? observation.getScale() : 1.0;
-            vecResiduals.push_back(huberLoss(delta, residual.norm() / scale));
+            vecResiduals.push_back(huberLoss(lossParameter, residual.norm() / scale));
         }
     }
 

--- a/src/aliceVision/sfm/utils/poseFilter.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter.cpp
@@ -27,7 +27,7 @@ bool poseFilter::process(sfmData::SfMData& sfmData, const bool filterPosition, c
     ALICEVISION_LOG_INFO("poseFilter::process start");
 
     // Fill in the blanks by interpolating new poses (so that every view gets a pose)
-    interpolateMissingPoses(sfmData, false);
+    interpolateMissingPoses(sfmData);
 
     for (const auto & [imageGroupID, imageGroup] : sfmData.getImageGroups().valueRange())
     {
@@ -254,13 +254,13 @@ Eigen::MatrixXd poseFilter::applyLimitedFilter(const sfmData::SfMData& sfmData, 
 }
 
 
-bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool ignoreFirstAndLast)
+bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData)
 {
     using namespace Eigen;
 
     ALICEVISION_LOG_INFO("poseFilter::interpolateMissingPoses start");
 
-    bool noInterpolationDone = true;
+    bool validImageSequence = false;
 
     for (const auto & [imageGroupID, imageGroup] : sfmData.getImageGroups().valueRange())
     {
@@ -269,14 +269,16 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
             continue;
         }
 
-        const sfmData::Views& sfmViews = sfmData.getViews();
+        IndexT minFrameId = UndefinedIndexT;
+        IndexT maxFrameId = UndefinedIndexT;
 
-        const int viewCount = std::count_if(sfmViews.begin(), sfmViews.end(), [&imageGroupID](const auto& viewPair)
+        if (!getFrameIdRange(sfmData, imageGroupID, minFrameId, maxFrameId))
         {
-            return viewPair.second->getImageGroupId() == imageGroupID;
-        });
+            ALICEVISION_LOG_WARNING("poseFilter::interpolateMissingPoses Missing or duplicate frame in ImageSequence " << imageGroupID);
+            return false;
+        }
 
-        ALICEVISION_LOG_INFO("imageGroup " << imageGroupID << " has " << viewCount << " views.");
+        const int viewCount = maxFrameId - minFrameId + 1;
 
         if (viewCount <= 1)
         {
@@ -284,100 +286,53 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
         }
 
         std::vector<IndexT> viewIdsVec(viewCount);
-
-        IndexT minFrameId = UndefinedIndexT;
-        IndexT maxFrameId = UndefinedIndexT;
-        IndexT minFrameIdWithPose;
-        IndexT maxFrameIdWithPose;
-
-        bool existingPoseFound = false;
-
-        // Get the frameIDs range and the frameID of the first and last views with an existing pose
-        for (const auto& [viewID, viewPtr] : sfmData.getViews())
+        std::map<IndexT, IndexT> viewIdIndices;
+        // Get the temporally ordered viewIDs in viewIdsVec
+        if (!getOrderedViewIds(sfmData, imageGroupID, viewIdsVec, viewIdIndices))
         {
-            if (viewPtr->getImageGroupId() != imageGroupID)
-            {
-                continue;
-            }
-
-            const IndexT frameId = viewPtr->getFrameId();
-            if (frameId < minFrameId || minFrameId == UndefinedIndexT)
-            {
-                minFrameId = frameId;
-            }
-            if (frameId > maxFrameId || maxFrameId == UndefinedIndexT)
-            {
-                maxFrameId = frameId;
-            }
-            if ( sfmData.existsPose(*viewPtr) )
-            {
-                if (!existingPoseFound || frameId < minFrameIdWithPose)
-                {
-                    minFrameIdWithPose = frameId;
-                }
-
-                if (!existingPoseFound || frameId > maxFrameIdWithPose)
-                {
-                    maxFrameIdWithPose = frameId;
-                }
-
-                existingPoseFound = true;
-            }
-        }
-
-        const int frameIdRange = maxFrameId - minFrameId + 1;
-
-        if ( !existingPoseFound || (frameIdRange != viewCount) )
-        {
-            ALICEVISION_LOG_WARNING("Invalid imageSequence found (with missing view(s) or missing pose(s))");
             return false;
         }
 
-        noInterpolationDone = false;
-
-        // Store the temporally ordered view IDs
-        for (const auto& [viewID, viewPtr] : sfmData.getViews())
+        std::vector<IndexT> poseIdsVec;
+        IndexT firstViewWithPose;
+        IndexT lastViewWithPose;
+        // Get the temporally ordered poseIDs in poseIdsVec
+        if (!getOrderedPoseIds(sfmData, imageGroupID, poseIdsVec, firstViewWithPose, lastViewWithPose))
         {
-            if (viewPtr->getImageGroupId() != imageGroupID)
-            {
-                continue;
-            }
-
-            const IndexT frameId = viewPtr->getFrameId();
-            viewIdsVec[frameId-minFrameId] = viewID;
-
-            if (!sfmData.existsPose(*viewPtr))
-            {
-                ALICEVISION_LOG_INFO(" frame in imageGroup " << imageGroupID  << " without pose: " << frameId);
-            }
+            return false;
         }
 
-        const sfmData::View& lastValidView = sfmData.getView(viewIdsVec[minFrameIdWithPose-minFrameId]);
-        sfmData::CameraPose lastValidPose = sfmData.getPose(lastValidView);
+        validImageSequence = true;
+
+        IndexT lastValidPoseViewId = viewIdsVec[firstViewWithPose];
 
         VectorX<bool> missingPosesMask(viewCount);
         missingPosesMask.setZero();
 
+        bool anyMissingPose = false;
+
         // Initialize the pose of the views without pose
         for (int frameIdx = 0; frameIdx < viewCount; frameIdx++)
         {
-            IndexT frameViewID = viewIdsVec[frameIdx];
-            const sfmData::View& currentView = sfmData.getView(frameViewID);
-
-            if (!sfmData.existsPose(currentView))
+            if (poseIdsVec[frameIdx] == UndefinedIndexT)
             {
+                anyMissingPose = true;
                 // Create a binary mask to be able to restore the original values
                 missingPosesMask(frameIdx) = true;
-
-                if (!ignoreFirstAndLast || (minFrameIdWithPose < (frameIdx + minFrameId) && (frameIdx + minFrameId) < maxFrameIdWithPose) )
-                {
-                    sfmData.setPose(currentView, lastValidPose);
-                }
+                const sfmData::View& currentView = sfmData.getView(viewIdsVec[frameIdx]);
+                sfmData::CameraPose lastValidPose = sfmData.getPose(sfmData.getView(lastValidPoseViewId));
+                sfmData.setPose(currentView, lastValidPose);
             }
             else
             {
-                lastValidPose = sfmData.getPose(currentView);
+                lastValidPoseViewId = viewIdsVec[frameIdx];
             }
+        }
+
+        if (!anyMissingPose)
+        {
+            // Fast path: no missing pose in this imageSequence, so that we can skip the interpolation
+            continue;
         }
 
         tempFilter tFilter;
@@ -422,7 +377,7 @@ bool poseFilter::interpolateMissingPoses(sfmData::SfMData& sfmData, const bool i
         }
     }
 
-    if (noInterpolationDone)
+    if (!validImageSequence)
     {
         ALICEVISION_LOG_WARNING("No valid imageSequence found");
         return false;
@@ -437,47 +392,8 @@ bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, const IndexT image
 {
     IndexT minFrameId = UndefinedIndexT;
     IndexT maxFrameId = UndefinedIndexT;
-    IndexT minFrameIdWithPose;
 
-    IndexT viewCount = 0;
-    bool existingPoseFound = false;
-
-    // Get the frameIDs range and the frameID of the first view with an existing pose
-    for (const auto& [viewID, viewPtr] : sfmData.getViews())
-    {
-        if (viewPtr->getImageGroupId() != imageGroupID)
-        {
-            continue;
-        }
-
-        viewCount++;
-
-        const IndexT frameId = viewPtr->getFrameId();
-        if (frameId < minFrameId || minFrameId == UndefinedIndexT)
-        {
-            minFrameId = frameId;
-        }
-        if ( (!existingPoseFound || frameId < minFrameIdWithPose) && sfmData.existsPose(*viewPtr) )
-        {
-            existingPoseFound = true;
-            minFrameIdWithPose = frameId;
-        }
-        if (frameId > maxFrameId || maxFrameId == UndefinedIndexT)
-        {
-            maxFrameId = frameId;
-        }
-    }
-
-    const int frameIdRange = maxFrameId - minFrameId + 1;
-
-    ALICEVISION_LOG_DEBUG(" minFrameId : " << minFrameId);
-
-    ALICEVISION_LOG_DEBUG(" maxFrameId : " << maxFrameId);
-
-    if ( !existingPoseFound || (frameIdRange != viewCount) )
-    {
-        return false;
-    }
+    getFrameIdRange(sfmData, imageGroupID, minFrameId, maxFrameId);
 
     // Store the temporally ordered view IDs
     for (const auto& [viewID, viewPtr] : sfmData.getViews())
@@ -497,116 +413,51 @@ bool poseFilter::getOrderedViewIds(sfmData::SfMData& sfmData, const IndexT image
         }
     }
 
-    ALICEVISION_LOG_DEBUG(" minFrameIdWithPose : " << minFrameIdWithPose);
-
-    const sfmData::View& lastValidView = sfmData.getView(viewIdsVec[minFrameIdWithPose-minFrameId]);
-    sfmData::CameraPose lastValidPose = sfmData.getPose(lastValidView);
-
-    // Fill in the blanks within the camera poses list (so that every view gets a pose)
-    // using the first view with an existing pose for the first views without existing pose
-    // and using the last known view with an existing pose for any other view without existing pose
-
-    for (IndexT frameViewID : viewIdsVec)
-    {
-        const sfmData::View& currentView = sfmData.getView(frameViewID);
-
-        if (!sfmData.existsPose(currentView))
-        {
-            sfmData.setPose(currentView, lastValidPose);
-        }
-        else
-        {
-            lastValidPose = sfmData.getPose(currentView);
-        }
-    }
-
     return true;
 }
 
 
 bool getOrderedPoseIds(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& poseIdsVec, IndexT& firstViewWithPose, IndexT& lastViewWithPose)
 {
-    std::map<std::string, std::vector<IndexT>> candidateViewIdLists;
-    std::map<std::string, std::vector<IndexT>> candidateFrameIdLists;
-
-    IndexT viewCount = 0;
-    // Group views by common filename pattern
-    for (const auto& [viewID, viewPtr] : sfmData.getViews())
+    IndexT minFrameId = UndefinedIndexT;
+    IndexT maxFrameId = UndefinedIndexT;
+    if (!getFrameIdRange(sfmData, imageGroupID, minFrameId, maxFrameId))
     {
-        if (viewPtr->getImageGroupId() != imageGroupID)
-        {
-            continue;
-        }
-        const std::filesystem::path imagePath = std::filesystem::path(viewPtr->getImage().getImagePath());
-        std::string parentPath = imagePath.parent_path().string();
-        // Remove every digit in the filename
-        std::string filePattern = std::regex_replace(imagePath.filename().string(), std::regex("\\d"), "");
-        candidateViewIdLists[parentPath+filePattern].push_back(viewID);
-        candidateFrameIdLists[parentPath+filePattern].push_back(viewPtr->getFrameId());
-        viewCount++;
-    }
-
-    if (viewCount <= 1)
-    {
-        firstViewWithPose = lastViewWithPose = 0;
         return false;
     }
 
-    IndexT minFrameId;
+    IndexT viewCount = maxFrameId - minFrameId + 1;
 
-    int longestValidRange = 1;
-    std::string longestValidList;
+    poseIdsVec.resize(viewCount);
+    std::fill(poseIdsVec.begin(), poseIdsVec.end(), UndefinedIndexT);
 
-    // Select the longest list of views having no hole in the frameIds range
-    for (const auto& [filePattern, frameIDs] : candidateFrameIdLists)
-    {
-        auto [listMin, listMax] = std::minmax_element(frameIDs.begin(), frameIDs.end());
-        auto listRange = *listMax + 1 - *listMin;
-        bool noHole = frameIDs.size() == listRange;
-        if (noHole && listRange > longestValidRange)
-        {
-            longestValidRange = listRange;
-            longestValidList = filePattern;
-            minFrameId = *listMin;
-        }
-    }
-
-    if (longestValidRange == 1)
-        return false;
-
-    poseIdsVec.resize(longestValidRange);
-
-    bool existingPoseFound = false;
-    IndexT minFrameIdWithPose;
-    IndexT maxFrameIdWithPose;
+    IndexT minFrameIdWithPose = UndefinedIndexT;
+    IndexT maxFrameIdWithPose = UndefinedIndexT;
 
     // Get the frameID of the first and last views with an existing pose
     // And store the temporally ordered poseIDs
-    for (const auto& viewID : candidateViewIdLists[longestValidList])
+    for (const auto& [viewID, viewPtr] : sfmData.getViews())
     {
-        const sfmData::View& view = sfmData.getView(viewID);
-
-        if ( sfmData.existsPose(view) )
+        if (viewPtr->getImageGroupId() != imageGroupID || !sfmData.existsPose(*viewPtr))
         {
-            const IndexT frameId = view.getFrameId();
-
-            if (!existingPoseFound || frameId < minFrameIdWithPose)
-            {
-                minFrameIdWithPose = frameId;
-            }
-
-            if (!existingPoseFound || frameId > maxFrameIdWithPose)
-            {
-                maxFrameIdWithPose = frameId;
-            }
-
-            existingPoseFound = true;
-
-            poseIdsVec[frameId-minFrameId] = view.getPoseId();
+            continue;
         }
+
+        const IndexT frameId = viewPtr->getFrameId();
+
+        if (frameId < minFrameIdWithPose || minFrameIdWithPose == UndefinedIndexT )
+        {
+            minFrameIdWithPose = frameId;
+        }
+        if (frameId > maxFrameIdWithPose || maxFrameIdWithPose == UndefinedIndexT)
+        {
+            maxFrameIdWithPose = frameId;
+        }
+
+        poseIdsVec[frameId-minFrameId] = viewPtr->getPoseId();
     }
 
-    if (!existingPoseFound)
+    if (minFrameIdWithPose == UndefinedIndexT)
     {
         return false;
     }
@@ -616,6 +467,42 @@ bool getOrderedPoseIds(const sfmData::SfMData& sfmData, const IndexT imageGroupI
 
     return true;
 }
+
+
+bool getFrameIdRange(const sfmData::SfMData& sfmData, const IndexT imageGroupID, IndexT& minFrameId, IndexT& maxFrameId)
+{
+    minFrameId = UndefinedIndexT;
+    maxFrameId = UndefinedIndexT;
+    IndexT viewCount = 0;
+
+    // Get the frameIDs range
+    for (const auto& [viewID, viewPtr] : sfmData.getViews())
+    {
+        if (viewPtr->getImageGroupId() != imageGroupID)
+        {
+            continue;
+        }
+
+        viewCount++;
+
+        const IndexT frameId = viewPtr->getFrameId();
+        if (frameId < minFrameId || minFrameId == UndefinedIndexT)
+        {
+            minFrameId = frameId;
+        }
+        if (frameId > maxFrameId || maxFrameId == UndefinedIndexT)
+        {
+            maxFrameId = frameId;
+        }
+    }
+
+    ALICEVISION_LOG_DEBUG(" frameID range: " << minFrameId  << " -- " << maxFrameId);
+
+    const int frameIdRange = maxFrameId - minFrameId + 1;
+
+    return (frameIdRange == viewCount);
+}
+
 
 inline double huberLoss(const double delta, const double x)
 {

--- a/src/aliceVision/sfm/utils/poseFilter.hpp
+++ b/src/aliceVision/sfm/utils/poseFilter.hpp
@@ -47,9 +47,10 @@ public:
      * @param maxErrorIncreaseRot the maximum reprojection error increase ratio for the camera orientations (-1 to bypass this reprojection error test)
      * @param minIterationCount the minimum number of filter iterations to apply at the smallest scales (in case the filter is limited by the reprojection error)
      * @param minScaleFactor the minimum scale to apply the filter with the minimum iteration count (in case the filter is limited by the reprojection error)
+     * @param lossParameter the loss parameter for the reprojection error computation (used in the Huber loss function)
      * @return false if an error occurred
     */
-    bool process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int maxIterationCount, const int maxScaleFactor, const double maxErrorIncreasePos, const double maxErrorIncreaseRot, const int minIterationCount, const int minScaleFactor);
+    bool process(sfmData::SfMData& sfmData, const bool filterPosition, const bool filterRotation, const int maxIterationCount, const int maxScaleFactor, const double maxErrorIncreasePos, const double maxErrorIncreaseRot, const int minIterationCount, const int minScaleFactor, const double lossParameter);
 
     /**
      * @brief Interpolate poses for views without poses using temporal filtering.
@@ -60,7 +61,7 @@ public:
 
 private:
     bool getOrderedViewIds(sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& viewIdsVec, std::map<IndexT, IndexT>& viewIdIndices);
-    Eigen::MatrixXd applyLimitedFilter(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, const PoseParamType paramToFilter, const int maxIterationCount, const int minIterationCount, const int maxScaleFactor, const int minScaleFactor, const double maxErrorIncrease);
+    Eigen::MatrixXd applyLimitedFilter(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, const PoseParamType paramToFilter, const int maxIterationCount, const int minIterationCount, const int maxScaleFactor, const int minScaleFactor, const double maxErrorIncrease, const double lossParameter);
 };
 
 bool getFrameIdRange(const sfmData::SfMData& sfmData, const IndexT imageGroupID, IndexT& minFrameId, IndexT& maxFrameId);
@@ -89,9 +90,10 @@ bool getOrderedPoseIds(const sfmData::SfMData& sfmData, const IndexT imageGroupI
  * @param[in]  viewIdIndices      A map from viewID to indices in the view positions/rotations vectors
  * @param[in]  viewCenters        Vector of view positions.
  * @param[in]  viewRotations      Vector of view rotations.
+ * @param[in]  lossParameter      The loss parameter for the reprojection error computation (used in the Huber loss function)
  * @return the sum of the reprojection errors.
  */
-double reprojectionError(const sfmData::SfMData& sfmData, const IndexT imageGroupID, const std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations);
+double reprojectionError(const sfmData::SfMData& sfmData, const IndexT imageGroupID, const std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, const double lossParameter);
 
 } // namespace sfm
 } // namespace aliceVision

--- a/src/aliceVision/sfm/utils/poseFilter.hpp
+++ b/src/aliceVision/sfm/utils/poseFilter.hpp
@@ -54,15 +54,16 @@ public:
     /**
      * @brief Interpolate poses for views without poses using temporal filtering.
      * @param sfmData The scene description containing the views and poses.
-     * @param ignoreFirstAndLast If true, the first and last views without poses are not interpolated.
      * @return false if an error occurred during interpolation, true otherwise.
      */
-    bool interpolateMissingPoses(sfmData::SfMData& sfmData, const bool ignoreFirstAndLast);
+    bool interpolateMissingPoses(sfmData::SfMData& sfmData);
 
 private:
     bool getOrderedViewIds(sfmData::SfMData& sfmData, const IndexT imageGroupID, std::vector<IndexT>& viewIdsVec, std::map<IndexT, IndexT>& viewIdIndices);
     Eigen::MatrixXd applyLimitedFilter(const sfmData::SfMData& sfmData, const IndexT imageGroupID, std::map<IndexT, IndexT>& viewIdIndices, const Eigen::MatrixXd& viewCenters, const Eigen::MatrixXd& viewRotations, const PoseParamType paramToFilter, const int maxIterationCount, const int minIterationCount, const int maxScaleFactor, const int minScaleFactor, const double maxErrorIncrease);
 };
+
+bool getFrameIdRange(const sfmData::SfMData& sfmData, const IndexT imageGroupID, IndexT& minFrameId, IndexT& maxFrameId);
 
 /**
  * @brief Retrieve the ordered list of pose IDs from the given SfMData.

--- a/src/aliceVision/sfm/utils/poseFilter_test.cpp
+++ b/src/aliceVision/sfm/utils/poseFilter_test.cpp
@@ -8,6 +8,10 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 #include <aliceVision/unitTest.hpp>
+#include <aliceVision/sfmDataIO/sceneSample.hpp>
+#include <aliceVision/sfmData/ImageSequence.hpp>
+#include <aliceVision/sfmData/ImageSet.hpp>
+#include <aliceVision/sfmData/SfMData.hpp>
 #include <aliceVision/sfm/utils/poseFilter.hpp>
 
 
@@ -175,4 +179,124 @@ BOOST_AUTO_TEST_CASE(PoseFilter_angles)
             EXPECT_MATRIX_NEAR(aa.toRotationMatrix(), filteredAA.toRotationMatrix(), 2e-15);
         }
     }
+}
+
+
+BOOST_AUTO_TEST_CASE(PoseFilter_interpolateMissingPoses)
+{
+    // Check that PoseFilter correctly interpolates missing poses
+
+    using namespace aliceVision;
+
+    makeRandomOperationsReproducible();
+
+    sfmData::SfMData sfmData;
+    sfmDataIO::generateSphereScene(sfmData, 100, 240);
+
+    // Generate new ImageSet
+    size_t imageGroupID2 = 3454613548;
+    for (IndexT idPV = 300; idPV <410; idPV++)
+    {
+        IndexT grpID1_viewID = idPV - 300;
+        sfmData.getPoses().assign(idPV, sfmData.getPose(sfmData.getView(grpID1_viewID)));
+        sfmData.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, 100, 100));
+        sfmData::View& view = sfmData.getView(idPV);
+        view.setFrameId(idPV);
+        view.setImageGroupId(imageGroupID2);
+    }
+    auto imageGroupPtr2 = std::make_shared<sfmData::ImageSet>();
+    sfmData.getImageGroups().emplace(imageGroupID2, imageGroupPtr2);
+
+    // Generate new ImageSequence
+    size_t imageGroupID3 = 845461354;
+    for (IndexT idPV = 500; idPV <640; idPV++)
+    {
+        IndexT grpID1_viewID = idPV - 500;
+        sfmData.getPoses().assign(idPV, sfmData.getPose(sfmData.getView(grpID1_viewID)));
+        sfmData.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, 100, 100));
+        sfmData.getView(idPV).setFrameId(idPV);
+        sfmData.getView(idPV).setImageGroupId(imageGroupID3);
+    }
+    auto imageGroupPtr3 = std::make_shared<sfmData::ImageSequence>();
+    sfmData.getImageGroups().emplace(imageGroupID3, imageGroupPtr3);
+
+    IndexT poses2remove[] = {0, 1, 2, 3, 24, 45, 46, 47, 48, 239, 350,
+                            500, 501, 502, 503, 504, 518, 519, 520, 521, 522, 523, 524,
+                            560, 561, 562, 563, 633, 634, 635, 636, 637, 638, 639};
+    for (IndexT i=0; i<sizeof(poses2remove)/sizeof(IndexT); i++)
+    {
+        sfmData.erasePose(poses2remove[i]);
+    }
+
+    for (IndexT i=0; i<sizeof(poses2remove)/sizeof(IndexT); i++)
+    {
+        BOOST_CHECK(!sfmData.isPoseDefined(poses2remove[i]));
+    }
+
+    sfm::poseFilter poseFilter;
+    BOOST_CHECK(poseFilter.interpolateMissingPoses(sfmData));
+    for (IndexT i=0; i<sizeof(poses2remove)/sizeof(IndexT); i++)
+    {
+        if (poses2remove[i] < 240 || poses2remove[i] >= 500)
+        {
+            BOOST_CHECK(sfmData.isPoseDefined(poses2remove[i]));
+        }
+        else
+        {
+            BOOST_CHECK(!sfmData.isPoseDefined(poses2remove[i]));
+        }
+    }
+    BOOST_CHECK(poseFilter.interpolateMissingPoses(sfmData));
+    for (IndexT i=0; i<sizeof(poses2remove)/sizeof(IndexT); i++)
+    {
+        if (poses2remove[i] < 240 || poses2remove[i] >= 500)
+        {
+            BOOST_CHECK(sfmData.isPoseDefined(poses2remove[i]));
+        }
+        else
+        {
+            BOOST_CHECK(!sfmData.isPoseDefined(poses2remove[i]));
+        }
+    }
+
+    // Generate new ImageSequence with a missing frame in the sequence
+    size_t imageGroupID4 = 875461355;
+    for (IndexT idPV = 800; idPV < 900; idPV++)
+    {
+        if (idPV == 850)
+        {
+            // Skip this view to create a missing frame in the sequence
+            continue;
+        }
+        IndexT grpID1_viewID = idPV - 800;
+        sfmData.getPoses().assign(idPV, sfmData.getPose(sfmData.getView(grpID1_viewID)));
+        sfmData.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, 100, 100));
+        sfmData.getView(idPV).setFrameId(idPV);
+        sfmData.getView(idPV).setImageGroupId(imageGroupID4);
+    }
+    auto imageGroupPtr4 = std::make_shared<sfmData::ImageSequence>();
+    sfmData.getImageGroups().emplace(imageGroupID4, imageGroupPtr4);
+
+    // InterpolateMissingPoses should fail because there is a missing frame in the sequence
+    BOOST_CHECK(!poseFilter.interpolateMissingPoses(sfmData));
+
+    IndexT idPV = 850;
+    IndexT grpID1_viewID = idPV - 800;
+    sfmData.getPoses().assign(idPV, sfmData.getPose(sfmData.getView(grpID1_viewID)));
+    sfmData.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, 100, 100));
+    sfmData.getView(idPV).setFrameId(idPV);
+    sfmData.getView(idPV).setImageGroupId(imageGroupID4);
+
+    // InterpolateMissingPoses should now succeed because the missing frame has been added back
+    BOOST_CHECK(poseFilter.interpolateMissingPoses(sfmData));
+
+    idPV = 900;
+    grpID1_viewID = idPV - 800;
+    sfmData.getPoses().assign(idPV, sfmData.getPose(sfmData.getView(grpID1_viewID)));
+    sfmData.getViews().emplace(idPV, std::make_shared<sfmData::View>("", idPV, 0, idPV, 100, 100));
+    sfmData.getView(idPV).setFrameId(850);
+    sfmData.getView(idPV).setImageGroupId(imageGroupID4);
+
+    // InterpolateMissingPoses should now fail because there is a duplicate frame in the sequence
+    BOOST_CHECK(!poseFilter.interpolateMissingPoses(sfmData));
 }

--- a/src/software/pipeline/main_sfmTemporalFiltering.cpp
+++ b/src/software/pipeline/main_sfmTemporalFiltering.cpp
@@ -40,6 +40,7 @@ int aliceVision_main(int argc, char** argv)
     double maxErrorIncreaseRot = -1.;
     int minIterationCount = 50;
     int minScaleFactor = 3;
+    double lossParameter = 4.0;
 
     // clang-format off
     po::options_description requiredParams("Required parameters");
@@ -57,7 +58,8 @@ int aliceVision_main(int argc, char** argv)
         ("maxErrorIncreaseRot", po::value<double>(&maxErrorIncreaseRot)->default_value(maxErrorIncreaseRot), "The maximum reprojection error increase ratio for the camera orientations. (-1 to bypass this reprojection error test)")
         ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).")
         ("minIterationCount", po::value<int>(&minIterationCount)->default_value(minIterationCount), "The minimum number of filter iterations to apply at the smallest scales. (in case the filter is limited by the reprojection error)")
-        ("minScaleFactor", po::value<int>(&minScaleFactor)->default_value(minScaleFactor), "The minimum scale to apply the filter with the minimum iteration count. (in case the filter is limited by the reprojection error)");
+        ("minScaleFactor", po::value<int>(&minScaleFactor)->default_value(minScaleFactor), "The minimum scale to apply the filter with the minimum iteration count. (in case the filter is limited by the reprojection error)")
+        ("lossParameter", po::value<double>(&lossParameter)->default_value(lossParameter), "Huber loss threshold, as used in bundle adjustment.");
     // clang-format on
 
     CmdLine cmdline("AliceVision SfM Temporal Filtering");
@@ -86,7 +88,7 @@ int aliceVision_main(int argc, char** argv)
     if (!poseFilter->process(sfmData, filterPosition, filterRotation,
                              maxIterationCount, maxScaleFactor,
                              maxErrorIncreasePos, maxErrorIncreaseRot,
-                             minIterationCount, minScaleFactor))
+                             minIterationCount, minScaleFactor, lossParameter))
     {
         ALICEVISION_LOG_INFO("Error processing sfmData");
         return EXIT_FAILURE;


### PR DESCRIPTION
This pull request refactors and improves the temporal pose interpolation and filtering logic in the SfM pipeline. The main changes focus on making pose interpolation more robust and simplifying helper functions for frame and pose ordering.

* Refactored `interpolateMissingPoses` to use new helper functions (`getFrameIdRange`, `getOrderedViewIds`, `getOrderedPoseIds`) for more reliable detection and interpolation of missing poses in image sequences, and made the logic more robust to invalid or incomplete sequences.

* Rewrote and simplified the logic for ordering views and poses (`getOrderedViewIds`, `getOrderedPoseIds`) and for determining the frame ID range (`getFrameIdRange`), removing previous pattern-matching code and making the process more direct and less error-prone.

* Added a `lossParameter` float parameter to control the Huber loss threshold used in reprojection error calculations to reflect recent similar change in the bundle adjustment.

* Added a new non-regression test for `interpolateMissingPoses`

These changes collectively make the pose interpolation and filtering process more robust and configurable, and improve the maintainability of the code.