### PR TITLE
[src] CMake: Switch `LEMON` linking to imported target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -912,7 +912,6 @@ set(ALICEVISION_INCLUDE_DIRS
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${generatedDir}
         ${CMAKE_CURRENT_SOURCE_DIR}/dependencies
-        ${LEMON_INCLUDE_DIRS}
         ${EIGEN3_INCLUDE_DIRS}
         ${CERES_INCLUDE_DIRS}
         ${UNCERTAINTYTE_INCLUDE_DIRS}

--- a/src/aliceVision/graph/CMakeLists.txt
+++ b/src/aliceVision/graph/CMakeLists.txt
@@ -14,5 +14,18 @@ alicevision_add_interface(aliceVision_graph
 )
 
 # Unit tests
-alicevision_add_test(connectedComponent_test.cpp NAME "graph_connectedComponent" LINKS aliceVision_graph ${LEMON_LIBRARY})
-alicevision_add_test(triplet_test.cpp            NAME "graph_triplet"            LINKS aliceVision_graph ${LEMON_LIBRARY})
+alicevision_add_test(connectedComponent_test.cpp
+    NAME
+        "graph_connectedComponent"
+    LINKS
+        aliceVision_graph
+        LEMON::lemon
+)
+
+alicevision_add_test(triplet_test.cpp
+    NAME
+        "graph_triplet"
+    LINKS
+        aliceVision_graph
+        LEMON::lemon
+)

--- a/src/aliceVision/multiview/CMakeLists.txt
+++ b/src/aliceVision/multiview/CMakeLists.txt
@@ -80,9 +80,9 @@ alicevision_add_library(aliceVision_multiview
         aliceVision_robustEstimation
         aliceVision_camera
         ${CERES_LIBRARIES}
+        LEMON::lemon
     PRIVATE_LINKS
         aliceVision_system
-        ${LEMON_LIBRARY}
 )
 
 alicevision_add_library(aliceVision_multiview_test_data

--- a/src/aliceVision/sfm/CMakeLists.txt
+++ b/src/aliceVision/sfm/CMakeLists.txt
@@ -117,6 +117,7 @@ alicevision_add_library(aliceVision_sfm_bundle
         aliceVision_sfmData
         Boost::boost
         ${CERES_LIBRARIES}
+        LEMON::lemon
 )
 
 alicevision_add_library(aliceVision_sfm
@@ -138,8 +139,8 @@ alicevision_add_library(aliceVision_sfm
         aliceVision_sfm_bundle
         aliceVision_dataio
         Boost::boost
+        LEMON::lemon
     PRIVATE_LINKS
-        ${LEMON_LIBRARY}
         nanoflann::nanoflann
 )
 
@@ -152,7 +153,7 @@ alicevision_add_test(bundle/bundleAdjustment_test.cpp
           aliceVision_multiview_test_data
           aliceVision_feature
           aliceVision_system
-          ${LEMON_LIBRARY}
+          LEMON::lemon
 )
 
 alicevision_add_test(bundle/bundleAdjustment_Enhanced_test.cpp
@@ -162,7 +163,7 @@ alicevision_add_test(bundle/bundleAdjustment_Enhanced_test.cpp
           aliceVision_multiview_test_data
           aliceVision_feature
           aliceVision_system
-          ${LEMON_LIBRARY}
+          LEMON::lemon
 )
 
 alicevision_add_test(bundle/bundleAdjustment_temporalConstraint_test.cpp
@@ -177,7 +178,7 @@ alicevision_add_test(utils/alignment_test.cpp
         aliceVision_sfm
         aliceVision_multiview
         aliceVision_multiview_test_data
-        ${LEMON_LIBRARY}
+        LEMON::lemon
 )
 
 alicevision_add_test(utils/poseFilter_test.cpp

--- a/src/aliceVision/track/CMakeLists.txt
+++ b/src/aliceVision/track/CMakeLists.txt
@@ -24,8 +24,7 @@ alicevision_add_library(aliceVision_track
         aliceVision_matching
         aliceVision_stl
         Boost::json
-    PRIVATE_LINKS
-        ${LEMON_LIBRARY}
+        LEMON::lemon
 )
 
 # Unit tests

--- a/src/software/utils/CMakeLists.txt
+++ b/src/software/utils/CMakeLists.txt
@@ -421,7 +421,7 @@ if (ALICEVISION_BUILD_SFM)
               Boost::program_options
               Boost::boost
               Boost::timer
-              ${LEMON_LIBRARY}
+              LEMON::lemon
     )
 
     # Keyframe selection


### PR DESCRIPTION
## Description

This pull request updates how the LEMON graph library is linked throughout the codebase, switching from the older `${LEMON_LIBRARY}` variable to the modern `LEMON::lemon` CMake target. This improves compatibility with CMake best practices and ensures consistent linking of the LEMON library across all relevant modules, libraries, and tests.

