### PR TITLE
Lidar Pipeline integration

### DIFF
--- a/meshroom/aliceVision/SfmExpanding.py
+++ b/meshroom/aliceVision/SfmExpanding.py
@@ -1,4 +1,4 @@
-__version__ = "2.5"
+__version__ = "2.6"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
@@ -299,6 +299,14 @@ Bundle adjustment is performed periodically to refine all camera poses and 3D po
             label="Enable observations weighting",
             description="Enable observations weighting to reduce impact of regions with high point density.",
             value=False,
+        ),
+        desc.FloatParam(
+            name="lossParameter",
+            label="Loss Parameter",
+            description="Huber loss threshold used in bundle adjustment.",
+            value=4.0,
+            range=(0.1, 100.0, 0.1),
+            advanced=True,
         ),
         desc.IntParam(
             name="minNbCamerasToRefinePrincipalPoint",

--- a/meshroom/cameraTrackingLidarExperimental.mg
+++ b/meshroom/cameraTrackingLidarExperimental.mg
@@ -1,0 +1,815 @@
+{
+    "header": {
+        "releaseVersion": "2026.1.0+develop",
+        "fileVersion": "2.1",
+        "nodesVersions": {
+            "ApplyCalibration": "1.0",
+            "CameraInit": "12.1",
+            "ConvertDistortion": "1.0",
+            "ConvertSfMFormat": "2.0",
+            "CopyFiles": "1.3",
+            "ExportAlembic": "1.0",
+            "ExportDistortion": "2.0",
+            "ExportImages": "1.1",
+            "FeatureExtraction": "1.3",
+            "FeatureMatching": "2.1",
+            "ImageMatching": "2.0",
+            "ImageMatchingMultiSfM": "1.1",
+            "ImageSegmentationSam3": "2.0",
+            "InputFile": "1.0",
+            "IntrinsicsTransforming": "1.1",
+            "KeyframeSelection": "5.0",
+            "MaskEroding": "1.0",
+            "MaskProcessing": "1.0",
+            "ScenePreview": "2.0",
+            "SfMBootStrapping": "4.2",
+            "SfMColorizing": "1.0",
+            "SfMExpanding": "2.6",
+            "SfMFilter": "2.0",
+            "SfMPoseInjecting": "1.0",
+            "SfMSplitReconstructed": "1.0",
+            "SfMSurveyInjecting": "1.1",
+            "SfMTransfer": "2.1",
+            "TracksBuilding": "1.0",
+            "TracksMerging": "3.0",
+            "VideoSegmentationSam3": "2.0"
+        },
+        "template": true
+    },
+    "graph": {
+        "ApplyCalibration_1": {
+            "nodeType": "ApplyCalibration",
+            "position": [
+                -1208,
+                10
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "useJson": true
+            },
+            "internalInputs": {
+                "color": "#c49156"
+            }
+        },
+        "Backdrop_1": {
+            "nodeType": "Backdrop",
+            "position": [
+                1746,
+                -616
+            ],
+            "internalInputs": {
+                "label": "Previsualisation Keyframes",
+                "nodeWidth": 1183,
+                "nodeHeight": 222
+            }
+        },
+        "Backdrop_2": {
+            "nodeType": "Backdrop",
+            "position": [
+                4028,
+                -81
+            ],
+            "internalInputs": {
+                "label": "Previz final",
+                "nodeHeight": 200
+            }
+        },
+        "Backdrop_3": {
+            "nodeType": "Backdrop",
+            "position": [
+                -1157,
+                242
+            ],
+            "internalInputs": {
+                "label": "Segmentation",
+                "nodeWidth": 646,
+                "nodeHeight": 279
+            }
+        },
+        "Backdrop_4": {
+            "nodeType": "Backdrop",
+            "position": [
+                -1257,
+                -124
+            ],
+            "internalInputs": {
+                "label": "External Info",
+                "nodeWidth": 1096,
+                "nodeHeight": 258
+            }
+        },
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [
+                -1577,
+                17
+            ],
+            "inputs": {
+                "isSequence": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "ConvertDistortion_1": {
+            "nodeType": "ConvertDistortion",
+            "position": [
+                3747,
+                384
+            ],
+            "inputs": {
+                "input": "{SfMColorizing_2.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ConvertSfMFormat_1": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                4140,
+                -31
+            ],
+            "inputs": {
+                "input": "{ExportImages_2.outputSfMData}",
+                "fileExt": "json",
+                "describerTypes": "{TracksBuilding_2.describerTypes}",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ConvertSfMFormat_2": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                705,
+                -573
+            ],
+            "inputs": {
+                "input": "{ExportImages_3.outputSfMData}",
+                "fileExt": "json",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ConvertSfMFormat_3": {
+            "nodeType": "ConvertSfMFormat",
+            "position": [
+                2499,
+                -553
+            ],
+            "inputs": {
+                "input": "{ExportImages_4.outputSfMData}",
+                "fileExt": "json",
+                "structure": false,
+                "observations": false
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "CopyFiles_1": {
+            "nodeType": "CopyFiles",
+            "position": [
+                4251,
+                299
+            ],
+            "inputs": {
+                "inputFiles": [
+                    "{ExportDistortion_1.distortionNukeNode}",
+                    "{ExportAlembic_1.output}"
+                ]
+            }
+        },
+        "ExportAlembic_1": {
+            "nodeType": "ExportAlembic",
+            "position": [
+                3957,
+                188
+            ],
+            "inputs": {
+                "input": "{ExportImages_2.outputSfMData}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportDistortion_1": {
+            "nodeType": "ExportDistortion",
+            "position": [
+                3957,
+                384
+            ],
+            "inputs": {
+                "input": "{ConvertDistortion_1.output}",
+                "exportLensGridsUndistorted": false
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportImages_2": {
+            "nodeType": "ExportImages",
+            "position": [
+                3747,
+                188
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_2.input}",
+                "target": "{IntrinsicsTransforming_2.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportImages_3": {
+            "nodeType": "ExportImages",
+            "position": [
+                495,
+                -573
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_3.input}",
+                "target": "{IntrinsicsTransforming_3.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ExportImages_4": {
+            "nodeType": "ExportImages",
+            "position": [
+                2289,
+                -553
+            ],
+            "inputs": {
+                "input": "{IntrinsicsTransforming_4.input}",
+                "target": "{IntrinsicsTransforming_4.output}",
+                "namingMode": "keep"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [
+                350,
+                -48
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "masksFolder": "{MaskEroding_1.output}",
+                "maskExtension": "exr"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                770,
+                -48
+            ],
+            "inputs": {
+                "input": "{ImageMatching_1.input}",
+                "featuresFolders": "{ImageMatching_1.featuresFolders}",
+                "imagePairsList": "{ImageMatching_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "FeatureMatching_2": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                2270,
+                354
+            ],
+            "inputs": {
+                "input": "{ImageMatching_2.input}",
+                "featuresFolders": "{ImageMatching_2.featuresFolders}",
+                "imagePairsList": "{ImageMatching_2.output}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingAllFrames",
+                "color": "#80766f"
+            }
+        },
+        "FeatureMatching_3": {
+            "nodeType": "FeatureMatching",
+            "position": [
+                2277,
+                188
+            ],
+            "inputs": {
+                "input": "{ImageMatchingMultiSfM_1.outputCombinedSfM}",
+                "featuresFolders": "{ImageMatchingMultiSfM_1.featuresFolders}",
+                "imagePairsList": "{ImageMatchingMultiSfM_1.output}",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            },
+            "internalInputs": {
+                "label": "FeatureMatchingFramesToKeyframes",
+                "color": "#80766f"
+            }
+        },
+        "ImageMatchingMultiSfM_1": {
+            "nodeType": "ImageMatchingMultiSfM",
+            "position": [
+                2067,
+                188
+            ],
+            "inputs": {
+                "input": "{SfMSurveyInjecting_1.output}",
+                "inputB": "{SfMExpanding_4.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "VocabularyTree",
+                "matchingMode": "a/b",
+                "nbMatches": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageMatching_1": {
+            "nodeType": "ImageMatching",
+            "position": [
+                560,
+                -48
+            ],
+            "inputs": {
+                "input": "{KeyframeSelection_1.outputSfMDataKeyframes}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Exhaustive"
+            },
+            "internalInputs": {
+                "label": "ImageMatchingKeyframes",
+                "color": "#575963"
+            }
+        },
+        "ImageMatching_2": {
+            "nodeType": "ImageMatching",
+            "position": [
+                2060,
+                354
+            ],
+            "inputs": {
+                "input": "{SfMSurveyInjecting_1.output}",
+                "featuresFolders": [
+                    "{FeatureExtraction_1.output}"
+                ],
+                "method": "Sequential",
+                "nbNeighbors": 20
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ImageSegmentationSam3_1": {
+            "nodeType": "ImageSegmentationSam3",
+            "position": [
+                -1115,
+                282
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "prompt": "person",
+                "maskInvert": true
+            }
+        },
+        "IntrinsicsTransforming_2": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                3537,
+                188
+            ],
+            "inputs": {
+                "input": "{SfMColorizing_2.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "IntrinsicsTransforming_3": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                285,
+                -573
+            ],
+            "inputs": {
+                "input": "{SfMSplitReconstructed_1.reconstructedOutput}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "IntrinsicsTransforming_4": {
+            "nodeType": "IntrinsicsTransforming",
+            "position": [
+                2079,
+                -553
+            ],
+            "inputs": {
+                "input": "{SfMSplitReconstructed_2.reconstructedOutput}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "KeyframeSelection_1": {
+            "nodeType": "KeyframeSelection",
+            "position": [
+                140,
+                -48
+            ],
+            "inputs": {
+                "inputPaths": [
+                    "{SfMSurveyInjecting_1.output}"
+                ],
+                "maskPaths": [
+                    "{MaskEroding_1.output}"
+                ],
+                "selectionMethod": {
+                    "useSmartSelection": true,
+                    "regularSelection": {
+                        "minFrameStep": 12,
+                        "maxFrameStep": 0,
+                        "maxNbOutFrames": 0
+                    },
+                    "smartSelection": {
+                        "pxDisplacement": 10.0,
+                        "minNbOutFrames": 70,
+                        "maxNbOutFrames": 2000,
+                        "rescaledWidthSharpness": 720,
+                        "rescaledWidthFlow": 720,
+                        "sharpnessWindowSize": 200,
+                        "flowCellSize": 90,
+                        "minBlockSize": 10
+                    }
+                }
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "Lidarmesh_1": {
+            "nodeType": "InputFile",
+            "position": [
+                -1207,
+                -77
+            ],
+            "inputs": {},
+            "internalInputs": {
+                "color": "#c49156"
+            }
+        },
+        "MaskEroding_1": {
+            "nodeType": "MaskEroding",
+            "position": [
+                -719,
+                329
+            ],
+            "inputs": {
+                "input": "{MaskProcessing_1.output}",
+                "radius": 15
+            }
+        },
+        "MaskProcessing_1": {
+            "nodeType": "MaskProcessing",
+            "position": [
+                -906,
+                336
+            ],
+            "inputs": {
+                "inputs": [
+                    "{VideoSegmentationSam3_1.output}",
+                    "{ImageSegmentationSam3_1.output}"
+                ]
+            }
+        },
+        "PrevisualisationLidar_1": {
+            "nodeType": "Backdrop",
+            "position": [
+                21,
+                -684
+            ],
+            "internalInputs": {
+                "label": "Previz Lidar",
+                "nodeWidth": 1122,
+                "nodeHeight": 282
+            }
+        },
+        "ScenePreview_1": {
+            "nodeType": "ScenePreview",
+            "position": [
+                4350,
+                -31
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_1.output}",
+                "model": "{Lidarmesh_1.inputFile}",
+                "undistortedImages": "{ExportImages_2.output}",
+                "masks": "{MaskEroding_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ScenePreview_2": {
+            "nodeType": "ScenePreview",
+            "position": [
+                915,
+                -573
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_2.output}",
+                "model": "{Lidarmesh_1.inputFile}",
+                "undistortedImages": "{ExportImages_3.output}",
+                "masks": "{MaskEroding_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "ScenePreview_3": {
+            "nodeType": "ScenePreview",
+            "position": [
+                2709,
+                -553
+            ],
+            "inputs": {
+                "cameras": "{ConvertSfMFormat_3.output}",
+                "model": "{Lidarmesh_1.inputFile}",
+                "undistortedImages": "{ExportImages_4.output}",
+                "masks": "{MaskEroding_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "SfMBootStrapping_1": {
+            "nodeType": "SfMBootStrapping",
+            "position": [
+                1190,
+                -48
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_1.input}",
+                "method": "mesh_single",
+                "tracksFilename": "{TracksBuilding_1.output}",
+                "meshFilename": "{Lidarmesh_1.inputFile}",
+                "pairs": "empty"
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "SfMColorizing_2": {
+            "nodeType": "SfMColorizing",
+            "position": [
+                3327,
+                188
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_3.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "SfMExpanding_2": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                2907,
+                188
+            ],
+            "inputs": {
+                "input": "{TracksBuilding_2.input}",
+                "tracksFilename": "{TracksMerging_1.output}",
+                "meshFilename": "{Lidarmesh_1.inputFile}",
+                "localizerEstimatorError": 4.0,
+                "nbFirstUnstableCameras": 0,
+                "maxImagesPerGroup": 0,
+                "bundleAdjustmentMaxOutliers": 5000000,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
+                "label": "SfmExpanding",
+                "color": "#80766f"
+            }
+        },
+        "SfMExpanding_3": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                3117,
+                188
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_2.output}",
+                "tracksFilename": "{SfMExpanding_2.tracksFilename}",
+                "meshFilename": "{SfMExpanding_2.meshFilename}",
+                "localizerEstimatorError": 4.0,
+                "useLocalBA": false,
+                "useTemporalConstraint": true,
+                "nbFirstUnstableCameras": 0,
+                "maxImagesPerGroup": 0,
+                "bundleAdjustmentMaxOutliers": 5000000,
+                "minNumberOfObservationsForTriangulation": 3,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the complete camera tracking sequence.",
+                "label": "Filtering",
+                "color": "#80766f"
+            }
+        },
+        "SfMExpanding_4": {
+            "nodeType": "SfMExpanding",
+            "position": [
+                1400,
+                -48
+            ],
+            "inputs": {
+                "input": "{SfMBootStrapping_1.output}",
+                "tracksFilename": "{SfMBootStrapping_1.tracksFilename}",
+                "meshFilename": "{SfMBootStrapping_1.meshFilename}",
+                "localizerEstimatorError": 4.0,
+                "maxImagesPerGroup": 1,
+                "minAngleForTriangulation": 1.0,
+                "minAngleForLandmark": 0.5
+            },
+            "internalInputs": {
+                "comment": "Estimate cameras parameters for the keyframes.",
+                "label": "SfMExpandingKeys",
+                "color": "#575963"
+            }
+        },
+        "SfMFilter_1": {
+            "nodeType": "SfMFilter",
+            "position": [
+                -788,
+                10
+            ],
+            "inputs": {
+                "inputFile": "{SfMPoseInjecting_1.output}",
+                "expression": "frameId == 977"
+            },
+            "internalInputs": {
+                "color": "#c49156"
+            }
+        },
+        "SfMPoseInjecting_1": {
+            "nodeType": "SfMPoseInjecting",
+            "position": [
+                -998,
+                10
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "offset": 977
+            },
+            "internalInputs": {
+                "color": "#c49156"
+            }
+        },
+        "SfMSplitReconstructed_1": {
+            "nodeType": "SfMSplitReconstructed",
+            "position": [
+                75,
+                -573
+            ],
+            "inputs": {
+                "input": "{TransferInjectedPose_1.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "SfMSplitReconstructed_2": {
+            "nodeType": "SfMSplitReconstructed",
+            "position": [
+                1869,
+                -553
+            ],
+            "inputs": {
+                "input": "{SfMExpanding_4.output}"
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "SfMSurveyInjecting_1": {
+            "nodeType": "SfMSurveyInjecting",
+            "position": [
+                -368,
+                10
+            ],
+            "inputs": {
+                "input": "{TransferInjectedPose_1.output}"
+            },
+            "internalInputs": {
+                "color": "#c49156"
+            }
+        },
+        "TracksBuilding_1": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                980,
+                -48
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_1.output}"
+                ],
+                "describerTypes": "{FeatureMatching_1.describerTypes}",
+                "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#575963"
+            }
+        },
+        "TracksBuilding_2": {
+            "nodeType": "TracksBuilding",
+            "position": [
+                2487,
+                188
+            ],
+            "inputs": {
+                "input": "{FeatureMatching_3.input}",
+                "featuresFolders": "{FeatureMatching_3.featuresFolders}",
+                "matchesFolders": [
+                    "{FeatureMatching_2.output}",
+                    "{FeatureMatching_3.output}"
+                ],
+                "describerTypes": "{FeatureMatching_3.describerTypes}",
+                "minInputTrackLength": 5,
+                "filterTrackForks": true
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "TracksMerging_1": {
+            "nodeType": "TracksMerging",
+            "position": [
+                2697,
+                188
+            ],
+            "inputs": {
+                "inputs": [
+                    "{TracksBuilding_2.output}"
+                ]
+            },
+            "internalInputs": {
+                "color": "#80766f"
+            }
+        },
+        "TransferInjectedPose_1": {
+            "nodeType": "SfMTransfer",
+            "position": [
+                -578,
+                10
+            ],
+            "inputs": {
+                "input": "{ApplyCalibration_1.output}",
+                "reference": "{SfMFilter_1.outputSfMData_selected}"
+            },
+            "internalInputs": {
+                "color": "#c49156"
+            }
+        },
+        "VideoSegmentationSam3_1": {
+            "nodeType": "VideoSegmentationSam3",
+            "position": [
+                -1114,
+                402
+            ],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "prompt": "vehicle",
+                "combineFwdAndBwdSeg": true,
+                "maskInvert": true
+            }
+        }
+    }
+}

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -42,6 +42,7 @@ set(sfm_files_headers
     pipeline/expanding/ExpansionPostProcessRig.hpp
     pipeline/expanding/ExpansionPolicy.hpp
     pipeline/expanding/ExpansionPolicyLegacy.hpp
+    pipeline/expanding/ExpansionPolicySequence.hpp
     pipeline/expanding/ExpansionProcess.hpp
     pipeline/expanding/ConnexityGraph.hpp
     pipeline/expanding/LbaPolicy.hpp
@@ -86,6 +87,7 @@ set(sfm_files_sources
     pipeline/expanding/ExpansionChunk.cpp
     pipeline/expanding/ExpansionIteration.cpp
     pipeline/expanding/ExpansionPolicyLegacy.cpp
+    pipeline/expanding/ExpansionPolicySequence.cpp
     pipeline/expanding/ExpansionPostProcessRig.cpp
     pipeline/expanding/ExpansionProcess.cpp
     pipeline/expanding/ConnexityGraph.cpp

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp
@@ -654,6 +654,12 @@ void BundleAdjustmentCeres::addLandmarksToProblem(const sfmData::SfMData& sfmDat
             else if (referencePoseBlockPtr != nullptr)
             {
                 bool samePose = (referencePoseBlockPtr == poseBlockPtr);
+
+                if (_ceresOptions.useParametersOrdering && !samePose)
+                {
+                    _linearSolverOrdering.AddElementToGroup(referencePoseBlockPtr, 1);
+                }
+
                 ceres::CostFunction* costFunction = ProjectionMeshErrorFunctor::createCostFunction(intrinsic, observation, landmark.getPointFetcher(), samePose);
 
                 std::vector<double*> params;

--- a/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
+++ b/src/aliceVision/sfm/bundle/BundleAdjustmentCeres.hpp
@@ -35,13 +35,13 @@ class BundleAdjustmentCeres : public BundleAdjustment, ceres::EvaluationCallback
      */
     struct CeresOptions
     {
-        CeresOptions(bool verbose = true, bool multithreaded = true, unsigned int maxIterations = 50)
+        CeresOptions(bool verbose = true, bool multithreaded = true, unsigned int maxIterations = 50, double huberLoss = 4.0)
           : verbose(verbose),
             nbThreads(multithreaded ? omp_get_max_threads() : 1),  // set number of threads, 1 if OpenMP is not enabled
             maxNumIterations(maxIterations)
         {
             setDenseBA();  // use dense BA by default
-            lossFunction.reset(new ceres::HuberLoss(Square(4.0)));
+            lossFunction.reset(new ceres::HuberLoss(huberLoss));
         }
 
         void setDenseBA();

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicySequence.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicySequence.cpp
@@ -1,0 +1,198 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <aliceVision/system/Logger.hpp>
+#include <aliceVision/sfm/pipeline/expanding/ExpansionPolicySequence.hpp>
+#include <aliceVision/stl/mapUtils.hpp>
+
+#include <limits>
+
+namespace aliceVision {
+namespace sfm {
+
+bool ExpansionPolicySequence::initialize(const sfmData::SfMData & sfmData)
+{
+    _availableViewsIds.clear();
+
+    const std::set<IndexT> allViewsIds = sfmData.getViewsKeys();
+    const std::set<IndexT> allReconstructedViewsIds = sfmData.getValidViews();
+
+    // Initial list is the set of non-localised views in the sfmData
+    std::set_difference(allViewsIds.begin(), allViewsIds.end(),
+                        allReconstructedViewsIds.begin(), allReconstructedViewsIds.end(),
+                        std::inserter(_availableViewsIds, _availableViewsIds.begin()));
+
+    return true;
+}
+
+bool ExpansionPolicySequence::process(const sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler)
+{
+    _selectedViews.clear();
+
+    if (_availableViewsIds.empty())
+    {
+        return false;
+    }
+
+    // Build the set of frame IDs that are already reconstructed
+    // UndefinedIndexT frames are skipped (they carry no sequence information)
+    std::set<IndexT> reconstructedFrameIds;
+    for (const IndexT viewId : sfmData.getValidViews())
+    {
+        const IndexT fid = sfmData.getView(viewId).getFrameId();
+        if (fid != UndefinedIndexT)
+        {
+            reconstructedFrameIds.insert(fid);
+        }
+    }
+
+    // Collect reconstructed track IDs for overlap counting
+    std::set<size_t> reconstructedTracksIds;
+    std::transform(sfmData.getLandmarks().begin(),
+                   sfmData.getLandmarks().end(),
+                   std::inserter(reconstructedTracksIds, reconstructedTracksIds.begin()),
+                   stl::RetrieveKey());
+
+    struct ViewScoring
+    {
+        IndexT id;
+        size_t count;       // number of shared reconstructed tracks
+        IndexT frameIdDist; // minimum frame-ID distance to any reconstructed view
+    };
+
+    std::vector<ViewScoring> vscoring;
+
+    std::vector<IndexT> vectorAvailableViewsIds(_availableViewsIds.begin(), _availableViewsIds.end());
+
+    #pragma omp parallel for schedule(dynamic)
+    for (int pos = 0; pos < static_cast<int>(vectorAvailableViewsIds.size()); pos++)
+    {
+        const IndexT cViewId = vectorAvailableViewsIds[pos];
+        const sfmData::View & v = sfmData.getView(cViewId);
+
+        // Skip views without intrinsics — resection is impossible
+        if (!sfmData.isIntrinsicDefined(v))
+        {
+            continue;
+        }
+
+        // Get tracks visible in this view
+        const auto tracksPerViewIt = tracksHandler.getTracksPerView().find(cViewId);
+        if (tracksPerViewIt == tracksHandler.getTracksPerView().end() || tracksPerViewIt->second.empty())
+        {
+            continue;
+        }
+        const aliceVision::track::TrackIdSet & tracksIds = tracksPerViewIt->second;
+
+        // Count reconstructed tracks shared with this view
+        std::vector<std::size_t> viewReconstructedTracksIds;
+        std::set_intersection(tracksIds.begin(), tracksIds.end(),
+                              reconstructedTracksIds.begin(), reconstructedTracksIds.end(),
+                              std::back_inserter(viewReconstructedTracksIds));
+
+        if (viewReconstructedTracksIds.empty())
+        {
+            continue;
+        }
+
+        // Compute minimum frame-ID distance to any already-reconstructed view.
+        // Views whose frameId is UndefinedIndexT are given maximum distance so
+        // that sequence-aware views are always preferred, but they remain
+        // eligible once all sequence-aware candidates are exhausted.
+        IndexT minDist = std::numeric_limits<IndexT>::max();
+        const IndexT fid = v.getFrameId();
+        if (fid != UndefinedIndexT && !reconstructedFrameIds.empty())
+        {
+            // std::set is ordered — find the nearest frame ID with lower_bound
+            auto it = reconstructedFrameIds.lower_bound(fid);
+            if (it != reconstructedFrameIds.end())
+            {
+                const IndexT d = *it - fid; // *it >= fid, so no underflow
+                if (d < minDist) minDist = d;
+            }
+            if (it != reconstructedFrameIds.begin())
+            {
+                --it;
+                const IndexT d = fid - *it; // fid > *it, so no underflow
+                if (d < minDist) minDist = d;
+            }
+        }
+
+        ViewScoring scoring;
+        scoring.id = cViewId;
+        scoring.count = viewReconstructedTracksIds.size();
+        scoring.frameIdDist = minDist;
+
+        #pragma omp critical
+        {
+            vscoring.push_back(scoring);
+        }
+    }
+
+    if (vscoring.empty())
+    {
+        return false;
+    }
+
+    // Sort: primary key = frame-ID distance (ascending), secondary = track count (descending)
+    std::sort(vscoring.begin(), vscoring.end(),
+              [](const ViewScoring & a, const ViewScoring & b)
+              {
+                  if (a.frameIdDist != b.frameIdDist)
+                      return a.frameIdDist < b.frameIdDist;
+                  return a.count > b.count;
+              });
+
+    // Always add the best candidate, whatever its characteristics
+    _selectedViews.insert(vscoring[0].id);
+
+    int maxSetSize = static_cast<int>(_maxViewsPerGroup);
+    if (maxSetSize == 0)
+    {
+        maxSetSize = std::numeric_limits<int>::max();
+    }
+
+    // During the unstable bootstrapping phase restrict to one view at a time
+    if (sfmData.getValidViews().size() < _nbFirstUnstableViews)
+    {
+        maxSetSize = 1;
+    }
+
+    // Add further views that meet the minimum-points threshold
+    for (int i = 1; i < static_cast<int>(vscoring.size()) && static_cast<int>(_selectedViews.size()) < maxSetSize; i++)
+    {
+        if (vscoring[i].count < _minPointsThreshold)
+        {
+            continue;
+        }
+
+        _selectedViews.insert(vscoring[i].id);
+    }
+
+    for (const IndexT id : _selectedViews)
+    {
+        _availableViewsIds.erase(id);
+    }
+
+    return true;
+}
+
+std::set<IndexT> ExpansionPolicySequence::getNextViews()
+{
+    return _selectedViews;
+}
+
+void ExpansionPolicySequence::rollback(const std::set<IndexT> & viewsSet)
+{
+    for (const auto & item : viewsSet)
+    {
+        ALICEVISION_LOG_INFO("Rollback view : " << item);
+        _availableViewsIds.insert(item);
+    }
+}
+
+}
+}

--- a/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicySequence.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/ExpansionPolicySequence.hpp
@@ -1,0 +1,100 @@
+// This file is part of the AliceVision project.
+// Copyright (c) 2026 AliceVision contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <aliceVision/sfm/pipeline/expanding/ExpansionPolicy.hpp>
+
+namespace aliceVision {
+namespace sfm {
+
+/**
+ * @brief Expansion policy that selects views by frame ID proximity.
+ *
+ * At each iteration the available view whose frame ID is closest (in absolute
+ * distance) to any already-reconstructed view is selected first, effectively
+ * filling holes in the frame-ID sequence before jumping to distant frames.
+ */
+class ExpansionPolicySequence : public ExpansionPolicy
+{
+public:
+    using uptr = std::unique_ptr<ExpansionPolicySequence>;
+
+public:
+    /**
+     * @brief Initialize policy for an iteration
+     * @param sfmData the scene to process
+     * @return true if the init succeeded
+     */
+    virtual bool initialize(const sfmData::SfMData & sfmData);
+
+    /**
+     * @brief compute policy for an iteration
+     * @param sfmData the scene to process
+     * @param tracksHandler the tracks for this scene
+     * @return true if the policy succeeded
+     */
+    virtual bool process(const sfmData::SfMData & sfmData, const track::TracksHandler & tracksHandler);
+
+    /**
+     * @brief Retrieve the selected next views
+     * @return a set of views to process
+     */
+    virtual std::set<IndexT> getNextViews();
+
+    /**
+     * @brief rollback some processed views inside the available views
+     * @param viewsSet the set of views that we want to be able to select again.
+     */
+    virtual void rollback(const std::set<IndexT> & viewsSet);
+
+    /**
+     * @brief Set the minimum number of reconstructed tracks required for a view to be selected
+     * @param count minimum track count
+     */
+    void setMinPointsThreshold(std::size_t count)
+    {
+        _minPointsThreshold = count;
+    }
+
+    /**
+     * @brief Set the number of views considered as unstable at the start
+     * @param count a number of views
+     */
+    void setNbFirstUnstableViews(size_t count)
+    {
+        _nbFirstUnstableViews = count;
+    }
+
+    /**
+     * @brief Set the maximum number of views selected per group
+     * @param count a number of views
+     */
+    void setMaxViewsPerGroup(size_t count)
+    {
+        _maxViewsPerGroup = count;
+    }
+
+private:
+    // Views selected for the current iteration
+    std::set<IndexT> _selectedViews;
+
+    // Views still available for reconstruction
+    std::set<IndexT> _availableViewsIds;
+
+private:
+    // Minimum number of reconstructed tracks a view must share with the scene
+    std::size_t _minPointsThreshold = 30;
+
+    // Number of cameras in scene under which the set is considered as unstable
+    size_t _nbFirstUnstableViews = 30;
+
+    // Maximum number of images in a chunk (0 = unlimited)
+    size_t _maxViewsPerGroup = 30;
+};
+
+}
+}

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.cpp
@@ -20,8 +20,7 @@ bool SfmBundle::process(sfmData::SfMData & sfmData, const track::TracksHandler &
 {
     ALICEVISION_LOG_INFO("SfmBundle::process start");
 
-    BundleAdjustmentCeres::CeresOptions options;
-    options.maxNumIterations = _maxIterationCount;
+    BundleAdjustmentCeres::CeresOptions options(true, true, _maxIterationCount, _lossParameter);
 
     BundleAdjustment::ERefineOptions refineOptions = BundleAdjustment::REFINE_NONE;
 

--- a/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
+++ b/src/aliceVision/sfm/pipeline/expanding/SfmBundle.hpp
@@ -106,6 +106,15 @@ public:
     }
 
     /**
+     * @brief Set the Huber loss parameter for bundle adjustment
+     * @param lossParameter the Huber loss threshold value
+    */
+    void setLossParameter(double lossParameter)
+    {
+        _lossParameter = lossParameter;
+    }
+
+    /**
      * @brief Get the number of valid points per pose required
      * @return the threshold used to discriminate a valid pose
     */
@@ -161,6 +170,7 @@ private:
     size_t _LBAMinNbOfMatches = 50;
     bool _isStructureRefinementEnabled = true;
     bool _enableObservationsWeighting = false;
+    double _lossParameter = 4.0;
 };
 
 } // namespace sfm

--- a/src/software/pipeline/main_imageMatching.cpp
+++ b/src/software/pipeline/main_imageMatching.cpp
@@ -154,7 +154,7 @@ int aliceVision_main(int argc, char** argv)
     sfmData::SfMData sfmDataA, sfmDataB;
 
     using namespace sfmDataIO;
-    if (!sfmDataIO::load(sfmDataA, sfmDataFilenameA, ESfMData(ESfMData::VIEWS | ESfMData::EXTRINSICS | ESfMData::INTRINSICS)))
+    if (!sfmDataIO::load(sfmDataA, sfmDataFilenameA, ESfMData(ESfMData::VIEWS | ESfMData::EXTRINSICS | ESfMData::INTRINSICS | ESfMData::SURVEYS)))
     {
         ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilenameA + "' cannot be read.");
         return EXIT_FAILURE;
@@ -162,7 +162,7 @@ int aliceVision_main(int argc, char** argv)
 
     if (useMultiSfM)
     {
-        if (!sfmDataIO::load(sfmDataB, sfmDataFilenameB, ESfMData(ESfMData::VIEWS | ESfMData::EXTRINSICS | ESfMData::INTRINSICS)))
+        if (!sfmDataIO::load(sfmDataB, sfmDataFilenameB, ESfMData(ESfMData::VIEWS | ESfMData::EXTRINSICS | ESfMData::INTRINSICS | ESfMData::SURVEYS)))
         {
             ALICEVISION_LOG_ERROR("The input SfMData file '" + sfmDataFilenameB + "' cannot be read.");
             return EXIT_FAILURE;

--- a/src/software/pipeline/main_sfmBootstrapping.cpp
+++ b/src/software/pipeline/main_sfmBootstrapping.cpp
@@ -393,11 +393,11 @@ int aliceVision_main(int argc, char** argv)
     ("input,i", po::value<std::string>(&sfmDataFilename)->required(), "SfMData file.")
     ("output,o", po::value<std::string>(&sfmDataOutputFilename)->required(), "SfMData output file.")
     ("method", po::value<std::string>(&methodString)->required(), "Bootstrapping method: classic (epipolar geometry), mesh (3D mesh constraints), or depth (depth map information).")
-    ("tracksFilename,t", po::value<std::string>(&tracksFilename)->required(), "Tracks file.")
-    ("pairs,p", po::value<std::string>(&pairsDirectory)->required(), "Path to the pairs directory.");
+    ("tracksFilename,t", po::value<std::string>(&tracksFilename)->required(), "Tracks file.");
 
     po::options_description optionalParams("Optional parameters");
     optionalParams.add_options()
+    ("pairs", po::value<std::string>(&pairsDirectory)->default_value(pairsDirectory), "Path to the pairs directory.")
     ("outputViewsAndPoses", po::value<std::string>(&outputSfMViewsAndPoses)->default_value(outputSfMViewsAndPoses), "Path to the output SfMData file (with only views and poses).")
     ("minAngleSoftInitialPair", po::value<double>(&minAngleSoft)->default_value(minAngleSoft), "Minimum angle for the initial pair (Score is downgraded heavily if angle is under this value).")
     ("minAngleHardInitialPair", po::value<double>(&minAngleHard)->default_value(minAngleHard), "Minimum angle for the initial pair validation.")
@@ -497,59 +497,69 @@ int aliceVision_main(int argc, char** argv)
     //Result of pair estimations are stored in multiple files
     std::vector<sfm::ReconstructedPair> reconstructedPairs;
     const std::regex regex("pairs\\_[0-9]+\\.json");
-    for(fs::directory_entry & file : boost::make_iterator_range(fs::directory_iterator(pairsDirectory), {}))
+
+    if (method != MESH_SINGLE)
     {
-        if (!std::regex_search(file.path().string(), regex))
+        if (pairsDirectory.empty())
         {
-            continue;
+            ALICEVISION_LOG_ERROR("Missing path to the pairs directory.");
+            return EXIT_FAILURE;
         }
-
-        std::ifstream inputfile(file.path().string());        
-
-        boost::system::error_code ec;
-        std::vector<boost::json::value> values = readJsons(inputfile, ec);
-        for (const boost::json::value & value : values)
-        {
-            std::vector<sfm::ReconstructedPair> localVector = boost::json::value_to<std::vector<sfm::ReconstructedPair>>(value);
         
-            for (const auto & pair: localVector)
+        for(fs::directory_entry & file : boost::make_iterator_range(fs::directory_iterator(pairsDirectory), {}))
+        {
+            if (!std::regex_search(file.path().string(), regex))
             {
-                // One of the view must match one of the first view filters
-                // If there is an existing filter
-                if (!firstViewFilters.empty())
-                {
-                    bool passFirstFilter = false;
+                continue;
+            }
 
-                    for (auto filter : firstViewFilters)
+            std::ifstream inputfile(file.path().string());        
+
+            boost::system::error_code ec;
+            std::vector<boost::json::value> values = readJsons(inputfile, ec);
+            for (const boost::json::value & value : values)
+            {
+                std::vector<sfm::ReconstructedPair> localVector = boost::json::value_to<std::vector<sfm::ReconstructedPair>>(value);
+            
+                for (const auto & pair: localVector)
+                {
+                    // One of the view must match one of the first view filters
+                    // If there is an existing filter
+                    if (!firstViewFilters.empty())
                     {
-                        if (pair.reference == filter || pair.next == filter)
+                        bool passFirstFilter = false;
+
+                        for (auto filter : firstViewFilters)
                         {
-                            passFirstFilter = true;
-                            break;
+                            if (pair.reference == filter || pair.next == filter)
+                            {
+                                passFirstFilter = true;
+                                break;
+                            }
+                        }
+
+                        if (!passFirstFilter)
+                        {
+                            continue;
                         }
                     }
 
-                    if (!passFirstFilter)
+                    //If the secondview filter is valid, use it.
+                    if (secondViewFilter != UndefinedIndexT)
                     {
-                        continue;
+                        if (pair.reference != secondViewFilter && pair.next != secondViewFilter)
+                        {
+                            continue;
+                        }
                     }
-                }
 
-                //If the secondview filter is valid, use it.
-                if (secondViewFilter != UndefinedIndexT)
-                {
-                    if (pair.reference != secondViewFilter && pair.next != secondViewFilter)
-                    {
-                        continue;
-                    }
+                    reconstructedPairs.push_back(pair);
                 }
-
-                reconstructedPairs.push_back(pair);
             }
         }
-    }
 
-    ALICEVISION_LOG_INFO("Pairs to process : " << reconstructedPairs.size());
+        ALICEVISION_LOG_INFO("Pairs to process : " << reconstructedPairs.size());
+    }
 
     
     bool ret;

--- a/src/software/pipeline/main_sfmExpanding.cpp
+++ b/src/software/pipeline/main_sfmExpanding.cpp
@@ -30,7 +30,7 @@
 // These constants define the current software version.
 // They must be updated when the command line is changed.
 #define ALICEVISION_SOFTWARE_VERSION_MAJOR 2
-#define ALICEVISION_SOFTWARE_VERSION_MINOR 5
+#define ALICEVISION_SOFTWARE_VERSION_MINOR 6
 
 using namespace aliceVision;
 
@@ -70,6 +70,7 @@ int aliceVision_main(int argc, char** argv)
     bool enableDepthPrior = true;
     bool ignoreMultiviewOnPrior = false;
     bool enableObservationsWeighting = false;
+    double lossParameter = 4.0;
 
     int randomSeed = std::mt19937::default_seed;
 
@@ -133,6 +134,7 @@ int aliceVision_main(int argc, char** argv)
     ("useRigConstraint", po::value<bool>(&useRigConstraint)->default_value(useRigConstraint), "Enable/Disable rig constraint.")
     ("rigMinNbCamerasForCalibration", po::value<int>(&minNbCamerasForRigCalibration)->default_value(minNbCamerasForRigCalibration),"Minimal number of cameras to start the calibration of the rig.")
     ("enableObservationsWeighting", po::value<bool>(&enableObservationsWeighting)->default_value(enableObservationsWeighting), "Enable observations weighting to reduce impact of regions with high point density.")
+    ("lossParameter", po::value<double>(&lossParameter)->default_value(lossParameter), "Huber loss threshold used in bundle adjustment.")
     ("meshFilename,t", po::value<std::string>(&meshFilename)->default_value(meshFilename), "Mesh file.");
     ;
      // clang-format on
@@ -217,6 +219,7 @@ int aliceVision_main(int argc, char** argv)
     sfmBundle->setMaxIterationCount(maxIterationCount);
     sfmBundle->setTemporalConstraintParams(tempConstrParams, useTemporalConstraint);
     sfmBundle->setIsObservationsWeightingEnabled(enableObservationsWeighting);
+    sfmBundle->setLossParameter(lossParameter);
 
     sfmData::PointFetcher::sptr pointFetcherHandler;
     if (!meshFilename.empty())


### PR DESCRIPTION
# PR: LiDAR Pipeline Integration & SfM Improvements

## Summary

This PR introduces a new camera tracking pipeline with LiDAR support and includes several fixes and improvements to the SfM (Structure from Motion) system.

## Changes

### New Features

- **LiDAR Camera Tracking Pipeline** (`meshroom/cameraTrackingLidarExperimental.mg`)
  Added a new Meshroom pipeline for camera tracking with LiDAR data integration (experimental). This pipeline defines 815 lines of graph configuration combining visual tracking with LiDAR-based constraints.

- **Configurable Huber Loss** (`meshroom/aliceVision/SfmExpanding.py`, `src/aliceVision/sfm/...`)
  Moved the Huber loss value from a hardcoded constant to an exposed parameter in the `SfmExpanding` node and the underlying `BundleAdjustmentCeres` / `SfmBundle` stack, giving users control over the robustness threshold during bundle adjustment.

### Bug Fixes

- **Missing pose in bundle ordering** (`src/aliceVision/sfm/bundle/BundleAdjustmentCeres.cpp`)
  Fixed a case where a pose was not included in the bundle ordering, which could lead to incorrect or incomplete bundle adjustment results.

- **Remove pairs requirement for `mesh_single` in bootstrapping** (`src/software/pipeline/main_sfmBootstrapping.cpp`)
  Refactored the bootstrapping logic so that the `mesh_single` mode no longer requires precomputed pairs, simplifying the pipeline and making bootstrapping more robust.

- **Propagate `surveyPoints` in image matching** (`src/software/pipeline/main_imageMatching.cpp`)
  Survey points are now correctly propagated through the image matching stage, ensuring downstream nodes have access to this data.

