### PR TITLE
[meshroom] Update `ImageSegmentationSam3` nodes in templates

### DIFF
--- a/meshroom/cameraTracking.mg
+++ b/meshroom/cameraTracking.mg
@@ -18,7 +18,7 @@
             "FeatureMatching": "2.1",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.1",
-            "ImageSegmentationSam3": "1.0",
+            "ImageSegmentationSam3": "2.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",

--- a/meshroom/cameraTrackingDepth.mg
+++ b/meshroom/cameraTrackingDepth.mg
@@ -19,7 +19,7 @@
             "FeatureMatching": "2.1",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.1",
-            "ImageSegmentationSam3": "1.0",
+            "ImageSegmentationSam3": "2.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",

--- a/meshroom/cameraTrackingRoma.mg
+++ b/meshroom/cameraTrackingRoma.mg
@@ -13,7 +13,7 @@
             "ExportDistortion": "2.0",
             "ExportImages": "1.1",
             "GeometricFilterEstimating": "1.1",
-            "ImageSegmentationSam3": "1.0",
+            "ImageSegmentationSam3": "2.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MatchMasking": "1.4",

--- a/meshroom/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/cameraTrackingWithoutCalibration.mg
@@ -17,7 +17,7 @@
             "FeatureMatching": "2.1",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.1",
-            "ImageSegmentationSam3": "1.0",
+            "ImageSegmentationSam3": "2.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",

--- a/meshroom/nodalCameraTracking.mg
+++ b/meshroom/nodalCameraTracking.mg
@@ -15,7 +15,7 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "ImageSegmentationSam3": "1.0",
+            "ImageSegmentationSam3": "2.0",
             "IntrinsicsTransforming": "1.1",
             "NodalSfM": "2.1",
             "RelativePoseEstimating": "3.1",

--- a/meshroom/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/nodalCameraTrackingWithoutCalibration.mg
@@ -13,7 +13,7 @@
             "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
             "ImageMatching": "2.0",
-            "ImageSegmentationSam3": "1.0",
+            "ImageSegmentationSam3": "2.0",
             "IntrinsicsTransforming": "1.1",
             "NodalSfM": "2.1",
             "RelativePoseEstimating": "3.1",

--- a/meshroom/photogrammetryAndCameraTracking.mg
+++ b/meshroom/photogrammetryAndCameraTracking.mg
@@ -18,7 +18,7 @@
             "FeatureMatching": "2.1",
             "ImageMatching": "2.0",
             "ImageMatchingMultiSfM": "1.1",
-            "ImageSegmentationSam3": "1.0",
+            "ImageSegmentationSam3": "2.0",
             "IntrinsicsTransforming": "1.1",
             "KeyframeSelection": "5.0",
             "MeshDecimate": "1.0",


### PR DESCRIPTION
## Description

Following https://github.com/meshroomHub/mrSegmentation/pull/59 which upgraded the version of the `ImageSegmentationSam3` node, all the templates including it must be udpated so the version matches the node's latest one.
