### PR TITLE
[fix] Missing intrinsics properties in usd I/O

### DIFF
--- a/src/aliceVision/camera/IntrinsicScaleOffset.cpp
+++ b/src/aliceVision/camera/IntrinsicScaleOffset.cpp
@@ -25,7 +25,13 @@ bool IntrinsicScaleOffset::operator==(const IntrinsicBase& otherBase) const
 
     const IntrinsicScaleOffset& other = static_cast<const IntrinsicScaleOffset&>(otherBase);
 
-    return _scale.isApprox(other._scale) && _offset.isApprox(other._offset);
+    bool initialScaleEqual = (_initialScale.isApprox(other._initialScale) || (_initialScale(0) < 0 && other._initialScale(0) < 0));
+
+    return _scale.isApprox(other._scale) && _offset.isApprox(other._offset) &&
+           initialScaleEqual &&
+           _ratioLocked == other._ratioLocked &&
+           _offsetLocked == other._offsetLocked &&
+           _scaleLocked == other._scaleLocked;
 }
 
 std::shared_ptr<IntrinsicScaleOffset> IntrinsicScaleOffset::cast(std::shared_ptr<IntrinsicBase> sptr)
@@ -240,6 +246,7 @@ void IntrinsicScaleOffset::setInitialFocalLength(double initialFocalInMillimeter
     {
         _initialScale(0) = -1.0;
         _initialScale(1) = -1.0;
+        return;
     }
 
     const double millimetersToPixels = double(w()) / sensorWidth();

--- a/src/aliceVision/sfmDataIO/AlembicImporter.cpp
+++ b/src/aliceVision/sfmDataIO/AlembicImporter.cpp
@@ -694,13 +694,12 @@ bool readCamera(const Version& abcVersion,
             // For compatibility with versions < 1.2 (value was in pixels)
             if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_initialFocalLengthPix"))
             {
-                initialFocalLengthPix(0) =
-                  getAbcProp<Alembic::Abc::IDoubleProperty>(userProps, *propHeader, "mvg_initialFocalLengthPix", sampleFrame);
+                initialFocalLengthPix(0) = getAbcProp<Alembic::Abc::IDoubleProperty>(userProps, *propHeader, "mvg_initialFocalLengthPix", sampleFrame);
             }
             if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_initialFocalLength"))
             {
-                initialFocalLengthPix(0) = (sensorSize_pix.at(0) / sensorSize_mm[0]) *
-                                           getAbcProp<Alembic::Abc::IDoubleProperty>(userProps, *propHeader, "mvg_initialFocalLength", sampleFrame);
+                const double initialFocalLengthMm = getAbcProp<Alembic::Abc::IDoubleProperty>(userProps, *propHeader, "mvg_initialFocalLength", sampleFrame);
+                initialFocalLengthPix(0) = (initialFocalLengthMm < 0) ? initialFocalLengthMm : (sensorSize_pix.at(0) / sensorSize_mm[0]) * initialFocalLengthMm;                      
             }
             if (const Alembic::Abc::PropertyHeader* propHeader = userProps.getPropertyHeader("mvg_fisheyeCircleCenterX"))
             {

--- a/src/aliceVision/sfmDataIO/usdIO.cpp
+++ b/src/aliceVision/sfmDataIO/usdIO.cpp
@@ -446,6 +446,7 @@ void writeIntrinsics(const UsdStageRefPtr& stage, const sfmData::SfMData& sfmDat
         {
             const Vec2 scale = scaleOffset->getScale();
             const Vec2 principalPoint = scaleOffset->getPrincipalPoint();
+            const Vec2 initialScale = scaleOffset->getInitialScale();
             setAttr(intrinsicPrim,
                 "av:focalLengthPix",
                 SdfValueTypeNames->Double2,
@@ -454,6 +455,13 @@ void writeIntrinsics(const UsdStageRefPtr& stage, const sfmData::SfMData& sfmDat
                 "av:principalPoint",
                 SdfValueTypeNames->Double2,
                 GfVec2d(principalPoint.x(), principalPoint.y()));
+            setAttr(intrinsicPrim,
+                "av:initialScale",
+                SdfValueTypeNames->Double2,
+                GfVec2d(initialScale.x(), initialScale.y()));
+            setAttr(intrinsicPrim, "av:ratioLocked", SdfValueTypeNames->Bool, scaleOffset->isRatioLocked());
+            setAttr(intrinsicPrim, "av:offsetLocked", SdfValueTypeNames->Bool, scaleOffset->isOffsetLocked());
+            setAttr(intrinsicPrim, "av:scaleLocked", SdfValueTypeNames->Bool, scaleOffset->isScaleLocked());
         }
 
         const auto equidistant = std::dynamic_pointer_cast<camera::Equidistant>(intrinsicPtr);
@@ -1290,6 +1298,34 @@ void loadIntrinsics(const UsdStageRefPtr& stage, const ExportPaths& paths, sfmDa
         if (getAttr(intrinsicPrim, "av:initializationMode", initializationMode))
         {
             intrinsic->setInitializationMode(static_cast<camera::EInitMode>(initializationMode));
+        }
+
+        const auto scaleOffset = std::dynamic_pointer_cast<camera::IntrinsicScaleOffset>(intrinsic);
+        if (scaleOffset)
+        {
+            GfVec2d initialScale(-1.0, -1.0);
+            if (getAttr(intrinsicPrim, "av:initialScale", initialScale))
+            {
+                scaleOffset->setInitialScale(Vec2(initialScale[0], initialScale[1]));
+            }
+
+            bool ratioLocked = true;
+            if (getAttr(intrinsicPrim, "av:ratioLocked", ratioLocked))
+            {
+                scaleOffset->setRatioLocked(ratioLocked);
+            }
+
+            bool offsetLocked = false;
+            if (getAttr(intrinsicPrim, "av:offsetLocked", offsetLocked))
+            {
+                scaleOffset->setOffsetLocked(offsetLocked);
+            }
+
+            bool scaleLocked = false;
+            if (getAttr(intrinsicPrim, "av:scaleLocked", scaleLocked))
+            {
+                scaleOffset->setScaleLocked(scaleLocked);
+            }
         }
 
         const auto equidistant = std::dynamic_pointer_cast<camera::Equidistant>(intrinsic);


### PR DESCRIPTION
IntrinsicScaleOffset locks and initialScaleOffset value were not handled in UsdIO. 

Additional changes on IntrinsicScaleOffset operator ==
